### PR TITLE
Rename ToolAwareResponse

### DIFF
--- a/src/avalan/agent/orchestrator/response.py
+++ b/src/avalan/agent/orchestrator/response.py
@@ -97,7 +97,7 @@ class OrchestratorResponse:
         self, response: TextGenerationResponse
     ) -> ObservableTextGenerationResponse:
         assert self._engine_agent.engine
-        return _ToolAwareResponse(
+        return ToolAwareResponse(
             response,
             self._event_manager,
             self._engine_agent.engine.model_id,
@@ -168,7 +168,7 @@ class OrchestratorResponse:
         return resp
 
 
-class _ToolAwareResponse(ObservableTextGenerationResponse):
+class ToolAwareResponse(ObservableTextGenerationResponse):
     """ObservableTextGenerationResponse that notifies on each token."""
 
     def __init__(

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from avalan.agent import Operation, Specification, EngineEnvironment
 from avalan.agent.orchestrator.response import (
     OrchestratorResponse,
-    _ToolAwareResponse,
+    ToolAwareResponse,
 )
 from avalan.event import EventType
 from avalan.event.manager import EventManager
@@ -63,7 +63,7 @@ class OrchestratorResponseInitTestCase(unittest.TestCase):
         self.assertIsNone(orch._event_manager)
         self.assertIsNone(orch._tool)
         self.assertEqual(len(orch._responses), 1)
-        self.assertIsInstance(orch._responses[0], _ToolAwareResponse)
+        self.assertIsInstance(orch._responses[0], ToolAwareResponse)
         self.assertEqual(orch._index, 0)
         self.assertFalse(orch._finished)
 
@@ -81,7 +81,7 @@ class OrchestratorResponseInitTestCase(unittest.TestCase):
         )
         self.assertIs(orch._event_manager, event_manager)
         self.assertIs(orch._tool, tool)
-        self.assertIsInstance(orch._responses[0], _ToolAwareResponse)
+        self.assertIsInstance(orch._responses[0], ToolAwareResponse)
 
 
 class OrchestratorWrapResponseTestCase(unittest.TestCase):
@@ -94,7 +94,7 @@ class OrchestratorWrapResponseTestCase(unittest.TestCase):
         orch = OrchestratorResponse(resp, agent, operation, {})
         new_resp = _dummy_response("x")
         wrapped = orch._wrap_response(new_resp)
-        self.assertIsInstance(wrapped, _ToolAwareResponse)
+        self.assertIsInstance(wrapped, ToolAwareResponse)
         self.assertIs(wrapped._event_manager, orch._event_manager)
         self.assertEqual(wrapped._model_id, engine.model_id)
         self.assertIs(wrapped._tokenizer, engine.tokenizer)


### PR DESCRIPTION
## Summary
- rename `_ToolAwareResponse` class to `ToolAwareResponse`
- update orchestrator response wrapper and tests

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format src/avalan/agent/orchestrator/response.py tests/agent/orchestrator_response_test.py`
- `poetry run pytest --verbose -s`