### PR TITLE
Replace Optional with union syntax

### DIFF
--- a/src/avalan/agent/__init__.py
+++ b/src/avalan/agent/__init__.py
@@ -6,7 +6,7 @@ from ..entities import (
 )
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Optional, Union
+from typing import Union
 
 
 class NoOperationAvailableException(Exception):
@@ -40,13 +40,13 @@ class Role:
 @dataclass(frozen=True, kw_only=True)
 class Specification:
     role: Role
-    goal: Optional[Goal]
+    goal: Goal | None
     rules: list[str] = field(default_factory=list)
     input_type: InputType = InputType.TEXT
     output_type: OutputType = OutputType.TEXT
-    settings: Optional[GenerationSettings] = None
-    template_id: Optional[str] = None
-    template_vars: Optional[dict] = None
+    settings: GenerationSettings | None = None
+    template_id: str | None = None
+    template_vars: dict | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/agent/engine.py
+++ b/src/avalan/agent/engine.py
@@ -15,19 +15,19 @@ from ..tool.manager import ToolManager
 from ..event import Event, EventType
 from ..event.manager import EventManager
 from dataclasses import replace
-from typing import Any, Optional, Union, Tuple
+from typing import Any, Union, Tuple
 from uuid import UUID, uuid4
 
 
 class EngineAgent(ABC):
     _id: UUID
-    _name: Optional[str]
+    _name: str | None
     _model: Engine
     _memory: MemoryManager
     _tool: ToolManager
     _event_manager: EventManager
-    _last_output: Optional[TextGenerationResponse] = None
-    _last_prompt: Optional[Tuple[Input, Optional[str]]] = None
+    _last_output: TextGenerationResponse | None = None
+    _last_prompt: Tuple[Input, str | None] | None = None
 
     @abstractmethod
     def _prepare_call(
@@ -44,10 +44,10 @@ class EngineAgent(ABC):
         return self._model
 
     @property
-    def output(self) -> Optional[TextGenerationResponse]:
+    def output(self) -> TextGenerationResponse | None:
         return self._last_output
 
-    async def input_token_count(self) -> Optional[int]:
+    async def input_token_count(self) -> int | None:
         if not self._last_prompt:
             return None
         await self._event_manager.trigger(
@@ -70,8 +70,8 @@ class EngineAgent(ABC):
         tool: ToolManager,
         event_manager: EventManager,
         *args,
-        name: Optional[str] = None,
-        id: Optional[UUID] = None,
+        name: str | None = None,
+        id: UUID | None = None,
     ):
         self._id = id or uuid4()
         self._name = name
@@ -96,8 +96,8 @@ class EngineAgent(ABC):
         self,
         input: str,
         *args,
-        settings: Optional[GenerationSettings] = None,
-        system_prompt: Optional[str] = None,
+        settings: GenerationSettings | None = None,
+        system_prompt: str | None = None,
         skip_special_tokens=True,
         **kwargs,
     ) -> Union[TextGenerationResponse]:
@@ -124,7 +124,7 @@ class EngineAgent(ABC):
             self._memory.has_permanent_message
             or self._memory.has_recent_message
         ) and isinstance(input, Message):
-            previous_message: Optional[Message] = None
+            previous_message: Message | None = None
             new_message: Message = input
 
             # Handle last message if not already consumed

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -20,7 +20,6 @@ from logging import Logger
 from os import access, R_OK
 from os.path import exists
 from tomllib import load
-from typing import Optional
 from uuid import UUID, uuid4
 
 
@@ -35,7 +34,7 @@ class OrchestratorLoader:
         cls,
         path: str,
         *args,
-        agent_id: Optional[UUID],
+        agent_id: UUID | None,
         hub: HuggingfaceHub,
         logger: Logger,
         participant_id: UUID,
@@ -357,8 +356,8 @@ class OrchestratorLoader:
         event_manager: EventManager,
         config: dict,
         agent_config: dict,
-        call_options: Optional[dict],
-        template_vars: Optional[dict],
+        call_options: dict | None,
+        template_vars: dict | None,
     ) -> JsonOrchestrator:
         assert "json" in config, "No json section in configuration"
         assert "instructions" in agent_config, (

--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -24,13 +24,13 @@ from contextlib import ExitStack
 from dataclasses import asdict
 from json import dumps
 from logging import Logger
-from typing import Any, Optional, Union, Type
+from typing import Any, Union, Type
 from uuid import UUID, uuid4
 
 
 class Orchestrator:
     _id: UUID
-    _name: Optional[str]
+    _name: str | None
     _operations: list[Operation]
     _renderer: Renderer
     _total_operations: int
@@ -41,10 +41,10 @@ class Orchestrator:
     _event_manager: EventManager
     _engine_agents: dict[EngineEnvironment, EngineAgent] = {}
     _engines_stack: ExitStack = ExitStack()
-    _operation_step: Optional[int] = None
+    _operation_step: int | None = None
     _model_ids: set[str] = set()
-    _call_options: Optional[dict] = None
-    _last_engine_agent: Optional[EngineAgent] = None
+    _call_options: dict | None = None
+    _last_engine_agent: EngineAgent | None = None
     _exit_memory: bool = True
 
     def __init__(
@@ -56,11 +56,11 @@ class Orchestrator:
         event_manager: EventManager,
         operations: Union[Operation, list[Operation]],
         *,
-        call_options: Optional[dict] = None,
+        call_options: dict | None = None,
         exit_memory: bool = True,
-        id: Optional[UUID] = None,
-        name: Optional[str] = None,
-        renderer: Optional[Renderer] = None,
+        id: UUID | None = None,
+        name: str | None = None,
+        renderer: Renderer | None = None,
     ):
         self._logger = logger
         self._model_manager = model_manager
@@ -78,11 +78,11 @@ class Orchestrator:
         self._call_options = call_options
 
     @property
-    def engine_agent(self) -> Optional[EngineAgent]:
+    def engine_agent(self) -> EngineAgent | None:
         return self._last_engine_agent
 
     @property
-    def engine(self) -> Optional[Engine]:
+    def engine(self) -> Engine | None:
         return (
             self._last_engine_agent.engine if self._last_engine_agent else None
         )
@@ -92,7 +92,7 @@ class Orchestrator:
         return self._id
 
     @property
-    def input_token_count(self) -> Optional[int]:
+    def input_token_count(self) -> int | None:
         return (
             self._last_engine_agent.input_token_count
             if self._last_engine_agent
@@ -115,7 +115,7 @@ class Orchestrator:
         return self._model_ids
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         return self._name
 
     @property
@@ -195,7 +195,7 @@ class Orchestrator:
         )
 
     async def __aenter__(self):
-        first_agent: Optional[TemplateEngineAgent] = None
+        first_agent: TemplateEngineAgent | None = None
         model_ids: list[str] = []
         for operation in self._operations:
             # Load engine with environment
@@ -233,9 +233,9 @@ class Orchestrator:
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[Any],
+        exc_type: Type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any | None,
     ):
         if (
             self._last_engine_agent

--- a/src/avalan/agent/orchestrator/orchestrators/default.py
+++ b/src/avalan/agent/orchestrator/orchestrators/default.py
@@ -6,7 +6,6 @@ from ....memory.manager import MemoryManager
 from ....model.manager import ModelManager
 from ....tool.manager import ToolManager
 from logging import Logger
-from typing import Optional
 from uuid import UUID
 
 
@@ -20,16 +19,16 @@ class DefaultOrchestrator(Orchestrator):
         tool: ToolManager,
         event_manager: EventManager,
         *,
-        name: Optional[str],
+        name: str | None,
         role: str,
         task: str,
         instructions: str,
-        rules: Optional[list[str]],
-        template_id: Optional[str] = None,
-        settings: Optional[TransformerEngineSettings] = None,
-        call_options: Optional[dict] = None,
-        template_vars: Optional[dict] = None,
-        id: Optional[UUID] = None,
+        rules: list[str] | None,
+        template_id: str | None = None,
+        settings: TransformerEngineSettings | None = None,
+        call_options: dict | None = None,
+        template_vars: dict | None = None,
+        id: UUID | None = None,
     ):
         specification = Specification(
             role=role,

--- a/src/avalan/agent/orchestrator/orchestrators/json.py
+++ b/src/avalan/agent/orchestrator/orchestrators/json.py
@@ -15,7 +15,7 @@ from ....model.manager import ModelManager
 from ....tool.manager import ToolManager
 from logging import Logger
 from dataclasses import dataclass
-from typing import Annotated, Optional, Union, get_args, get_origin
+from typing import Annotated, Union, get_args, get_origin
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -31,7 +31,7 @@ class Property:
     }
     name: str
     data_type: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class JsonSpecification(Specification):
