### PR TITLE
Add memory loader tests

### DIFF
--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -580,6 +580,59 @@ enable_thinking = true
                 )
             await stack.aclose()
 
+    async def test_permanent_memory_from_file(self):
+        config_tmpl = """
+[agent]
+role = \"assistant\"
+task = \"do\"
+instructions = \"how\"
+
+[engine]
+uri = \"ai://local/model\"
+
+[memory]
+permanent = {{ {entries} }}
+"""
+        cases = [
+            {"code": "dsn1"},
+            {"code": "dsn1", "docs": "dsn2"},
+            {
+                "code": "dsn1",
+                "docs": "dsn2",
+                "more": "dsn3",
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                entries = ", ".join(f'{k} = "{v}"' for k, v in case.items())
+                config = config_tmpl.format(entries=entries)
+                with TemporaryDirectory() as tmp:
+                    path = f"{tmp}/agent.toml"
+                    with open(path, "w", encoding="utf-8") as fh:
+                        fh.write(config)
+
+                    stack = AsyncExitStack()
+                    with patch.object(
+                        OrchestratorLoader,
+                        "load_from_settings",
+                        new=AsyncMock(return_value="orch"),
+                    ) as lfs_patch:
+                        result = await OrchestratorLoader.from_file(
+                            path,
+                            agent_id=uuid4(),
+                            hub=MagicMock(spec=HuggingfaceHub),
+                            logger=MagicMock(spec=Logger),
+                            participant_id=uuid4(),
+                            stack=stack,
+                        )
+
+                        self.assertEqual(result, "orch")
+                        lfs_patch.assert_awaited_once()
+                        settings = lfs_patch.call_args.args[0]
+                        self.assertEqual(settings.permanent_memory, case)
+                    await stack.aclose()
+
 
 class LoaderFromSettingsTestCase(IsolatedAsyncioTestCase):
     async def test_load_default_orchestrator_from_settings(self):
@@ -656,6 +709,104 @@ class LoaderFromSettingsTestCase(IsolatedAsyncioTestCase):
             model_patch.assert_called_once_with(hub, logger)
             mm_patch.assert_awaited_once()
         await stack.aclose()
+
+    async def test_permanent_memory_from_settings(self):
+        base_settings = dict(
+            agent_id=uuid4(),
+            orchestrator_type=None,
+            agent_config={"role": "assistant"},
+            uri="ai://local/model",
+            engine_config={},
+            tools=None,
+            call_options=None,
+            template_vars=None,
+            memory_permanent_message=None,
+            memory_recent=False,
+            sentence_model_id=OrchestratorLoader.DEFAULT_SENTENCE_MODEL_ID,
+            sentence_model_engine_config=None,
+            sentence_model_max_tokens=500,
+            sentence_model_overlap_size=125,
+            sentence_model_window_size=250,
+            json_config=None,
+        )
+
+        cases = [
+            {"code": "dsn1"},
+            {"code": "dsn1", "docs": "dsn2"},
+            {
+                "code": "dsn1",
+                "docs": "dsn2",
+                "more": "dsn3",
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                hub = MagicMock(spec=HuggingfaceHub)
+                logger = MagicMock(spec=Logger)
+                stack = AsyncExitStack()
+
+                sentence_model = MagicMock()
+                sentence_model.__enter__.return_value = sentence_model
+
+                model_manager = MagicMock()
+                model_manager.__enter__.return_value = model_manager
+                model_manager.parse_uri.return_value = "uri_obj"
+                model_manager.get_engine_settings.return_value = "settings_obj"
+
+                memory = MagicMock()
+                tool = MagicMock()
+                event_manager = MagicMock()
+
+                settings = OrchestratorSettings(
+                    **base_settings,
+                    permanent_memory=case,
+                )
+
+                with (
+                    patch(
+                        "avalan.agent.loader.SentenceTransformerModel",
+                        return_value=sentence_model,
+                    ),
+                    patch("avalan.agent.loader.TextPartitioner"),
+                    patch(
+                        "avalan.agent.loader.MemoryManager.create_instance",
+                        new=AsyncMock(return_value=memory),
+                    ),
+                    patch(
+                        "avalan.agent.loader.ModelManager",
+                        return_value=model_manager,
+                    ),
+                    patch(
+                        "avalan.agent.loader.PgsqlRawMemory.create_instance",
+                        new=AsyncMock(side_effect=[MagicMock() for _ in case]),
+                    ) as pg_patch,
+                    patch(
+                        "avalan.agent.loader.DefaultOrchestrator",
+                        return_value="orch",
+                    ),
+                    patch(
+                        "avalan.agent.loader.ToolManager.create_instance",
+                        return_value=tool,
+                    ),
+                    patch(
+                        "avalan.agent.loader.EventManager",
+                        return_value=event_manager,
+                    ),
+                ):
+                    await OrchestratorLoader.load_from_settings(
+                        settings,
+                        hub=hub,
+                        logger=logger,
+                        participant_id=uuid4(),
+                        stack=stack,
+                    )
+
+                    self.assertEqual(pg_patch.await_count, len(case))
+                    self.assertEqual(
+                        memory.add_permanent_memory.call_count, len(case)
+                    )
+                await stack.aclose()
 
     async def test_load_json_orchestrator_from_settings(self):
         hub = MagicMock(spec=HuggingfaceHub)
@@ -735,6 +886,51 @@ class LoaderFromSettingsTestCase(IsolatedAsyncioTestCase):
             self.assertEqual(result, "json_orch")
             json_patch.assert_called_once()
         await stack.aclose()
+
+    async def test_load_json_orchestrator_properties(self):
+        agent_id = uuid4()
+        engine_uri = MagicMock()
+        engine_settings = MagicMock()
+        logger = MagicMock()
+        model_manager = MagicMock()
+        memory = MagicMock()
+        tool = MagicMock()
+        event_manager = MagicMock()
+
+        config = {
+            "json": {
+                "name": {"type": "string", "description": "n"},
+                "age": {"type": "integer", "description": "a"},
+            }
+        }
+
+        agent_config = {
+            "role": "assistant",
+            "task": "do",
+            "instructions": "how",
+        }
+
+        with patch("avalan.agent.loader.JsonOrchestrator") as orch_patch:
+            OrchestratorLoader._load_json_orchestrator(
+                agent_id=agent_id,
+                engine_uri=engine_uri,
+                engine_settings=engine_settings,
+                logger=logger,
+                model_manager=model_manager,
+                memory=memory,
+                tool=tool,
+                event_manager=event_manager,
+                config=config,
+                agent_config=agent_config,
+                call_options=None,
+                template_vars=None,
+            )
+
+            orch_patch.assert_called_once()
+            properties = orch_patch.call_args.args[6]
+            self.assertEqual(len(properties), 2)
+            self.assertEqual(properties[0].name, "name")
+            self.assertEqual(properties[1].data_type, "integer")
 
 
 if __name__ == "__main__":

--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -1,7 +1,11 @@
 from avalan.entities import EngineMessage, Message, MessageRole
 from avalan.memory.manager import MemoryManager
 from avalan.memory import RecentMessageMemory
-from avalan.memory.permanent import PermanentMessageMemory, VectorFunction
+from avalan.memory.permanent import (
+    PermanentMessageMemory,
+    PermanentMemory,
+    VectorFunction,
+)
 from uuid import uuid4
 from unittest import IsolatedAsyncioTestCase, main
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -137,6 +141,188 @@ class MemoryManagerOperationTestCase(IsolatedAsyncioTestCase):
         self.assertIn("code", self.manager._permanent_memories)
         self.manager.delete_permanent_memory("code")
         self.assertNotIn("code", self.manager._permanent_memories)
+
+
+class MemoryManagerInitTestCase(IsolatedAsyncioTestCase):
+    def test_constructor_variants(self):
+        agent_id = uuid4()
+        participant_id = uuid4()
+        tp = AsyncMock()
+
+        manager = MemoryManager(
+            agent_id=agent_id,
+            participant_id=participant_id,
+            permanent_message_memory=None,
+            recent_message_memory=None,
+            text_partitioner=tp,
+        )
+        self.assertFalse(manager.has_recent_message)
+        self.assertFalse(manager.has_permanent_message)
+        self.assertEqual(manager.participant_id, participant_id)
+        self.assertIsNone(manager.recent_messages)
+
+        pmem = MagicMock(spec=PermanentMemory)
+        manager = MemoryManager(
+            agent_id=agent_id,
+            participant_id=participant_id,
+            permanent_message_memory=None,
+            recent_message_memory=RecentMessageMemory(),
+            text_partitioner=tp,
+            permanent_memories={"code": pmem},
+        )
+        self.assertTrue(manager.has_recent_message)
+        self.assertIn("code", manager._permanent_memories)
+
+        pmem2 = MagicMock(spec=PermanentMemory)
+        manager = MemoryManager(
+            agent_id=agent_id,
+            participant_id=participant_id,
+            permanent_message_memory=None,
+            recent_message_memory=RecentMessageMemory(),
+            text_partitioner=tp,
+            permanent_memories={"code": pmem, "docs": pmem2},
+        )
+        self.assertEqual(len(manager._permanent_memories), 2)
+
+
+class MemoryManagerPropertyTestCase(IsolatedAsyncioTestCase):
+    def test_recent_messages_property(self):
+        tp = AsyncMock()
+        rm = RecentMessageMemory()
+        msg = EngineMessage(
+            agent_id=uuid4(),
+            model_id="m",
+            message=Message(role=MessageRole.USER, content="hi"),
+        )
+        rm.append(msg)
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=rm,
+            text_partitioner=tp,
+        )
+        self.assertEqual(manager.recent_messages, [msg])
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=None,
+            text_partitioner=tp,
+        )
+        self.assertIsNone(manager.recent_messages)
+
+
+class MemoryManagerMethodsTestCase(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.tp = AsyncMock()
+        self.pm = AsyncMock(spec=PermanentMessageMemory)
+        self.rm = RecentMessageMemory()
+
+    async def test_append_message_variants(self):
+        msg = EngineMessage(
+            agent_id=uuid4(),
+            model_id="m",
+            message=Message(role=MessageRole.USER, content="hi"),
+        )
+
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=self.pm,
+            recent_message_memory=None,
+            text_partitioner=self.tp,
+        )
+        await manager.append_message(msg)
+        self.tp.assert_awaited_once()
+        self.pm.append_with_partitions.assert_awaited_once()
+
+        self.tp.reset_mock()
+        self.pm.reset_mock()
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=self.rm,
+            text_partitioner=self.tp,
+        )
+        await manager.append_message(msg)
+        self.tp.assert_not_called()
+        self.assertEqual(manager.recent_messages, [msg])
+
+        self.tp.reset_mock()
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=None,
+            text_partitioner=self.tp,
+        )
+        await manager.append_message(msg)
+        self.tp.assert_not_called()
+
+    async def test_continue_and_start_session_variants(self):
+        session_id = uuid4()
+        messages = [
+            EngineMessage(
+                agent_id=uuid4(),
+                model_id="m",
+                message=Message(role=MessageRole.USER, content="x"),
+            )
+        ]
+        self.pm.get_recent_messages.return_value = messages
+
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=self.pm,
+            recent_message_memory=None,
+            text_partitioner=self.tp,
+        )
+        await manager.continue_session(session_id)
+        self.pm.continue_session.assert_awaited()
+        self.pm.get_recent_messages.assert_not_awaited()
+        await manager.start_session()
+        self.pm.reset_session.assert_awaited()
+
+        self.pm.reset_mock()
+        self.pm.get_recent_messages.reset_mock()
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=self.rm,
+            text_partitioner=self.tp,
+        )
+        await manager.continue_session(session_id)
+        self.pm.continue_session.assert_not_awaited()
+        self.assertEqual(manager.recent_messages, [])
+        await manager.start_session()
+        self.assertTrue(self.rm.is_empty)
+
+        self.pm.reset_mock()
+        self.pm.get_recent_messages.reset_mock()
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=None,
+            text_partitioner=self.tp,
+        )
+        await manager.continue_session(session_id)
+        await manager.start_session()
+
+
+class MemoryManagerContextTestCase(IsolatedAsyncioTestCase):
+    async def test_context_exit(self):
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=None,
+            text_partitioner=AsyncMock(),
+        )
+        self.assertIsNone(manager.__exit__(None, None, None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- improve coverage for OrchestratorLoader by checking permanent memory settings
- verify multiple property handling in JSON orchestrator loader
- expand MemoryManager tests to cover constructor and methods

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_684c3d3f447c8323ba4266cca7728818