### PR TITLE
Add TogetherAI vendor

### DIFF
--- a/docs/ai_uri.md
+++ b/docs/ai_uri.md
@@ -10,7 +10,7 @@ This document describes the formal structure of the `ai://` Uniform Resource Ide
 <host>          ::= <vendor> | <model-host>
 <vendor>        ::= "anthropic" | "deepseek" | "google" | \
                     "groq" | "huggingface" | "local" | \
-                    "openai" | "openrouter" | "ollama" | "litellm"
+                    "openai" | "openrouter" | "ollama" | "litellm" | "together"
 <path>          ::= 1*( pchar | "/" )
 <query>         ::= *( pchar | "=" | "&" )
 ```
@@ -48,6 +48,7 @@ When `vendor` is `None`, the model is considered local.  Otherwise, the URI desc
 | `ai://secret:openai_key@openai/gpt-4o`     | vendor `openai`, secret key `openai_key`, model `gpt-4o`       |
 | `ai://ollama/llama3`                        | vendor `ollama`, model `llama3`                                |
 | `ai://litellm/gpt-3.5-turbo`                | vendor `litellm`, model `gpt-3.5-turbo`                        |
+| `ai://tg_key@together/mistral-7b`           | vendor `together`, model `mistral-7b`                          |
 
 These examples correspond to those used in the test-suite and highlight both local and remote forms.
 

--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -44,6 +44,7 @@ Vendor = Literal[
     "openrouter",
     "ollama",
     "litellm",
+    "together",
 ]
 
 WeightType = Literal[

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -134,6 +134,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "openrouter":
             from ..model.nlp.text.vendor.openrouter import OpenRouterModel
             model = OpenRouterModel(**model_load_args)
+        elif engine_uri.vendor == "together":
+            from ..model.nlp.text.vendor.together import TogetherModel
+            model = TogetherModel(**model_load_args)
         elif engine_uri.vendor == "deepseek":
             from ..model.nlp.text.vendor.deepseek import DeepSeekModel
             model = DeepSeekModel(**model_load_args)

--- a/src/avalan/model/nlp/text/vendor/together.py
+++ b/src/avalan/model/nlp/text/vendor/together.py
@@ -1,0 +1,18 @@
+from .....model import TextGenerationVendor
+from .openai import OpenAIClient, OpenAIModel
+from transformers import PreTrainedModel
+
+class TogetherClient(OpenAIClient):
+    def __init__(self, api_key: str, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url or "https://api.together.xyz/v1",
+        )
+
+class TogetherModel(OpenAIModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        assert self._settings.access_token
+        return TogetherClient(
+            base_url=self._settings.base_url,
+            api_key=self._settings.access_token,
+        )

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -97,6 +97,20 @@ class ManagerTestCase(TestCase):
                 None
             ),
             (
+                "ai://tog_key:@together/mistral-7b",
+                "together",
+                "mistral-7b",
+                "tog_key",
+                None
+            ),
+            (
+                "ai://tog_key@together/mistral-7b",
+                "together",
+                "mistral-7b",
+                "tog_key",
+                None
+            ),
+            (
                 "ai://seek_key:@deepseek/deepseek-chat",
                 "deepseek",
                 "deepseek-chat",
@@ -256,6 +270,12 @@ class ManagerLoadEngineTestCase(TestCase):
                 "ai://router@openrouter/gpt-3.5-turbo",
                 "avalan.model.nlp.text.vendor.openrouter.OpenRouterModel",
                 "gpt-3.5-turbo",
+                False,
+            ),
+            "together": (
+                "ai://tg@together/mistral-7b",
+                "avalan.model.nlp.text.vendor.together.TogetherModel",
+                "mistral-7b",
                 False,
             ),
             "deepseek": (


### PR DESCRIPTION
## Summary
- support a new `together` vendor with streaming
- document `together` in the AI URI guide
- load the new vendor in `ModelManager`
- test URI parsing and loading for TogetherAI

## Testing
- `poetry run pytest --verbose -s`