### PR TITLE
Add Makefile for linting, testing and releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: lint test release
+
+lint:
+	poetry run ruff check --fix
+	poetry run ruff format
+
+test:
+	poetry sync --extras test
+	poetry run pytest --verbose -s
+
+release:
+	$(eval VERSION := $(filter-out $@,$(MAKECMDGOALS)))
+	@if [ -z "$(VERSION)" ]; then \
+	    echo "Usage: make release X.Y.Z"; \
+	    exit 1; \
+	fi
+	git checkout main
+	git pull --rebase
+	git tag v$(VERSION) -m "Release v$(VERSION)"
+	git push origin --follow-tags
+	poetry publish --build
+	gh release create v$(VERSION) \
+	  --title "v$(VERSION)" \
+	  --notes-file <(git log --format=%B -n1 v$(VERSION))
+
+%:
+	@:


### PR DESCRIPTION
## Summary
- add Makefile with `lint`, `test`, and `release` targets

## Testing
- `poetry run ruff check --fix`
- `poetry run ruff format`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_683c6dd18f888323a35b448fad5d9e80