@@ -94,12 +94,12 @@ class JsonOrchestrator(Orchestrator):
         role: str,
         task: str,
         instructions: str,
-        name: Optional[str] = None,
-        rules: Optional[list[str]] = [],
-        template_id: Optional[str] = None,
-        settings: Optional[TransformerEngineSettings] = None,
-        call_options: Optional[dict] = None,
-        template_vars: Optional[dict] = None,
+        name: str | None = None,
+        rules: list[str] | None = [],
+        template_id: str | None = None,
+        settings: TransformerEngineSettings | None = None,
+        call_options: dict | None = None,
+        template_vars: dict | None = None,
     ):
         specification = JsonSpecification(
             output=output,

--- a/src/avalan/agent/renderer.py
+++ b/src/avalan/agent/renderer.py
@@ -11,7 +11,7 @@ from jinja2 import (
 )
 from os import linesep
 from os.path import dirname, join
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 
@@ -22,7 +22,7 @@ class Renderer:
     _templates: dict[str, Template] = {}
 
     def __init__(
-        self, templates_path: Optional[str] = None, clean_spaces: bool = True
+        self, templates_path: str | None = None, clean_spaces: bool = True
     ):
         self._clean_spaces = clean_spaces
         self._environment = TemplateEnvironment(
@@ -48,7 +48,7 @@ class Renderer:
     def from_string(
         self,
         template: str,
-        template_vars: Optional[dict] = None,
+        template_vars: dict | None = None,
         encoding: str = "utf-8",
     ) -> str:
         return (
@@ -69,8 +69,8 @@ class TemplateEngineAgent(EngineAgent):
         event_manager: EventManager,
         renderer: Renderer,
         *args,
-        name: Optional[str] = None,
-        id: Optional[UUID] = None,
+        name: str | None = None,
+        id: UUID | None = None,
     ):
         super().__init__(
             model,

--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -4,7 +4,6 @@ from rich.padding import Padding
 from rich.prompt import Confirm, Prompt
 from select import select
 from sys import stdin
-from typing import Optional
 
 
 class PromptWithoutPrefix(Prompt):
@@ -26,7 +25,7 @@ def has_input(console: Console) -> bool:
 
 def get_input(
     console: Console,
-    prompt: Optional[str],
+    prompt: str | None,
     *,
     echo_stdin: bool = True,
     force_prompt: bool = False,
@@ -36,7 +35,7 @@ def get_input(
     strip_stdin: bool = True,
     suffix_line: bool = True,
     tty_path: str = "/dev/tty",
-) -> Optional[str]:
+) -> str | None:
     full_prompt = f"{prompt} "
     is_input_available = has_input(console)
     if not force_prompt and is_input_available:

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1132,7 +1132,7 @@ class CLI:
         hub: HuggingfaceHub,
         suggest_login: bool = False,
     ) -> None:
-        user: Optional[User] = None
+        user: User | None = None
         _ = theme._
 
         verbosity = args.verbose or 0

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 from rich.syntax import Syntax
 from rich.theme import Theme
-from typing import Optional, Mapping
+from typing import Mapping
 from dataclasses import fields
 from ...tool.browser import BrowserToolSettings
 from uuid import UUID, uuid4
@@ -392,7 +392,7 @@ async def agent_run(
                 )
             )
 
-        input_string: Optional[str] = None
+        input_string: str | None = None
         in_conversation = False
         while not input_string or in_conversation:
             logger.debug(

--- a/src/avalan/cli/commands/tokenizer.py
+++ b/src/avalan/cli/commands/tokenizer.py
@@ -6,7 +6,6 @@ from ...model.nlp.text.generation import TextGenerationModel
 from logging import Logger
 from rich.console import Console
 from rich.theme import Theme
-from typing import Optional
 
 
 async def tokenize(
@@ -15,7 +14,7 @@ async def tokenize(
     theme: Theme,
     hub: HuggingfaceHub,
     logger: Logger,
-) -> Optional[list[Token]]:
+) -> list[Token] | None:
     assert args.tokenizer
 
     _, _i, _n = theme._, theme.icons, theme._n

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -24,7 +24,7 @@ from humanize import intcomma, intword, naturalsize, naturaltime
 from logging import Logger
 from numpy import ndarray
 from rich.console import RenderableType
-from typing import Callable, Generator, Literal, Optional, Tuple, Union
+from typing import Callable, Generator, Literal, Tuple, Union
 from uuid import UUID
 
 Formatter = Union[
@@ -93,7 +93,7 @@ class Theme(ABC):
         agent: Orchestrator,
         *args,
         models: list[Model | str],
-        cans_access: Optional[bool],
+        cans_access: bool | None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -123,7 +123,7 @@ class Theme(ABC):
 
     @abstractmethod
     def cache_delete(
-        self, cache_deletion: Optional[HubCacheDeletion], deleted: bool
+        self, cache_deletion: HubCacheDeletion | None, deleted: bool
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -132,7 +132,7 @@ class Theme(ABC):
         self,
         cache_dir: str,
         cached_models: list[HubCache],
-        display_models: Optional[list[str]] = None,
+        display_models: list[str] | None = None,
         show_summary: bool = False,
     ) -> RenderableType:
         raise NotImplementedError()
@@ -171,12 +171,12 @@ class Theme(ABC):
         meanv: float,
         stdv: float,
         normv: float,
-        embedding_peek: Optional[int] = 3,
+        embedding_peek: int | None = 3,
         horizontal: bool = True,
         input_string_peek: int = 40,
         show_stats: bool = True,
-        partition: Optional[int] = None,
-        total_partitions: Optional[int] = None,
+        partition: int | None = None,
+        total_partitions: int | None = None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -203,7 +203,7 @@ class Theme(ABC):
         self,
         model: Model,
         *args,
-        can_access: Optional[bool] = None,
+        can_access: bool | None = None,
         expand: bool = False,
         summary: bool = False,
     ) -> RenderableType:
@@ -212,9 +212,7 @@ class Theme(ABC):
     @abstractmethod
     def model_display(
         self,
-        model_config: Optional[
-            Union[ModelConfig, SentenceTransformerModelConfig]
-        ],
+        model_config: Union[ModelConfig, SentenceTransformerModelConfig] | None,
         tokenizer_config: TokenizerConfig,
         *args,
         is_runnable: bool | None = None,
@@ -260,9 +258,9 @@ class Theme(ABC):
     def tokenizer_tokens(
         self,
         dtokens: list[Token],
-        added_tokens: Optional[list[str]],
-        special_tokens: Optional[list[str]],
-        current_dtoken: Optional[Token] = None,
+        added_tokens: list[str] | None,
+        special_tokens: list[str] | None,
+        current_dtoken: Token | None = None,
         dtokens_selected: list[Token] = [],
     ) -> RenderableType:
         raise NotImplementedError()
@@ -271,14 +269,14 @@ class Theme(ABC):
     async def tokens(
         self,
         model_id: str,
-        added_tokens: Optional[list[str]],
-        special_tokens: Optional[list[str]],
-        display_token_size: Optional[int],
+        added_tokens: list[str] | None,
+        special_tokens: list[str] | None,
+        display_token_size: int | None,
         display_probabilities: bool,
         pick: int,
-        focus_on_token_when: Optional[Callable[[Token], bool]],
+        focus_on_token_when: Callable[[Token], bool] | None,
         text_tokens: list[str],
-        tokens: Optional[list[Token]],
+        tokens: list[Token] | None,
         input_token_count: int,
         total_tokens: int,
         tool_events: list[Event] | None,
@@ -289,9 +287,9 @@ class Theme(ABC):
         ellapsed: float,
         console_width: int,
         logger: Logger,
-        event_stats: Optional[EventStats] = None,
-        maximum_frames: Optional[int] = None,
-        logits_count: Optional[int] = None,
+        event_stats: EventStats | None = None,
+        maximum_frames: int | None = None,
+        logits_count: int | None = None,
         tool_events_limit: int | None = None,
         think_height: int = 6,
         think_padding: int = 1,
@@ -301,7 +299,7 @@ class Theme(ABC):
         limit_think_height: bool = True,
         limit_answer_height: bool = False,
         start_thinking: bool = False,
-    ) -> Generator[Tuple[Optional[Token], RenderableType], None, None]:
+    ) -> Generator[Tuple[Token | None, RenderableType], None, None]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -311,7 +309,7 @@ class Theme(ABC):
         name: str,
         version: str,
         license: str,
-        user: Optional[User],
+        user: User | None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -395,7 +393,7 @@ class Theme(ABC):
         self,
         data: Data,
         value: DataValue,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
         icon: Union[bool, str] = True,
     ) -> str:
         return (

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -49,7 +49,7 @@ from rich.rule import Rule
 from rich.table import Column, Table
 from rich.text import Text
 from textwrap import wrap
-from typing import Callable, Generator, Optional, Tuple, Union
+from typing import Callable, Generator, Tuple, Union
 from uuid import UUID
 
 
@@ -190,7 +190,7 @@ class FancyTheme(Theme):
         agent: Orchestrator,
         *args,
         models: list[Model | str],
-        can_access: Optional[bool],
+        can_access: bool | None,
     ) -> RenderableType:
         _, _f, _i = self._, self._f, self._icons
         models_group = Group(
@@ -277,7 +277,7 @@ class FancyTheme(Theme):
         return _i["bye"] + " " + _("bye :)")
 
     def cache_delete(
-        self, cache_deletion: Optional[HubCacheDeletion], deleted=False
+        self, cache_deletion: HubCacheDeletion | None, deleted=False
     ) -> RenderableType:
         _, _f, _n, _i = self._, self._f, self._n, self._icons
         if not cache_deletion or (
@@ -356,7 +356,7 @@ class FancyTheme(Theme):
         self,
         cache_dir: str,
         cached_models: list[HubCache],
-        display_models: Optional[list[str]] = None,
+        display_models: list[str] | None = None,
         show_summary: bool = False,
     ) -> RenderableType:
         _ = self._
@@ -387,7 +387,7 @@ class FancyTheme(Theme):
                     footer_style="bold cyan",
                 )
 
-                last_revision: Optional[str] = None
+                last_revision: str | None = None
                 for revision, files in model_cache.files.items():
                     for file in files:
                         new_revision = (
@@ -527,12 +527,12 @@ class FancyTheme(Theme):
         meanv: float,
         stdv: float,
         normv: float,
-        embedding_peek: Optional[int] = 3,
+        embedding_peek: int | None = 3,
         horizontal: bool = True,
         input_string_peek: int = 30,
         show_stats: bool = True,
-        partition: Optional[int] = None,
-        total_partitions: Optional[int] = None,
+        partition: int | None = None,
+        total_partitions: int | None = None,
     ) -> RenderableType:
         _ = self._
 
@@ -542,7 +542,7 @@ class FancyTheme(Theme):
             or (embedding_peek and embeddings.size > 2 * embedding_peek)
         )
 
