### PR TITLE
Ensure device options passed on model load

### DIFF
--- a/src/avalan/model/audio.py
+++ b/src/avalan/model/audio.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from ..compat import override
 from ..model import TextGenerationVendor, TokenizerNotSupportedException
 from ..model.engine import Engine
 from PIL import Image
@@ -50,9 +51,11 @@ class SpeechRecognitionModel(BaseAudioModel):
             trust_remote_code=self._settings.trust_remote_code,
             pad_token_id=self._processor.tokenizer.pad_token_id,
             ctc_loss_reduction="mean",
+            device_map=self._device,
         )
         return model
 
+    @override
     async def __call__(
         self,
         audio_source: str,

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.entities import Input
 from ...model.nlp import BaseNLPModel
@@ -27,6 +28,7 @@ class QuestionAnsweringModel(BaseNLPModel):
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,
+            device_map=self._device,
         )
         return model
 
@@ -46,6 +48,7 @@ class QuestionAnsweringModel(BaseNLPModel):
         inputs = inputs.to(self._model.device)
         return inputs
 
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.entities import Input
 from ...model.nlp import BaseNLPModel
@@ -58,6 +59,7 @@ class SentenceTransformerModel(BaseNLPModel):
     ) -> BatchEncoding:
         raise NotImplementedError()
 
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.entities import GenerationSettings, Input
 from ...model.nlp import BaseNLPModel
@@ -33,6 +34,7 @@ class SequenceClassificationModel(BaseNLPModel):
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,
+            device_map=self._device,
         )
         return model
 
@@ -52,6 +54,7 @@ class SequenceClassificationModel(BaseNLPModel):
         inputs = inputs.to(self._model.device)
         return inputs
 
+    @override
     async def __call__(
         self,
         input: Input
@@ -90,6 +93,7 @@ class SequenceToSequenceModel(BaseNLPModel):
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,
+            device_map=self._device,
         )
         return model
 
@@ -109,6 +113,7 @@ class SequenceToSequenceModel(BaseNLPModel):
         inputs = inputs.to(self._model.device)
         return inputs["input_ids"]
 
+    @override
     async def __call__(
         self,
         input: Input,
@@ -136,6 +141,7 @@ class SequenceToSequenceModel(BaseNLPModel):
         )
 
 class TranslationModel(SequenceToSequenceModel):
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -1,4 +1,5 @@
 from asyncio import sleep
