### PR TITLE
Add CLI usage

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -49,6 +49,381 @@ You'll need your Huggingface access token exported as `HF_ACCESS_TOKEN`.
 > script, created by [@AlexCheema](https://github.com/AlexCheema), which
 > empirically reduces the time to first token and the tokens per second ratio.
 
+## Usage
+
+### `avalan model --help`
+
+```text
+usage: avalan model [-h] {display,install,run,search,uninstall} ...
+
+Manage a model, showing details, loading or downloading it
+
+positional arguments:
+  {display,install,run,search,uninstall}
+
+options:
+  -h, --help            show this help message and exit
+```
+
+### `avalan model display --help`
+
+```text
+usage: avalan model display [-h] [--cache-dir CACHE_DIR] [--device DEVICE]
+                            [--disable-loading-progress-bar]
+                            [--hf-token HF_TOKEN] [--locale LOCALE]
+                            [--loader-class {auto,gemma3,mistral3}]
+                            [--locales LOCALES] [--low-cpu-mem-usage]
+                            [--login] [--no-repl] [--quiet]
+                            [--revision REVISION] [--skip-hub-access-check]
+                            [--verbose]
+                            [--weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}]
+                            [--load] [--special-token SPECIAL_TOKEN]
+                            [--token TOKEN] [--tokenizer TOKENIZER]
+                            [--sentence-transformer] [--summary]
+                            model
+
+Show information about a model
+
+positional arguments:
+  model                 Model to use
+
+options:
+  -h, --help            show this help message and exit
+  --cache-dir CACHE_DIR Path to huggingface cache hub (defaults to
+                        /root/.cache/huggingface/hub, can also be specified
+                        with $HF_HUB_CACHE)
+  --device DEVICE       Device to use (cpu, cuda, mps). Defaults to cpu
+  --disable-loading-progress-bar
+                        If specified, the shard loading progress bar will not
+                        be shown
+  --hf-token HF_TOKEN   Your Huggingface access token
+  --locale LOCALE       Language to use (defaults to en_US)
+  --loader-class {auto,gemma3,mistral3}
+                        Loader class to use (defaults to "auto")
+  --locales LOCALES     Path to locale files (defaults to
+                        /workspace/avalan/locale)
+  --low-cpu-mem-usage   If specified, loads the model using ~1x model size CPU
+                        memory
+  --login               Login to main hub (huggingface)
+  --no-repl             Don't echo input coming from stdin
+  --quiet, -q           If specified, no welcome screen and only model output
+                        is displayed in model run (sets --disable-loading-
+                        progress-bar, --skip-hub-access-check, --skip-special-
+                        tokens automatically)
+  --revision REVISION   Model revision to use
+  --skip-hub-access-check
+                        If specified, skip hub model access check
+  --verbose, -v         Set verbosity
+  --weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}
+                        Weight type to use (defaults to best available)
+  --load                If specified, load model and show more information
+  --special-token SPECIAL_TOKEN
+                        Special token to add to tokenizer, only when model is
+                        loaded
+  --token TOKEN         Token to add to tokenizer, only when model is loaded
+  --tokenizer TOKENIZER Path to tokenizer to use instead of model's default,
+                        only if model is loaded
+  --sentence-transformer
+                        Load the model as a SentenceTransformer model
+  --summary
+```
+
+### `avalan model install --help`
+
+```text
+usage: avalan model install [-h] [--cache-dir CACHE_DIR] [--device DEVICE]
+                            [--disable-loading-progress-bar]
+                            [--hf-token HF_TOKEN] [--locale LOCALE]
+                            [--loader-class {auto,gemma3,mistral3}]
+                            [--locales LOCALES] [--low-cpu-mem-usage]
+                            [--login] [--no-repl] [--quiet]
+                            [--revision REVISION] [--skip-hub-access-check]
+                            [--verbose]
+                            [--weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}]
+                            [--load] [--special-token SPECIAL_TOKEN]
+                            [--token TOKEN] [--tokenizer TOKENIZER]
+                            model
+
+Install a model
+
+positional arguments:
+  model                 Model to use
+
+options:
+  -h, --help            show this help message and exit
+  --cache-dir CACHE_DIR Path to huggingface cache hub (defaults to
+                        /root/.cache/huggingface/hub, can also be specified
+                        with $HF_HUB_CACHE)
+  --device DEVICE       Device to use (cpu, cuda, mps). Defaults to cpu
+  --disable-loading-progress-bar
+                        If specified, the shard loading progress bar will not
+                        be shown
+  --hf-token HF_TOKEN   Your Huggingface access token
+  --locale LOCALE       Language to use (defaults to en_US)
+  --loader-class {auto,gemma3,mistral3}
+                        Loader class to use (defaults to "auto")
+  --locales LOCALES     Path to locale files (defaults to
+                        /workspace/avalan/locale)
+  --low-cpu-mem-usage   If specified, loads the model using ~1x model size CPU
+                        memory
+  --login               Login to main hub (huggingface)
+  --no-repl             Don't echo input coming from stdin
+  --quiet, -q           If specified, no welcome screen and only model output
+                        is displayed in model run (sets --disable-loading-
+                        progress-bar, --skip-hub-access-check, --skip-special-
+                        tokens automatically)
+  --revision REVISION   Model revision to use
+  --skip-hub-access-check
+                        If specified, skip hub model access check
+  --verbose, -v         Set verbosity
+  --weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}
+                        Weight type to use (defaults to best available)
+  --load                If specified, load model and show more information
+  --special-token SPECIAL_TOKEN
+                        Special token to add to tokenizer, only when model is
+                        loaded
+  --token TOKEN         Token to add to tokenizer, only when model is loaded
+  --tokenizer TOKENIZER Path to tokenizer to use instead of model's default,
+                        only if model is loaded
+```
+
+### `avalan model run --help`
+
+```text
+usage: avalan model run [-h] [--cache-dir CACHE_DIR] [--device DEVICE]
+                        [--disable-loading-progress-bar] [--hf-token HF_TOKEN]
+                        [--locale LOCALE]
+                        [--loader-class {auto,gemma3,mistral3}]
+                        [--locales LOCALES] [--low-cpu-mem-usage] [--login]
+                        [--no-repl] [--quiet] [--revision REVISION]
+                        [--skip-hub-access-check] [--verbose]
+                        [--weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}]
+                        [--load] [--special-token SPECIAL_TOKEN]
+                        [--token TOKEN] [--tokenizer TOKENIZER]
+                        [--display-pause [DISPLAY_PAUSE]]
+                        [--display-probabilities]
+                        [--display-probabilities-maximum DISPLAY_PROBABILITIES_MAXIMUM]
+                        [--display-probabilities-sample-minimum DISPLAY_PROBABILITIES_SAMPLE_MINIMUM]
+                        [--display-time-to-n-token [DISPLAY_TIME_TO_N_TOKEN]]
+                        [--display-tokens [DISPLAY_TOKENS]]
+                        [--attention {eager,flash_attention_2,flex_attention,sdpa}]
+                        [--do-sample] [--enable-gradient-calculation]
+                        [--use-cache] [--max-new-tokens MAX_NEW_TOKENS]
+                        [--min-p MIN_P]
+                        [--repetition-penalty REPETITION_PENALTY]
+                        [--skip-special-tokens] [--system SYSTEM]
+                        [--start-thinking] [--stop_on_keyword STOP_ON_KEYWORD]
+                        [--temperature TEMPERATURE] [--top-k TOP_K]
+                        [--top-p TOP_P] [--trust-remote-code]
+                        model
+
+Run a model
+
+positional arguments:
+  model                 Model to use
+
+options:
+  -h, --help            show this help message and exit
+  --cache-dir CACHE_DIR Path to huggingface cache hub (defaults to
+                        /root/.cache/huggingface/hub, can also be specified
+                        with $HF_HUB_CACHE)
+  --device DEVICE       Device to use (cpu, cuda, mps). Defaults to cpu
+  --disable-loading-progress-bar
+                        If specified, the shard loading progress bar will not
+                        be shown
+  --hf-token HF_TOKEN   Your Huggingface access token
+  --locale LOCALE       Language to use (defaults to en_US)
+  --loader-class {auto,gemma3,mistral3}
+                        Loader class to use (defaults to "auto")
+  --locales LOCALES     Path to locale files (defaults to
+                        /workspace/avalan/locale)
+  --low-cpu-mem-usage   If specified, loads the model using ~1x model size CPU
+                        memory
+  --login               Login to main hub (huggingface)
+  --no-repl             Don't echo input coming from stdin
+  --quiet, -q           If specified, no welcome screen and only model output
+                        is displayed in model run (sets --disable-loading-
+                        progress-bar, --skip-hub-access-check, --skip-special-
+                        tokens automatically)
+  --revision REVISION   Model revision to use
+  --skip-hub-access-check
+                        If specified, skip hub model access check
+  --verbose, -v         Set verbosity
+  --weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}
+                        Weight type to use (defaults to best available)
+  --load                If specified, load model and show more information
+  --special-token SPECIAL_TOKEN
+                        Special token to add to tokenizer, only when model is
+                        loaded
+  --token TOKEN         Token to add to tokenizer, only when model is loaded
+  --tokenizer TOKENIZER Path to tokenizer to use instead of model's default,
+                        only if model is loaded
+  --display-pause [DISPLAY_PAUSE]
+                        Pause (in ms.) when cycling through selected tokens as
+                        defined by --display-probabilities
+  --display-probabilities
+                        If --display-tokens specified, show also the token
+                        probability distribution
+  --display-probabilities-maximum DISPLAY_PROBABILITIES_MAXIMUM
+                        When --display-probabilities is used, select tokens
+                        which logit probability is no higher than this value.
+                        Defaults to 0.8
+  --display-probabilities-sample-minimum DISPLAY_PROBABILITIES_SAMPLE_MINIMUM
+                        When --display-probabilities is used, select tokens
+                        that have alternate tokens with a logit probability at
+                        least or higher than this value. Defaults to 0.1
+  --display-time-to-n-token [DISPLAY_TIME_TO_N_TOKEN]
+                        Display the time it takes to reach the given Nth token
+                        (defaults to 256)
+  --display-tokens [DISPLAY_TOKENS]
+                        How many tokens with full information to display at a
+                        time
+  --attention {eager,flash_attention_2,flex_attention,sdpa}
+                        Attention implementation to use (defaults to best
+                        available)
+  --do-sample           Tell if the token generation process should be
+                        deterministic or stochastic. When enabled, it's
+                        stochastic and uses probability distribution.
+  --enable-gradient-calculation
+                        Enable gradient calculation.
+  --use-cache           Past key values are used to speed up decoding if
+                        applicable to model.
+  --max-new-tokens MAX_NEW_TOKENS
+                        Maximum number of tokens to generate
+  --min-p MIN_P         Minimum token probability, which will be scaled by the
+                        probability of the most likely token [0, 1]
+  --repetition-penalty REPETITION_PENALTY
+                        Exponential penalty on sequences not in the original
+                        input. Defaults to 1.0, which means no penalty.
+  --skip-special-tokens
+                        If specified, skip special tokens when decoding
+  --system SYSTEM       Use this as system prompt
+  --start-thinking      If specified, assume model response starts with
+                        reasoning
+  --stop_on_keyword STOP_ON_KEYWORD
+                        Stop token generation when this keyword is found
+  --temperature TEMPERATURE
+                        Temperature [0, 1]
+  --top-k TOP_K         Number of highest probability vocabulary tokens to
+                        keep for top-k-filtering.
+  --top-p TOP_P         If set to < 1, only the smallest set of most probable
+                        tokens with probabilities that add up to top_p or
+                        higher are kept for generation.
+  --trust-remote-code
+```
+
+### `avalan model search --help`
+
+```text
+usage: avalan model search [-h] [--cache-dir CACHE_DIR] [--device DEVICE]
+                           [--disable-loading-progress-bar]
+                           [--hf-token HF_TOKEN] [--locale LOCALE]
+                           [--loader-class {auto,gemma3,mistral3}]
+                           [--locales LOCALES] [--low-cpu-mem-usage] [--login]
+                           [--no-repl] [--quiet] [--revision REVISION]
+                           [--skip-hub-access-check] [--verbose]
+                           [--weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}]
+                           [--search SEARCH] [--filter FILTER] [--limit LIMIT]
+
+Search for models
+
+options:
+  -h, --help            show this help message and exit
+  --cache-dir CACHE_DIR Path to huggingface cache hub (defaults to
+                        /root/.cache/huggingface/hub, can also be specified
+                        with $HF_HUB_CACHE)
+  --device DEVICE       Device to use (cpu, cuda, mps). Defaults to cpu
+  --disable-loading-progress-bar
+                        If specified, the shard loading progress bar will not
+                        be shown
+  --hf-token HF_TOKEN   Your Huggingface access token
+  --locale LOCALE       Language to use (defaults to en_US)
+  --loader-class {auto,gemma3,mistral3}
+                        Loader class to use (defaults to "auto")
+  --locales LOCALES     Path to locale files (defaults to
+                        /workspace/avalan/locale)
+  --low-cpu-mem-usage   If specified, loads the model using ~1x model size CPU
+                        memory
+  --login               Login to main hub (huggingface)
+  --no-repl             Don't echo input coming from stdin
+  --quiet, -q           If specified, no welcome screen and only model output
+                        is displayed in model run (sets --disable-loading-
+                        progress-bar, --skip-hub-access-check, --skip-special-
+                        tokens automatically)
+  --revision REVISION   Model revision to use
+  --skip-hub-access-check
+                        If specified, skip hub model access check
+  --verbose, -v         Set verbosity
+  --weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}
+                        Weight type to use (defaults to best available)
+  --search SEARCH       Search for models matching given expression
+  --filter FILTER       Filter models on this (e.g: text-classification)
+  --limit LIMIT         Maximum number of models to return
+```
+
+### `avalan model uninstall --help`
+
+```text
+usage: avalan model uninstall [-h] [--cache-dir CACHE_DIR] [--device DEVICE]
+                              [--disable-loading-progress-bar]
+                              [--hf-token HF_TOKEN] [--locale LOCALE]
+                              [--loader-class {auto,gemma3,mistral3}]
+                              [--locales LOCALES] [--low-cpu-mem-usage]
+                              [--login] [--no-repl] [--quiet]
+                              [--revision REVISION] [--skip-hub-access-check]
+                              [--verbose]
+                              [--weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}]
+                              [--load] [--special-token SPECIAL_TOKEN]
+                              [--token TOKEN] [--tokenizer TOKENIZER]
+                              [--delete]
+                              model
+
+Uninstall a model
+
+positional arguments:
+  model                 Model to use
+
+options:
+  -h, --help            show this help message and exit
+  --cache-dir CACHE_DIR Path to huggingface cache hub (defaults to
+                        /root/.cache/huggingface/hub, can also be specified
+                        with $HF_HUB_CACHE)
+  --device DEVICE       Device to use (cpu, cuda, mps). Defaults to cpu
+  --disable-loading-progress-bar
+                        If specified, the shard loading progress bar will not
+                        be shown
+  --hf-token HF_TOKEN   Your Huggingface access token
+  --locale LOCALE       Language to use (defaults to en_US)
+  --loader-class {auto,gemma3,mistral3}
+                        Loader class to use (defaults to "auto")
+  --locales LOCALES     Path to locale files (defaults to
+                        /workspace/avalan/locale)
+  --low-cpu-mem-usage   If specified, loads the model using ~1x model size CPU
+                        memory
+  --login               Login to main hub (huggingface)
+  --no-repl             Don't echo input coming from stdin
+  --quiet, -q           If specified, no welcome screen and only model output
+                        is displayed in model run (sets --disable-loading-
+                        progress-bar, --skip-hub-access-check, --skip-special-
+                        tokens automatically)
+  --revision REVISION   Model revision to use
+  --skip-hub-access-check
+                        If specified, skip hub model access check
+  --verbose, -v         Set verbosity
+  --weight-type {auto,bool,bf16,f16,f32,f64,i8,i16,i32,i64,ui8}
+                        Weight type to use (defaults to best available)
+  --load                If specified, load model and show more information
+  --special-token SPECIAL_TOKEN
+                        Special token to add to tokenizer, only when model is
+                        loaded
+  --token TOKEN         Token to add to tokenizer, only when model is loaded
+  --tokenizer TOKENIZER Path to tokenizer to use instead of model's default,
+                        only if model is loaded
+  --delete              Actually delete. If not provided, a dry run is
+                        performed and data that would be deleted is shown, yet
+                        not deleted
+```
+
 ## agent
 
 ### agent run


### PR DESCRIPTION
## Summary
- document `avalan model` command usage with all subcommands

## Testing
- `poetry run pytest --verbose -s`