### PR TITLE
Add tutorial notebook

### DIFF
--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Avalan\n",
+    "\n",
+    "This short tutorial shows how to install **avalan**, search for models, install one locally, and run inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installing with Poetry\n",
+    "\n",
+    "Clone the repository and install the dependencies using [Poetry](https://python-poetry.org/):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "git clone https://github.com/avalan-ai/avalan.git\n",
+    "cd avalan\n",
+    "poetry install\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Searching for a text-generation model\n",
+    "\n",
+    "List available text-generation models with the `model search` command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "avalan model search --task text-generation llama\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installing the Hermes-3 model\n",
+    "\n",
+    "Download the model once you have located it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "avalan model install NousResearch/Hermes-3-Llama-3.1-8B\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running inference\n",
+    "\n",
+    "Pipe a prompt into `model run`, specify a system message, and tweak sampling parameters:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "echo 'Tell me a joke about AI.' | \\",
+    "  avalan model run NousResearch/Hermes-3-Llama-3.1-8B \\",
+    "    --system 'You are a helpful assistant.' \\",
+    "    --top-k 50 \\",
+    "    --temperature 0.7\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bash",
+   "language": "bash",
+   "name": "bash"
+  },
+  "language_info": {
+   "name": "bash"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `docs/tutorials` directory with a getting-started notebook

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_683afac6b80483238e5721eca57aeeb2