### PR TITLE
Fix uuid comparisons in tool tests

### DIFF
--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -3,7 +3,8 @@ from avalan.tool import ToolSet
 from avalan.tool.calculator import calculator
 from avalan.tool.manager import ToolManager
 from unittest import IsolatedAsyncioTestCase, main, TestCase
-from uuid import uuid4
+from unittest.mock import patch
+from uuid import uuid4 as _uuid4
 
 
 class ToolManagerCreationTestCase(TestCase):
@@ -37,25 +38,30 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
             '<tool_call>{"name": "calculator", '
             '"arguments": {"expression": "1 + 1"}}</tool_call>'
         )
-        calls = self.manager.get_calls(text)
+        call_id = _uuid4()
+        result_id = _uuid4()
+        with (
+            patch("avalan.tool.parser.uuid4", return_value=call_id),
+            patch("avalan.tool.manager.uuid4", return_value=result_id),
+        ):
+            calls = self.manager.get_calls(text)
+            expected_call = ToolCall(
+                id=call_id,
+                name="calculator",
+                arguments={"expression": "1 + 1"},
+            )
+            self.assertEqual(calls, [expected_call])
 
-        expected_call = ToolCall(
-            id=uuid4(),
-            name="calculator",
-            arguments={"expression": "1 + 1"},
-        )
-        self.assertEqual(calls, [expected_call])
+            results = await self.manager(calls[0])
 
-        results = await self.manager(calls[0])
-
-        expected_result = ToolCallResult(
-            id=uuid4(),
-            call=expected_call,
-            name="calculator",
-            arguments={"expression": "1 + 1"},
-            result="2",
-        )
-        self.assertEqual(results, expected_result)
+            expected_result = ToolCallResult(
+                id=result_id,
+                call=expected_call,
+                name="calculator",
+                arguments={"expression": "1 + 1"},
+                result="2",
+            )
+            self.assertEqual(results, expected_result)
 
     async def test_set_eos_token(self):
         self.manager.set_eos_token("<END>")
@@ -64,25 +70,31 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
             '"arguments": {"expression": "2"}}</tool_call><END>'
         )
 
-        calls = self.manager.get_calls(text)
-        expected_call = ToolCall(
-            id=uuid4(),
-            name="calculator",
-            arguments={"expression": "2"},
-        )
-        self.assertEqual(calls, [expected_call])
+        call_id = _uuid4()
+        result_id = _uuid4()
+        with (
+            patch("avalan.tool.parser.uuid4", return_value=call_id),
+            patch("avalan.tool.manager.uuid4", return_value=result_id),
+        ):
+            calls = self.manager.get_calls(text)
+            expected_call = ToolCall(
+                id=call_id,
+                name="calculator",
+                arguments={"expression": "2"},
+            )
+            self.assertEqual(calls, [expected_call])
 
-        results = await self.manager(calls[0])
+            results = await self.manager(calls[0])
 
-        expected_result = ToolCallResult(
-            id=uuid4(),
-            call=expected_call,
-            name="calculator",
-            arguments={"expression": "2"},
-            result="2",
-        )
-        self.assertEqual(results, expected_result)
-        self.assertEqual(self.manager._parser._eos_token, "<END>")
+            expected_result = ToolCallResult(
+                id=result_id,
+                call=expected_call,
+                name="calculator",
+                arguments={"expression": "2"},
+                result="2",
+            )
+            self.assertEqual(results, expected_result)
+            self.assertEqual(self.manager._parser._eos_token, "<END>")
 
     async def test_namespaced_tool(self):
         namespaced_manager = ToolManager.create_instance(
@@ -94,24 +106,30 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
             '"arguments": {"expression": "3"}}</tool_call>'
         )
 
-        calls = namespaced_manager.get_calls(text)
-        expected_call = ToolCall(
-            id=uuid4(),
-            name="math.calculator",
-            arguments={"expression": "3"},
-        )
-        self.assertEqual(calls, [expected_call])
+        call_id = _uuid4()
+        result_id = _uuid4()
+        with (
+            patch("avalan.tool.parser.uuid4", return_value=call_id),
+            patch("avalan.tool.manager.uuid4", return_value=result_id),
+        ):
+            calls = namespaced_manager.get_calls(text)
+            expected_call = ToolCall(
+                id=call_id,
+                name="math.calculator",
+                arguments={"expression": "3"},
+            )
+            self.assertEqual(calls, [expected_call])
 
-        results = await namespaced_manager(calls[0])
+            results = await namespaced_manager(calls[0])
 
-        expected_result = ToolCallResult(
-            id=uuid4(),
-            call=expected_call,
-            name="math.calculator",
-            arguments={"expression": "3"},
-            result="3",
-        )
-        self.assertEqual(results, expected_result)
+            expected_result = ToolCallResult(
+                id=result_id,
+                call=expected_call,
+                name="math.calculator",
+                arguments={"expression": "3"},
+                result="3",
+            )
+            self.assertEqual(results, expected_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- patch `uuid4` in tool manager and parser tests to avoid random UUID mismatches

## Testing
- `poetry run ruff check --fix tests/tool/tool_manager_test.py tests/tool/tool_parser_test.py`
- `poetry run ruff format tests/tool/tool_manager_test.py tests/tool/tool_parser_test.py`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_683e1c21fc508323b08486e1e6a42281