### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --extras all
+      - name: Run tests
+        run: poetry run pytest --verbose

--- a/tests/model/nlp/text_test.py
+++ b/tests/model/nlp/text_test.py
@@ -4,6 +4,7 @@ from avalan.model.nlp.text.generation import (
     AutoModelForCausalLM,
     TextGenerationModel
 )
+from avalan.model.engine import Engine
 from logging import Logger
 from transformers import (
     PretrainedConfig,
@@ -117,7 +118,7 @@ class TextGenerationModelTestCase(TestCase):
                     state_dict=None,
                     local_files_only=False,
                     low_cpu_mem_usage=True,
-                    device_map="mps",
+                    device_map=Engine.get_default_device(),
                     token=None,
                     quantization_config=None,
                     revision=None


### PR DESCRIPTION
## Summary
- run Python tests in GitHub Actions on push
- fix TextGenerationModel tests to check device map from Engine

## Testing
- `poetry install --extras all`
- `poetry run pytest --verbose` *(fails: ImportError: cannot import name 'override' from 'typing')*