### PR TITLE
Replace no_grad with inference_mode

### DIFF
--- a/src/avalan/model/audio.py
+++ b/src/avalan/model/audio.py
@@ -3,7 +3,7 @@ from ..compat import override
 from ..model import TextGenerationVendor, TokenizerNotSupportedException
 from ..model.engine import Engine
 from PIL import Image
-from torch import argmax, no_grad
+from torch import argmax, inference_mode
 from torchaudio import load
 from torchaudio.transforms import Resample
 from transformers import (
@@ -72,7 +72,7 @@ class SpeechRecognitionModel(BaseAudioModel):
             sampling_rate=sampling_rate,
             return_tensors=tensor_format,
         )
-        with no_grad():
+        with inference_mode():
             # shape (batch, time_steps, vocab_size)
             logits = self._model(inputs.input_values).logits
         predicted_ids = argmax(logits, dim=-1)

--- a/src/avalan/model/nlp/__init__.py
+++ b/src/avalan/model/nlp/__init__.py
@@ -13,7 +13,7 @@ from torch import (
     int16,
     int32,
     int64,
-    no_grad,
+    inference_mode,
     Tensor,
     uint8,
 )
@@ -78,7 +78,7 @@ class BaseNLPModel(TransformerModel, ABC):
             del generation_kwargs["eos_token_id"]
 
         with (
-            no_grad()
+            inference_mode()
             if not settings.enable_gradient_calculation
             else nullcontext()
         ):

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -4,7 +4,7 @@ from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from contextlib import nullcontext
 from numpy import ndarray
-from torch import no_grad
+from torch import inference_mode
 from transformers import PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
 from typing import Literal
@@ -72,6 +72,10 @@ class SentenceTransformerModel(BaseNLPModel):
             + "needs to be loaded first"
         )
         assert isinstance(input, str) or isinstance(input, list)
-        with no_grad() if not enable_gradient_calculation else nullcontext():
+        with (
+            inference_mode()
+            if not enable_gradient_calculation
+            else nullcontext()
+        ):
             embeddings = self._model.encode(input, convert_to_numpy=True)
         return embeddings

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -3,7 +3,7 @@ from ...entities import GenerationSettings, Input
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from dataclasses import replace
-from torch import argmax, no_grad, softmax, Tensor
+from torch import argmax, inference_mode, softmax, Tensor
 from transformers import (
     AutoModelForSequenceClassification,
     AutoModelForSeq2SeqLM,
@@ -69,7 +69,7 @@ class SequenceClassificationModel(BaseNLPModel):
             + "needs to be loaded first"
         )
         inputs = self._tokenize_input(input, system_prompt=None, context=None)
-        with no_grad():
+        with inference_mode():
             outputs = self._model(**inputs)
             # logits shape (batch_size, num_labels)
             label_probs = softmax(outputs.logits, dim=-1)

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -1,7 +1,7 @@
 from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
-from torch import argmax, no_grad
+from torch import argmax, inference_mode
 from transformers import AutoModelForTokenClassification, PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
 from typing import Literal
@@ -62,7 +62,7 @@ class TokenClassificationModel(BaseNLPModel):
             + "needs to be loaded first"
         )
         inputs = self._tokenize_input(input, system_prompt=None, context=None)
-        with no_grad():
+        with inference_mode():
             outputs = self._model(**inputs)
             # logits shape (1, seq_len, num_labels)
             label_ids = argmax(outputs.logits, dim=2)

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -11,7 +11,7 @@ from ...model.nlp import BaseNLPModel
 from ...model.vision import BaseVisionModel
 from ...model.transformer import TransformerModel
 from PIL import Image
