### PR TITLE
Add KeyringSecrets tests

### DIFF
--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -7,6 +7,7 @@ from os import chmod
 from uuid import uuid4
 from unittest import IsolatedAsyncioTestCase, main
 from unittest.mock import AsyncMock, MagicMock, patch
+import os
 
 class LoaderFromFileTestCase(IsolatedAsyncioTestCase):
     async def test_file_not_found(self):
@@ -23,6 +24,8 @@ class LoaderFromFileTestCase(IsolatedAsyncioTestCase):
         await stack.aclose()
 
     async def test_permission_error(self):
+        if os.geteuid() == 0:
+            self.skipTest("Running as root; permission error won't occur")
         with NamedTemporaryFile(delete=False) as tmp:
             path = tmp.name
         chmod(path, 0)

--- a/tests/secrets/keyring_secrets_test.py
+++ b/tests/secrets/keyring_secrets_test.py
@@ -1,0 +1,36 @@
+from avalan.secrets import KeyringSecrets
+from unittest import TestCase, main
+from unittest.mock import MagicMock, patch
+
+
+class KeyringSecretsTestCase(TestCase):
+    def test_init_with_get_keyring(self):
+        ring = MagicMock()
+        with patch("avalan.secrets.get_keyring", return_value=ring):
+            secrets = KeyringSecrets()
+        self.assertIs(secrets._ring, ring)
+
+    def test_read_write_delete(self):
+        ring = MagicMock()
+        ring.get_password.return_value = "val"
+        secrets = KeyringSecrets(ring)
+
+        self.assertEqual(secrets.read("k"), "val")
+        ring.get_password.assert_called_once_with("avalan", "k")
+
+        secrets.write("k", "v")
+        ring.set_password.assert_called_once_with("avalan", "k", "v")
+
+        ring.delete_password.side_effect = Exception()
+        secrets.delete("k")
+        ring.delete_password.assert_called_once_with("avalan", "k")
+
+    def test_read_without_backend(self):
+        with patch("avalan.secrets.get_keyring", None):
+            secrets = KeyringSecrets()
+        with self.assertRaises(AssertionError):
+            secrets.read("k")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- test KeyringSecrets for using the keyring backend
- ensure permission error test skips when running as root

## Testing
- `poetry run pytest --verbose -s`