-        peek_table: Optional[Table] = None
+        peek_table: Table | None = None
         if embedding_peek and embeddings.size > 2 * embedding_peek:
             input_title = (
                 input_string[:input_string_peek] + "…"
@@ -604,7 +604,7 @@ class FancyTheme(Theme):
                         intcomma(start_i + i), clamp(v, format="{:.4g}")
                     )
 
-        stats: Optional[Table] = None
+        stats: Table | None = None
         if show_stats:
             stats = Table(
                 show_footer=False,
@@ -812,7 +812,7 @@ class FancyTheme(Theme):
         self,
         model: Model,
         *args,
-        can_access: Optional[bool] = None,
+        can_access: bool | None = None,
         expand: bool = False,
         summary: bool = False,
     ) -> RenderableType:
@@ -948,9 +948,7 @@ class FancyTheme(Theme):
 
     def model_display(
         self,
-        model_config: Optional[
-            Union[ModelConfig, SentenceTransformerModelConfig]
-        ],
+        model_config: Union[ModelConfig, SentenceTransformerModelConfig] | None,
         tokenizer_config: TokenizerConfig,
         *args,
         is_runnable: bool | None = None,
@@ -1296,10 +1294,10 @@ class FancyTheme(Theme):
     def tokenizer_tokens(
         self,
         dtokens: list[Token],
-        added_tokens: Optional[list[str]],
-        special_tokens: Optional[list[str]],
+        added_tokens: list[str] | None,
+        special_tokens: list[str] | None,
         display_details: bool = False,
-        current_dtoken: Optional[Token] = None,
+        current_dtoken: Token | None = None,
         dtokens_selected: list[Token] = [],
     ) -> RenderableType:
         # Build token panels
@@ -1343,14 +1341,14 @@ class FancyTheme(Theme):
     async def tokens(
         self,
         model_id: str,
-        added_tokens: Optional[list[str]],
-        special_tokens: Optional[list[str]],
-        display_token_size: Optional[int],
+        added_tokens: list[str] | None,
+        special_tokens: list[str] | None,
+        display_token_size: int | None,
         display_probabilities: bool,
         pick: int,
-        focus_on_token_when: Optional[Callable[[Token], bool]],
+        focus_on_token_when: Callable[[Token], bool] | None,
         text_tokens: list[str],
-        tokens: Optional[list[Token]],
+        tokens: list[Token] | None,
         input_token_count: int,
         total_tokens: int,
         tool_events: list[Event] | None,
@@ -1362,9 +1360,9 @@ class FancyTheme(Theme):
         ellapsed: float,
         console_width: int,
         logger: Logger,
-        event_stats: Optional[EventStats] = None,
-        maximum_frames: Optional[int] = None,
-        logits_count: Optional[int] = None,
+        event_stats: EventStats | None = None,
+        maximum_frames: int | None = None,
+        logits_count: int | None = None,
         tool_events_limit: int | None = None,
         think_height: int = 6,
         think_padding: int = 1,
@@ -1374,7 +1372,7 @@ class FancyTheme(Theme):
         limit_think_height: bool = True,
         limit_answer_height: bool = False,
         start_thinking: bool = False,
-    ) -> Generator[Tuple[Optional[Token], RenderableType], None, None]:
+    ) -> Generator[Tuple[Token | None, RenderableType], None, None]:
         _, _n, _f, _l = self._, self._n, self._f, logger.debug
 
         # Prepare data for rendering
