### PR TITLE
Support file indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,12 @@ Add a document to the memory index so its contents become searchable:
 avalan memory document index README.md \
                            --dsn postgresql://user:pass@localhost/db \
                            --participant 123e4567-e89b-12d3-a456-426614174000 \
-                           --namespace docs
+                           --namespace docs \
+                           --partitioner code \
+                           --language python \
+                           --encoding utf-8
 ```
+Use `--identifier` to override the default identifier (the source path or URL).
 
 ## model
 

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -748,6 +748,28 @@ class CLI:
             help="Source to index (an URL or a file path)",
         )
         memory_doc_index_parser.add_argument(
+            "--partitioner",
+            choices=["text", "code"],
+            default="text",
+            help="Partitioner to use when indexing a file",
+        )
+        memory_doc_index_parser.add_argument(
+            "--language",
+            type=str,
+            help="Programming language for the code partitioner",
+        )
+        memory_doc_index_parser.add_argument(
+            "--encoding",
+            type=str,
+            default="utf-8",
+            help="File encoding used when reading a local file",
+        )
+        memory_doc_index_parser.add_argument(
+            "--identifier",
+            type=str,
+            help="Identifier for the memory entry (defaults to the source)",
+        )
+        memory_doc_index_parser.add_argument(
             "--dsn",
             type=str,
             required=True,

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -34,6 +34,7 @@ class VectorFunction(StrEnum):
 class MemoryType(StrEnum):
     CODE = "code"
     FILE = "file"
+    URL = "url"
     RAW = "raw"
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/memory/permanent/migrations/pgsql/up/00001-messages-up.sql
+++ b/src/avalan/memory/permanent/migrations/pgsql/up/00001-messages-up.sql
@@ -11,7 +11,8 @@ CREATE TYPE "message_author_type" AS ENUM (
 CREATE TYPE "memory_types" AS ENUM (
     'code',
     'file',
-    'raw'
+    'raw',
+    'url'
 );
 
 CREATE TABLE IF NOT EXISTS "sessions" (


### PR DESCRIPTION
## Summary
- allow indexing files for memory
- expose --partitioner, --language and --identifier options for `memory document index`
- update README with example usage

## Testing
- `poetry run pytest --verbose` *(fails: ModuleNotFoundError for tiktoken, tree_sitter_python, pgvector)*