### PR TITLE
Add SpeechRecognitionModel tests

### DIFF
--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -1,0 +1,125 @@
+from pytest import importorskip
+from unittest import TestCase, IsolatedAsyncioTestCase, main
+from unittest.mock import MagicMock, patch, PropertyMock
+from logging import Logger
+from contextlib import nullcontext
+
+importorskip("torchaudio", reason="torchaudio not installed")
+
+from avalan.model.entities import EngineSettings
+from avalan.model.audio import SpeechRecognitionModel, AutoProcessor, AutoModelForCTC
+
+
+class SpeechRecognitionModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+
+    def test_instantiation_no_load(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
+        ):
+            settings = EngineSettings(auto_load_model=False)
+            model = SpeechRecognitionModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+            self.assertIsInstance(model, SpeechRecognitionModel)
+            processor_mock.assert_not_called()
+            model_mock.assert_not_called()
+
+    def test_instantiation_with_load_model(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
+        ):
+            processor_instance = MagicMock()
+            type(processor_instance.tokenizer).pad_token_id = PropertyMock(return_value=1)
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock()
+            model_mock.return_value = model_instance
+
+            settings = EngineSettings()
+            model = SpeechRecognitionModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+            self.assertIs(model.model, model_instance)
+            processor_mock.assert_called_once_with(
+                self.model_id,
+                trust_remote_code=False,
+                use_fast=True,
+            )
+            model_mock.assert_called_once_with(
+                self.model_id,
+                trust_remote_code=False,
+                pad_token_id=processor_instance.tokenizer.pad_token_id,
+                ctc_loss_reduction="mean",
+            )
+
+
+class SpeechRecognitionModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+
+    async def test_call_with_resampling(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
+            patch("avalan.model.audio.load") as load_mock,
+            patch("avalan.model.audio.Resample") as resample_mock,
+            patch("avalan.model.audio.argmax") as argmax_mock,
+            patch("avalan.model.audio.no_grad", new=lambda: nullcontext()),
+        ):
+            processor_instance = MagicMock()
+            processor_instance.return_value = MagicMock(input_values="inputs")
+            processor_instance.batch_decode.return_value = ["ok"]
+            type(processor_instance.tokenizer).pad_token_id = PropertyMock(return_value=1)
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock()
+            call_result = MagicMock(logits="logits")
+            model_instance.return_value = call_result
+            model_mock.return_value = model_instance
+
+            audio_wave = MagicMock()
+            squeezed = MagicMock()
+            squeezed.numpy.return_value = "audio"
+            audio_wave.squeeze.return_value = squeezed
+            load_mock.return_value = (audio_wave, 8000)
+
+            resampler_instance = MagicMock()
+            resampler_instance.return_value = audio_wave
+            resample_mock.return_value = resampler_instance
+
+            argmax_mock.return_value = "pred"
+
+            settings = EngineSettings()
+            model = SpeechRecognitionModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+
+            result = await model("file.wav", sampling_rate=16000)
+
+            self.assertEqual(result, "ok")
+            load_mock.assert_called_once_with("file.wav")
+            resample_mock.assert_called_once_with(orig_freq=8000, new_freq=16000)
+            resampler_instance.assert_called_once_with(audio_wave)
+            processor_instance.assert_called_with(
+                "audio",
+                sampling_rate=16000,
+                return_tensors="pt",
+            )
+            model_instance.assert_called_once_with("inputs")
+            argmax_mock.assert_called_once_with("logits", dim=-1)
+            processor_instance.batch_decode.assert_called_once_with("pred")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add unit tests for SpeechRecognitionModel covering model loading and audio transcription

## Testing
- `poetry run pytest --verbose -s`