@@ -1563,7 +1561,8 @@ class FancyTheme(Theme):
                     + event.payload["result"].result
                     + "[/spring_green3]",
                 )
-                if event.type == EventType.TOOL_RESULT and event.payload["result"]
+                if event.type == EventType.TOOL_RESULT
+                and event.payload["result"]
                 else _n(
                     "Executing {total_calls} tool: {calls}",
                     "Executing {total_calls} tools: {calls}",
@@ -1626,19 +1625,19 @@ class FancyTheme(Theme):
             return
 
         # Deal with token details
-        dtokens_selected_last_index_yielded: Optional[int] = None
+        dtokens_selected_last_index_yielded: int | None = None
         yielded_frames = 0
         yield_next_frame = True
 
         # As long as we need more frames, we keep yielding
         while yield_next_frame:
-            current_selected_index: Optional[int] = None
-            tokens_distribution_panel: Optional[Panel] = None
+            current_selected_index: int | None = None
+            tokens_distribution_panel: Panel | None = None
 
             if display_token_size and tokens:
                 # Pick current token to highlight
                 current_data = None
-                current_dtoken: Optional[Token] = None
+                current_dtoken: Token | None = None
                 if display_probabilities and dtokens_selected:
                     current_selected_index = (
                         0
@@ -1819,8 +1818,8 @@ class FancyTheme(Theme):
     def _tokens_table(
         self,
         dbatch: list[Token],
-        current_dtoken: Optional[Token],
-        max_dtoken: Optional[Token],
+        current_dtoken: Token | None,
+        max_dtoken: Token | None,
     ):
         _p = self._percentage
 
@@ -1860,7 +1859,7 @@ class FancyTheme(Theme):
         name: str,
         version: str,
         license: str,
-        user: Optional[User],
+        user: User | None,
     ) -> RenderableType:
         _, _f, _i = self._, self._f, self._icons
         license_text = _("{license} license").format(license=license)
@@ -1889,7 +1888,7 @@ class FancyTheme(Theme):
             pad=(0, 0, 0, 0),  # Might bring lower padding back (0,0,1,0)
         )
 
