### PR TITLE
Add AnyScale vendor support

### DIFF
--- a/docs/ai_uri.md
+++ b/docs/ai_uri.md
@@ -8,7 +8,7 @@ This document describes the formal structure of the `ai://` Uniform Resource Ide
 <userinfo>      ::= <user> [":" <password>]
 <hostport>      ::= <host> [":" <port>]
 <host>          ::= <vendor> | <model-host>
-<vendor>        ::= "anthropic" | "deepseek" | "google" | \
+<vendor>        ::= "anthropic" | "anyscale" | "deepseek" | "google" | \
                     "groq" | "huggingface" | "local" | \
                     "openai" | "openrouter" | "ollama" | "litellm" | "together"
 <path>          ::= 1*( pchar | "/" )

--- a/src/avalan/model/entities.py
+++ b/src/avalan/model/entities.py
@@ -35,6 +35,7 @@ TextGenerationLoaderClass = Literal[
 
 Vendor = Literal[
     "anthropic",
+    "anyscale",
     "deepseek",
     "google",
     "groq",

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -134,6 +134,9 @@ class ModelManager(ContextDecorator):
         elif engine_uri.vendor == "openrouter":
             from ..model.nlp.text.vendor.openrouter import OpenRouterModel
             model = OpenRouterModel(**model_load_args)
+        elif engine_uri.vendor == "anyscale":
+            from ..model.nlp.text.vendor.anyscale import AnyScaleModel
+            model = AnyScaleModel(**model_load_args)
         elif engine_uri.vendor == "together":
             from ..model.nlp.text.vendor.together import TogetherModel
             model = TogetherModel(**model_load_args)

--- a/src/avalan/model/nlp/text/vendor/anyscale.py
+++ b/src/avalan/model/nlp/text/vendor/anyscale.py
@@ -1,0 +1,18 @@
+from .....model import TextGenerationVendor
+from .openai import OpenAIClient, OpenAIModel
+from transformers import PreTrainedModel
+
+class AnyScaleClient(OpenAIClient):
+    def __init__(self, api_key: str, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url or "https://api.endpoints.anyscale.com/v1"
+        )
+
+class AnyScaleModel(OpenAIModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        assert self._settings.access_token
+        return AnyScaleClient(
+            base_url=self._settings.base_url,
+            api_key=self._settings.access_token,
+        )

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -97,6 +97,20 @@ class ManagerTestCase(TestCase):
                 None
             ),
             (
+                "ai://scale_key:@anyscale/gpt-3.5-turbo",
+                "anyscale",
+                "gpt-3.5-turbo",
+                "scale_key",
+                None
+            ),
+            (
+                "ai://scale_key@anyscale/gpt-3.5-turbo",
+                "anyscale",
+                "gpt-3.5-turbo",
+                "scale_key",
+                None
+            ),
+            (
                 "ai://tog_key:@together/mistral-7b",
                 "together",
                 "mistral-7b",
@@ -269,6 +283,12 @@ class ManagerLoadEngineTestCase(TestCase):
             "openrouter": (
                 "ai://router@openrouter/gpt-3.5-turbo",
                 "avalan.model.nlp.text.vendor.openrouter.OpenRouterModel",
+                "gpt-3.5-turbo",
+                False,
+            ),
+            "anyscale": (
+                "ai://as@anyscale/gpt-3.5-turbo",
+                "avalan.model.nlp.text.vendor.anyscale.AnyScaleModel",
                 "gpt-3.5-turbo",
                 False,
             ),


### PR DESCRIPTION
## Summary
- support new `anyscale` vendor in `EngineUri`
- implement AnyScale vendor module
- load AnyScale models via `ModelManager`
- cover AnyScale parse/load paths in tests
- document new vendor in AI URI spec

## Testing
- `poetry run pytest --verbose -s`