### PR TITLE
Add EngineResponse alias

### DIFF
--- a/src/avalan/model/__init__.py
+++ b/src/avalan/model/__init__.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from ..model.entities import (
     GenerationSettings,
+    ImageEntity,
     Message,
     Token,
     TokenDetail
@@ -10,12 +11,15 @@ from io import StringIO
 from inspect import iscoroutine
 from json import loads, JSONDecodeError
 from re import compile, DOTALL, Pattern
+from numpy import ndarray
 from typing import (
     AsyncGenerator,
     AsyncIterator,
     Awaitable,
     Callable,
     Literal,
+    Generator,
+    Union,
     TypedDict,
 )
 
@@ -210,4 +214,18 @@ class TextGenerationVendorStream(TextGenerationStream):
     def __aiter__(self):
         assert self._generator
         return self
+
+
+EngineResponse = Union[
+    TextGenerationResponse,
+    TextGenerationVendorStream,
+    Generator[str, None, None],
+    Generator[Union[Token, TokenDetail], None, None],
+    ImageEntity,
+    list[ImageEntity],
+    list[str],
+    dict[str, str],
+    ndarray,
+    str,
+]
 

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from ..model import (
+    EngineResponse,
     ModelAlreadyLoadedException,
-    TextGenerationResponse,
     TextGenerationVendor,
-    TextGenerationVendorStream,
     TokenizerAlreadyLoadedException,
     TokenizerNotSupportedException
 )
@@ -20,7 +19,6 @@ from ..model.entities import (
 from contextlib import ExitStack
 from importlib.util import find_spec
 from logging import ERROR, Logger, getLogger
-from numpy import ndarray
 from torch import cuda
 from torch.backends import mps
 from transformers import (
@@ -118,18 +116,7 @@ class Engine(ABC):
         self,
         input: Input,
         **kwargs
-    ) -> Union[
-        TextGenerationResponse,
-        TextGenerationVendorStream,
-        Generator[str,None,None],
-        Generator[Union[Token,TokenDetail],None,None],
-        ImageEntity,
-        list[ImageEntity],
-        list[str],
-        dict[str,str],
-        ndarray,
-        str
-    ]:
+    ) -> EngineResponse:
         raise NotImplementedError()
 
     @abstractmethod


### PR DESCRIPTION
## Summary
- define `EngineResponse` union type for engine outputs
- use alias in `Engine.__call__`

## Testing
- `poetry run pytest --verbose -s`