### PR TITLE
Add VisionEncoderDecoderModel wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .DS_Store
 *.sw[nop]
 .session.vim
+.env
+.env.sh

--- a/docs/examples/vision_encoder_decoder.py
+++ b/docs/examples/vision_encoder_decoder.py
@@ -1,15 +1,16 @@
 from asyncio import run
-from avalan.model.vision.image import ImageToTextModel
+from avalan.model.vision.image import VisionEncoderDecoderModel
 from os.path import isfile
 from sys import argv, exit
 
 async def example(path: str) -> None:
     print("Loading model... ", end="", flush=True)
-    with ImageToTextModel("salesforce/blip-image-captioning-base") as img:
-        print(f"DONE. Running classification for {path}", flush=True)
+    with VisionEncoderDecoderModel("microsoft/trocr-base-printed") as vm:
+        print(f"DONE. Running image recognition for {path}", flush=True)
 
-        caption = await img(path)
-        print(caption, flush=True)
+        text = await vm(path)
+
+        print(text, flush=True)
 
 if __name__ == "__main__":
     path = argv[1] if len(argv)==2 and isfile(argv[1]) \

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -201,7 +201,7 @@ class Loader:
 
             # Agent creation
 
-            logger.debug(f"Creating agent {orchestrator_type} #{agent_id}")
+            logger.debug(f"Creating orchestrator {orchestrator_type} #{agent_id}")
 
             model_manager = ModelManager(hub, logger)
             model_manager = stack.enter_context(model_manager)

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -9,6 +9,7 @@ from transformers import (
     AutoModelForImageClassification,
     AutoModelForVision2Seq,
     PreTrainedModel,
+    VisionEncoderDecoderModel as HFVisionEncoderDecoderModel,
 )
 from transformers.tokenization_utils_base import BatchEncoding
 from typing import Literal
@@ -75,4 +76,15 @@ class ImageToTextModel(TransformerModel):
             skip_special_tokens=skip_special_tokens
         )
         return caption
+
+
+class VisionEncoderDecoderModel(ImageToTextModel):
+    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+        self._processor = AutoImageProcessor.from_pretrained(
+            self._model_id,
+            # default behavior in transformers v4.48
+            use_fast=True,
+        )
+        model = HFVisionEncoderDecoderModel.from_pretrained(self._model_id)
+        return model
 

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -1,0 +1,97 @@
+from avalan.model.entities import TransformerEngineSettings
+from avalan.model.vision.image import (
+    AutoImageProcessor,
+    HFVisionEncoderDecoderModel,
+    VisionEncoderDecoderModel,
+)
+from logging import Logger
+from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
+from unittest import TestCase, IsolatedAsyncioTestCase, main
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class PTMWithGenerate(PreTrainedModel):
+    def generate(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class VisionEncoderDecoderModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+
+    def test_instantiation_with_load_model_and_tokenizer(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoImageProcessor, "from_pretrained") as processor_mock,
+            patch.object(HFVisionEncoderDecoderModel, "from_pretrained") as model_mock,
+            patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
+        ):
+            processor_instance = MagicMock()
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock(spec=PTMWithGenerate)
+            model_mock.return_value = model_instance
+
+            tokenizer_instance = MagicMock(spec=PreTrainedTokenizerFast)
+            type(tokenizer_instance).all_special_tokens = PropertyMock(return_value=[])
+            type(tokenizer_instance).name_or_path = PropertyMock(return_value=self.model_id)
+            tokenizer_mock.return_value = tokenizer_instance
+
+            model = VisionEncoderDecoderModel(
+                self.model_id,
+                TransformerEngineSettings(),
+                logger=logger_mock,
+            )
+
+            self.assertIs(model.model, model_instance)
+            processor_mock.assert_called_once_with(self.model_id, use_fast=True)
+            model_mock.assert_called_once_with(self.model_id)
+            model_instance.eval.assert_called_once()
+            tokenizer_mock.assert_called_once_with(self.model_id, use_fast=True)
+
+
+class VisionEncoderDecoderModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+
+    async def test_call(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoImageProcessor, "from_pretrained") as processor_mock,
+            patch.object(HFVisionEncoderDecoderModel, "from_pretrained") as model_mock,
+            patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
+            patch("avalan.model.vision.image.Image.open") as image_open_mock,
+        ):
+            processor_instance = MagicMock()
+            processor_instance.return_value = {"pixel_values": "t"}
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock(spec=PTMWithGenerate)
+            output_ids = [[1, 2, 3]]
+            model_instance.generate.return_value = output_ids
+
+            model_mock.return_value = model_instance
+
+            tokenizer_instance = MagicMock(spec=PreTrainedTokenizerFast)
+            tokenizer_instance.decode.return_value = "caption"
+            type(tokenizer_instance).all_special_tokens = PropertyMock(return_value=[])
+            type(tokenizer_instance).name_or_path = PropertyMock(return_value=self.model_id)
+            tokenizer_mock.return_value = tokenizer_instance
+
+            image_instance = MagicMock()
+            image_open_mock.return_value = image_instance
+
+            model = VisionEncoderDecoderModel(
+                self.model_id,
+                TransformerEngineSettings(),
+                logger=logger_mock,
+            )
+
+            caption = await model("img.jpg")
+
+            self.assertEqual(caption, "caption")
+            image_open_mock.assert_called_once_with("img.jpg")
+            processor_instance.assert_called_with(images=image_instance, return_tensors="pt")
+            model_instance.generate.assert_called_once_with(**processor_instance.return_value)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add wrapper for HF `VisionEncoderDecoderModel`
- test instantiation and call logic for the new wrapper

## Testing
- `poetry run pytest --verbose -s`