-    def _parameter_count(self, parameters: Optional[int]) -> str:
+    def _parameter_count(self, parameters: int | None) -> str:
         _ = self._
         if not parameters:
             return _("N/A")

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import StrEnum
 from numpy import ndarray
 from torch import dtype, Tensor
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 from uuid import UUID
 
 AttentionImplementation = Literal[
@@ -80,23 +80,23 @@ class DistanceType(StrEnum):
 class EngineSettings:
     auto_load_model: bool = True
     auto_load_tokenizer: bool = True
-    cache_dir: Optional[str] = None
+    cache_dir: str | None = None
     change_transformers_logging_level = True
-    device: Optional[str] = None
+    device: str | None = None
     disable_loading_progress_bar: bool = True
     enable_eval: bool = True
     trust_remote_code: bool = False
-    tokenizer_name_or_path: Optional[str] = None
+    tokenizer_name_or_path: str | None = None
 
 
 @dataclass(kw_only=True, frozen=True)
 class EngineUri:
-    host: Optional[str]
-    port: Optional[int]
-    user: Optional[str]
-    password: Optional[str]
-    vendor: Optional[Vendor]
-    model_id: Optional[str]
+    host: str | None
+    port: int | None
+    user: str | None
+    password: str | None
+    vendor: Vendor | None
+    model_id: str | None
     params: dict[str, Union[str, int, float, bool]]
 
     @property
@@ -108,29 +108,29 @@ class EngineUri:
 class GenerationSettings:
     # Generation length ------------------------------------------------------
     # The minimum numbers of tokens to generate, ignoring the number of tokens in the prompt.
-    min_new_tokens: Optional[int] = None
+    min_new_tokens: int | None = None
     # The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt
-    max_new_tokens: Optional[int] = None
+    max_new_tokens: int | None = None
     # The minimum length of the sequence to be generated. Corresponds to the length of the input prompt + min_new_tokens. Its effect is overridden by min_new_tokens, if also set.
-    min_length: Optional[int] = 0
+    min_length: int | None = 0
     # The maximum length the generated tokens can have. Corresponds to the length of the input prompt + max_new_tokens. Its effect is overridden by max_new_tokens, if also set.
-    max_length: Optional[int] = 20
+    max_length: int | None = 20
     # Controls the stopping condition for beam-based methods, like beam-search. It accepts the following values: True, where the generation stops as soon as there are num_beams complete candidates; False, where an heuristic is applied and the generation stops when is it very unlikely to find better candidates; "never", where the beam search procedure only stops when there cannot be better candidates (canonical beam search algorithm)
-    early_stopping: Optional[Union[str, bool]] = False
+    early_stopping: Union[str, bool] | None = False
     # The maximum amount of time you allow the computation to run for in seconds. generation will still finish the current pass after allocated time has been passed.
-    max_time: Optional[float] = None
+    max_time: float | None = None
     # A string or a list of strings that should terminate generation if the model outputs them.
-    stop_strings: Optional[Union[str, list[str]]] = None
+    stop_strings: Union[str, list[str]] | None = None
 
     # Generation strategy ----------------------------------------------------
     # Whether or not to use sampling. Use greedy decoding otherwise
     do_sample: bool = False
     # Number of beams for beam search. 1 means no beam search.
-    num_beams: Optional[int] = 1
+    num_beams: int | None = 1
     # Number of groups to divide num_beams into in order to ensure diversity among different groups of beams
-    num_beam_groups: Optional[int] = 1
+    num_beam_groups: int | None = 1
     # The values balance the model confidence and the degeneration penalty in contrastive search decoding
-    penalty_alpha: Optional[float] = None
+    penalty_alpha: float | None = None
 
     # Cache ------------------------------------------------------------------
     # Whether or not the model should use the past last key/values attentions (if applicable to the model) to speed up decoding
@@ -138,47 +138,47 @@ class GenerationSettings:
 
     # Generation output variables --------------------------------------------
     # The number of independently computed returned sequences for each element in the batch.
-    num_return_sequences: Optional[int] = 1
+    num_return_sequences: int | None = 1
     # Whether or not to return the attentions tensors of all attention layers. See attentions under returned tensors for more details.
-    output_attentions: Optional[bool] = False
+    output_attentions: bool | None = False
     # Whether or not to return the hidden states of all layers. See hidden_states under returned tensors for more details.
-    output_hidden_states: Optional[bool] = False
+    output_hidden_states: bool | None = False
     # Whether or not to return the prediction scores. See scores under returned tensors for more details.
-    output_scores: Optional[bool] = False
+    output_scores: bool | None = False
     # Whether or not to return the unprocessed prediction logit scores. See logits under returned tensors for more details.
-    output_logits: Optional[bool] = None
+    output_logits: bool | None = None
     # Whether or not to return a ModelOutput, as opposed to returning exclusively the generated sequence. This flag must be set to True to return the generation cache (when use_cache is True) or optional outputs (see flags starting with output_)
-    return_dict_in_generate: Optional[bool] = False
+    return_dict_in_generate: bool | None = False
 
     # Output logits manipulation ---------------------------------------------
     # The value used to module the next token probabilities
-    temperature: Optional[float] = 1.0
+    temperature: float | None = 1.0
     # The number of highest probability vocabulary tokens to keep for top-k-filtering
-    top_k: Optional[int] = 50
+    top_k: int | None = 50
     # If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to top_p or higher are kept for generation
-    top_p: Optional[float] = 1.0
+    top_p: float | None = 1.0
     # Minimum token probability, which will be scaled by the probability of the most likely token. It must be a value between 0 and 1. Typical values are in the 0.01-0.2 range, comparably selective as setting top_p in the 0.99-0.8 range (use the opposite of normal top_p values)
-    min_p: Optional[float] = None
+    min_p: float | None = None
     # The parameter for repetition penalty. 1.0 means no penalty
-    repetition_penalty: Optional[float] = 1.0
+    repetition_penalty: float | None = 1.0
     # This value is subtracted from a beam’s score if it generates a token same as any beam from other group at a particular time. Note that diversity_penalty is only effective if group beam search is enabled
-    diversity_penalty: Optional[float] = 0.0
+    diversity_penalty: float | None = 0.0
     # The id of the token to force as the first generated token after the decoder_start_token_id. Useful for multilingual models like mBART where the first generated token needs to be the target language token.
-    forced_bos_token_id: Optional[int] = None
+    forced_bos_token_id: int | None = None
     # The id of the token to force as the last generated token when max_length is reached. Optionally, use a list to set multiple end-of-sequence tokens
-    forced_eos_token_id: Optional[Union[int, list[int]]] = None
+    forced_eos_token_id: Union[int, list[int]] | None = None
 
     # Special token usage in generation --------------------------------------
     # The id of the padding token.
-    pad_token_id: Optional[int] = None
+    pad_token_id: int | None = None
     # The id of the beginning-of-sequence token
-    bos_token_id: Optional[int] = None
+    bos_token_id: int | None = None
     # The id of the end-of-sequence token. Optionally, use a list to set multiple end-of-sequence tokens
-    eos_token_id: Optional[Union[int, list[int]]] = None
+    eos_token_id: Union[int, list[int]] | None = None
 
     # Assistant generation ---------------------------------------------------
     # The number of tokens to be output as candidate tokens.
-    prompt_lookup_num_tokens: Optional[int] = None
+    prompt_lookup_num_tokens: int | None = None
 
     # Inference settings -----------------------------------------------------
     # Gradient calculation (set to true when torch.backwards() is called)
@@ -230,16 +230,16 @@ class HubCacheDeletion:
 @dataclass(frozen=True, kw_only=True)
 class ImageEntity:
     label: str
-    score: Optional[float] = None
-    box: Optional[list[float]] = None
+    score: float | None = None
+    box: list[float] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
 class Message:
     role: MessageRole
     content: str
-    name: Optional[str] = None
-    arguments: Optional[dict] = None
+    name: str | None = None
+    arguments: dict | None = None
 
 
 Input = Union[str, list[str], Message, list[Message]]
@@ -264,24 +264,24 @@ class EngineMessageScored(EngineMessage):
 @dataclass(frozen=True, kw_only=True)
 class Model:
     id: str
-    parameters: Optional[int]
-    parameter_types: Optional[list[str]]
-    inference: Optional[str]
-    library_name: Optional[str]
-    license: Optional[str]
-    pipeline_tag: Optional[str]
+    parameters: int | None
+    parameter_types: list[str] | None
+    inference: str | None
+    library_name: str | None
+    license: str | None
+    pipeline_tag: str | None
     tags: list[str]
-    architectures: Optional[list[str]]
-    model_type: Optional[str]
-    auto_model: Optional[str]
-    processor: Optional[str]
-    gated: Optional[Literal["auto", "manual", False]]
+    architectures: list[str] | None
+    model_type: str | None
+    auto_model: str | None
+    processor: str | None
+    gated: Literal["auto", "manual", False] | None
     private: bool
-    disabled: Optional[bool]
+    disabled: bool | None
     last_downloads: int
     downloads: int
     likes: int
-    ranking: Optional[int]
+    ranking: int | None
     author: str
     created_at: datetime
     updated_at: datetime
@@ -290,77 +290,77 @@ class Model:
 @dataclass(frozen=True, kw_only=True)
 class ModelConfig:
     # Model architectures that can be used with the model pretrained weights
-    architectures: Optional[list[str]]
+    architectures: list[str] | None
     # A dict that maps model specific attribute names to the standardized naming of attributes
     attribute_map: dict[str, str]
     # The id of the beginning-of-stream token
-    bos_token_id: Optional[str]
-    bos_token: Optional[str]
+    bos_token_id: str | None
+    bos_token: str | None
     # If an encoder-decoder model starts decoding with a different token than bos, the id of that token
-    decoder_start_token_id: Optional[int]
+    decoder_start_token_id: int | None
     # The id of the end-of-stream token
-    eos_token_id: Optional[int]
-    eos_token: Optional[str]
+    eos_token_id: int | None
+    eos_token: str | None
     # Name of the task used to fine-tune the model. This can be used when converting from an original (TensorFlow or PyTorch) checkpoint
-    finetuning_task: Optional[str]
+    finetuning_task: str | None
     # The hidden size of the model
-    hidden_size: Optional[int]
+    hidden_size: int | None
     # The hidden sizes of the model (ResNet)
-    hidden_sizes: Optional[list[int]]
+    hidden_sizes: list[int] | None
     # A list of keys to ignore by default when looking at dictionary outputs of the model during inference
     keys_to_ignore_at_inference: list[str]
     # The type of loss that the model should use
-    loss_type: Optional[str]
+    loss_type: str | None
     # Maximum input sequence length
-    max_position_embeddings: Optional[int]
+    max_position_embeddings: int | None
     # An identifier for the model type
     model_type: str
     # The number of attention heads used in the multi-head attention layers of the model
-    num_attention_heads: Optional[int]
+    num_attention_heads: int | None
     # The number of blocks in the model
-    num_hidden_layers: Optional[int]
+    num_hidden_layers: int | None
     # Number of labels to use in the last layer added to the model, typically for a classification task
-    num_labels: Optional[int]
+    num_labels: int | None
     # Whether or not the model should returns all attentions
     output_attentions: bool
     # Whether or not the model should return all hidden-states
     output_hidden_states: bool
     # The id of the padding token
-    pad_token_id: Optional[int]
-    pad_token: Optional[str]
+    pad_token_id: int | None
+    pad_token: str | None
     # A specific prompt that should be added at the beginning of each text before calling the model
-    prefix: Optional[str]
+    prefix: str | None
     # The id of the separation token
-    sep_token_id: Optional[int]
-    sep_token: Optional[str]
+    sep_token_id: int | None
+    sep_token: str | None
     state_size: int
     # Additional keyword arguments to store for the current task
-    task_specific_params: Optional[dict[str, any]]
+    task_specific_params: dict[str, any] | None
     # The dtype of the weight. Since the config object is stored in plain text, this attribute contains just the floating type string without the torcha
     torch_dtype: dtype
     # The number of tokens in the vocabulary, which is also the first dimension of the embeddings matrix
-    vocab_size: Optional[int]
+    vocab_size: int | None
     # The name of the associated tokenizer class to use (if none is set, will use the tokenizer associated to the model by default)
-    tokenizer_class: Optional[str]
+    tokenizer_class: str | None
 
 
 @dataclass(frozen=True, kw_only=True)
 class OrchestratorSettings:
     agent_id: UUID
-    orchestrator_type: Optional[str]
+    orchestrator_type: str | None
     agent_config: dict
     uri: str
     engine_config: dict
-    call_options: Optional[dict]
-    template_vars: Optional[dict]
-    memory_permanent: Optional[str]
+    call_options: dict | None
+    template_vars: dict | None
+    memory_permanent: str | None
     memory_recent: bool
     sentence_model_id: str
-    sentence_model_engine_config: Optional[dict]
+    sentence_model_engine_config: dict | None
     sentence_model_max_tokens: int
     sentence_model_overlap_size: int
     sentence_model_window_size: int
-    json_config: Optional[dict]
+    json_config: dict | None
     tools: list[str]
 
 
@@ -374,8 +374,8 @@ class SearchMatch:
 @dataclass(frozen=True, kw_only=True)
 class SentenceTransformerModelConfig:
     backend: Literal["torch", "onnx", "openvino"]
-    similarity_function: Optional[SimilarityFunction]
-    truncate_dimension: Optional[int]
+    similarity_function: SimilarityFunction | None
+    truncate_dimension: int | None
     transformer_model_config: ModelConfig
 
 
@@ -391,8 +391,8 @@ class Similarity:
 @dataclass(frozen=True, kw_only=True)
 class TokenizerConfig:
     name_or_path: str
-    tokens: Optional[list[str]]
-    special_tokens: Optional[list[str]]
+    tokens: list[str] | None
+    special_tokens: list[str] | None
     # Maximum sequence length the tokenizer supports
     tokenizer_model_max_length: int
     # Wether tokenizer is a Rust-based tokenizer
@@ -403,21 +403,21 @@ class TokenizerConfig:
 class Token:
     id: Union[Tensor, int]
     token: str
-    probability: Optional[float] = None
+    probability: float | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
 class TokenDetail(Token):
-    step: Optional[int] = None
-    probability_distribution: Optional[ProbabilityDistribution] = None
-    tokens: Optional[list[Token]] = None
+    step: int | None = None
+    probability_distribution: ProbabilityDistribution | None = None
+    tokens: list[Token] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
 class ToolCall:
     id: UUID
     name: str
-    arguments: Optional[dict[str, ToolValue]] = None
+    arguments: dict[str, ToolValue] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -429,7 +429,7 @@ class ToolCallContext:
 class ToolCallResult(ToolCall):
     id: UUID
     call: ToolCall
-    result: Optional[ToolValue] = None
+    result: ToolValue | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -449,22 +449,22 @@ class TextPartition:
 
 @dataclass(frozen=True, kw_only=True)
 class TransformerEngineSettings(EngineSettings):
-    access_token: Optional[str] = None
-    attention: Optional[AttentionImplementation] = None
-    base_url: Optional[str] = None
-    loader_class: Optional[TextGenerationLoaderClass] = "auto"
+    access_token: str | None = None
+    attention: AttentionImplementation | None = None
+    base_url: str | None = None
+    loader_class: TextGenerationLoaderClass | None = "auto"
     local_files_only: bool = False
     low_cpu_mem_usage: bool = False
-    quantization: Optional[QuantizationSettings] = None
-    revision: Optional[str] = None
-    special_tokens: Optional[list[str]] = None
+    quantization: QuantizationSettings | None = None
+    revision: str | None = None
+    special_tokens: list[str] | None = None
     state_dict: dict[str, Tensor] = None
-    tokens: Optional[list[str]] = None
+    tokens: list[str] | None = None
     weight_type: WeightType = "auto"
 
 
 @dataclass(frozen=True, kw_only=True)
 class User:
     name: str
-    full_name: Optional[str] = None
-    access_token_name: Optional[str] = None
+    full_name: str | None = None
+    access_token_name: str | None = None

--- a/src/avalan/flow/connection.py
+++ b/src/avalan/flow/connection.py
@@ -1,5 +1,5 @@
 from ..flow.node import Node
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 class Connection:
@@ -7,13 +7,13 @@ class Connection:
         self,
         src: Node,
         dest: Node,
-        label: Optional[str] = None,
-        conditions: Optional[list[Callable[[Any], bool]]] = None,
-        filters: Optional[list[Callable[[Any], Any]]] = None,
+        label: str | None = None,
+        conditions: list[Callable[[Any], bool]] | None = None,
+        filters: list[Callable[[Any], Any]] | None = None,
     ) -> None:
         self.src: Node = src
         self.dest: Node = dest
