### PR TITLE
Add compatibility for Python 3.11

### DIFF
--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -175,9 +175,11 @@ async def memory_embeddings(
 
             # Comparisons
             if compare_strings:
-                logger.debug(f"Calculating similarities between "
-                            f"\"{input_string} and "
-                            f"[\"{'\", \"'.join(compare_strings)}\"]")
+                joined = '", "'.join(compare_strings)
+                logger.debug(
+                    f'Calculating similarities between "{input_string}" and '
+                    f'["{joined}"]'
+                )
                 embeddings = embeddings[1:]
                 comparisons = dict(zip(compare_strings, embeddings))
                 # Calculate similarities
@@ -220,9 +222,12 @@ async def memory_embeddings(
                     reverse=False
                 ))
 
-                logger.debug(f"Similarities between \"{input_string} and "
-                            f"[\"{'\", \"'.join(compare_strings)}\"]: " +
-                            similarities.__repr__())
+                joined = '", "'.join(compare_strings)
+                logger.debug(
+                    f'Similarities between "{input_string}" and '
+                    f'["{joined}"]: '
+                    + similarities.__repr__()
+                )
 
                 # Closest match
                 most_similar = next(iter(similarities))

--- a/src/avalan/compat.py
+++ b/src/avalan/compat.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+try:
+    from typing import override as _override
+except ImportError:  # Python < 3.12
+    T = TypeVar("T", bound=Callable[..., object])
+    def _override(func: T) -> T:  # type: ignore
+        return func
+
+override = _override
+
+__all__ = ["override"]

--- a/src/avalan/memory/__init__.py
+++ b/src/avalan/memory/__init__.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 from avalan.model.entities import EngineMessage
 from dataclasses import dataclass
 from threading import Lock
-from typing import Generic, Optional, override, TypeVar
+from typing import Generic, Optional, TypeVar
+from avalan.compat import override
 from uuid import UUID
 
 T = TypeVar("T")

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from numpy import ndarray
-from typing import Literal, Optional, override
+from typing import Literal, Optional
+from avalan.compat import override
 from uuid import UUID
 
 Order = Literal["asc", "desc"]

--- a/src/avalan/model/nlp/text/vendor/__init__.py
+++ b/src/avalan/model/nlp/text/vendor/__init__.py
@@ -14,7 +14,8 @@ from tiktoken import encoding_for_model, get_encoding
 from torch import Tensor
 from transformers.tokenization_utils_base import BatchEncoding
 from transformers import PreTrainedModel
-from typing import AsyncGenerator, Literal, override
+from typing import AsyncGenerator, Literal
+from avalan.compat import override
 
 class TextGenerationVendorStream(TextGenerationStream):
     _generator: AsyncGenerator


### PR DESCRIPTION
## Summary
- create `compat` module to provide a fallback `override` decorator when running on Python < 3.12
- update imports to use the compatibility decorator
- fix f-string backslash issues in memory CLI to allow Python 3.11 compilation

## Testing
- `poetry install --extras all` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest --verbose` *(fails: errors during collection)*