### PR TITLE
Fix MLX LM async stream tests

### DIFF
--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -22,9 +22,9 @@ class MlxLmStream(TextGenerationVendorStream):
         self._iterator = generator
 
     async def __anext__(self) -> str:
-        try:
-            chunk = await to_thread(next, self._iterator)
-        except StopIteration:
+        sentinel = object()
+        chunk = await to_thread(next, self._iterator, sentinel)
+        if chunk is sentinel:
             raise StopAsyncIteration
         return chunk
 

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -2,7 +2,10 @@ import sys
 import importlib
 import types
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import avalan.model  # noqa: F401
+
 
 from avalan.entities import GenerationSettings, TransformerEngineSettings
 
@@ -69,6 +72,7 @@ class MlxLmModelTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 self.mod.MlxLmModel,
                 "_stream_generator",
+                new_callable=AsyncMock,
                 return_value=self.mod.MlxLmStream(iter(["x"])),
             ) as stream_mock,
         ):


### PR DESCRIPTION
## Summary
- prevent StopIteration from leaking in MlxLmStream
- ensure mlxlm async tests load module and patch async generator correctly

## Testing
- `make lint`
- `poetry run pytest tests/model/nlp/mlxlm_extra_test.py -q`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_684eda80c9608323b392a190da723521