### PR TITLE
Fix vllm tests

### DIFF
--- a/src/avalan/model/nlp/text/vllm.py
+++ b/src/avalan/model/nlp/text/vllm.py
@@ -25,9 +25,11 @@ class VllmStream(TextGenerationVendorStream):
         self._iterator = generator
 
     async def __anext__(self) -> str:
-        try:
-            chunk = await to_thread(next, self._iterator)
-        except StopIteration:
+        def _next(default: str | None = None) -> str | None:
+            return next(self._iterator, default)
+
+        chunk = await to_thread(_next)
+        if chunk is None:
             raise StopAsyncIteration
         return chunk
 


### PR DESCRIPTION
## Summary
- patch VllmStream to avoid raising StopIteration from threads
- update vllm_extra_test expectations and tokenizer mocks

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68458ec57cb483238a1d5eca7249e43d