### PR TITLE
Add Huggingface text vendor

### DIFF
--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -38,6 +38,7 @@ Vendor = Literal[
     "deepseek",
     "google",
     "groq",
+    "huggingface",
     "local",
     "openai",
     "openrouter",

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -136,6 +136,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "ollama":
             from ..model.nlp.text.vendor.ollama import OllamaModel
             model = OllamaModel(**model_load_args)
+        elif engine_uri.vendor == "huggingface":
+            from ..model.nlp.text.vendor.huggingface import HuggingfaceModel
+            model = HuggingfaceModel(**model_load_args)
 
         self._stack.enter_context(model)
         return model

--- a/src/avalan/model/nlp/text/vendor/huggingface.py
+++ b/src/avalan/model/nlp/text/vendor/huggingface.py
@@ -1,0 +1,66 @@
+from .....model import TextGenerationVendor
+from .....model.entities import (
+    GenerationSettings,
+    Message,
+    Token,
+    TokenDetail,
+)
+from .....model.nlp.text.vendor import (
+    TextGenerationVendorModel,
+    TextGenerationVendorStream
+)
+from .....tool.manager import ToolManager
+from huggingface_hub import AsyncInferenceClient
+from transformers import PreTrainedModel
+from typing import AsyncIterator
+
+class HuggingfaceStream(TextGenerationVendorStream):
+    def __init__(self, stream: AsyncIterator):
+        super().__init__(stream.__aiter__())
+
+    async def __anext__(self) -> Token | TokenDetail | str:
+        chunk = await self._generator.__anext__()
+        delta = chunk.choices[0].delta
+        text = getattr(delta, "content", None) or ""
+        return text
+
+class HuggingfaceClient(TextGenerationVendor):
+    _client: AsyncInferenceClient
+
+    def __init__(self, api_key: str, base_url: str | None = None):
+        self._client = AsyncInferenceClient(token=api_key, base_url=base_url)
+
+    async def __call__(
+        self,
+        model_id: str,
+        messages: list[Message],
+        settings: GenerationSettings | None = None,
+        *,
+        tool: ToolManager | None = None,
+        use_async_generator: bool = True
+    ) -> AsyncIterator[Token | TokenDetail | str]:
+        settings = settings or GenerationSettings()
+        template_messages = self._template_messages(messages)
+        response = await self._client.chat_completion(
+            model=model_id,
+            messages=template_messages,
+            temperature=settings.temperature,
+            max_tokens=settings.max_new_tokens,
+            top_p=settings.top_p,
+            stop=settings.stop_strings,
+            stream=use_async_generator,
+        )
+        if use_async_generator:
+            return HuggingfaceStream(response)
+        else:
+            async def single_gen():
+                yield response.choices[0].message.content or ""
+            return single_gen()
+
+class HuggingfaceModel(TextGenerationVendorModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        assert self._settings.access_token
+        return HuggingfaceClient(
+            api_key=self._settings.access_token,
+            base_url=self._settings.base_url,
+        )

--- a/src/avalan/model/nlp/text/vendor/huggingface.py
+++ b/src/avalan/model/nlp/text/vendor/huggingface.py
@@ -5,7 +5,7 @@ from .....model.entities import (
     Token,
     TokenDetail,
 )
-from .....model.nlp.text.vendor import (
+from . import (
     TextGenerationVendorModel,
     TextGenerationVendorStream
 )

--- a/tests/model/manager_test.py
+++ b/tests/model/manager_test.py
@@ -106,6 +106,18 @@ class ManagerTestCase(TestCase):
                 "groq_key"
             ),
             (
+                "ai://hf_key:@huggingface/meta-llama/Llama-3-8B-Instruct",
+                "huggingface",
+                "meta-llama/Llama-3-8B-Instruct",
+                "hf_key"
+            ),
+            (
+                "ai://hf_key@huggingface/meta-llama/Llama-3-8B-Instruct",
+                "huggingface",
+                "meta-llama/Llama-3-8B-Instruct",
+                "hf_key"
+            ),
+            (
                 "ai://ollama/llama3",
                 "ollama",
                 "llama3",


### PR DESCRIPTION
## Summary
- support Huggingface remote text generation vendor
- recognize `huggingface` vendor when parsing engine URIs
- load Huggingface models in the manager
- test parsing of the new vendor URIs

## Testing
- `poetry run pytest --verbose` *(fails: ModuleNotFoundError: No module named 'tiktoken', 'tree_sitter_python', 'pgvector')*