### PR TITLE
Implement streaming orchestration

### DIFF
--- a/src/avalan/__init__.py
+++ b/src/avalan/__init__.py
@@ -14,6 +14,7 @@ def _config() -> dict:
 
 config = _config()
 
+
 def license() -> str:
     assert (
         "project" in config

--- a/src/avalan/agent/orchestrator.py
+++ b/src/avalan/agent/orchestrator.py
@@ -89,7 +89,7 @@ class ObservableTextGenerationResponse(TextGenerationResponse):
         return await self._response.to(entity_class)
 
 
-class OrchestrationResponse:
+class OrchestratorResponse:
     """Async iterator yielding TextGenerationResponses handling tool calls."""
 
     _responses: list[ObservableTextGenerationResponse]
@@ -174,7 +174,7 @@ class OrchestrationResponse:
 
         self._buffer = StringIO()
 
-    def __aiter__(self) -> "OrchestrationResponse":
+    def __aiter__(self) -> "OrchestratorResponse":
         return self
 
     async def __anext__(self) -> ObservableTextGenerationResponse:
@@ -379,7 +379,7 @@ class Orchestrator:
             await self._event_manager.trigger(Event(type=EventType.END))
             return result
 
-        return OrchestrationResponse(
+        return OrchestratorResponse(
             result,
             engine_agent,
             operation,

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -1,5 +1,6 @@
 from argparse import Namespace
 from ...agent.loader import OrchestrationLoader
+from ...agent.orchestrator import OrchestratorResponse
 from ...cli import get_input
 from ...cli.commands.model import token_generation
 from ...event import EventStats
@@ -245,7 +246,11 @@ async def agent_run(
             if not args.quiet and not args.stats:
                 console.print(_i["agent_output"] + " ", end="")
 
-            if isinstance(output, TextGenerationResponse):
+            assert isinstance(output, OrchestratorResponse)
+
+            async for response in output:
+                assert isinstance(response, TextGenerationResponse)
+
                 if not use_async_generator:
                     console.print(await output.to_str())
                 else:
@@ -258,13 +263,11 @@ async def agent_run(
                         event_stats=event_stats,
                         lm=orchestrator.engine,
                         input_string=input_string,
-                        response=output,
+                        response=response,
                         dtokens_pick=dtokens_pick,
                         display_tokens=display_tokens,
                         with_stats=with_stats,
                     )
-            else:
-                console.print(output)
 
             if args.conversation:
                 console.print("")

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -141,10 +141,7 @@ class ImageTextToTextModel(ImageToTextModel):
         if width:
             ratio = width / image.width
             height = int(ratio * image.height)
-            image = image.resize(
-                (width, height),
-                Image.Resampling.LANCZOS
-            )
+            image = image.resize((width, height), Image.Resampling.LANCZOS)
 
         messages = []
         if system_prompt:

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -259,6 +259,13 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
 
                 return gen()
 
+        class DummyOrchestratorResponse:
+            def __aiter__(self_inner):
+                async def gen():
+                    yield DummyResponse()
+
+                return gen()
+
         with (
             patch.object(agent_cmds, "get_input", return_value="hi"),
             patch.object(
@@ -273,8 +280,11 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
                 agent_cmds, "token_generation", new_callable=AsyncMock
             ) as tg_patch,
             patch.object(agent_cmds, "TextGenerationResponse", DummyResponse),
+            patch.object(
+                agent_cmds, "OrchestratorResponse", DummyOrchestratorResponse
+            ),
         ):
-            self.orch.return_value = DummyResponse()
+            self.orch.return_value = DummyOrchestratorResponse()
             await agent_cmds.agent_run(
                 self.args, self.console, self.theme, self.hub, self.logger, 1
             )

--- a/tests/cli/memory_test.py
+++ b/tests/cli/memory_test.py
@@ -31,6 +31,7 @@ md_stub.DocumentConverterResult = object
 md_stub.__spec__ = importlib.machinery.ModuleSpec("markitdown", loader=None)
 sys.modules.setdefault("markitdown", md_stub)
 
+
 class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
         self.args = Namespace(
@@ -79,12 +80,8 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 memory_cmds, "get_model_settings", return_value={}
             ) as gms_patch,
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
-            patch.object(
-                memory_cmds.Path, "read_text", return_value="content"
-            ),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
+            patch.object(memory_cmds.Path, "read_text", return_value="content"),
             patch.object(
                 memory_cmds, "TextPartitioner", return_value=tp_inst
             ) as tp_patch,
@@ -153,12 +150,8 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
         client.get = AsyncMock(return_value=response)
 
         with (
-            patch.object(
-                memory_cmds, "get_model_settings", return_value={}
-            ),
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
+            patch.object(memory_cmds, "get_model_settings", return_value={}),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
             patch.object(
                 memory_cmds, "AsyncClient", return_value=client
             ) as ac_patch,
@@ -227,15 +220,9 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
 
         cp_inst = MagicMock()
         with (
-            patch.object(
-                memory_cmds, "get_model_settings", return_value={}
-            ),
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
-            patch.object(
-                memory_cmds.Path, "read_text", return_value="code"
-            ),
+            patch.object(memory_cmds, "get_model_settings", return_value={}),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
+            patch.object(memory_cmds.Path, "read_text", return_value="code"),
             patch.object(
                 memory_cmds, "CodePartitioner", return_value=cp_inst
             ) as cp_patch,
@@ -313,9 +300,7 @@ class CliMemoryEmbeddingsTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 memory_cmds, "get_model_settings", return_value={}
             ) as gms_patch,
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
             patch.object(memory_cmds, "model_display"),
         ):
             await memory_cmds.memory_embeddings(
@@ -353,9 +338,7 @@ class CliMemoryEmbeddingsTestCase(IsolatedAsyncioTestCase):
                 memory_cmds, "get_input", return_value=None
             ) as gi_patch,
             patch.object(memory_cmds, "ModelManager"),
-            patch.object(
-                memory_cmds, "get_model_settings", return_value={}
-            ),
+            patch.object(memory_cmds, "get_model_settings", return_value={}),
             patch.object(memory_cmds, "model_display"),
         ):
             await memory_cmds.memory_embeddings(
@@ -391,12 +374,8 @@ class CliMemoryEmbeddingsTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 memory_cmds, "get_input", return_value="text"
             ) as gi_patch,
-            patch.object(
-                memory_cmds, "get_model_settings", return_value={}
-            ),
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
+            patch.object(memory_cmds, "get_model_settings", return_value={}),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
             patch.object(
                 memory_cmds, "IndexFlatL2", return_value=index
             ) as idx_patch,
@@ -461,12 +440,8 @@ class CliMemorySearchTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 memory_cmds, "get_input", return_value="query"
             ) as gi_patch,
-            patch.object(
-                memory_cmds, "get_model_settings", return_value={}
-            ),
-            patch.object(
-                memory_cmds, "ModelManager", return_value=manager
-            ),
+            patch.object(memory_cmds, "get_model_settings", return_value={}),
+            patch.object(memory_cmds, "ModelManager", return_value=manager),
             patch.object(
                 memory_cmds, "TextPartitioner", return_value=tp_inst
             ) as tp_patch,

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from unittest.mock import MagicMock, AsyncMock, patch, call
 from unittest import IsolatedAsyncioTestCase, main, TestCase
 
+
 class CliModelTestCase(TestCase):
     def setUp(self):
         self.console = MagicMock()
@@ -406,9 +407,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                 "get_model_settings",
                 return_value={"engine_uri": engine_uri},
             ) as gms_patch,
-            patch.object(
-                model_cmds, "get_input", return_value=None
-            ),
+            patch.object(model_cmds, "get_input", return_value=None),
             patch.object(
                 model_cmds, "token_generation", new_callable=AsyncMock
             ) as tg_patch,
@@ -486,9 +485,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                 "get_model_settings",
                 return_value={"engine_uri": engine_uri},
             ) as gms_patch,
-            patch.object(
-                model_cmds, "get_input", return_value="hi"
-            ),
+            patch.object(model_cmds, "get_input", return_value="hi"),
             patch.object(
                 model_cmds, "token_generation", new_callable=AsyncMock
             ) as tg_patch,
@@ -558,9 +555,7 @@ class CliModelSearchTestCase(IsolatedAsyncioTestCase):
 
         with (
             patch.object(model_cmds, "Live", return_value=live),
-            patch.object(
-                model_cmds, "Group", side_effect=fake_group
-            ),
+            patch.object(model_cmds, "Group", side_effect=fake_group),
             patch.object(model_cmds, "to_thread", side_effect=to_thread_stub),
         ):
             await model_cmds.model_search(args, console, theme, hub, 5)


### PR DESCRIPTION
## Summary
- introduce `OrchestrationResponse` for streaming tool execution
- wrap text generation output with `_ToolAwareResponse`
- adapt orchestrator to return orchestration responses when tools are enabled

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format`
- `poetry run pytest --verbose -s`