### PR TITLE
Add LiteLLM vendor

### DIFF
--- a/docs/ai_uri.md
+++ b/docs/ai_uri.md
@@ -10,7 +10,7 @@ This document describes the formal structure of the `ai://` Uniform Resource Ide
 <host>          ::= <vendor> | <model-host>
 <vendor>        ::= "anthropic" | "deepseek" | "google" | \
                     "groq" | "huggingface" | "local" | \
-                    "openai" | "openrouter" | "ollama"
+                    "openai" | "openrouter" | "ollama" | "litellm"
 <path>          ::= 1*( pchar | "/" )
 <query>         ::= *( pchar | "=" | "&" )
 ```
@@ -47,6 +47,7 @@ When `vendor` is `None`, the model is considered local.  Otherwise, the URI desc
 | `ai://hf_key:@huggingface/meta-llama/Llama-3-8B-Instruct` | vendor `huggingface`, user `hf_key`, model `meta-llama/Llama-3-8B-Instruct` |
 | `ai://secret:openai_key@openai/gpt-4o`     | vendor `openai`, secret key `openai_key`, model `gpt-4o`       |
 | `ai://ollama/llama3`                        | vendor `ollama`, model `llama3`                                |
+| `ai://litellm/gpt-3.5-turbo`                | vendor `litellm`, model `gpt-3.5-turbo`                        |
 
 These examples correspond to those used in the test-suite and highlight both local and remote forms.
 

--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -43,6 +43,7 @@ Vendor = Literal[
     "openai",
     "openrouter",
     "ollama",
+    "litellm",
 ]
 
 WeightType = Literal[

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -146,6 +146,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "huggingface":
             from ..model.nlp.text.vendor.huggingface import HuggingfaceModel
             model = HuggingfaceModel(**model_load_args)
+        elif engine_uri.vendor == "litellm":
+            from ..model.nlp.text.vendor.litellm import LiteLLMModel
+            model = LiteLLMModel(**model_load_args)
 
         self._stack.enter_context(model)
         return model

--- a/src/avalan/model/nlp/text/vendor/litellm.py
+++ b/src/avalan/model/nlp/text/vendor/litellm.py
@@ -1,0 +1,18 @@
+from .....model import TextGenerationVendor
+from .....model.nlp.text.vendor.openai import OpenAIClient, OpenAIModel
+from transformers import PreTrainedModel
+
+class LiteLLMClient(OpenAIClient):
+    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key or "",
+            base_url=base_url or "http://localhost:4000",
+        )
+
+class LiteLLMModel(OpenAIModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        return LiteLLMClient(
+            base_url=self._settings.base_url,
+            api_key=self._settings.access_token,
+        )
+

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -151,6 +151,13 @@ class ManagerTestCase(TestCase):
                 "llama3",
                 None,
                 None
+            ),
+            (
+                "ai://litellm/gpt-3.5-turbo",
+                "litellm",
+                "gpt-3.5-turbo",
+                None,
+                None
             )
         ]
 
@@ -267,6 +274,12 @@ class ManagerLoadEngineTestCase(TestCase):
                 "ai://ollama/llama3",
                 "avalan.model.nlp.text.vendor.ollama.OllamaModel",
                 "llama3",
+                False,
+            ),
+            "litellm": (
+                "ai://litellm/gpt-3.5-turbo",
+                "avalan.model.nlp.text.vendor.litellm.LiteLLMModel",
+                "gpt-3.5-turbo",
                 False,
             ),
             "huggingface": (


### PR DESCRIPTION
## Summary
- support LiteLLM via OpenAI-compatible client
- document LiteLLM in AI URI spec
- allow ModelManager to load LiteLLM models
- extend test suite for LiteLLM URIs

## Testing
- `poetry run pytest --verbose -s`