### PR TITLE
Fix pydantic deprecation warnings

### DIFF
--- a/src/avalan/server/routers/chat.py
+++ b/src/avalan/server/routers/chat.py
@@ -70,7 +70,7 @@ async def create_chat_completion(
                     model=request.model,
                     choices=[choice],
                 )
-                yield f"data: {chunk.json()}\n\n"  # SSE data event
+                yield f"data: {chunk.model_dump_json()}\n\n"  # SSE data event
             yield "data: [DONE]\n\n"  # end of stream
 
         return StreamingResponse(

--- a/tests/server/entities_test.py
+++ b/tests/server/entities_test.py
@@ -37,7 +37,7 @@ class ChatEntitiesTestCase(TestCase):
             choices=[choice],
             usage=usage,
         )
-        data = resp.dict()
+        data = resp.model_dump()
         self.assertEqual(data["choices"][0]["message"]["content"], "ok")
-        json_str = resp.json()
+        json_str = resp.model_dump_json()
         self.assertIn('"chat.completion"', json_str)


### PR DESCRIPTION
## Summary
- replace deprecated json/dict usage with model_dump/model_dump_json

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_684e9b83a7a08323aac7966ecc69d16f