### PR TITLE
Fix orchestrator tests

### DIFF
--- a/tests/agent/default_orchestrator_test.py
+++ b/tests/agent/default_orchestrator_test.py
@@ -73,7 +73,7 @@ class DefaultOrchestratorExecutionTestCase(IsolatedAsyncioTestCase):
         super().setUp()
         self.addCleanup(patch.stopall)
 
-    @patch("avalan.agent.renderer.TemplateEngineAgent")
+    @patch("avalan.agent.orchestrator.TemplateEngineAgent")
     async def test_stream_end_event(self, Agent):
         engine_uri = EngineUri(
             host=None,

--- a/tests/agent/json_orchestrator_test.py
+++ b/tests/agent/json_orchestrator_test.py
@@ -1,7 +1,7 @@
 from avalan.agent import InputType, OutputType, Role
 from avalan.agent.orchestrator.orchestrators.json import (
     JsonOrchestrator,
-    JsonSpecification
+    JsonSpecification,
 )
 from avalan.agent.renderer import TemplateEngineAgent
 from avalan.event.manager import EventManager
@@ -85,18 +85,8 @@ class JsonOrchestratorExecutionTestCase(IsolatedAsyncioTestCase):
         super().setUp()
         self.addCleanup(patch.stopall)
 
-    @patch("avalan.agent.renderer.TemplateEngineAgent")
+    @patch("avalan.agent.orchestrator.TemplateEngineAgent")
     async def test_json_return(self, Agent):
-        class DummyOrchestratorResponse:
-            def __init__(self_inner, item):
-                self_inner._item = item
-
-            def __aiter__(self_inner):
-                async def gen():
-                    yield self_inner._item
-
-                return gen()
-
         engine_uri = EngineUri(
             host=None,
             port=None,
@@ -128,12 +118,10 @@ class JsonOrchestratorExecutionTestCase(IsolatedAsyncioTestCase):
             return '{"value": "ok"}'
 
         response = TextGenerationResponse(output_fn, use_async_generator=False)
-        orchestrator_response = DummyOrchestratorResponse(response)
-
 
         agent_mock = AsyncMock(spec=TemplateEngineAgent)
         agent_mock.engine = engine
-        agent_mock.return_value = orchestrator_response
+        agent_mock.return_value = response
 
         Agent.return_value = agent_mock
 


### PR DESCRIPTION
## Summary
- update patch paths for TemplateEngineAgent
- simplify JsonOrchestrator test to use TextGenerationResponse directly

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format`
- `poetry run pytest --verbose -s`
