### PR TITLE
Add tool execution timing

### DIFF
--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -28,6 +28,9 @@ class EventType(StrEnum):
 class Event:
     type: EventType
     payload: dict[str, Any] | None = None
+    started: float | None = None
+    finished: float | None = None
+    ellapsed: float | None = None
 
 
 class EventStats:

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -306,7 +306,7 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
                 dtokens_pick=0,
                 with_stats=True,
                 tool_events_limit=2,
-                refresh_per_second=2
+                refresh_per_second=2,
             )
 
         self.assertEqual(theme.tokens.call_args[0][9], 5)
@@ -331,7 +331,7 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
                 dtokens_pick=0,
                 with_stats=True,
                 tool_events_limit=2,
-                refresh_per_second=2
+                refresh_per_second=2,
             )
 
         self.assertEqual(theme.tokens.call_args[0][9], 7)
@@ -355,7 +355,7 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
                 dtokens_pick=0,
                 with_stats=True,
                 tool_events_limit=2,
-                refresh_per_second=2
+                refresh_per_second=2,
             )
 
         self.assertEqual(theme.tokens.call_args[0][9], 33)

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -1,0 +1,47 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch, MagicMock
+from rich.spinner import Spinner
+
+from avalan.cli.theme.fancy import FancyTheme
+from avalan.event import Event, EventType
+
+
+class FancyThemeTokensTestCase(IsolatedAsyncioTestCase):
+    async def test_tool_running_spinner_text(self):
+        theme = FancyTheme(lambda s: s, lambda s, p, n: s if n == 1 else p)
+        spinner = Spinner("dots", text="[cyan]run[/cyan]", style="cyan")
+        with patch(
+            "avalan.cli.theme.fancy._lf", lambda i: list(filter(None, i or []))
+        ):
+            gen = theme.tokens(
+                model_id="m",
+                added_tokens=None,
+                special_tokens=None,
+                display_token_size=None,
+                display_probabilities=False,
+                pick=0,
+                focus_on_token_when=None,
+                text_tokens=["a"],
+                tokens=None,
+                input_token_count=0,
+                total_tokens=0,
+                tool_events=[],
+                tool_event_calls=[
+                    Event(type=EventType.TOOL_PROCESS, payload=[])
+                ],
+                tool_event_results=[],
+                tool_running_spinner=spinner,
+                ttft=0.0,
+                ttnt=0.0,
+                ellapsed=1.0,
+                console_width=80,
+                logger=MagicMock(),
+            )
+            frame = await gen.__anext__()
+        self.assertTrue(
+            any(
+                getattr(r, "renderable", None) is spinner
+                for r in frame[1].renderables
+            )
+        )
+        self.assertIn("second", spinner.text)


### PR DESCRIPTION
## Summary
- track tool execution start/finish time in `Event`
- emit timing info from `OrchestratorResponse`
- display tool running spinner with elapsed time in `FancyTheme`
- test tool timing events and spinner text

## Testing
- `poetry run ruff format src/avalan/event/__init__.py src/avalan/agent/orchestrator/response/orchestrator_response.py src/avalan/cli/theme/fancy.py tests/agent/orchestrator_response_test.py tests`
- `poetry run ruff check --fix`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_683e8c111da88323875cdc6e09170c74