### PR TITLE
Enable tool settings in config

### DIFF
--- a/src/avalan/agent/blueprint.toml
+++ b/src/avalan/agent/blueprint.toml
@@ -34,3 +34,16 @@ uri = "{{ orchestrator.uri }}"
 [run]
 max_new_tokens = {{ orchestrator.call_options['max_new_tokens'] }}
 skip_special_tokens = {{ orchestrator.call_options['skip_special_tokens'] | lower }}
+
+{% if browser_tool %}
+[tool.browser.open]
+{% for k, v in browser_tool.items() %}
+{% if v is boolean %}
+{{ k }} = {{ v | lower }}
+{% elif v is number %}
+{{ k }} = {{ v }}
+{% elif v is string %}
+{{ k }} = "{{ v }}"
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -184,12 +184,26 @@ class OrchestratorLoader:
                 else None,
             )
 
+            tool_config = config.get("tool", {}).get("browser", {}).get("open")
+            if not tool_config and "browser" in config.get("tool", {}):
+                tool_config = config["tool"]["browser"]
+            browser_settings = None
+            if tool_config:
+                if "debug_source" in tool_config and isinstance(
+                    tool_config["debug_source"], str
+                ):
+                    tool_config["debug_source"] = open(
+                        tool_config["debug_source"]
+                    )
+                browser_settings = BrowserToolSettings(**tool_config)
+
             return await cls.load_from_settings(
                 settings,
                 hub=hub,
                 logger=logger,
                 participant_id=participant_id,
                 stack=stack,
+                browser_settings=browser_settings,
             )
 
     @classmethod

--- a/tests/cli/get_tool_settings_test.py
+++ b/tests/cli/get_tool_settings_test.py
@@ -15,6 +15,7 @@ class GetToolSettingsTestCase(unittest.TestCase):
         settings = agent_cmds.get_tool_settings(
             args, prefix="browser", settings_cls=BrowserToolSettings
         )
+        self.assertIsInstance(settings, BrowserToolSettings)
         self.assertEqual(settings.engine, "webkit")
         self.assertTrue(settings.debug)
         self.assertFalse(settings.search)
@@ -30,7 +31,4 @@ class GetToolSettingsTestCase(unittest.TestCase):
         settings = agent_cmds.get_tool_settings(
             args, prefix="browser", settings_cls=BrowserToolSettings
         )
-        self.assertEqual(settings.engine, "firefox")
-        self.assertFalse(settings.debug)
-        self.assertFalse(settings.search)
-        self.assertEqual(settings.search_context, 10)
+        self.assertIsNone(settings)


### PR DESCRIPTION
## Summary
- support `[tool.browser.open]` sections when loading orchestrators from TOML
- expose tool settings in `agent init` output
- generalize parsing of tool settings from CLI and dicts
- update tests for loader and agent CLI

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68436f7ff4b0832386f685416602413e