### PR TITLE
Improve tool coverage

### DIFF
--- a/tests/tool/search_engine_tool_test.py
+++ b/tests/tool/search_engine_tool_test.py
@@ -1,0 +1,18 @@
+from avalan.tool.search_engine import SearchEngineTool
+from unittest import IsolatedAsyncioTestCase, main
+
+
+class SearchEngineToolTestCase(IsolatedAsyncioTestCase):
+    async def test_call_returns_placeholder(self):
+        tool = SearchEngineTool()
+        result = await tool("rain", engine="google")
+        self.assertEqual(tool.__name__, "search")
+        expected = (
+            "The weather is nice and warm, with 23 degrees celsius, "
+            "clear skies, and winds under 11 kmh."
+        )
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tool/tool_parser_extra_test.py
+++ b/tests/tool/tool_parser_extra_test.py
@@ -1,0 +1,52 @@
+from avalan.entities import ToolCall, ToolFormat
+from avalan.tool.parser import ToolCallParser
+from unittest import TestCase, main
+from unittest.mock import patch
+from uuid import uuid4 as _uuid4
+
+
+class ToolCallParserExtraTestCase(TestCase):
+    def test_react_invalid_json_exception(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        text = 'Action: calc\nAction Input: {"value": 1,}'
+        self.assertIsNone(parser(text))
+
+    def test_bracket_no_match(self):
+        parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
+        self.assertIsNone(parser("nothing"))
+
+    def test_regex_fallback(self):
+        parser = ToolCallParser()
+        call_id = _uuid4()
+        text = (
+            '<tool_call>{"name": "calculator", "arguments": {"expression":'
+            ' "1"}}</tool_call></extra>'
+        )
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={"expression": "1"},
+                )
+            ]
+            self.assertEqual(parser(text), expected)
+
+    def test_named_tool_call_invalid_json(self):
+        parser = ToolCallParser()
+        text = '<tool_call name="calc">{"expr": 2,}</tool_call>'
+        self.assertIsNone(parser(text))
+
+    def test_tool_tag_invalid_json(self):
+        parser = ToolCallParser()
+        text = '<tool name="calc">{"expr": 2,}</tool>'
+        self.assertIsNone(parser(text))
+
+    def test_self_closing_invalid_json(self):
+        parser = ToolCallParser()
+        text = '<tool_call name="calc" arguments=\'{"expr": 2,}\'/>'
+        self.assertIsNone(parser(text))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing unit tests for `ToolCallParser`
- cover the simple `SearchEngineTool`

## Testing
- `make lint`
- `make test`
- `poetry run pytest --cov=src/avalan/tool --cov-report=json`

------
https://chatgpt.com/codex/tasks/task_e_684e50cda0788323b3a89b44841a01c5