### PR TITLE
Add EventManager integration to EngineAgent

### DIFF
--- a/src/avalan/agent/orchestrator.py
+++ b/src/avalan/agent/orchestrator.py
@@ -256,6 +256,7 @@ class Orchestrator:
                     engine,
                     self._memory,
                     self._tool,
+                    self._event_manager,
                     self._renderer,
                     name=self._name,
                     id=self._id

--- a/src/avalan/agent/renderer.py
+++ b/src/avalan/agent/renderer.py
@@ -3,6 +3,7 @@ from ..agent.engine import EngineAgent
 from ..memory.manager import MemoryManager
 from ..model.engine import Engine
 from ..tool.manager import ToolManager
+from ..event.manager import EventManager
 from jinja2 import (
     Environment as TemplateEnvironment,
     FileSystemLoader,
@@ -61,6 +62,7 @@ class TemplateEngineAgent(EngineAgent):
         model: Engine,
         memory: MemoryManager,
         tool: ToolManager,
+        event_manager: EventManager,
         renderer: Renderer,
         *args,
         name: Optional[str]=None,
@@ -70,6 +72,7 @@ class TemplateEngineAgent(EngineAgent):
             model,
             memory,
             tool,
+            event_manager,
             name=name,
             id=id,
         )

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -9,6 +9,14 @@ class EventType(StrEnum):
     TOOL_RESULT = "tool_result"
     END = "end"
     STREAM_END = "stream_end"
+    CALL_PREPARE_BEFORE = "call_prepare_before"
+    CALL_PREPARE_AFTER = "call_prepare_after"
+    MEMORY_APPEND_BEFORE = "memory_append_before"
+    MEMORY_APPEND_AFTER = "memory_append_after"
+    MODEL_EXECUTE_BEFORE = "model_execute_before"
+    MODEL_EXECUTE_AFTER = "model_execute_after"
+    INPUT_TOKEN_COUNT_BEFORE = "input_token_count_before"
+    INPUT_TOKEN_COUNT_AFTER = "input_token_count_after"
 
 @dataclass(frozen=True, kw_only=True)
 class Event:

--- a/tests/agent/engine_agent_event_test.py
+++ b/tests/agent/engine_agent_event_test.py
@@ -1,0 +1,54 @@
+from avalan.agent.engine import EngineAgent
+from avalan.event import EventType
+from avalan.event.manager import EventManager
+from avalan.model.entities import Message, MessageRole, GenerationSettings
+from avalan.memory.manager import MemoryManager
+from avalan.tool.manager import ToolManager
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+class DummyEngine:
+    model_id = "m"
+    async def __call__(self, input, **kwargs):
+        return "out"
+    def input_token_count(self, *args, **kwargs):
+        return 5
+
+class DummyAgent(EngineAgent):
+    def _prepare_call(self, specification, input, **kwargs):
+        return {"settings": GenerationSettings()}
+
+class EngineAgentEventTestCase(IsolatedAsyncioTestCase):
+    async def test_events_triggered(self):
+        memory = MagicMock(spec=MemoryManager)
+        memory.has_permanent_message = False
+        memory.has_recent_message = True
+        memory.recent_message = Message(role=MessageRole.USER, content="last")
+        memory.recent_messages = []
+        memory.append_message = AsyncMock()
+
+        tool = MagicMock(spec=ToolManager)
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        agent = DummyAgent(DummyEngine(), memory, tool, event_manager)
+        await agent(MagicMock(), Message(role=MessageRole.USER, content="hi"))
+
+        await agent.input_token_count()
+
+        called_types = [c.args[0].type for c in event_manager.trigger.await_args_list]
+        for t in [
+            EventType.CALL_PREPARE_BEFORE,
+            EventType.CALL_PREPARE_AFTER,
+            EventType.MEMORY_APPEND_BEFORE,
+            EventType.MEMORY_APPEND_AFTER,
+            EventType.MODEL_EXECUTE_BEFORE,
+            EventType.MODEL_EXECUTE_AFTER,
+            EventType.INPUT_TOKEN_COUNT_BEFORE,
+            EventType.INPUT_TOKEN_COUNT_AFTER,
+        ]:
+            self.assertIn(t, called_types)
+        self.assertTrue(any(
+            c.args[0].type == EventType.INPUT_TOKEN_COUNT_AFTER and c.args[0].payload["count"] == 5
+            for c in event_manager.trigger.await_args_list
+        ))


### PR DESCRIPTION
## Summary
- define new event types for EngineAgent lifecycle
- extend EngineAgent to trigger events for call prep, memory updates, model execution and token counting
- pass EventManager through TemplateEngineAgent and Orchestrator
- add tests covering EngineAgent event triggers
- trigger events directly without creating async tasks

## Testing
- `poetry install --extras all` *(fails: unable to connect to pypi.org)*
- `poetry run pytest --verbose` *(fails: 6 errors during collection)*