### PR TITLE
Add tests for text generation call

### DIFF
--- a/tests/model/nlp/text_generation_call_test.py
+++ b/tests/model/nlp/text_generation_call_test.py
@@ -97,6 +97,68 @@ class TextGenerationModelCallTestCase(IsolatedAsyncioTestCase):
                     settings=GenerationSettings(temperature=0.2),
                 )
 
+    async def test_default_settings_used_when_none_provided(self):
+        tok_inputs = {"input_ids": [[5]]}
+        self.model._tokenize_input = MagicMock(return_value=tok_inputs)
+        stream_output = MagicMock()
+        self.model._stream_generator = stream_output
+
+        response = await self.model("hey")
+
+        self.assertIs(response._output_fn, stream_output)
+        self.assertTrue(response._use_async_generator)
+        self.assertTrue(response._kwargs["settings"].do_sample)
+        self.assertEqual(
+            response._kwargs["settings"].pad_token_id,
+            self.model._tokenizer.eos_token_id,
+        )
+
+    async def test_manual_sampling_selects_token_generator(self):
+        tok_inputs = {"input_ids": [[6]]}
+        self.model._tokenize_input = MagicMock(return_value=tok_inputs)
+        token_gen = MagicMock()
+        self.model._token_generator = token_gen
+
+        settings = GenerationSettings(
+            use_async_generator=True, temperature=None
+        )
+        response = await self.model(
+            "x", settings=settings, manual_sampling=True
+        )
+
+        self.assertIs(response._output_fn, token_gen)
+        self.assertTrue(response._use_async_generator)
+
+    async def test_use_async_generator_true_stream_output(self):
+        tok_inputs = {"input_ids": [[7]]}
+        self.model._tokenize_input = MagicMock(return_value=tok_inputs)
+        stream_output = MagicMock()
+        self.model._stream_generator = stream_output
+
+        settings = GenerationSettings(
+            use_async_generator=True, temperature=None
+        )
+        response = await self.model("y", settings=settings)
+
+        self.assertIs(response._output_fn, stream_output)
+        self.assertTrue(response._use_async_generator)
+
+    async def test_use_async_generator_false_string_output(self):
+        tok_inputs = {"input_ids": [[8]]}
+        self.model._tokenize_input = MagicMock(return_value=tok_inputs)
+        string_output = MagicMock()
+        self.model._string_output = string_output
+
+        settings = GenerationSettings(
+            use_async_generator=False,
+            temperature=0.7,
+        )
+        response = await self.model("z", settings=settings)
+
+        self.assertIs(response._output_fn, string_output)
+        self.assertFalse(response._use_async_generator)
+        self.assertTrue(response._kwargs["settings"].do_sample)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- expand coverage for `TextGenerationModel.__call__`

## Testing
- `poetry run ruff format tests/model/nlp/text_generation_call_test.py`
- `poetry run ruff check --fix tests/model/nlp/text_generation_call_test.py`
- `poetry run pytest --verbose -s`