-from torch import no_grad, Tensor
+from torch import inference_mode, Tensor
 from transformers import (
     AutoImageProcessor,
     AutoModelForImageClassification,
@@ -50,7 +50,7 @@ class ImageClassificationModel(BaseVisionModel):
         image = BaseVisionModel._get_image(image_source)
         inputs = self._processor(image, return_tensors=tensor_format)
 
-        with no_grad():
+        with inference_mode():
             logits = self._model(**inputs).logits
 
         label_index = logits.argmax(dim=1).item()

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -78,7 +78,9 @@ class SpeechRecognitionModelCallTestCase(IsolatedAsyncioTestCase):
             patch("avalan.model.audio.load") as load_mock,
             patch("avalan.model.audio.Resample") as resample_mock,
             patch("avalan.model.audio.argmax") as argmax_mock,
-            patch("avalan.model.audio.no_grad", new=lambda: nullcontext()),
+            patch(
+                "avalan.model.audio.inference_mode", return_value=nullcontext()
+            ) as inference_mode_mock,
         ):
             processor_instance = MagicMock()
             processor_instance.return_value = MagicMock(input_values="inputs")
@@ -128,6 +130,7 @@ class SpeechRecognitionModelCallTestCase(IsolatedAsyncioTestCase):
             model_instance.assert_called_once_with("inputs")
             argmax_mock.assert_called_once_with("logits", dim=-1)
             processor_instance.batch_decode.assert_called_once_with("pred")
+            inference_mode_mock.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/model/nlp/sequence_test.py
+++ b/tests/model/nlp/sequence_test.py
@@ -103,8 +103,9 @@ class SequenceClassificationModelCallTestCase(IsolatedAsyncioTestCase):
                 AutoModelForSequenceClassification, "from_pretrained"
             ) as auto_model_mock,
             patch(
-                "avalan.model.nlp.sequence.no_grad", new=lambda: nullcontext()
-            ),
+                "avalan.model.nlp.sequence.inference_mode",
+                return_value=nullcontext(),
+            ) as inference_mode_mock,
             patch("avalan.model.nlp.sequence.softmax") as softmax_mock,
             patch("avalan.model.nlp.sequence.argmax") as argmax_mock,
         ):
@@ -153,6 +154,7 @@ class SequenceClassificationModelCallTestCase(IsolatedAsyncioTestCase):
             )
             softmax_mock.assert_called_once_with(outputs.logits, dim=-1)
             argmax_mock.assert_called_once_with("probs", dim=-1)
+            inference_mode_mock.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/model/nlp/token_test.py
+++ b/tests/model/nlp/token_test.py
@@ -131,7 +131,10 @@ class TokenClassificationModelCallTestCase(IsolatedAsyncioTestCase):
                 TokenClassificationModel, "_tokenize_input", return_value=inputs
             ) as tokenize_mock,
             patch("avalan.model.nlp.token.argmax") as argmax_mock,
-            patch("avalan.model.nlp.token.no_grad", new=lambda: nullcontext()),
+            patch(
+                "avalan.model.nlp.token.inference_mode",
+                return_value=nullcontext(),
+            ) as inference_mode_mock,
         ):
             tokenizer_mock = MagicMock(spec=PreTrainedTokenizerFast)
             tokenizer_mock.convert_ids_to_tokens.return_value = ["a", "b", "c"]
@@ -169,6 +172,7 @@ class TokenClassificationModelCallTestCase(IsolatedAsyncioTestCase):
                 self.model_id, use_fast=True
             )
             auto_model_mock.assert_called_once()
+            inference_mode_mock.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/model/vision/image_classification_test.py
+++ b/tests/model/vision/image_classification_test.py
@@ -83,8 +83,9 @@ class ImageClassificationModelCallTestCase(IsolatedAsyncioTestCase):
                 AutoModelForImageClassification, "from_pretrained"
             ) as model_mock,
             patch(
-                "avalan.model.vision.image.no_grad", new=lambda: nullcontext()
-            ),
+                "avalan.model.vision.image.inference_mode",
+                return_value=nullcontext(),
+            ) as inference_mode_mock,
             patch.object(BaseVisionModel, "_get_image") as get_image_mock,
         ):
             processor_instance = MagicMock()
@@ -124,6 +125,7 @@ class ImageClassificationModelCallTestCase(IsolatedAsyncioTestCase):
             self.assertEqual(
                 model_instance.call_args, call(**{"pixel_values": "inputs"})
             )
+            inference_mode_mock.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- speed up model inference by replacing `no_grad` with `inference_mode`
- ensure inference_mode is invoked in token, sequence, audio and vision tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6846bb29689c8323b95154a05a75c677