+from ....compat import override
 from ....model import TextGenerationVendor
 from ....model.entities import (
     GenerationSettings,
@@ -100,6 +101,7 @@ class TextGenerationModel(BaseNLPModel):
         )
         return model
 
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -1,3 +1,4 @@
+from ....compat import override
 from ....model.entities import (
     GenerationSettings,
     Input,
@@ -85,6 +86,7 @@ class MlxLmModel(TextGenerationModel):
         params = self._build_params(settings)
         return generate(self._model, self._tokenizer, prompt, **params)
 
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/text/vendor/anthropic.py
+++ b/src/avalan/model/nlp/text/vendor/anthropic.py
@@ -1,5 +1,6 @@
 from anthropic import AsyncAnthropic
 from anthropic.types import RawContentBlockDeltaEvent, RawMessageStopEvent
+from .....compat import override
 from .....model import TextGenerationVendor
 from .....model.entities import (
     GenerationSettings,
@@ -45,6 +46,7 @@ class AnthropicClient(TextGenerationVendor):
     def __init__(self, api_key: str, base_url: str | None = None):
         self._client = AsyncAnthropic(api_key=api_key, base_url=base_url)
 
+    @override
     async def __call__(
         self,
         model_id: str,

--- a/src/avalan/model/nlp/text/vendor/google.py
+++ b/src/avalan/model/nlp/text/vendor/google.py
@@ -1,5 +1,6 @@
 from google.genai import Client
 from google.genai.types import GenerateContentResponse
+from .....compat import override
 from .....model import TextGenerationVendor
 from .....model.entities import (
     GenerationSettings,
@@ -29,6 +30,7 @@ class GoogleClient(TextGenerationVendor):
     def __init__(self, api_key: str):
         self._client = Client(api_key=api_key)
 
+    @override
     async def __call__(
         self,
         model_id: str,

--- a/src/avalan/model/nlp/text/vendor/huggingface.py
+++ b/src/avalan/model/nlp/text/vendor/huggingface.py
@@ -1,3 +1,4 @@
+from .....compat import override
 from .....model import TextGenerationVendor
 from .....model.entities import (
     GenerationSettings,
@@ -30,6 +31,7 @@ class HuggingfaceClient(TextGenerationVendor):
     def __init__(self, api_key: str, base_url: str | None = None):
         self._client = AsyncInferenceClient(token=api_key, base_url=base_url)
 
+    @override
     async def __call__(
         self,
         model_id: str,

--- a/src/avalan/model/nlp/text/vendor/ollama.py
+++ b/src/avalan/model/nlp/text/vendor/ollama.py
@@ -1,3 +1,4 @@
+from .....compat import override
 from .....model import TextGenerationVendor
 from .....model.entities import (
     GenerationSettings,
@@ -37,6 +38,7 @@ class OllamaClient(TextGenerationVendor):
         assert AsyncClient, "ollama is not available"
         self._client = AsyncClient(host=base_url) if base_url else AsyncClient()
 
+    @override
     async def __call__(
         self,
         model_id: str,

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -1,3 +1,4 @@
+from .....compat import override
 from .....model import TextGenerationVendor
 from .....model.entities import (
     GenerationSettings,
@@ -32,6 +33,7 @@ class OpenAIClient(TextGenerationVendor):
             api_key = api_key
         )
 
+    @override
     async def __call__(
         self,
         model_id: str,

--- a/src/avalan/model/nlp/text/vllm.py
+++ b/src/avalan/model/nlp/text/vllm.py
@@ -1,4 +1,5 @@
 from asyncio import to_thread
+from ....compat import override
 from ....model.entities import (
     GenerationSettings,
     Input,
@@ -101,6 +102,7 @@ class VllmModel(TextGenerationModel):
         results = list(self._model.generate([prompt], params))
         return results[0].outputs[0].text if results else ""
 
+    @override
     async def __call__(
         self,
         input: Input,

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from torch import argmax, no_grad
@@ -26,6 +27,7 @@ class TokenClassificationModel(BaseNLPModel):
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,
+            device_map=self._device,
         )
         return model
 
@@ -45,6 +47,7 @@ class TokenClassificationModel(BaseNLPModel):
         inputs = inputs.to(self._model.device)
         return inputs
 
+    @override
     async def __call__(
         self,
         input: str

--- a/src/avalan/model/vision/detection.py
+++ b/src/avalan/model/vision/detection.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.entities import ImageEntity, EngineSettings
 from ...model.vision import BaseVisionModel
@@ -32,10 +33,12 @@ class ObjectDetectionModel(ImageClassificationModel):
         )
         model = AutoModelForObjectDetection.from_pretrained(
             self._model_id,
-            revision=self._revision
+            revision=self._revision,
+            device_map=self._device,
         )
         return model
 
+    @override
     async def __call__(
         self,
         image_source: str | Image.Image,

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -31,9 +31,13 @@ class ImageClassificationModel(BaseVisionModel):
             # default behavior in transformers v4.48
             use_fast=True
         )
-        model = AutoModelForImageClassification.from_pretrained(self._model_id)
+        model = AutoModelForImageClassification.from_pretrained(
+            self._model_id,
+            device_map=self._device,
+        )
         return model
 
+    @override
     async def __call__(
         self,
         image_source: str | Image.Image,
@@ -57,7 +61,10 @@ class ImageToTextModel(TransformerModel):
             # default behavior in transformers v4.48
             use_fast=True
         )
-        model = AutoModelForVision2Seq.from_pretrained(self._model_id)
+        model = AutoModelForVision2Seq.from_pretrained(
+            self._model_id,
+            device_map=self._device,
+        )
         return model
 
     def _tokenize_input(
@@ -71,6 +78,7 @@ class ImageToTextModel(TransformerModel):
     ):
         raise NotImplementedError()
 
+    @override
     async def __call__(
         self,
         image_source: str | Image.Image,
@@ -166,7 +174,10 @@ class VisionEncoderDecoderModel(ImageToTextModel):
             self._model_id,
             use_fast=True,
         )
-        model = HFVisionEncoderDecoderModel.from_pretrained(self._model_id)
+        model = HFVisionEncoderDecoderModel.from_pretrained(
+            self._model_id,
+            device_map=self._device,
+        )
         return model
 
 

--- a/src/avalan/model/vision/segmentation.py
+++ b/src/avalan/model/vision/segmentation.py
@@ -1,3 +1,4 @@
+from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from PIL import Image
@@ -17,11 +18,13 @@ class SemanticSegmentationModel(BaseVisionModel):
             use_fast=True
         )
         model = AutoModelForSemanticSegmentation.from_pretrained(
-            self._model_id
+            self._model_id,
+            device_map=self._device,
         )
         model.eval()
         return model
 
+    @override
     async def __call__(
         self,
         image_source: str | Image.Image,

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import EngineSettings
+from avalan.model.engine import Engine
 from avalan.model.audio import SpeechRecognitionModel, AutoProcessor, AutoModelForCTC
 from contextlib import nullcontext
 from logging import Logger
@@ -55,6 +56,7 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
                 trust_remote_code=False,
                 pad_token_id=processor_instance.tokenizer.pad_token_id,
                 ctc_loss_reduction="mean",
+                device_map=Engine.get_default_device(),
             )
 
 

--- a/tests/model/nlp/question_test.py
+++ b/tests/model/nlp/question_test.py
@@ -1,5 +1,6 @@
 from avalan.model.transformer import AutoTokenizer
 from avalan.model.entities import TransformerEngineSettings
+from avalan.model.engine import Engine
 from avalan.model.nlp.question import (
     AutoModelForQuestionAnswering,
     QuestionAnsweringModel,
@@ -83,6 +84,7 @@ class QuestionAnsweringModelInstantiationTestCase(TestCase):
                 state_dict=None,
                 local_files_only=False,
                 token=None,
+                device_map=Engine.get_default_device(),
             )
             tokenizer_mock.assert_called_once_with(
                 self.model_id,

--- a/tests/model/nlp/sequence_test.py
+++ b/tests/model/nlp/sequence_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import TransformerEngineSettings
+from avalan.model.engine import Engine
 from avalan.model.nlp.sequence import SequenceClassificationModel
 from logging import Logger
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, PreTrainedModel, PreTrainedTokenizerFast
@@ -62,6 +63,7 @@ class SequenceClassificationModelInstantiationTestCase(TestCase):
                 state_dict=None,
                 local_files_only=False,
                 token=None,
+                device_map=Engine.get_default_device(),
             )
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id,

--- a/tests/model/nlp/sequence_to_sequence_model_test.py
+++ b/tests/model/nlp/sequence_to_sequence_model_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import GenerationSettings, TransformerEngineSettings
+from avalan.model.engine import Engine
 from avalan.model.nlp.sequence import SequenceToSequenceModel
 from logging import Logger
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, PreTrainedModel, PreTrainedTokenizerFast
@@ -61,6 +62,7 @@ class SequenceToSequenceModelInstantiationTestCase(TestCase):
                 state_dict=None,
                 local_files_only=False,
                 token=None,
+                device_map=Engine.get_default_device(),
             )
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id,

--- a/tests/model/nlp/token_test.py
+++ b/tests/model/nlp/token_test.py
@@ -1,5 +1,6 @@
 from avalan.model.transformer import AutoTokenizer
 from avalan.model.entities import TransformerEngineSettings
+from avalan.model.engine import Engine
 from avalan.model.nlp.token import TokenClassificationModel, AutoModelForTokenClassification
 from logging import Logger
 from transformers import PreTrainedModel, PreTrainedTokenizerFast
@@ -89,6 +90,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
                 state_dict=None,
                 local_files_only=False,
                 token=None,
+                device_map=Engine.get_default_device(),
             )
             auto_tokenizer_mock.assert_called_once_with(self.model_id, use_fast=True)
 

--- a/tests/model/vision/detection_test.py
+++ b/tests/model/vision/detection_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import EngineSettings, ImageEntity
+from avalan.model.engine import Engine
 from avalan.model.vision.detection import (
     ObjectDetectionModel,
     AutoImageProcessor,
@@ -61,6 +62,7 @@ class ObjectDetectionModelInstantiationTestCase(TestCase):
             model_mock.assert_called_once_with(
                 self.model_id,
                 revision="no_timm",
+                device_map=Engine.get_default_device(),
             )
 
 

--- a/tests/model/vision/image_classification_test.py
+++ b/tests/model/vision/image_classification_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import EngineSettings, ImageEntity
+from avalan.model.engine import Engine
 from avalan.model.vision.image import (
     ImageClassificationModel,
     AutoImageProcessor,
@@ -55,7 +56,10 @@ class ImageClassificationModelInstantiationTestCase(TestCase):
                 self.model_id,
                 use_fast=True,
             )
-            model_mock.assert_called_once_with(self.model_id)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                device_map=Engine.get_default_device(),
+            )
 
 
 class ImageClassificationModelCallTestCase(IsolatedAsyncioTestCase):

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -4,6 +4,7 @@ from avalan.model.vision.image import (
     AutoModelForVision2Seq,
     ImageToTextModel,
 )
+from avalan.model.engine import Engine
 from logging import Logger
 from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
 from unittest import IsolatedAsyncioTestCase, main, TestCase
@@ -42,7 +43,10 @@ class ImageToTextModelInstantiationTestCase(TestCase):
 
             self.assertIs(model.model, model_instance)
             processor_mock.assert_called_once_with(self.model_id, use_fast=True)
-            model_mock.assert_called_once_with(self.model_id)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                device_map=Engine.get_default_device(),
+            )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(self.model_id, use_fast=True)
 

--- a/tests/model/vision/segmentation_test.py
+++ b/tests/model/vision/segmentation_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import EngineSettings
+from avalan.model.engine import Engine
 from avalan.model.vision.segmentation import (
     AutoImageProcessor,
     AutoModelForSemanticSegmentation,
@@ -36,7 +37,10 @@ class SemanticSegmentationModelInstantiationTestCase(TestCase):
 
             self.assertIs(model.model, model_instance)
             processor_mock.assert_called_once_with(self.model_id, use_fast=True)
-            model_mock.assert_called_once_with(self.model_id)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                device_map=Engine.get_default_device(),
+            )
             #model_instance.eval.assert_called_once_with()
 
 

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -1,4 +1,5 @@
 from avalan.model.entities import TransformerEngineSettings
+from avalan.model.engine import Engine
 from avalan.model.vision.image import (
     AutoImageProcessor,
     HFVisionEncoderDecoderModel,
@@ -44,7 +45,10 @@ class VisionEncoderDecoderModelInstantiationTestCase(TestCase):
 
             self.assertIs(model.model, model_instance)
             processor_mock.assert_called_once_with(self.model_id, use_fast=True)
-            model_mock.assert_called_once_with(self.model_id)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                device_map=Engine.get_default_device(),
+            )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(self.model_id, use_fast=True)
 


### PR DESCRIPTION
## Summary
- pass `device_map` to every model load and `use_fast` for processors
- add `@override` on model `__call__` implementations
- update tests to check device handling

## Testing
- `poetry run pytest --verbose -s`