### PR TITLE
Expand tool coverage

### DIFF
--- a/tests/tool/browser_tool_test.py
+++ b/tests/tool/browser_tool_test.py
@@ -1,6 +1,6 @@
 import types
 from contextlib import AsyncExitStack
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 from avalan.tool.browser import BrowserTool, BrowserToolSet
@@ -82,3 +82,13 @@ class BrowserToolSetTestCase(IsolatedAsyncioTestCase):
         self.assertIs(result, toolset)
         dummy_stack.enter_async_context.assert_awaited_once_with("client1")
         dummy_tool.with_client.assert_called_once_with("client2")
+
+
+class BrowserToolWithClientTestCase(TestCase):
+    def test_with_client(self):
+        client1 = MagicMock()
+        client2 = MagicMock()
+        tool = BrowserTool(client1)
+        result = tool.with_client(client2)
+        self.assertIs(result, tool)
+        self.assertIs(tool._client, client2)

--- a/tests/tool/tool_set_test.py
+++ b/tests/tool/tool_set_test.py
@@ -1,6 +1,8 @@
 from avalan.tool import Tool, ToolSet
 from avalan.tool.math import CalculatorTool
+from contextlib import AsyncExitStack
 from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest.mock import AsyncMock, MagicMock
 
 
 class ToolSetTestCase(TestCase):
@@ -54,6 +56,7 @@ class ContextTool(DummyTool):
     async def __aexit__(self, exc_type, exc, tb):
         self.exited = True
 
+
 class ToolSetCallableTestCase(IsolatedAsyncioTestCase):
     async def test_async_context_and_schema(self):
         tool = ContextTool()
@@ -64,13 +67,102 @@ class ToolSetCallableTestCase(IsolatedAsyncioTestCase):
             self.assertEqual(len(schemas), 1)
             self.assertEqual(schemas[0]["type"], "function")
             self.assertEqual(schemas[0]["function"]["name"], "dummy")
-            self.assertEqual(schemas[0]["function"]["description"], "Return upper-case text.")
-            self.assertEqual(schemas[0]["function"]["parameters"]["type"], "object")
-            self.assertEqual(schemas[0]["function"]["parameters"]["properties"]["text"]["type"], "string")
-            self.assertEqual(schemas[0]["function"]["parameters"]["properties"]["text"]["description"], "Text to upper-case.")
+            self.assertEqual(
+                schemas[0]["function"]["description"], "Return upper-case text."
+            )
+            self.assertEqual(
+                schemas[0]["function"]["parameters"]["type"], "object"
+            )
+            self.assertEqual(
+                schemas[0]["function"]["parameters"]["properties"]["text"][
+                    "type"
+                ],
+                "string",
+            )
+            self.assertEqual(
+                schemas[0]["function"]["parameters"]["properties"]["text"][
+                    "description"
+                ],
+                "Text to upper-case.",
+            )
             self.assertEqual(schemas[0]["function"]["return"]["type"], "string")
-            self.assertEqual(schemas[0]["function"]["return"]["description"], "Upper-cased text.")
+            self.assertEqual(
+                schemas[0]["function"]["return"]["description"],
+                "Upper-cased text.",
+            )
         self.assertTrue(tool.exited)
+
+
+class ToolJsonSchemaPrefixTestCase(TestCase):
+    def test_json_schema_with_prefix(self):
+        tool = CalculatorTool()
+        ToolSet(tools=[tool])
+        schema = tool.json_schema(prefix="pre.")
+        self.assertEqual(schema["function"]["name"], "pre.calculator")
+
+
+class ToolSetEnterExitTestCase(IsolatedAsyncioTestCase):
+    async def test_aenter_and_aexit(self):
+        async_tool = MagicMock(spec=["__aenter__", "__aexit__"])
+        sync_tool = MagicMock(spec=["__enter__", "__exit__"])
+        stack = AsyncMock(spec=AsyncExitStack)
+        stack.enter_async_context = AsyncMock()
+        stack.enter_context = MagicMock()
+        stack.__aexit__ = AsyncMock(return_value=False)
+
+        toolset = ToolSet(exit_stack=stack, tools=[async_tool, sync_tool])
+        result = await toolset.__aenter__()
+        self.assertIs(result, toolset)
+        stack.enter_async_context.assert_awaited_once_with(async_tool)
+        stack.enter_context.assert_called_once_with(sync_tool)
+
+        exit_result = await toolset.__aexit__(None, None, None)
+        stack.__aexit__.assert_awaited_once_with(None, None, None)
+        self.assertFalse(exit_result)
+
+
+class ToolSetDocstringFallbackTestCase(TestCase):
+    def test_docstring_fallback(self):
+        class DoclessTool(Tool):
+            def __init__(self) -> None:
+                super().__init__()
+                self.__name__ = "docless"
+
+            async def __call__(self) -> str:
+                """Call doc"""
+                return "ok"
+
+        tool = DoclessTool()
+        self.assertIsNone(tool.__doc__)
+        ToolSet(tools=[tool])
+        self.assertEqual(tool.__doc__, "Call doc")
+
+
+class ToolSetJsonSchemasTestCase(TestCase):
+    def test_nested_toolsets_and_function(self):
+        def greet(name: str) -> str:
+            """Greet.
+
+            Args:
+                name: Name.
+            """
+            return f"hi {name}"
+
+        inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
+        outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
+        mix = ToolSet(namespace="mix", tools=[greet])
+
+        schemas_outer = outer.json_schemas()
+        self.assertEqual(
+            [s["function"]["name"] for s in schemas_outer],
+            ["outer.calculator", "outer..calculator"],
+        )
+
+        schemas_mix = mix.json_schemas()
+        self.assertEqual(
+            [s["function"]["name"] for s in schemas_mix],
+            ["mix.greet"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- test BrowserTool.with_client updates client and returns self
- check Tool.json_schema prefix handling
- exercise ToolSet __aenter__ and __aexit__
- ensure ToolSet copies __call__ docstring when needed
- verify ToolSet.json_schemas with nested sets and function tools

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68426c149db88323aa5b9432bb1a74ab