### PR TITLE
Add DeepSeek vendor

### DIFF
--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -35,6 +35,7 @@ TextGenerationLoaderClass = Literal[
 
 Vendor = Literal[
     "anthropic",
+    "deepseek",
     "google",
     "local",
     "openai",

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -127,6 +127,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "openrouter":
             from ..model.nlp.text.vendor.openrouter import OpenRouterModel
             model = OpenRouterModel(**model_load_args)
+        elif engine_uri.vendor == "deepseek":
+            from ..model.nlp.text.vendor.deepseek import DeepSeekModel
+            model = DeepSeekModel(**model_load_args)
 
         self._stack.enter_context(model)
         return model

--- a/src/avalan/model/nlp/text/vendor/deepseek.py
+++ b/src/avalan/model/nlp/text/vendor/deepseek.py
@@ -1,5 +1,5 @@
 from .....model import TextGenerationVendor
-from .....model.nlp.text.vendor.openai import OpenAIClient, OpenAIModel
+from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
 class DeepSeekClient(OpenAIClient):

--- a/src/avalan/model/nlp/text/vendor/deepseek.py
+++ b/src/avalan/model/nlp/text/vendor/deepseek.py
@@ -1,0 +1,19 @@
+from .....model import TextGenerationVendor
+from .....model.nlp.text.vendor.openai import OpenAIClient, OpenAIModel
+from transformers import PreTrainedModel
+
+class DeepSeekClient(OpenAIClient):
+    def __init__(self, api_key: str, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url or "https://api.deepseek.com"
+        )
+
+class DeepSeekModel(OpenAIModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        assert self._settings.access_token
+        return DeepSeekClient(
+            base_url=self._settings.base_url,
+            api_key=self._settings.access_token,
+        )
+

--- a/tests/model/manager_test.py
+++ b/tests/model/manager_test.py
@@ -80,6 +80,18 @@ class ManagerTestCase(TestCase):
                 "openrouter",
                 "gpt-3.5-turbo",
                 "router_api_key"
+            ),
+            (
+                "ai://seek_key:@deepseek/deepseek-chat",
+                "deepseek",
+                "deepseek-chat",
+                "seek_key"
+            ),
+            (
+                "ai://seek_key@deepseek/deepseek-chat",
+                "deepseek",
+                "deepseek-chat",
+                "seek_key"
             )
         ]
 


### PR DESCRIPTION
## Summary
- support new `deepseek` vendor for text generation
- load DeepSeek using OpenAI-compatible client
- test parsing of DeepSeek engine URIs

## Testing
- `poetry run pytest --verbose` *(fails: ModuleNotFoundError: No module named 'tiktoken', 'tree_sitter_python', 'pgvector')*