### PR TITLE
Add CLI flags for BrowserTool settings

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -201,6 +201,7 @@ class OrchestratorLoader:
         logger: Logger,
         participant_id: UUID,
         stack: AsyncExitStack,
+        browser_settings: BrowserToolSettings | None = None,
     ) -> Orchestrator:
         sentence_model_engine_settings = (
             TransformerEngineSettings(**settings.sentence_model_engine_config)
@@ -247,16 +248,23 @@ class OrchestratorLoader:
             settings.sentence_model_window_size,
         )
 
-        browser_settings = BrowserToolSettings(
-            debug=True,
-            debug_urls={
-                "https://pypi.org/project/avalan/": open("docs/examples/pypi_avalan_source.md")
-            },
-            search=True
-        )
+        if browser_settings is None:
+            browser_settings = BrowserToolSettings(
+                debug=True,
+                debug_urls={
+                    "https://pypi.org/project/avalan/": open(
+                        "docs/examples/pypi_avalan_source.md"
+                    )
+                },
+                search=True,
+            )
         available_toolsets = [
-            BrowserToolSet(settings=browser_settings, partitioner=text_partitioner, namespace="browser"),
-            MathToolSet(namespace="math")
+            BrowserToolSet(
+                settings=browser_settings,
+                partitioner=text_partitioner,
+                namespace="browser",
+            ),
+            MathToolSet(namespace="math"),
         ]
 
         tool = ToolManager.create_instance(

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -48,7 +48,9 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.prompt import Confirm, Prompt
 from rich.theme import Theme
-from typing import get_args, Optional
+from typing import get_args, Optional, get_origin, get_args as get_type_args
+from dataclasses import fields
+from ..tool.browser import BrowserToolSettings
 from uuid import uuid4
 from warnings import filterwarnings
 
@@ -122,6 +124,60 @@ def add_agent_settings_arguments(parser: ArgumentParser) -> ArgumentParser:
         help="Skip special tokens on output",
     )
     group.add_argument("--tool", type=str, action="append", help="Enable tool")
+    return group
+
+
+def add_tool_settings_arguments(
+    parser: ArgumentParser, *, prefix: str, settings_cls: type
+) -> ArgumentParser:
+    """Add tool settings arguments using dataclass ``settings_cls``.
+
+    Parameters
+    ----------
+    parser: ArgumentParser
+        Parser to which the options will be added.
+    prefix: str
+        Prefix for the CLI options (e.g. ``browser``).
+    settings_cls: type
+        Dataclass defining the settings.
+
+    Returns
+    -------
+    ArgumentParser
+        The argument group created.
+    """
+
+    group = parser.add_argument_group(f"{prefix} tool settings")
+
+    for field in fields(settings_cls):
+        if field.name == "debug_urls":
+            continue
+
+        option = f"--tool-{prefix}-{field.name.replace('_', '-')}"
+        dest = f"tool_{prefix}_{field.name}"
+
+        ftype = field.type
+        origin = get_origin(ftype)
+        args = get_type_args(ftype)
+        if origin is not None:
+            if origin is list or origin is tuple:
+                ftype = args[0]
+            elif origin is Optional or type(None) in args:
+                ftype = next((a for a in args if a is not type(None)), str)
+            elif origin.__name__ == "Literal":
+                ftype = type(args[0])
+
+        if ftype is bool or isinstance(field.default, bool):
+            group.add_argument(
+                option, dest=dest, action="store_true", default=None
+            )
+        elif ftype is int or isinstance(field.default, int):
+            group.add_argument(option, dest=dest, type=int, default=None)
+        elif ftype is float or isinstance(field.default, float):
+            group.add_argument(option, dest=dest, type=float, default=None)
+        else:
+            group.add_argument(option, dest=dest, type=str, default=None)
+
     return group
 
 
@@ -519,6 +575,9 @@ class CLI:
         )
 
         add_agent_settings_arguments(agent_run_parser)
+        add_tool_settings_arguments(
+            agent_run_parser, prefix="browser", settings_cls=BrowserToolSettings
+        )
 
         agent_serve_parser = agent_command_parsers.add_parser(
             name="serve",

--- a/tests/cli/get_tool_settings_test.py
+++ b/tests/cli/get_tool_settings_test.py
@@ -1,0 +1,36 @@
+import unittest
+from argparse import Namespace
+from avalan.cli.commands import agent as agent_cmds
+from avalan.tool.browser import BrowserToolSettings
+
+
+class GetToolSettingsTestCase(unittest.TestCase):
+    def test_values(self):
+        args = Namespace(
+            tool_browser_engine="webkit",
+            tool_browser_debug=True,
+            tool_browser_search=False,
+            tool_browser_search_context=7,
+        )
+        settings = agent_cmds.get_tool_settings(
+            args, prefix="browser", settings_cls=BrowserToolSettings
+        )
+        self.assertEqual(settings.engine, "webkit")
+        self.assertTrue(settings.debug)
+        self.assertFalse(settings.search)
+        self.assertEqual(settings.search_context, 7)
+
+    def test_defaults(self):
+        args = Namespace(
+            tool_browser_engine=None,
+            tool_browser_debug=None,
+            tool_browser_search=None,
+            tool_browser_search_context=None,
+        )
+        settings = agent_cmds.get_tool_settings(
+            args, prefix="browser", settings_cls=BrowserToolSettings
+        )
+        self.assertEqual(settings.engine, "firefox")
+        self.assertFalse(settings.debug)
+        self.assertFalse(settings.search)
+        self.assertEqual(settings.search_context, 10)


### PR DESCRIPTION
## Summary
- add generic CLI argument generator for tool settings based on dataclass fields
- parse BrowserToolSettings from CLI in `agent run`
- support passing those settings to `OrchestratorLoader`
- test browser tool CLI parsing and agent run behaviour

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_684330146d8083239438a58d58b5c901