### PR TITLE
Move get_model_settings helper

### DIFF
--- a/src/avalan/cli/commands/__init__.py
+++ b/src/avalan/cli/commands/__init__.py
@@ -1,0 +1,40 @@
+from argparse import Namespace
+from logging import Logger
+
+from ...model.entities import EngineUri
+from ...model.hubs.huggingface import HuggingfaceHub
+
+
+def get_model_settings(
+    args: Namespace,
+    hub: HuggingfaceHub,
+    logger: Logger,
+    engine_uri: EngineUri,
+    is_sentence_transformer: bool | None = None,
+) -> dict:
+    """Return settings used to load a model."""
+
+    return dict(
+        engine_uri=engine_uri,
+        attention=args.attention if hasattr(args, "attention") else None,
+        device=args.device,
+        disable_loading_progress_bar=args.disable_loading_progress_bar,
+        is_sentence_transformer=is_sentence_transformer
+        or (
+            hasattr(args, "sentence_transformer") and args.sentence_transformer
+        ),
+        loader_class=args.loader_class,
+        low_cpu_mem_usage=args.low_cpu_mem_usage,
+        quiet=args.quiet,
+        revision=args.revision,
+        special_tokens=args.special_token
+        if args.special_token and isinstance(args.special_token, list)
+        else None,
+        tokenizer=args.tokenizer or None,
+        tokens=args.token if args.token and isinstance(args.token, list) else None,
+        trust_remote_code=(
+            args.trust_remote_code if hasattr(args, "trust_remote_code") else None
+        ),
+        weight_type=args.weight_type,
+    )
+

--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -1,7 +1,8 @@
 from argparse import Namespace
 from asyncio import to_thread
 from ...cli import get_input
-from ...cli.commands.model import get_model_settings, model_display
+from ...cli.commands import get_model_settings
+from ...cli.commands.model import model_display
 from ...memory.partitioner.text import TextPartitioner, TextPartition
 from ...memory.partitioner.code import CodePartitioner
 from ...memory.permanent import MemoryType, VectorFunction

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -17,6 +17,7 @@ from ...model.criteria import KeywordStoppingCriteria
 from ...model.nlp.sentence import SentenceTransformerModel
 from ...model.nlp.text.generation import TextGenerationModel
 from ...secrets import KeyringSecrets
+from . import get_model_settings
 from rich.prompt import Prompt
 from logging import Logger
 from rich.console import Console, Group, RenderableType
@@ -415,39 +416,4 @@ async def token_generation(
                     await sleep(display_pause / 1000)
                 elif frame_minimum_pause_ms > 0:
                     await sleep(frame_minimum_pause_ms / 1000)
-
-def get_model_settings(
-    args: Namespace,
-    hub: HuggingfaceHub,
-    logger: Logger,
-    engine_uri: EngineUri,
-    is_sentence_transformer: bool | None=None
-) -> dict:
-    return dict(
-        engine_uri=engine_uri,
-        attention=args.attention if hasattr(args, "attention") else None,
-        device=args.device,
-        disable_loading_progress_bar=args.disable_loading_progress_bar,
-        is_sentence_transformer=is_sentence_transformer or (
-            hasattr(args, "sentence_transformer")
-            and args.sentence_transformer
-        ),
-        loader_class=args.loader_class,
-        low_cpu_mem_usage=args.low_cpu_mem_usage,
-        quiet=args.quiet,
-        revision=args.revision,
-        special_tokens=args.special_token
-            if args.special_token
-            and isinstance(args.special_token,list)
-            else None,
-        tokenizer=args.tokenizer or None,
-        tokens=args.token
-            if args.token and isinstance(args.token,list) else None,
-        trust_remote_code=(
-            args.trust_remote_code
-            if hasattr(args, "trust_remote_code")
-            else None
-        ),
-        weight_type=args.weight_type
-    )
 

--- a/tests/cli/get_model_settings_test.py
+++ b/tests/cli/get_model_settings_test.py
@@ -1,0 +1,65 @@
+import unittest
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+from avalan.cli.commands import get_model_settings
+
+
+class GetModelSettingsTestCase(unittest.TestCase):
+    def test_basic(self):
+        engine_uri = MagicMock()
+        args = Namespace(
+            attention="flash",
+            device="cpu",
+            disable_loading_progress_bar=True,
+            sentence_transformer=True,
+            loader_class="auto",
+            low_cpu_mem_usage=True,
+            quiet=False,
+            revision="rev",
+            special_token=["<s>"],
+            tokenizer="tok",
+            token=["t"],
+            trust_remote_code=True,
+            weight_type="fp16",
+        )
+
+        result = get_model_settings(args, MagicMock(), MagicMock(), engine_uri)
+        expected = {
+            "engine_uri": engine_uri,
+            "attention": "flash",
+            "device": "cpu",
+            "disable_loading_progress_bar": True,
+            "is_sentence_transformer": True,
+            "loader_class": "auto",
+            "low_cpu_mem_usage": True,
+            "quiet": False,
+            "revision": "rev",
+            "special_tokens": ["<s>"],
+            "tokenizer": "tok",
+            "tokens": ["t"],
+            "trust_remote_code": True,
+            "weight_type": "fp16",
+        }
+        self.assertEqual(result, expected)
+
+    def test_override_sentence_transformer(self):
+        engine_uri = MagicMock()
+        args = Namespace(
+            device="cpu",
+            disable_loading_progress_bar=False,
+            loader_class="auto",
+            low_cpu_mem_usage=False,
+            quiet=True,
+            revision="main",
+            special_token=None,
+            tokenizer=None,
+            token=None,
+            weight_type="fp32",
+        )
+
+        result = get_model_settings(
+            args, MagicMock(), MagicMock(), engine_uri, is_sentence_transformer=True
+        )
+        self.assertTrue(result["is_sentence_transformer"])
+

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from unittest.mock import MagicMock, AsyncMock, patch, call
 
 from avalan.cli.commands import model as model_cmds
+from avalan.cli.commands import get_model_settings
 
 
 class CliModelTestCase(unittest.TestCase):
@@ -32,7 +33,7 @@ class CliModelTestCase(unittest.TestCase):
             weight_type="fp16",
         )
 
-        result = model_cmds.get_model_settings(args, self.hub, self.logger, engine_uri)
+        result = get_model_settings(args, self.hub, self.logger, engine_uri)
         expected = {
             "engine_uri": engine_uri,
             "attention": "flash",


### PR DESCRIPTION
## Summary
- move `get_model_settings()` into `cli.commands` package
- use new helper location in `model` and `memory` commands
- add dedicated tests for `get_model_settings`

## Testing
- `poetry run pytest --verbose -s`