### PR TITLE
Add string support for agent model display

### DIFF
--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -70,8 +70,12 @@ async def agent_message_search(
 
             can_access = args.skip_hub_access_check or \
                         hub.can_access(orchestrator.engine.model_id)
+            is_local = not isinstance(
+                orchestrator.engine,
+                TextGenerationVendorModel
+            )
             models = [
-                hub.model(model_id)
+                hub.model(model_id) if is_local else model_id
                 for model_id in orchestrator.model_ids
             ]
 
@@ -163,9 +167,9 @@ async def agent_run(
                 or hub.can_access(orchestrator.engine.model_id)
             )
             models = [
-                hub.model(model_id)
+                hub.model(model_id) if is_local else model_id
                 for model_id in orchestrator.model_ids
-            ] if is_local else []
+            ]
 
             console.print(theme.agent(
                 orchestrator,

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -101,7 +101,7 @@ class Theme(ABC):
         self,
         agent: Orchestrator,
         *args,
-        model: Model,
+        models: list[Model | str],
         cans_access: Optional[bool]
     ) -> RenderableType:
         raise NotImplementedError()
@@ -385,7 +385,7 @@ class Theme(ABC):
     def get_spinner(self, spinner_name: str) -> Spinner:
         return self._all_spinners[spinner_name]
 
-    def __call__(self, item: Union[Model]) -> RenderableType:
+    def __call__(self, item: Model | str) -> RenderableType:
         return \
             self.model(item) if isinstance(item, Model) else \
             str(item)

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -167,7 +167,7 @@ class FancyTheme(Theme):
         self,
         agent: Orchestrator,
         *args,
-        models: list[Model],
+        models: list[Model | str],
         can_access: Optional[bool],
     ) -> RenderableType:
         _, _f, _i = self._, self._f, self._icons
@@ -182,7 +182,7 @@ class FancyTheme(Theme):
                         ),
                         icon=False
                     )
-                )
+                ) if isinstance(model, Model) else str(model)
                 for model in models
             ]),
             _f("memory", _j(", ", [


### PR DESCRIPTION
## Summary
- allow `FancyTheme.agent()` to accept model strings
- support union type in Theme API
- handle non-local engines by passing model IDs
- use the `|` union operator for model arguments

## Testing
- `poetry install --extras all` *(fails: could not connect to pypi.org)*
- `poetry run pytest --verbose` *(fails: errors during collection)*