### PR TITLE
Add ImageTextToTextModel tests

### DIFF
--- a/tests/model/vision/image_text_to_text_model_test.py
+++ b/tests/model/vision/image_text_to_text_model_test.py
@@ -2,6 +2,7 @@ from avalan.model.entities import GenerationSettings, TransformerEngineSettings,
 from avalan.model.vision.image import (
     AutoModelForImageTextToText,
     AutoProcessor,
+    Gemma3ForConditionalGeneration,
     ImageTextToTextModel,
 )
 from avalan.model.vision import BaseVisionModel
@@ -68,11 +69,95 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 device_map=model._device,
             )
 
+    def test_instantiation_default_loader(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(AutoModelForImageTextToText, "from_pretrained") as model_mock,
+            patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
+            patch.object(BaseNLPModel, "_get_weight_type", return_value="dtype") as wt_mock,
+        ):
+            processor_instance = MagicMock()
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock(spec=PTMWithGenerate)
+            model_mock.return_value = model_instance
+
+            tokenizer_instance = MagicMock(spec=PreTrainedTokenizerFast)
+            type(tokenizer_instance).all_special_tokens = PropertyMock(return_value=[])
+            type(tokenizer_instance).name_or_path = PropertyMock(return_value=self.model_id)
+            tokenizer_mock.return_value = tokenizer_instance
+
+            settings = TransformerEngineSettings()
+            model = ImageTextToTextModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+
+            self.assertIs(model.model, model_instance)
+            self.assertIs(model._processor, processor_instance)
+            processor_mock.assert_called_once_with(self.model_id, use_fast=True)
+            wt_mock.assert_called_once_with(settings.weight_type)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                torch_dtype="dtype",
+                device_map=model._device,
+            )
+
+    def test_instantiation_gemma3_loader(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(Gemma3ForConditionalGeneration, "from_pretrained") as gemma_mock,
+            patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
+            patch.object(BaseNLPModel, "_get_weight_type", return_value="dtype") as wt_mock,
+        ):
+            processor_instance = MagicMock()
+            processor_mock.return_value = processor_instance
+
+            model_instance = MagicMock(spec=PTMWithGenerate)
+            gemma_mock.return_value = model_instance
+
+            tokenizer_instance = MagicMock(spec=PreTrainedTokenizerFast)
+            type(tokenizer_instance).all_special_tokens = PropertyMock(return_value=[])
+            type(tokenizer_instance).name_or_path = PropertyMock(return_value=self.model_id)
+            tokenizer_mock.return_value = tokenizer_instance
+
+            settings = TransformerEngineSettings(loader_class="gemma3")
+            model = ImageTextToTextModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+
+            self.assertIs(model.model, model_instance)
+            processor_mock.assert_called_once_with(self.model_id, use_fast=True)
+            wt_mock.assert_called_once_with(settings.weight_type)
+            gemma_mock.assert_called_once_with(
+                self.model_id,
+                torch_dtype="dtype",
+                device_map=model._device,
+            )
+
+    def test_instantiation_invalid_loader(self):
+        with (
+            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
+        ):
+            processor_mock.return_value = MagicMock()
+            tokenizer_mock.return_value = MagicMock()
+            with self.assertRaises(AssertionError):
+                ImageTextToTextModel(
+                    self.model_id,
+                    TransformerEngineSettings(loader_class="bad"),
+                )
+
 
 class ImageTextToTextModelCallTestCase(IsolatedAsyncioTestCase):
     model_id = "dummy/model"
 
-    async def _run_call(self, batch_decode_return):
+    async def _run_call(self, batch_decode_return, system_prompt=None):
         logger_mock = MagicMock(spec=Logger)
         with (
             patch.object(AutoProcessor, "from_pretrained") as processor_mock,
@@ -110,22 +195,28 @@ class ImageTextToTextModelCallTestCase(IsolatedAsyncioTestCase):
             result = await model(
                 "img.jpg",
                 "prompt",
+                system_prompt=system_prompt,
                 settings=GenerationSettings(max_new_tokens=5),
             )
 
             self.assertEqual(result, batch_decode_return[0] if isinstance(batch_decode_return, list) else batch_decode_return)
             get_image_mock.assert_called_once_with("img.jpg")
             image.convert.assert_called_once_with("RGB")
-            processor_instance.apply_chat_template.assert_called_once_with(
-                [
-                    {
-                        "role": str(MessageRole.USER),
-                        "content": [
-                            {"type": "image", "image": rgb_image},
-                            {"type": "text", "text": "prompt"},
-                        ],
-                    }
+            expected_messages = []
+            if system_prompt:
+                expected_messages.append({
+                    "role": str(MessageRole.SYSTEM),
+                    "content": [{"type": "text", "text": system_prompt}],
+                })
+            expected_messages.append({
+                "role": str(MessageRole.USER),
+                "content": [
+                    {"type": "image", "image": rgb_image},
+                    {"type": "text", "text": "prompt"},
                 ],
+            })
+            processor_instance.apply_chat_template.assert_called_once_with(
+                expected_messages,
                 tokenize=False,
                 add_generation_prompt=True,
             )
@@ -152,6 +243,12 @@ class ImageTextToTextModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call_string_output(self):
         await self._run_call("ok")
+
+    async def test_call_without_system_prompt(self):
+        await self._run_call("ok", system_prompt=None)
+
+    async def test_call_with_system_prompt(self):
+        await self._run_call("ok", system_prompt="sys")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend ImageTextToTextModel test coverage
  - default loader should use the auto model
  - gemma3 loader support
  - invalid loader raises an AssertionError
  - calling with/without system prompt

## Testing
- `poetry run pytest --verbose -s`