### PR TITLE
Add Ollama vendor

### DIFF
--- a/docs/examples/text_generation_ollama.py
+++ b/docs/examples/text_generation_ollama.py
@@ -1,0 +1,23 @@
+from asyncio import run
+from avalan.model.entities import GenerationSettings, TransformerEngineSettings
+from avalan.model.nlp.text.vendor.ollama import OllamaModel
+
+async def example() -> None:
+    print("Loading model... ", end="", flush=True)
+    with OllamaModel("llama3", TransformerEngineSettings()) as lm:
+        print("DONE.", flush=True)
+
+        system_prompt = """
+            You are Leo Messi, the greatest football/soccer player of all
+            times.
+        """
+
+        async for token in await lm(
+            "Who are you?",
+            system_prompt=system_prompt,
+            settings=GenerationSettings(temperature=0.9, max_new_tokens=256),
+        ):
+            print(token, end="", flush=True)
+
+if __name__ == "__main__":
+    run(example())

--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -40,6 +40,7 @@ Vendor = Literal[
     "local",
     "openai",
     "openrouter",
+    "ollama",
 ]
 
 WeightType = Literal[

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -130,6 +130,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "deepseek":
             from ..model.nlp.text.vendor.deepseek import DeepSeekModel
             model = DeepSeekModel(**model_load_args)
+        elif engine_uri.vendor == "ollama":
+            from ..model.nlp.text.vendor.ollama import OllamaModel
+            model = OllamaModel(**model_load_args)
 
         self._stack.enter_context(model)
         return model

--- a/src/avalan/model/nlp/text/vendor/ollama.py
+++ b/src/avalan/model/nlp/text/vendor/ollama.py
@@ -1,0 +1,79 @@
+from .....model import TextGenerationVendor
+from .....model.entities import (
+    GenerationSettings,
+    Message,
+    Token,
+    TokenDetail,
+    TransformerEngineSettings,
+)
+from .....model.nlp.text.vendor import (
+    TextGenerationVendorModel,
+    TextGenerationVendorStream,
+)
+from .....model.nlp.text.generation import TextGenerationModel
+from .....tool.manager import ToolManager
+from dataclasses import replace
+from logging import Logger
+from typing import AsyncIterator
+
+try:
+    from ollama import AsyncClient
+except Exception:  # pragma: no cover - ollama may not be installed
+    AsyncClient = None
+
+class OllamaStream(TextGenerationVendorStream):
+    def __init__(self, stream: AsyncIterator[dict]):
+        super().__init__(stream)
+
+    async def __anext__(self) -> Token | TokenDetail | str:
+        chunk = await self._generator.__anext__()
+        message = chunk.get("message", {}) if isinstance(chunk, dict) else {}
+        return message.get("content", "")
+
+class OllamaClient(TextGenerationVendor):
+    _client: AsyncClient
+
+    def __init__(self, base_url: str | None = None):
+        assert AsyncClient, "ollama is not available"
+        self._client = AsyncClient(host=base_url) if base_url else AsyncClient()
+
+    async def __call__(
+        self,
+        model_id: str,
+        messages: list[Message],
+        settings: GenerationSettings | None = None,
+        *,
+        tool: ToolManager | None = None,
+        use_async_generator: bool = True
+    ) -> AsyncIterator[Token | TokenDetail | str]:
+        template_messages = self._template_messages(messages)
+        if use_async_generator:
+            stream = await self._client.chat(
+                model=model_id,
+                messages=template_messages,
+                stream=True,
+            )
+            return OllamaStream(stream)
+        else:
+            response = await self._client.chat(
+                model=model_id,
+                messages=template_messages,
+                stream=False,
+            )
+            async def single_gen():
+                yield response["message"]["content"]
+            return single_gen()
+
+class OllamaModel(TextGenerationVendorModel):
+    def __init__(
+        self,
+        model_id: str,
+        settings: TransformerEngineSettings | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        settings = settings or TransformerEngineSettings()
+        settings = replace(settings, enable_eval=False)
+        TextGenerationModel.__init__(self, model_id, settings, logger)
+
+    def _load_model(self):
+        return OllamaClient(base_url=self._settings.base_url)

--- a/tests/model/manager_test.py
+++ b/tests/model/manager_test.py
@@ -92,6 +92,12 @@ class ManagerTestCase(TestCase):
                 "deepseek",
                 "deepseek-chat",
                 "seek_key"
+            ),
+            (
+                "ai://ollama/llama3",
+                "ollama",
+                "llama3",
+                None
             )
         ]
 


### PR DESCRIPTION
## Summary
- implement Ollama vendor client with streaming support
- recognise `ollama` vendor in engine manager and entity enum
- test URI parsing for the new vendor
- document example usage of the Ollama model

## Testing
- `poetry install --extras all` *(fails: Could not connect to pypi.org)*
- `poetry run pytest --verbose` *(fails: 5 errors during collection)*
