### PR TITLE
Add Groq text generation vendor

### DIFF
--- a/docs/examples/text_generation_groq.py
+++ b/docs/examples/text_generation_groq.py
@@ -1,0 +1,29 @@
+from asyncio import run
+from avalan.model.entities import GenerationSettings, TransformerEngineSettings
+from avalan.model.nlp.text.vendor.groq import GroqModel
+from os import environ
+
+async def example() -> None:
+    print("Loading model... ", end="", flush=True)
+
+    api_key = environ["GROQ_API_KEY"]
+    assert api_key, "Need an $GROQ_API_KEY environment variable set"
+    settings = TransformerEngineSettings(access_token=api_key)
+
+    with GroqModel("llama3-8b-8192", settings) as lm:
+        print("DONE.", flush=True)
+
+        system_prompt = """
+            You are Leo Messi, the greatest football/soccer player of all
+            times.
+        """
+
+        async for token in await lm(
+            "Who are you?",
+            system_prompt=system_prompt,
+            settings=GenerationSettings(temperature=0.9, max_new_tokens=256),
+        ):
+            print(token, end="", flush=True)
+
+if __name__ == "__main__":
+    run(example())

--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -37,6 +37,7 @@ Vendor = Literal[
     "anthropic",
     "deepseek",
     "google",
+    "groq",
     "local",
     "openai",
     "openrouter",

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -130,6 +130,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "deepseek":
             from ..model.nlp.text.vendor.deepseek import DeepSeekModel
             model = DeepSeekModel(**model_load_args)
+        elif engine_uri.vendor == "groq":
+            from ..model.nlp.text.vendor.groq import GroqModel
+            model = GroqModel(**model_load_args)
         elif engine_uri.vendor == "ollama":
             from ..model.nlp.text.vendor.ollama import OllamaModel
             model = OllamaModel(**model_load_args)

--- a/src/avalan/model/nlp/text/vendor/groq.py
+++ b/src/avalan/model/nlp/text/vendor/groq.py
@@ -1,0 +1,18 @@
+from .....model import TextGenerationVendor
+from .openai import OpenAIClient, OpenAIModel
+from transformers import PreTrainedModel
+
+class GroqClient(OpenAIClient):
+    def __init__(self, api_key: str, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url or "https://api.groq.com/openai/v1"
+        )
+
+class GroqModel(OpenAIModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        assert self._settings.access_token
+        return GroqClient(
+            base_url=self._settings.base_url,
+            api_key=self._settings.access_token,
+        )

--- a/tests/model/manager_test.py
+++ b/tests/model/manager_test.py
@@ -94,6 +94,18 @@ class ManagerTestCase(TestCase):
                 "seek_key"
             ),
             (
+                "ai://groq_key:@groq/llama3-8b-8192",
+                "groq",
+                "llama3-8b-8192",
+                "groq_key"
+            ),
+            (
+                "ai://groq_key@groq/llama3-8b-8192",
+                "groq",
+                "llama3-8b-8192",
+                "groq_key"
+            ),
+            (
                 "ai://ollama/llama3",
                 "ollama",
                 "llama3",


### PR DESCRIPTION
## Summary
- support Groq as a text generation vendor
- allow `ModelManager` to load Groq models
- document Groq usage with a new example
- test URI parsing for the Groq vendor

## Testing
- `poetry run pytest --verbose` *(fails: 5 errors during collection)*