### PR TITLE
Add memory search command

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -12,7 +12,8 @@ from ..cli.commands.agent import (
 from ..cli.commands.cache import cache_delete, cache_download, cache_list
 from ..cli.commands.memory import (
     memory_document_index,
-    memory_embeddings
+    memory_embeddings,
+    memory_search
 )
 from ..cli.commands.model import (
     model_display,
@@ -684,6 +685,47 @@ class CLI:
             default=DistanceType.L2,
             help="Sort comparison results using the given similarity measure",
         )
+
+        memory_search_parser = memory_command_parsers.add_parser(
+            name="search",
+            description="Search memories",
+            parents=[
+                global_parser,
+                model_options_parser,
+                memory_partitions_parser
+            ]
+        )
+        memory_search_parser.add_argument(
+            "--dsn",
+            type=str,
+            required=True,
+            help="PostgreSQL DSN for searching"
+        )
+        memory_search_parser.add_argument(
+            "--participant",
+            type=str,
+            required=True,
+            help="Participant ID to search"
+        )
+        memory_search_parser.add_argument(
+            "--namespace",
+            type=str,
+            required=True,
+            help="Namespace to search"
+        )
+        memory_search_parser.add_argument(
+            "--function",
+            type=VectorFunction,
+            choices=list(VectorFunction),
+            required=True,
+            default=VectorFunction.L2_DISTANCE,
+            help="Vector function to use for searching"
+        )
+        memory_search_parser.add_argument(
+            "--limit",
+            type=int,
+            help="Return up to this many memories"
+        )
         memory_doc_parser = memory_command_parsers.add_parser(
             name="document",
             description="Manage memory indexed documents",
@@ -1084,6 +1126,14 @@ class CLI:
                                     hub,
                                     self._logger
                                 )
+                    case "search":
+                        await memory_search(
+                            args,
+                            console,
+                            theme,
+                            hub,
+                            self._logger
+                        )
                     case "embeddings":
                         await memory_embeddings(
                             args,

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -14,6 +14,7 @@ from ...model.entities import (
     TokenizerConfig,
     User
 )
+from ...memory.permanent import Memory
 from ...model.nlp import Token
 from dataclasses import fields
 from datetime import datetime
@@ -256,6 +257,15 @@ class Theme(ABC):
         agent: Orchestrator,
         messages: list[EngineMessageScored]
     ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def memory_search_matches(
+        self,
+        participant_id: UUID,
+        namespace: str,
+        memories: list[Memory]
+    ) -> RenderableType:
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -15,6 +15,7 @@ from ...model.entities import (
     User
 )
 from ...cli.theme import Data, Spinner, Theme
+from ...memory.permanent import Memory
 from ...utils import _j, _lf
 from humanize import clamp, intcomma, intword, naturalday, naturalsize
 from locale import format_string
@@ -1098,6 +1099,33 @@ class FancyTheme(Theme):
                 box=box.SQUARE
             )
             for engine_message in messages
+        ]))
+        return group
+
+    def memory_search_matches(
+        self,
+        participant_id: UUID,
+        namespace: str,
+        memories: list[Memory]
+    ) -> RenderableType:
+        _, _f, _i = self._, self._f, self._icons
+        group = Group(*_lf([
+            Panel(
+                memory.data,
+                title=(
+                    _i["memory"] + " " +
+                    _f("id", memory.identifier)
+                ),
+                title_align="left",
+                subtitle=_("Participant: {participant} – Namespace: {ns}").format(
+                    participant=_f("participant_id", participant_id),
+                    ns=_f("id", namespace)
+                ),
+                subtitle_align="left",
+                expand=True,
+                box=box.SQUARE
+            )
+            for memory in memories
         ]))
         return group
 


### PR DESCRIPTION
## Summary
- add `memory search` CLI command
- display memory search matches using new theme helpers
- support memory searching in CLI parser and execution

## Testing
- `poetry install --extras all` *(fails: no internet access)*
- `poetry run pytest --verbose` *(fails: missing dependencies)*