### PR TITLE
Add chat template settings

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -102,6 +102,10 @@ class OrchestratorLoader:
             )
 
             call_options = config["run"] if "run" in config else None
+            if call_options and "chat" in call_options:
+                call_options["chat_template_settings"] = call_options.pop(
+                    "chat"
+                )
             template_vars = config["template"] if "template" in config else None
 
             # Memory configuration

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser, Namespace
+import sys
 from asyncio import run as run_in_loop
 from asyncio.exceptions import CancelledError
 from .. import license, name, site, version
@@ -1079,8 +1080,25 @@ class CLI:
 
         return parser
 
+    @staticmethod
+    def _extract_chat_template_settings(
+        argv: list[str],
+    ) -> tuple[list[str], dict[str, bool]]:
+        options: dict[str, bool] = {}
+        new_argv: list[str] = []
+        for arg in argv:
+            if arg.startswith("--run-chat-"):
+                key = arg[len("--run-chat-") :].replace("-", "_")
+                options[key] = True
+            else:
+                new_argv.append(arg)
+        return new_argv, options
+
     async def __call__(self) -> None:
-        args = self._parser.parse_args()
+        argv, chat_opts = self._extract_chat_template_settings(sys.argv[1:])
+        args = self._parser.parse_args(argv)
+        for key, value in chat_opts.items():
+            setattr(args, f"run_chat_{key}", value)
 
         current_locale, _ = getlocale()
         try:

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -57,6 +57,12 @@ def get_orchestrator_settings(
         else args.run_max_new_tokens
     )
 
+    chat_template_settings = {
+        k[len("run_chat_") :]: v
+        for k, v in vars(args).items()
+        if k.startswith("run_chat_") and v is not None
+    }
+
     return OrchestratorSettings(
         agent_id=agent_id,
         orchestrator_type=None,
@@ -77,6 +83,11 @@ def get_orchestrator_settings(
         call_options={
             "max_new_tokens": call_tokens,
             "skip_special_tokens": args.run_skip_special_tokens,
+            **(
+                {"chat_template_settings": chat_template_settings}
+                if chat_template_settings
+                else {}
+            ),
         },
         template_vars=None,
         memory_permanent=(

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from numpy import ndarray
@@ -185,6 +185,15 @@ class GenerationSettings:
     enable_gradient_calculation: bool = False
     # Use async generator (token streaming)
     use_async_generator: bool = True
+    # Parameters passed to tokenizer.apply_chat_template
+    chat_template_settings: dict[str, object] | None = field(
+        default_factory=lambda: {
+            "add_generation_prompt": True,
+            "tokenize": True,
+            "add_special_tokens": True,
+            "return_dict": True,
+        }
+    )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -232,7 +241,9 @@ class Message:
     name: Optional[str] = None
     arguments: Optional[dict] = None
 
+
 Input = Union[str, list[str], Message, list[Message]]
+
 
 @dataclass(frozen=True, kw_only=True)
 class EngineMessage:
@@ -457,5 +468,3 @@ class User:
     name: str
     full_name: Optional[str] = None
     access_token_name: Optional[str] = None
-
-

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -39,6 +39,7 @@ class QuestionAnsweringModel(BaseNLPModel):
         system_prompt: str | None,
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
+        chat_template_settings: dict[str, object] | None = None,
     ) -> BatchEncoding:
         assert not system_prompt, (
             "Token classification model "

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -59,6 +59,7 @@ class SentenceTransformerModel(BaseNLPModel):
         system_prompt: str | None,
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
+        chat_template_settings: dict[str, object] | None = None,
     ) -> BatchEncoding:
         raise NotImplementedError()
 

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -45,6 +45,7 @@ class SequenceClassificationModel(BaseNLPModel):
         system_prompt: str | None,
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
+        chat_template_settings: dict[str, object] | None = None,
     ) -> BatchEncoding:
         assert not system_prompt, (
             "Sequence classification model "
@@ -108,6 +109,7 @@ class SequenceToSequenceModel(BaseNLPModel):
         system_prompt: str | None,
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
+        chat_template_settings: dict[str, object] | None = None,
     ) -> Tensor:
         assert not system_prompt, (
             "SequenceToSequence model "

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -152,7 +152,11 @@ class TextGenerationModel(BaseNLPModel):
             else self._tokenizer.eos_token_id,
         )
         inputs = self._tokenize_input(
-            input, system_prompt, context=None, tool=tool
+            input,
+            system_prompt,
+            context=None,
+            tool=tool,
+            chat_template_settings=settings.chat_template_settings,
         )
         return TextGenerationResponse(
             output_fn,
@@ -337,6 +341,7 @@ class TextGenerationModel(BaseNLPModel):
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
         chat_template: str | None = None,
+        chat_template_settings: dict[str, object] | None = None,
         tool: ToolManager | None = None,
     ) -> dict[str, Tensor] | BatchEncoding | Tensor:
         _l = self._log
@@ -375,13 +380,8 @@ class TextGenerationModel(BaseNLPModel):
             inputs = self._tokenizer.apply_chat_template(
                 template_messages,
                 chat_template=chat_template,
-                tools=tool.json_schemas()
-                if tool
-                else None,
-                add_generation_prompt=True,
-                tokenize=True,
-                add_special_tokens=True,
-                return_dict=True,
+                tools=tool.json_schemas() if tool else None,
+                **(chat_template_settings or {}),
                 return_tensors=tensor_format,
             )
 

--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -100,6 +100,7 @@ class MlxLmModel(TextGenerationModel):
             context=None,
             tensor_format="pt",
             tool=tool,
+            chat_template_settings=settings.chat_template_settings,
         )
         prompt = self._tokenizer.decode(
             inputs["input_ids"][0],

--- a/src/avalan/model/nlp/text/vllm.py
+++ b/src/avalan/model/nlp/text/vllm.py
@@ -68,7 +68,11 @@ class VllmModel(TextGenerationModel):
         )
 
     def _prompt(
-        self, input: Input, system_prompt: str | None, tool: ToolManager | None
+        self,
+        input: Input,
+        system_prompt: str | None,
+        tool: ToolManager | None,
+        chat_template_settings: dict[str, object] | None,
     ) -> str:
         inputs = super()._tokenize_input(
             input,
@@ -76,6 +80,7 @@ class VllmModel(TextGenerationModel):
             context=None,
             tensor_format="pt",
             tool=tool,
+            chat_template_settings=chat_template_settings,
         )
         return self._tokenizer.decode(
             inputs["input_ids"][0], skip_special_tokens=False
@@ -111,7 +116,12 @@ class VllmModel(TextGenerationModel):
         tool: ToolManager | None = None,
     ) -> TextGenerationVendorStream | str:
         settings = settings or GenerationSettings()