-        self.label: Optional[str] = label
+        self.label: str | None = label
         self.conditions: list[Callable[[Any], bool]] = conditions or []
         self.filters: list[Callable[[Any], Any]] = filters or []
 

--- a/src/avalan/flow/flow.py
+++ b/src/avalan/flow/flow.py
@@ -1,6 +1,6 @@
 from ..flow.connection import Connection
 from ..flow.node import Node
-from typing import Any, Callable, Dict, Optional, Union, Tuple
+from typing import Any, Callable, Dict, Union, Tuple
 from re import match
 
 
@@ -18,9 +18,9 @@ class Flow:
         self,
         src_name: str,
         dest_name: str,
-        label: Optional[str] = None,
-        conditions: Optional[list[Callable[[Any], bool]]] = None,
-        filters: Optional[list[Callable[[Any], Any]]] = None,
+        label: str | None = None,
+        conditions: list[Callable[[Any], bool]] | None = None,
+        filters: list[Callable[[Any], Any]] | None = None,
     ) -> None:
         if src_name not in self.nodes or dest_name not in self.nodes:
             raise KeyError(f"Unknown node: {src_name} or {dest_name}")
@@ -61,9 +61,7 @@ class Flow:
                         node.shape = nshape
             self.add_connection(src_id, dst_id, label=label)
 
-    def _parse_node(
-        self, text: str
-    ) -> Tuple[str, Optional[str], Optional[str]]:
+    def _parse_node(self, text: str) -> Tuple[str, str | None, str | None]:
         m = match(r"^([A-Za-z0-9_]+)", text)
         if not m:
             return text, None, None
@@ -91,7 +89,7 @@ class Flow:
 
     def execute(
         self,
-        initial_node: Optional[Union[str, Node]] = None,
+        initial_node: Union[str, Node] | None = None,
         initial_data: Any = None,
     ) -> Any:
         # Determine start nodes

--- a/src/avalan/flow/node.py
+++ b/src/avalan/flow/node.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..flow.flow import Flow
@@ -9,20 +9,20 @@ class Node:
     def __init__(
         self,
         name: str,
-        label: Optional[str] = None,
-        shape: Optional[str] = None,
-        input_schema: Optional[type] = None,
-        output_schema: Optional[type] = None,
-        func: Optional[Callable[..., Any]] = None,
-        subgraph: Optional[Flow] = None,
+        label: str | None = None,
+        shape: str | None = None,
+        input_schema: type | None = None,
+        output_schema: type | None = None,
+        func: Callable[..., Any] | None = None,
+        subgraph: Flow | None = None,
     ) -> None:
         self.name: str = name
         self.label: str = label or name
-        self.shape: Optional[str] = shape
-        self.input_schema: Optional[type] = input_schema
-        self.output_schema: Optional[type] = output_schema
-        self.func: Optional[Callable[..., Any]] = func
-        self.subgraph: Optional[Flow] = subgraph
+        self.shape: str | None = shape
+        self.input_schema: type | None = input_schema
+        self.output_schema: type | None = output_schema
+        self.func: Callable[..., Any] | None = func
+        self.subgraph: Flow | None = subgraph
 
     def execute(self, inputs: Dict[str, Any]) -> Any:
         # Delegate to subgraph if present

--- a/src/avalan/memory/__init__.py
+++ b/src/avalan/memory/__init__.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from ..entities import EngineMessage
 from dataclasses import dataclass
 from threading import Lock
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 from ..compat import override
 from uuid import UUID
 
@@ -12,7 +12,7 @@ T = TypeVar("T")
 @dataclass(frozen=True)
 class MemoryChunk(Generic[T]):
     repository_key: str
-    key: Optional[str]
+    key: str | None
     data: T
 
 
@@ -26,12 +26,12 @@ class MemoryStore(ABC, Generic[T]):
         raise NotImplementedError()
 
     @abstractmethod
-    async def search(self, query: str) -> Optional[list[T]]:
+    async def search(self, query: str) -> list[T] | None:
         raise NotImplementedError()
 
 
 class MessageMemory(MemoryStore[EngineMessage], ABC):
