### PR TITLE
Add token event emission

### DIFF
--- a/src/avalan/agent/orchestrator.py
+++ b/src/avalan/agent/orchestrator.py
@@ -19,15 +19,12 @@ from ..model.entities import (
 )
 from ..model.manager import ModelManager
 from ..model.nlp.text import TextGenerationResponse
-
-from typing import Any
-
 from ..tool.manager import ToolManager
 from contextlib import ExitStack
 from dataclasses import asdict
 from json import dumps
 from logging import Logger
-from typing import Optional, Union, Type
+from typing import Any, Optional, Union, Type
 from uuid import UUID, uuid4
 
 

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -17,6 +17,7 @@ class EventType(StrEnum):
     MODEL_EXECUTE_AFTER = "model_execute_after"
     INPUT_TOKEN_COUNT_BEFORE = "input_token_count_before"
     INPUT_TOKEN_COUNT_AFTER = "input_token_count_after"
+    TOKEN_GENERATED = "token_generated"
 
 @dataclass(frozen=True, kw_only=True)
 class Event:


### PR DESCRIPTION
## Summary
- support a new `TOKEN_GENERATED` event
- emit token events in `Orchestrator` when streaming tokens
- check token events in orchestrator tests
- create ObservableTextGenerationResponse wrapper

## Testing
- `poetry run pytest --verbose -s`