### PR TITLE
Add RestrictedPython CodeTool

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -15,6 +15,7 @@ from ..model.nlp.sentence import SentenceTransformerModel
 from ..tool.browser import BrowserToolSet, BrowserToolSettings
 from ..tool.manager import ToolManager
 from ..tool.math import MathToolSet
+from ..tool.code import CodeToolSet
 from contextlib import AsyncExitStack
 from logging import Logger
 from os import access, R_OK
@@ -280,6 +281,7 @@ class OrchestratorLoader:
                 namespace="browser",
             ),
             MathToolSet(namespace="math"),
+            CodeToolSet(namespace="code"),
         ]
 
         tool = ToolManager.create_instance(

--- a/src/avalan/tool/code.py
+++ b/src/avalan/tool/code.py
@@ -1,0 +1,47 @@
+from contextlib import AsyncExitStack
+from importlib import import_module
+
+from . import Tool, ToolSet
+from ..compat import override
+from ..entities import ToolCallContext
+
+
+class CodeTool(Tool):
+    """Execute Python code in a restricted environment.
+
+    Args:
+        code: Python code to execute.
+
+    Returns:
+        Value of a variable named ``result`` defined in the executed code,
+        or an empty string if not present.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__name__ = "code"
+
+    async def __call__(self, code: str, *, context: ToolCallContext) -> str:
+        compile_restricted = import_module(
+            "RestrictedPython"
+        ).compile_restricted
+        safe_builtins = import_module("RestrictedPython.Guards").safe_builtins
+        compiled = compile_restricted(code, "<tool>", "exec")
+        globals_dict: dict[str, object] = {"__builtins__": safe_builtins}
+        locals_dict: dict[str, object] = {}
+        exec(compiled, globals_dict, locals_dict)
+        return str(locals_dict.get("result", ""))
+
+
+class CodeToolSet(ToolSet):
+    @override
+    def __init__(
+        self,
+        *,
+        exit_stack: AsyncExitStack | None = None,
+        namespace: str | None = None,
+    ) -> None:
+        tools = [CodeTool()]
+        super().__init__(
+            exit_stack=exit_stack, namespace=namespace, tools=tools
+        )

--- a/tests/tool/code_tool_test.py
+++ b/tests/tool/code_tool_test.py
@@ -1,0 +1,23 @@
+from avalan.entities import ToolCallContext
+from avalan.tool.code import CodeTool
+from pytest import importorskip
+from unittest import IsolatedAsyncioTestCase, main
+
+importorskip("RestrictedPython", reason="RestrictedPython not installed")
+
+
+class CodeToolTestCase(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.tool = CodeTool()
+
+    async def test_exec(self):
+        result = await self.tool("result = 1 + 1", context=ToolCallContext())
+        self.assertEqual(result, "2")
+
+    async def test_restricted_builtin(self):
+        with self.assertRaises(NameError):
+            await self.tool("open('f', 'w')", context=ToolCallContext())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CodeTool and CodeToolSet for running restricted Python code
- expose CodeToolSet in OrchestratorLoader
- cover CodeTool with positive and negative tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6849c3eef4f08323857782205f80a564