-    def search(self, query: str) -> Optional[list[EngineMessage]]:
+    def search(self, query: str) -> list[EngineMessage] | None:
         raise NotImplementedError()
 
 

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -2,15 +2,15 @@ from ..entities import EngineMessage
 from ..memory import RecentMessageMemory
 from ..memory.partitioner.text import TextPartitioner
 from ..memory.permanent import PermanentMessageMemory, VectorFunction
-from typing import Any, Optional, Type
+from typing import Any, Type
 from uuid import UUID
 
 
 class MemoryManager:
     _agent_id: UUID
     _participant_id: UUID
-    _permanent_message_memory: Optional[PermanentMessageMemory] = None
-    _recent_message_memory: Optional[RecentMessageMemory] = None
+    _permanent_message_memory: PermanentMessageMemory | None = None
+    _recent_message_memory: RecentMessageMemory | None = None
     _text_partitioner: TextPartitioner
 
     @classmethod
@@ -20,10 +20,10 @@ class MemoryManager:
         agent_id: UUID,
         participant_id: UUID,
         text_partitioner: TextPartitioner,
-        with_permanent_message_memory: Optional[str] = None,
+        with_permanent_message_memory: str | None = None,
         with_recent_message_memory: bool = True,
     ):
-        permanent_memory: Optional[PermanentMessageMemory] = None
+        permanent_memory: PermanentMessageMemory | None = None
         if with_permanent_message_memory:
             from .permanent.pgsql.message import PgsqlMessageMemory
 
@@ -48,8 +48,8 @@ class MemoryManager:
         *args,
         agent_id: UUID,
         participant_id: UUID,
-        permanent_message_memory: Optional[PermanentMessageMemory],
-        recent_message_memory: Optional[RecentMessageMemory],
+        permanent_message_memory: PermanentMessageMemory | None,
+        recent_message_memory: RecentMessageMemory | None,
         text_partitioner: TextPartitioner,
     ):
         assert agent_id and participant_id
@@ -70,15 +70,15 @@ class MemoryManager:
         return bool(self._recent_message_memory)
 
     @property
-    def permanent_message(self) -> Optional[PermanentMessageMemory]:
+    def permanent_message(self) -> PermanentMessageMemory | None:
         return self._permanent_message_memory
 
     @property
-    def recent_message(self) -> Optional[RecentMessageMemory]:
+    def recent_message(self) -> RecentMessageMemory | None:
         return self._recent_message_memory
 
     @property
-    def recent_messages(self) -> Optional[list[EngineMessage]]:
+    def recent_messages(self) -> list[EngineMessage] | None:
         return (
             self._recent_message_memory.data
             if self._recent_message_memory
@@ -115,7 +115,7 @@ class MemoryManager:
         session_id: UUID,
         *args,
         load_recent_messages: bool = True,
-        load_recent_messages_limit: Optional[int] = None,
+        load_recent_messages_limit: int | None = None,
     ) -> None:
         if self._permanent_message_memory:
             await self._permanent_message_memory.continue_session(
@@ -155,7 +155,7 @@ class MemoryManager:
         participant_id: UUID,
         *args,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessage]:
         assert self._permanent_message_memory
         search_partitions = await self._text_partitioner(search)
@@ -171,8 +171,8 @@ class MemoryManager:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[Any],
+        exc_type: Type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any | None,
     ):
         pass

--- a/src/avalan/memory/partitioner/code.py
+++ b/src/avalan/memory/partitioner/code.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from logging import Logger
 from tree_sitter_python import language as python
 from tree_sitter import Language, Node, Parser
-from typing import Literal, Optional
+from typing import Literal
 
 LanguageName = Literal["python"]
 
@@ -27,17 +27,17 @@ ParameterType = Literal[
 class Parameter:
     parameter_type: ParameterType
     name: str
-    type: Optional[str]
+    type: str | None
 
 
 @dataclass(frozen=True, kw_only=True)
 class Function:
     id: str
-    namespace: Optional[str]
-    class_name: Optional[str]
+    namespace: str | None
+    class_name: str | None
     name: str
-    parameters: Optional[list[Parameter]]
-    return_type: Optional[str]
+    parameters: list[Parameter] | None
+    return_type: str | None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -66,8 +66,8 @@ class CodePartitioner:
         input: str,
         encoding: Encoding,
         max_chars: int,
-        namespace: Optional[str] = None,
-    ) -> tuple[list[CodePartition], Optional[list[Function]]]:
+        namespace: str | None = None,
+    ) -> tuple[list[CodePartition], list[Function] | None]:
         parser, language = self._get_parser(language_name)
         tree = parser.parse(input.encode(encoding), encoding=encoding)
         root_node = tree.root_node
@@ -117,9 +117,9 @@ class CodePartitioner:
         max_chars: int,
         node: Node,
         last_end: int = 0,
-        current_namespace: Optional[str] = None,
-        current_class_name: Optional[str] = None,
-        current_symbols: Optional[list[Symbol]] = None,
+        current_namespace: str | None = None,
+        current_class_name: str | None = None,
+        current_symbols: list[Symbol] | None = None,
     ) -> list[CodePartition]:
         if current_symbols is None:
             current_symbols = []
@@ -202,10 +202,10 @@ class CodePartitioner:
     @classmethod
     def _get_functions(
         cls,
-        current_namespace: Optional[str],
+        current_namespace: str | None,
         node: Node,
         encoding: Encoding,
-        current_class_name: Optional[str] = None,
+        current_class_name: str | None = None,
     ) -> list[Function]:
         assert node and encoding
         results = []
@@ -244,8 +244,8 @@ class CodePartitioner:
     @classmethod
     def _get_function_from_node(
         cls,
-        current_namespace: Optional[str],
-        current_class_name: Optional[str],
+        current_namespace: str | None,
+        current_class_name: str | None,
         node: Node,
         encoding: Encoding,
     ) -> Function:
@@ -270,8 +270,8 @@ class CodePartitioner:
 
     @staticmethod
     def _get_function_id_and_name_from_node(
-        current_namespace: Optional[str],
-        current_class_name: Optional[str],
+        current_namespace: str | None,
+        current_class_name: str | None,
         node: Node,
         encoding: Encoding,
     ) -> tuple[str, str]:
@@ -288,7 +288,7 @@ class CodePartitioner:
     @staticmethod
     def _get_parameters(
         node: Node, encoding: Encoding
-    ) -> list[dict[str, Optional[str]]]:
+    ) -> list[dict[str, str | None]]:
         assert node
         parameters = []
         for child in node.children:

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from numpy import ndarray
-from typing import Literal, Optional
+from typing import Literal
 from ...compat import override
 from uuid import UUID
 
@@ -68,7 +68,7 @@ class PermanentMessage:
     id: UUID
     agent_id: UUID
     model_id: str
-    session_id: Optional[UUID]
+    session_id: UUID | None
     author: MessageRole
     data: str
     partitions: int
@@ -83,7 +83,7 @@ class PermanentMessageScored(PermanentMessage):
 @dataclass(frozen=True, kw_only=True)
 class PermanentMessagePartition:
     agent_id: UUID
-    session_id: Optional[UUID]
+    session_id: UUID | None
     message_id: UUID
     partition: int
     data: str
@@ -102,7 +102,7 @@ class PermanentMemoryPartition:
 
 
 class PermanentMessageMemory(MessageMemory):
-    _session_id: Optional[UUID] = None
+    _session_id: UUID | None = None
     _sentence_model: SentenceTransformerModel
 
     def __init__(
@@ -118,7 +118,7 @@ class PermanentMessageMemory(MessageMemory):
         return bool(self._session_id)
 
     @property
-    def session_id(self) -> Optional[UUID]:
+    def session_id(self) -> UUID | None:
         return self._session_id
 
     def reset(self) -> None:
@@ -176,7 +176,7 @@ class PermanentMessageMemory(MessageMemory):
         session_id: UUID,
         participant_id: UUID,
         *args,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessage]:
         raise NotImplementedError()
 
