### PR TITLE
Add secret storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ poetry lock && poetry install
 > for example with:
 >
 > ```bash
-> poetry install --extras 'agent audio cpu memory server test translation vision'
+> poetry install --extras 'agent audio cpu memory secrets server test translation vision'
 > ```
 >
 > Or you can install all extras at once with:

--- a/docs/ai_uri.md
+++ b/docs/ai_uri.md
@@ -16,7 +16,7 @@ This document describes the formal structure of the `ai://` Uniform Resource Ide
 ```
 
 - The URI **scheme** must be `ai`.  If omitted, the parser assumes the prefix `ai://`.
-- `<userinfo>` is optional and typically holds an API key used when accessing a remote vendor.  The password component may be omitted or empty.
+- `<userinfo>` is optional. When only the username is present it is interpreted as the vendor access key. If a password is also supplied, the username denotes a secret storage identifier and the password the key used to retrieve the vendor access token.
 - `<host>` identifies either a known vendor (from the list above) or a local model host.  When the host is not a recognised vendor or equals `local`, the URI is interpreted as a local model reference.
 - `<path>` denotes the model identifier.  For local models the first segment of the path can contain a host component that becomes part of the model identifier.  For remote vendors the path is used directly as the model identifier.
 - `<query>` parameters are parsed into key–value pairs and attached to the resulting `EngineUri` object.
@@ -30,8 +30,8 @@ Parsing an AI URI results in an `EngineUri` structure containing:
 | `vendor`  | Vendor name if `<host>` matches a recognised vendor, otherwise `None`. |
 | `host`    | `<host>` when it is a vendor, else `None`.                    |
 | `port`    | Optional port when supplied for a vendor.                     |
-| `user`    | Username from `<userinfo>` (e.g. an API key), if present.     |
-| `password`| Password from `<userinfo>` if provided and non-empty.         |
+| `user`    | Value of `<user>` when the password is omitted, otherwise the secret storage identifier. |
+| `password`| Value of `<password>` when supplied; used as the key in the chosen secret storage. |
 | `model_id`| Normalised model identifier derived from `<path>`.            |
 | `params`  | Mapping of query parameters.                                  |
 
@@ -45,6 +45,7 @@ When `vendor` is `None`, the model is considered local.  Otherwise, the URI desc
 | `ai://local/tiiuae/Falcon-E-3B-Instruct`    | same as above                                                  |
 | `ai://messi_api_key@openai/gpt-4o`         | vendor `openai`, user `messi_api_key`, model `gpt-4o`          |
 | `ai://hf_key:@huggingface/meta-llama/Llama-3-8B-Instruct` | vendor `huggingface`, user `hf_key`, model `meta-llama/Llama-3-8B-Instruct` |