-        prompt = self._prompt(input, system_prompt, tool)
+        prompt = self._prompt(
+            input,
+            system_prompt,
+            tool,
+            settings.chat_template_settings,
+        )
         generation_settings = replace(settings, do_sample=False)
         if settings.use_async_generator:
             return await self._stream_generator(prompt, generation_settings)

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -38,6 +38,7 @@ class TokenClassificationModel(BaseNLPModel):
         system_prompt: str | None,
         context: str | None,
         tensor_format: Literal["pt"] = "pt",
+        chat_template_settings: dict[str, object] | None = None,
     ) -> BatchEncoding:
         assert not system_prompt, (
             "Token classification model "

--- a/tests/cli/get_orchestrator_settings_test.py
+++ b/tests/cli/get_orchestrator_settings_test.py
@@ -79,3 +79,28 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
         self.assertEqual(result.memory_permanent, "dsn")
         self.assertEqual(result.tools, ["b"])
         self.assertEqual(result.sentence_model_id, "m")
+
+    def test_chat_template_settings(self):
+        args = Namespace(
+            name="a",
+            role="r",
+            task=None,
+            instructions=None,
+            engine_uri="ai://m",
+            run_max_new_tokens=10,
+            run_skip_special_tokens=False,
+            memory_recent=None,
+            no_session=False,
+            memory_permanent="dsn",
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=200,
+            memory_engine_overlap=20,
+            memory_engine_window=40,
+            tool=None,
+            run_chat_enable_thinking=True,
+        )
+        uid = UUID("00000000-0000-0000-0000-000000000003")
+        result = agent_cmds.get_orchestrator_settings(args, agent_id=uid)
+        self.assertTrue(
+            result.call_options["chat_template_settings"]["enable_thinking"]
+        )

--- a/tests/model/nlp/text_generation_call_test.py
+++ b/tests/model/nlp/text_generation_call_test.py
@@ -29,7 +29,11 @@ class TextGenerationModelCallTestCase(IsolatedAsyncioTestCase):
         response = await self.model("hi", settings=settings)
 
         tokenize_mock.assert_called_once_with(
-            "hi", None, context=None, tool=None
+            "hi",
+            None,
+            context=None,
+            tool=None,
+            chat_template_settings=settings.chat_template_settings,
         )
         self.assertIs(response._output_fn, string_output)
         self.assertEqual(response._kwargs["inputs"], tok_inputs)

--- a/tests/model/nlp/vllm_extra_test.py
+++ b/tests/model/nlp/vllm_extra_test.py
@@ -103,9 +103,14 @@ class VllmModelTestCase(IsolatedAsyncioTestCase):
             "_tokenize_input",
             return_value={"input_ids": [[1, 2]]},
         ) as tok:
-            prompt = model._prompt("hello", "sys", None)
+            prompt = model._prompt("hello", "sys", None, None)
         tok.assert_called_once_with(
-            "hello", "sys", context=None, tensor_format="pt", tool=None
+            "hello",
+            "sys",
+            context=None,
+            tensor_format="pt",
+            tool=None,
+            chat_template_settings=None,
         )
         model._tokenizer.decode.assert_called_once_with(
             [1, 2], skip_special_tokens=False


### PR DESCRIPTION
## Summary
- add `chat_template_settings` to `GenerationSettings`
- allow chat template settings in CLI arguments and loader
- adjust tokenization to pass chat template settings
- update tokenizer methods to accept the new parameter
- test coverage for new settings

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6846b229ce4c8323921713113b553e96