### PR TITLE
Propagate IDs to ToolCallContext

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -190,6 +190,13 @@ class Orchestrator:
             engine_args,
             event_manager=self._event_manager,
             tool=self._tool,
+            agent_id=self._id,
+            participant_id=self._memory.participant_id,
+            session_id=(
+                self._memory.permanent_message.session_id
+                if self._memory.permanent_message
+                else None
+            ),
         )
 
     async def __aenter__(self):

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -62,6 +62,11 @@ class MemoryManager:
             self.add_recent_message_memory(recent_message_memory)
 
     @property
+    def participant_id(self) -> UUID:
+        """Return the participant identifier associated with this memory."""
+        return self._participant_id
+
+    @property
     def has_permanent_message(self) -> bool:
         return bool(self._permanent_message_memory)
 

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -413,3 +413,39 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(result, "r")
         agent.assert_awaited_once()
         tool.assert_awaited_once()
+
+
+class OrchestratorResponseContextTestCase(IsolatedAsyncioTestCase):
+    async def test_tool_context_ids(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = True
+
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        aid = uuid4()
+        pid = uuid4()
+        sid = uuid4()
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("hi", async_gen=False),
+            agent,
+            operation,
+            {},
+            tool=tool,
+            event_manager=event_manager,
+            agent_id=aid,
+            participant_id=pid,
+            session_id=sid,
+        )
+        resp.__aiter__()
+
+        self.assertEqual(resp._tool_context.agent_id, aid)
+        self.assertEqual(resp._tool_context.participant_id, pid)
+        self.assertEqual(resp._tool_context.session_id, sid)


### PR DESCRIPTION
## Summary
- pass agent, participant, and session IDs when creating `OrchestratorResponse`
- include those IDs when building `ToolCallContext`
- verify tool context IDs via unit test
- expose participant ID via `MemoryManager.participant_id`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_684aefcc6c6083239c763cdf651cd9d3