@@ -189,7 +189,7 @@ class PermanentMessageMemory(MessageMemory):
         session_id: UUID,
         participant_id: UUID,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessage]:
         raise NotImplementedError()
 
@@ -220,8 +220,8 @@ class PermanentMemory(MemoryStore[Memory]):
         data: str,
         identifier: str,
         partitions: list[TextPartition],
-        symbols: Optional[dict] = None,
-        model_id: Optional[str] = None,
+        symbols: dict | None = None,
+        model_id: str | None = None,
     ) -> None:
         raise NotImplementedError()
 
@@ -233,7 +233,7 @@ class PermanentMemory(MemoryStore[Memory]):
         participant_id: UUID,
         namespace: str,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[Memory]:
         raise NotImplementedError()
 

--- a/src/avalan/memory/permanent/pgsql/__init__.py
+++ b/src/avalan/memory/permanent/pgsql/__init__.py
@@ -11,7 +11,7 @@ from psycopg_pool import AsyncConnectionPool
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 from psycopg.types import TypeInfo
-from typing import Optional, TypeVar, Type, Union
+from typing import TypeVar, Type, Union
 
 
 T = TypeVar("T")
@@ -26,7 +26,7 @@ class BasePgsqlMemory(MemoryStore[T]):
     async def open(self) -> None:
         await self._database.open()
 
-    async def search(self, query: str) -> Optional[list[T]]:
+    async def search(self, query: str) -> list[T] | None:
         raise NotImplementedError()
 
     async def _fetch_all(
@@ -52,8 +52,8 @@ class BasePgsqlMemory(MemoryStore[T]):
         return result
 
     async def _fetch_field(
-        self, field: str, query: str, parameters: Optional[tuple] = None
-    ) -> Optional[str]:
+        self, field: str, query: str, parameters: tuple | None = None
+    ) -> str | None:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await cursor.execute(query, parameters)
@@ -73,7 +73,7 @@ class BasePgsqlMemory(MemoryStore[T]):
 
     async def _try_fetch_one(
         self, entity: Type[T], query: str, parameters: tuple
-    ) -> Optional[T]:
+    ) -> T | None:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await cursor.execute(query, parameters)
@@ -113,7 +113,7 @@ class BasePgsqlMemory(MemoryStore[T]):
 
 
 class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
-    _composite_types: Optional[list[str]]
+    _composite_types: list[str] | None
 
     @classmethod
     async def create_instance_from_pool(
@@ -127,12 +127,12 @@ class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
 
     def __init__(
         self,
-        dsn: Optional[str],
+        dsn: str | None,
         *args,
-        pool: Optional[AsyncConnectionPool] = None,
-        composite_types: Optional[list[str]] = None,
-        pool_minimum: Optional[int] = None,
-        pool_maximum: Optional[int] = None,
+        pool: AsyncConnectionPool | None = None,
+        composite_types: list[str] | None = None,
+        pool_minimum: int | None = None,
+        pool_maximum: int | None = None,
         **kwargs,
     ):
         assert pool or (
@@ -176,7 +176,7 @@ class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
     def _to_engine_messages(
         messages: Union[list[PermanentMessage], list[PermanentMessageScored]],
         *args,
-        limit: Optional[int],
+        limit: int | None,
         reverse: bool = False,
         scored: bool = False,
     ) -> Union[list[EngineMessage], list[EngineMessageScored]]:

--- a/src/avalan/memory/permanent/pgsql/message.py
+++ b/src/avalan/memory/permanent/pgsql/message.py
@@ -11,7 +11,6 @@ from ....memory.permanent import (
 from ....memory.permanent.pgsql import PgsqlMemory
 from datetime import datetime, timezone
 from pgvector.psycopg import Vector
-from typing import Optional
 from uuid import UUID, uuid4
 
 
@@ -203,7 +202,7 @@ class PgsqlMessageMemory(PgsqlMemory[PermanentMessage], PermanentMessageMemory):
         session_id: UUID,
         participant_id: UUID,
         *args,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessage]:
         messages = await self._fetch_all(
             PermanentMessage,
@@ -240,7 +239,7 @@ class PgsqlMessageMemory(PgsqlMemory[PermanentMessage], PermanentMessageMemory):
         session_id: UUID,
         participant_id: UUID,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessageScored]:
         assert agent_id and session_id and participant_id and search_partitions
         search_function = str(function)

--- a/src/avalan/memory/permanent/pgsql/raw.py
+++ b/src/avalan/memory/permanent/pgsql/raw.py
@@ -12,7 +12,6 @@ from ....memory.permanent import (
 from ....memory.permanent.pgsql import PgsqlMemory
 from datetime import datetime, timezone
 from pgvector.psycopg import Vector
-from typing import Optional
 from uuid import UUID, uuid4
 
 
@@ -133,7 +132,7 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
         participant_id: UUID,
         namespace: str,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[Memory]:
         assert participant_id and namespace and search_partitions
         search_function = str(function)
@@ -182,7 +181,7 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
         session_id: UUID,
         participant_id: UUID,
         function: VectorFunction,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> list[EngineMessageScored]:
         assert agent_id and session_id and participant_id and search_partitions
         search_function = str(function)

--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -1,6 +1,6 @@
 from ..entities import MessageRole
 from pydantic import BaseModel, Field
-from typing import Optional, Union
+from typing import Union
 
 
 class ChatMessage(BaseModel):
@@ -15,42 +15,42 @@ class ChatCompletionRequest(BaseModel):
     messages: list[ChatMessage] = Field(
         ..., description="List of messages in the conversation"
     )
-    temperature: Optional[float] = Field(
+    temperature: float | None = Field(
         1.0, ge=0.0, le=2.0, description="Sampling temperature"
     )
-    top_p: Optional[float] = Field(
+    top_p: float | None = Field(
         1.0, ge=0.0, le=1.0, description="Nucleus sampling probability"
     )
-    n: Optional[int] = Field(
+    n: int | None = Field(
         1, ge=1, description="Number of completions to generate"
     )
-    stream: Optional[bool] = Field(
+    stream: bool | None = Field(
         False, description="Whether to stream back partial progress"
     )
-    stop: Optional[Union[str, list[str]]] = Field(
+    stop: Union[str, list[str]] | None = Field(
         None,
         description="Sequence where the API will stop generating further tokens",
     )
-    max_tokens: Optional[int] = Field(
+    max_tokens: int | None = Field(
         None, ge=1, description="Maximum tokens to generate in the completion"
     )
-    presence_penalty: Optional[float] = Field(
+    presence_penalty: float | None = Field(
         0.0,
         ge=-2.0,
         le=2.0,
         description="Penalty for new tokens based on whether they appear in text so far",
     )
-    frequency_penalty: Optional[float] = Field(
+    frequency_penalty: float | None = Field(
         0.0,
         ge=-2.0,
         le=2.0,
         description="Penalty for new tokens based on their frequency in text so far",
     )
-    logit_bias: Optional[dict[str, int]] = Field(
+    logit_bias: dict[str, int] | None = Field(
         None,
         description="Modify the likelihood of specified tokens appearing in the completion",
     )
-    user: Optional[str] = Field(
+    user: str | None = Field(
         None, description="Unique identifier representing your end-user"
     )
 


### PR DESCRIPTION
## Summary
- switch typing.Optional annotations to use `| None`
- drop unused Optional imports

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6846d417fedc83239ac3ba802fa9868a