+| `ai://secret:openai_key@openai/gpt-4o`     | vendor `openai`, secret key `openai_key`, model `gpt-4o`       |
 | `ai://ollama/llama3`                        | vendor `ollama`, model `llama3`                                |
 
 These examples correspond to those used in the test-suite and highlight both local and remote forms.

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,6 +299,23 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+description = "Backport of CPython tarfile module"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"secrets\" or extra == \"all\") and python_version == \"3.11\""
+files = [
+    {file = "backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34"},
+    {file = "backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["jaraco.test", "pytest (!=8.0.*)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)"]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 description = "Screen-scraping library"
@@ -486,7 +503,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name == \"pypy\" and platform_python_implementation != \"PyPy\" and python_version < \"3.13\" and (extra == \"memory\" or extra == \"all\" or extra == \"vllm\") or (extra == \"memory\" or extra == \"all\") and platform_python_implementation != \"PyPy\" or extra == \"vllm\" and implementation_name == \"pypy\" and python_version < \"3.13\""
+markers = "sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name == \"pypy\" and python_version < \"3.13\" and (extra == \"secrets\" or extra == \"all\" or extra == \"memory\" or extra == \"vllm\") or sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and (extra == \"secrets\" or extra == \"all\" or extra == \"memory\") or extra == \"vllm\" and implementation_name == \"pypy\" and python_version < \"3.13\" or platform_python_implementation != \"PyPy\" and implementation_name == \"pypy\" and python_version < \"3.13\" and (extra == \"memory\" or extra == \"all\" or extra == \"vllm\") or (extra == \"memory\" or extra == \"all\") and platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -752,7 +769,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["main"]
-markers = "extra == \"memory\" or extra == \"all\""
+markers = "(extra == \"secrets\" or extra == \"all\" or extra == \"memory\") and (sys_platform == \"linux\" or extra == \"memory\" or extra == \"all\")"
 files = [
     {file = "cryptography-45.0.2-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:61a8b1bbddd9332917485b2453d1de49f142e6334ce1d97b7916d5a85d179c84"},
     {file = "cryptography-45.0.2-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cc31c66411e14dd70e2f384a9204a859dc25b05e1f303df0f5326691061b839"},
@@ -1766,7 +1783,7 @@ description = "Read metadata from Python packages"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version < \"3.13\" and extra == \"vllm\""
+markers = "python_version < \"3.13\" and extra == \"vllm\" or python_version == \"3.11\" and (extra == \"vllm\" or extra == \"secrets\" or extra == \"all\")"
 files = [
     {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
     {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
@@ -1805,6 +1822,87 @@ files = [
     {file = "interegular-0.3.3-py37-none-any.whl", hash = "sha256:b0c07007d48c89d6d19f7204972d369b2a77222722e126b6aa63aa721dc3b19c"},
     {file = "interegular-0.3.3.tar.gz", hash = "sha256:d9b697b21b34884711399ba0f0376914b81899ce670032486d0d048344a76600"},
 ]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+description = "Utility functions for Python class constructs"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"secrets\" or extra == \"all\""
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.1"
+description = "Useful decorators and context managers"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"secrets\" or extra == \"all\""
+files = [
+    {file = "jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4"},
+    {file = "jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3"},
+]
+
+[package.dependencies]
+"backports.tarfile" = {version = "*", markers = "python_version < \"3.12\""}
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["portend", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.1.0"
+description = "Functools like those found in stdlib"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"secrets\" or extra == \"all\""
+files = [
+    {file = "jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649"},
+    {file = "jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy"]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "(extra == \"secrets\" or extra == \"all\") and sys_platform == \"linux\""
+files = [
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
+]
+
+[package.extras]
+test = ["async-timeout ; python_version < \"3.11\"", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["trio"]
 
 [[package]]
 name = "jinja2"
@@ -1963,6 +2061,37 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "keyring"
+version = "25.6.0"
+description = "Store and access your passwords safely."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"secrets\" or extra == \"all\""
+files = [
+    {file = "keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd"},
+    {file = "keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66"},
+]
+
+[package.dependencies]
+importlib_metadata = {version = ">=4.11.4", markers = "python_version < \"3.12\""}
+"jaraco.classes" = "*"
+"jaraco.context" = "*"
+"jaraco.functools" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy", "shtab", "types-pywin32"]
 
 [[package]]
 name = "lark"
@@ -2365,6 +2494,19 @@ transformers = {version = ">=4.39.3", extras = ["sentencepiece"]}
 evaluate = ["lm-eval", "tqdm"]
 lwq = ["datasets"]
 test = ["datasets"]
+
+[[package]]
+name = "more-itertools"
+version = "10.7.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"secrets\" or extra == \"all\""
+files = [
+    {file = "more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e"},
+    {file = "more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3"},
+]
 
 [[package]]
 name = "mpmath"
@@ -4400,7 +4542,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name == \"pypy\" and platform_python_implementation != \"PyPy\" and python_version < \"3.13\" and (extra == \"memory\" or extra == \"all\" or extra == \"vllm\") or (extra == \"memory\" or extra == \"all\") and platform_python_implementation != \"PyPy\" or extra == \"vllm\" and implementation_name == \"pypy\" and python_version < \"3.13\""
+markers = "sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name == \"pypy\" and python_version < \"3.13\" and (extra == \"secrets\" or extra == \"all\" or extra == \"memory\" or extra == \"vllm\") or sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and (extra == \"secrets\" or extra == \"all\" or extra == \"memory\") or extra == \"vllm\" and implementation_name == \"pypy\" and python_version < \"3.13\" or (extra == \"memory\" or extra == \"all\") and platform_python_implementation != \"PyPy\" or platform_python_implementation != \"PyPy\" and implementation_name == \"pypy\" and python_version < \"3.13\" and (extra == \"memory\" or extra == \"all\" or extra == \"vllm\")"
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -4744,6 +4886,19 @@ groups = ["main"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = true
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "(extra == \"secrets\" or extra == \"all\") and sys_platform == \"win32\""
+files = [
+    {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
+    {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
 ]
 
 [[package]]
@@ -5490,6 +5645,23 @@ numpy = ">=1.23.5,<2.5"
 dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy (==1.10.0)", "pycodestyle", "pydevtool", "rich-click", "ruff (>=0.0.292)", "types-psutil", "typing_extensions"]
 doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.0.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)"]
 test = ["Cython", "array-api-strict (>=2.0,<2.1.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = true
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "(extra == \"secrets\" or extra == \"all\") and sys_platform == \"linux\""
+files = [
+    {file = "SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"},
+    {file = "SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
 
 [[package]]
 name = "sentence-transformers"
@@ -7115,7 +7287,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.13\" and extra == \"vllm\""
+markers = "python_version < \"3.13\" and extra == \"vllm\" or python_version == \"3.11\" and (extra == \"vllm\" or extra == \"secrets\" or extra == \"all\")"
 files = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
     {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
@@ -7131,12 +7303,13 @@ type = ["pytest-mypy"]
 
 [extras]
 agent = ["jinja2"]
-all = ["accelerate", "anthropic", "bitsandbytes", "faiss-cpu", "fastapi", "google-genai", "jinja2", "markitdown", "mcp", "mlx-lm", "openai", "pgvector", "pillow", "protobuf", "psycopg", "pydantic", "pytest", "sentence-transformers", "sentencepiece", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn"]
+all = ["accelerate", "anthropic", "bitsandbytes", "faiss-cpu", "fastapi", "google-genai", "jinja2", "keyring", "markitdown", "mcp", "mlx-lm", "openai", "pgvector", "pillow", "protobuf", "psycopg", "pydantic", "pytest", "sentence-transformers", "sentencepiece", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn"]
 audio = ["torchaudio"]
 cpu = ["accelerate"]
 memory = ["faiss-cpu", "markitdown", "pgvector", "psycopg", "sentence-transformers", "tree-sitter", "tree-sitter-python"]
 mlx = ["mlx-lm"]
 quantization = ["bitsandbytes"]
+secrets = ["keyring"]
 server = ["fastapi", "mcp", "pydantic", "uvicorn"]
 test = ["pgvector", "psycopg", "pytest", "tiktoken", "tree-sitter", "tree-sitter-python"]
 tool = ["sympy"]
@@ -7148,4 +7321,4 @@ vllm = ["vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.11"
-content-hash = "a583c4f0e5fa6fb3eb0d6fe7acff1e4bc3252582da0165c5f7b608714aadc796"
+content-hash = "8a3bc0053fe3f9e8d8cd2b8c9cbcea5e847fcf9975443148c4a7ea08865cebf2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ test = [
 tool = [
   "sympy",
 ]
+secrets = [
+  "keyring",
+]
 translation = [
   "protobuf",
   "sentencepiece",
@@ -121,6 +124,7 @@ all = [
   "pytest",
   "sentence-transformers",
   "sentencepiece",
+  "keyring",
   "sympy",
   "tiktoken",
   "torchaudio",

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -120,6 +120,14 @@ class Theme(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def ask_secret_password(self, key: str) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def ask_override_secret(self, key: str) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
     def bye(self) -> RenderableType:
         raise NotImplementedError()
 

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -224,6 +224,14 @@ class FancyTheme(Theme):
         _ = self._
         return _("Login to huggingface?")
 
+    def ask_secret_password(self, key: str) -> str:
+        _ = self._
+        return _("Enter secret for {key}").format(key=key)
+
+    def ask_override_secret(self, key: str) -> str:
+        _ = self._
+        return _("Secret {key} exists, override?").format(key=key)
+
     def bye(self) -> RenderableType:
         _, _i = self._, self._icons
         return _i["bye"] + " " + _("bye :)")

--- a/src/avalan/secrets/__init__.py
+++ b/src/avalan/secrets/__init__.py
@@ -1,0 +1,39 @@
+"""Secret storage utilities."""
+
+from typing import Optional
+
+try:
+    from keyring import get_keyring
+    from keyring.backend import KeyringBackend
+except Exception:  # Module may not be installed
+    get_keyring = None  # type: ignore
+    KeyringBackend = object  # type: ignore
+
+
+class KeyringSecrets:
+    """Wrapper around :mod:`keyring` to store and retrieve secrets."""
+
+    _SERVICE = "avalan"
+
+    def __init__(self, ring: KeyringBackend | None = None):
+        if ring is None:
+            if get_keyring is None:
+                raise RuntimeError("keyring package is required for secret storage")
+            ring = get_keyring()
+        self._ring = ring
+
+    def read(self, key: str) -> Optional[str]:
+        """Retrieve secret associated with ``key``."""
+        return self._ring.get_password(self._SERVICE, key)
+
+    def write(self, key: str, secret: str) -> None:
+        """Store ``secret`` under ``key``."""
+        self._ring.set_password(self._SERVICE, key, secret)
+
+    def delete(self, key: str) -> None:
+        """Remove secret stored under ``key`` if present."""
+        try:
+            self._ring.delete_password(self._SERVICE, key)
+        except Exception:
+            pass
+

--- a/src/avalan/secrets/__init__.py
+++ b/src/avalan/secrets/__init__.py
@@ -1,37 +1,28 @@
-"""Secret storage utilities."""
-
-from typing import Optional
-
 try:
     from keyring import get_keyring
     from keyring.backend import KeyringBackend
-except Exception:  # Module may not be installed
+except Exception:  # pragma Module may not be installed
     get_keyring = None  # type: ignore
     KeyringBackend = object  # type: ignore
 
-
 class KeyringSecrets:
-    """Wrapper around :mod:`keyring` to store and retrieve secrets."""
-
     _SERVICE = "avalan"
 
     def __init__(self, ring: KeyringBackend | None = None):
-        if ring is None:
-            if get_keyring is None:
-                raise RuntimeError("keyring package is required for secret storage")
+        if ring is None and get_keyring:
             ring = get_keyring()
         self._ring = ring
 
-    def read(self, key: str) -> Optional[str]:
-        """Retrieve secret associated with ``key``."""
+    def read(self, key: str) -> str | None:
+        assert self._ring, "keyring package not installed"
         return self._ring.get_password(self._SERVICE, key)
 
     def write(self, key: str, secret: str) -> None:
-        """Store ``secret`` under ``key``."""
+        assert self._ring, "keyring package not installed"
         self._ring.set_password(self._SERVICE, key, secret)
 
     def delete(self, key: str) -> None:
-        """Remove secret stored under ``key`` if present."""
+        assert self._ring, "keyring package not installed"
         try:
             self._ring.delete_password(self._SERVICE, key)
         except Exception:

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -13,114 +13,140 @@ class ManagerTestCase(TestCase):
                 "tiiuae/Falcon-E-3B-Instruct",
                 None,
                 "tiiuae/Falcon-E-3B-Instruct",
+                None,
                 None
             ),
             (
                 "ai://local/tiiuae/Falcon-E-3B-Instruct",
                 None,
                 "tiiuae/Falcon-E-3B-Instruct",
+                None,
                 None
             ),
             (
                 "meta-llama/Meta-Llama-3-8B-Instruct",
                 None,
                 "meta-llama/Meta-Llama-3-8B-Instruct",
+                None,
                 None
             ),
             (
                 "ai://local/meta-llama/Meta-Llama-3-8B-Instruct",
                 None,
                 "meta-llama/Meta-Llama-3-8B-Instruct",
+                None,
                 None
             ),
             (
                 "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
                 None,
                 "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+                None,
                 None
             ),
             (
                 "ai://local/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
                 None,
                 "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+                None,
                 None
             ),
             (
                 "Qwen/Qwen2.5-7B-Instruct",
                 None,
                 "Qwen/Qwen2.5-7B-Instruct",
+                None,
                 None
             ),
             (
                 "ai://local/Qwen/Qwen2.5-7B-Instruct",
                 None,
                 "Qwen/Qwen2.5-7B-Instruct",
+                None,
                 None
             ),
             (
                 "ai://messi_api_key:@openai/gpt-4o",
                 "openai",
                 "gpt-4o",
-                "messi_api_key"
+                "messi_api_key",
+                None
             ),
             (
                 "ai://messi_api_key@openai/gpt-4o",
                 "openai",
                 "gpt-4o",
-                "messi_api_key"
+                "messi_api_key",
+                None
             ),
             (
                 "ai://router_api_key:@openrouter/gpt-3.5-turbo",
                 "openrouter",
                 "gpt-3.5-turbo",
-                "router_api_key"
+                "router_api_key",
+                None
             ),
             (
                 "ai://router_api_key@openrouter/gpt-3.5-turbo",
                 "openrouter",
                 "gpt-3.5-turbo",
-                "router_api_key"
+                "router_api_key",
+                None
             ),
             (
                 "ai://seek_key:@deepseek/deepseek-chat",
                 "deepseek",
                 "deepseek-chat",
-                "seek_key"
+                "seek_key",
+                None
             ),
             (
                 "ai://seek_key@deepseek/deepseek-chat",
                 "deepseek",
                 "deepseek-chat",
-                "seek_key"
+                "seek_key",
+                None
             ),
             (
                 "ai://groq_key:@groq/llama3-8b-8192",
                 "groq",
                 "llama3-8b-8192",
-                "groq_key"
+                "groq_key",
+                None
             ),
             (
                 "ai://groq_key@groq/llama3-8b-8192",
                 "groq",
                 "llama3-8b-8192",
-                "groq_key"
+                "groq_key",
+                None
             ),
             (
                 "ai://hf_key:@huggingface/meta-llama/Llama-3-8B-Instruct",
                 "huggingface",
                 "meta-llama/Llama-3-8B-Instruct",
-                "hf_key"
+                "hf_key",
+                None
             ),
             (
                 "ai://hf_key@huggingface/meta-llama/Llama-3-8B-Instruct",
                 "huggingface",
                 "meta-llama/Llama-3-8B-Instruct",
-                "hf_key"
+                "hf_key",
+                None
+            ),
+            (
+                "ai://secret:openai_key@openai/gpt-4o",
+                "openai",
+                "gpt-4o",
+                "secret",
+                "openai_key"
             ),
             (
                 "ai://ollama/llama3",
                 "ollama",
                 "llama3",
+                None,
                 None
             )
         ]
@@ -130,7 +156,7 @@ class ManagerTestCase(TestCase):
         logger_mock = MagicMock(spec=Logger)
         with ModelManager(hub_mock, logger_mock) as manager:
             for fixture_uri in self.fixture_uris:
-                uri, vendor, model_id, user = fixture_uri
+                uri, vendor, model_id, user, password = fixture_uri
                 with self.subTest():
                     result = manager.parse_uri(uri)
                     self.assertIsInstance(result, EngineUri)
@@ -141,7 +167,7 @@ class ManagerTestCase(TestCase):
                         self.assertIsNone(result.host)
                         self.assertIsNone(result.port)
                         self.assertIsNone(result.user)
-                        self.assertIsNone(result.password)
+                        self.assertEqual(password, result.password)
                     else:
                         self.assertFalse(result.is_local)
                         self.assertEqual(vendor, result.vendor)
@@ -149,7 +175,7 @@ class ManagerTestCase(TestCase):
                         self.assertEqual(vendor, result.host)
                         self.assertIsNone(result.port)
                         self.assertEqual(user, result.user)
-                        self.assertIsNone(result.password)
+                        self.assertEqual(password, result.password)
         logger_mock.assert_not_called()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow retrieving vendor API keys from secret stores via AI URIs
- prompt for storing secrets during model install and remove them on uninstall
- manage secrets through a `KeyringSecrets` helper
- let `ModelManager` use a `KeyringSecrets` instance
- translate new prompts via `_()`

## Testing
- `poetry install --extras all` *(fails: pyproject.toml changed significantly)*
- `poetry run pytest --verbose` *(fails: missing optional dependencies)*
