### PR TITLE
Add server entity and router tests

### DIFF
--- a/tests/server/chat_router_unit_test.py
+++ b/tests/server/chat_router_unit_test.py
@@ -1,0 +1,94 @@
+from avalan.server.entities import ChatCompletionRequest, ChatMessage
+from avalan.agent.orchestrator import Orchestrator
+from avalan.entities import MessageRole
+from avalan.model import TextGenerationResponse
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+import importlib
+import sys
+
+
+class DummyOrchestrator(Orchestrator):
+    async def __call__(self, messages, settings=None):
+        return TextGenerationResponse(lambda: "ok", use_async_generator=False)
+
+
+class ChatRouterUnitTest(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        sys.modules.pop("avalan.server.routers.chat", None)
+        self.chat = importlib.import_module("avalan.server.routers.chat")
+
+    def tearDown(self) -> None:
+        sys.modules.pop("avalan.server.routers.chat", None)
+
+    async def test_create_chat_completion_non_stream(self) -> None:
+        orch = AsyncMock(spec=DummyOrchestrator)
+        orch.return_value = TextGenerationResponse(
+            lambda: "ok", use_async_generator=False
+        )
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+        )
+        with patch("avalan.server.routers.chat.time", return_value=1):
+            resp = await self.chat.create_chat_completion(req, orch)
+        self.assertEqual(resp.object, "chat.completion")
+        self.assertEqual(resp.choices[0].message.content, "ok")
+        orch.assert_awaited_once()
+
+    async def test_dependency_get_orchestrator(self) -> None:
+        req = type(
+            "Req",
+            (),
+            {
+                "app": type(
+                    "App", (), {"state": type("S", (), {"orchestrator": 1})()}
+                )()
+            },
+        )()
+        self.assertEqual(self.chat.dependency_get_orchestrator(req), 1)
+
+    async def test_create_chat_completion_stream(self) -> None:
+        async def output_gen():
+            yield "a"
+            yield "b"
+
+        orch = AsyncMock(spec=DummyOrchestrator)
+        orch.return_value = TextGenerationResponse(
+            lambda: output_gen(), use_async_generator=True
+        )
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+        with patch("avalan.server.routers.chat.time", return_value=1):
+            resp = await self.chat.create_chat_completion(req, orch)
+        chunks = [chunk async for chunk in resp.body_iterator]
+        self.assertIn('"content":"a"', chunks[0])
+        self.assertIn('"content":"b"', chunks[1])
+        self.assertEqual(chunks[-1], "data: [DONE]\n\n")
+        orch.assert_awaited_once()
+
+    async def test_streaming_skips_event_tokens(self) -> None:
+        from avalan.event import Event, EventType
+
+        async def output_gen():
+            yield "a"
+            yield Event(type=EventType.TOOL_RESULT, payload={})
+            yield "b"
+
+        orch = AsyncMock(spec=DummyOrchestrator)
+        orch.return_value = output_gen()
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+        with patch("avalan.server.routers.chat.time", return_value=1):
+            resp = await self.chat.create_chat_completion(req, orch)
+        chunks = [chunk async for chunk in resp.body_iterator]
+        self.assertIn('"content":"a"', chunks[0])
+        self.assertIn('"content":"b"', chunks[1])
+        self.assertEqual(len(chunks), 3)
+        orch.assert_awaited_once()

--- a/tests/server/entities_test.py
+++ b/tests/server/entities_test.py
@@ -1,0 +1,43 @@
+from avalan.server.entities import (
+    ChatCompletionRequest,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    ChatMessage,
+)
+from avalan.entities import MessageRole
+from pydantic import ValidationError
+from unittest import TestCase
+
+
+class ChatEntitiesTestCase(TestCase):
+    def test_request_defaults(self) -> None:
+        msg = ChatMessage(role=MessageRole.USER, content="hi")
+        req = ChatCompletionRequest(model="m", messages=[msg])
+        self.assertEqual(req.temperature, 1.0)
+        self.assertEqual(req.top_p, 1.0)
+        self.assertEqual(req.n, 1)
+        self.assertFalse(req.stream)
+
+    def test_request_validation_error(self) -> None:
+        msg = ChatMessage(role=MessageRole.USER, content="hi")
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(model="m", messages=[msg], temperature=3.0)
+
+    def test_response_serialization(self) -> None:
+        msg = ChatMessage(role=MessageRole.ASSISTANT, content="ok")
+        choice = ChatCompletionChoice(message=msg, finish_reason="stop")
+        usage = ChatCompletionUsage(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2
+        )
+        resp = ChatCompletionResponse(
+            id="1",
+            created=123,
+            model="m",
+            choices=[choice],
+            usage=usage,
+        )
+        data = resp.dict()
+        self.assertEqual(data["choices"][0]["message"]["content"], "ok")
+        json_str = resp.json()
+        self.assertIn('"chat.completion"', json_str)


### PR DESCRIPTION
## Summary
- add coverage tests for server entities and chat router

## Testing
- `make lint`
- `poetry run pytest --verbose -s`
- `make test-coverage -- 0 src/avalan/server`

------
https://chatgpt.com/codex/tasks/task_e_684e1b1401048323abc493836ff4c715