### PR TITLE
Add mandatory logging to Pgsql memory classes

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -282,6 +282,7 @@ class OrchestratorLoader:
             agent_id=settings.agent_id,
             participant_id=participant_id,
             text_partitioner=text_partitioner,
+            logger=logger,
             with_permanent_message_memory=settings.memory_permanent_message,
             with_recent_message_memory=settings.memory_recent,
         )
@@ -292,7 +293,9 @@ class OrchestratorLoader:
                 namespace,
                 settings.agent_id,
             )
-            store = await PgsqlRawMemory.create_instance(dsn=dsn)
+            store = await PgsqlRawMemory.create_instance(
+                dsn=dsn, logger=logger
+            )
             memory.add_permanent_memory(namespace, store)
 
         logger.debug(

--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -116,7 +116,9 @@ async def memory_document_index(
                         )
                     )
 
-            memory_store = await PgsqlRawMemory.create_instance(dsn=dsn)
+            memory_store = await PgsqlRawMemory.create_instance(
+                dsn=dsn, logger=logger
+            )
             await memory_store.append_with_partitions(
                 namespace,
                 participant_id,
@@ -414,7 +416,9 @@ async def memory_search(
             )
             search_partitions = await partitioner(input_string)
 
-            memory_store = await PgsqlRawMemory.create_instance(dsn=dsn)
+            memory_store = await PgsqlRawMemory.create_instance(
+                dsn=dsn, logger=logger
+            )
             memories = await memory_store.search_memories(
                 search_partitions=search_partitions,
                 participant_id=participant_id,

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -6,6 +6,7 @@ from ..memory.permanent import (
     PermanentMemory,
     VectorFunction,
 )
+from logging import Logger
 from typing import Any
 from uuid import UUID
 
@@ -25,6 +26,7 @@ class MemoryManager:
         agent_id: UUID,
         participant_id: UUID,
         text_partitioner: TextPartitioner,
+        logger: Logger,
         with_permanent_message_memory: str | None = None,
         with_recent_message_memory: bool = True,
     ):
@@ -33,7 +35,8 @@ class MemoryManager:
             from .permanent.pgsql.message import PgsqlMessageMemory
 
             permanent_memory = await PgsqlMessageMemory.create_instance(
-                dsn=with_permanent_message_memory
+                dsn=with_permanent_message_memory,
+                logger=logger,
             )
         recent_memory = (
             RecentMessageMemory() if with_recent_message_memory else None

--- a/src/avalan/memory/permanent/pgsql/message.py
+++ b/src/avalan/memory/permanent/pgsql/message.py
@@ -9,6 +9,7 @@ from ....memory.permanent import (
     VectorFunction,
 )
 from ....memory.permanent.pgsql import PgsqlMemory
+from logging import Logger
 from datetime import datetime, timezone
 from pgvector.psycopg import Vector
 from uuid import UUID, uuid4
@@ -22,6 +23,7 @@ class PgsqlMessageMemory(
         cls,
         dsn: str,
         *args,
+        logger: Logger,
         pool_minimum: int = 1,
         pool_maximum: int = 10,
         pool_open: bool = True,
@@ -30,6 +32,7 @@ class PgsqlMessageMemory(
         memory = cls(
             dsn=dsn,
             composite_types=["message_author_type"],
+            logger=logger,
             pool_minimum=pool_minimum,
             pool_maximum=pool_maximum,
             **kwargs,

--- a/src/avalan/memory/permanent/pgsql/raw.py
+++ b/src/avalan/memory/permanent/pgsql/raw.py
@@ -7,6 +7,7 @@ from ....memory.permanent import (
     VectorFunction,
 )
 from ....memory.permanent.pgsql import PgsqlMemory
+from logging import Logger
 from datetime import datetime, timezone
 from json import dumps
 from pgvector.psycopg import Vector
@@ -19,6 +20,7 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
         cls,
         dsn: str,
         *args,
+        logger: Logger,
         pool_minimum: int = 1,
         pool_maximum: int = 10,
         pool_open: bool = True,
@@ -26,6 +28,7 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
     ):
         memory = cls(
             dsn=dsn,
+            logger=logger,
             pool_minimum=pool_minimum,
             pool_maximum=pool_maximum,
             **kwargs,

--- a/tests/cli/memory_test.py
+++ b/tests/cli/memory_test.py
@@ -115,7 +115,9 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
             overlap_size=self.args.partition_overlap,
         )
         tp_inst.assert_awaited_once_with("content")
-        mem_patch.assert_awaited_once_with(dsn=self.args.dsn)
+        mem_patch.assert_awaited_once_with(
+            dsn=self.args.dsn, logger=self.logger
+        )
         memory_store.append_with_partitions.assert_awaited_once_with(
             self.args.namespace,
             UUID(self.args.participant),
@@ -192,7 +194,9 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
             overlap_size=self.args.partition_overlap,
         )
         tp_inst.assert_awaited_once_with("content")
-        mem_patch.assert_awaited_once_with(dsn=self.args.dsn)
+        mem_patch.assert_awaited_once_with(
+            dsn=self.args.dsn, logger=self.logger
+        )
         memory_store.append_with_partitions.assert_awaited_once_with(
             self.args.namespace,
             UUID(self.args.participant),
@@ -310,7 +314,9 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
             self.args.encoding,
             self.args.partition_max_tokens,
         )
-        mem_patch.assert_awaited_once_with(dsn=self.args.dsn)
+        mem_patch.assert_awaited_once_with(
+            dsn=self.args.dsn, logger=self.logger
+        )
         call = memory_store.append_with_partitions.await_args
         self.assertEqual(call.kwargs["memory_type"], MemoryType.CODE)
         self.assertEqual(len(call.kwargs["partitions"]), 1)
@@ -658,7 +664,9 @@ class CliMemorySearchTestCase(IsolatedAsyncioTestCase):
             overlap_size=self.args.partition_overlap,
         )
         tp_inst.assert_awaited_once_with("query")
-        mem_patch.assert_awaited_once_with(dsn=self.args.dsn)
+        mem_patch.assert_awaited_once_with(
+            dsn=self.args.dsn, logger=self.logger
+        )
         memory_store.search_memories.assert_awaited_once_with(
             search_partitions=[partition],
             participant_id=UUID(self.args.participant),

--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -22,6 +22,7 @@ class MemoryManagerCreateTestCase(IsolatedAsyncioTestCase):
             agent_id=agent_id,
             participant_id=participant_id,
             text_partitioner=tp,
+            logger=MagicMock(),
         )
 
         self.assertIsInstance(manager.recent_message, RecentMessageMemory)
@@ -46,13 +47,17 @@ class MemoryManagerCreateTestCase(IsolatedAsyncioTestCase):
             with patch.dict(
                 "sys.modules", {"avalan.memory.permanent.pgsql.message": dummy}
             ):
+                logger = MagicMock()
                 manager = await MemoryManager.create_instance(
                     agent_id=agent_id,
                     participant_id=participant_id,
                     text_partitioner=tp,
+                    logger=logger,
                     with_permanent_message_memory="dsn",
                 )
-            PgsqlDummy.create_instance.assert_awaited_once_with(dsn="dsn")
+            PgsqlDummy.create_instance.assert_awaited_once_with(
+                dsn="dsn", logger=logger
+            )
 
         self.assertIs(manager.permanent_message, pmemory)
         self.assertIsInstance(manager.recent_message, RecentMessageMemory)

--- a/tests/memory/permanent/pgsql_raw_memory_test.py
+++ b/tests/memory/permanent/pgsql_raw_memory_test.py
@@ -12,16 +12,17 @@ from uuid import uuid4, UUID
 
 class PgsqlRawMemoryTestCase(IsolatedAsyncioTestCase):
     async def test_create_instance(self):
+        logger = MagicMock()
         with patch.object(PgsqlRawMemory, "open", AsyncMock()) as open_patch:
             memory = await PgsqlRawMemory.create_instance(
-                dsn="dsn", pool_minimum=1, pool_maximum=2
+                dsn="dsn", pool_minimum=1, pool_maximum=2, logger=logger
             )
             self.assertIsInstance(memory, PgsqlRawMemory)
             open_patch.assert_awaited_once()
 
         with patch.object(PgsqlRawMemory, "open", AsyncMock()) as open_patch:
             memory = await PgsqlRawMemory.create_instance(
-                dsn="dsn", pool_open=False
+                dsn="dsn", pool_open=False, logger=logger
             )
             self.assertIsInstance(memory, PgsqlRawMemory)
             open_patch.assert_not_awaited()
@@ -29,7 +30,8 @@ class PgsqlRawMemoryTestCase(IsolatedAsyncioTestCase):
     async def test_append_with_partitions(self):
         pool_mock, connection_mock, cursor_mock, txn_mock = self.mock_insert()
         memory_store = await PgsqlRawMemory.create_instance_from_pool(
-            pool=pool_mock
+            pool=pool_mock,
+            logger=MagicMock(),
         )
 
         base_memory = Memory(

--- a/tests/memory/permanent/pgsql_test.py
+++ b/tests/memory/permanent/pgsql_test.py
@@ -162,8 +162,9 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
         with patch.object(
             PgsqlMessageMemory, "open", AsyncMock()
         ) as open_patch:
+            logger = MagicMock()
             memory = await PgsqlMessageMemory.create_instance(
-                dsn="dsn", pool_minimum=1, pool_maximum=2
+                dsn="dsn", pool_minimum=1, pool_maximum=2, logger=logger
             )
             self.assertIsInstance(memory, PgsqlMessageMemory)
             open_patch.assert_awaited_once()
@@ -172,7 +173,7 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
             PgsqlMessageMemory, "open", AsyncMock()
         ) as open_patch:
             memory = await PgsqlMessageMemory.create_instance(
-                dsn="dsn", pool_open=False
+                dsn="dsn", pool_open=False, logger=logger
             )
             self.assertIsInstance(memory, PgsqlMessageMemory)
             open_patch.assert_not_awaited()
@@ -180,7 +181,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
     async def test_create_session(self):
         pool_mock, connection_mock, cursor_mock = self.mock_query({})
         memory = await PgsqlMessageMemory.create_instance_from_pool(
-            pool=pool_mock
+            pool=pool_mock,
+            logger=MagicMock(),
         )
         agent_id = uuid4()
         participant_id = uuid4()
@@ -219,7 +221,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
     async def test_append_with_partitions(self):
         pool_mock, connection_mock, cursor_mock, txn_mock = self.mock_insert()
         memory = await PgsqlMessageMemory.create_instance_from_pool(
-            pool=pool_mock
+            pool=pool_mock,
+            logger=MagicMock(),
         )
         session_id = uuid4()
         memory._session_id = session_id
@@ -299,7 +302,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
     async def test_append_with_partitions_without_session(self):
         pool_mock, connection_mock, cursor_mock, _ = self.mock_insert()
         memory = await PgsqlMessageMemory.create_instance_from_pool(
-            pool=pool_mock
+            pool=pool_mock,
+            logger=MagicMock(),
         )
         agent_id = uuid4()
 
@@ -376,7 +380,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 memory = await PgsqlMessageMemory.create_instance_from_pool(
-                    pool=pool_mock
+                    pool=pool_mock,
+                    logger=MagicMock(),
                 )
 
                 result = await memory.continue_session_and_get_id(
@@ -436,7 +441,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 memory = await PgsqlMessageMemory.create_instance_from_pool(
-                    pool=pool_mock
+                    pool=pool_mock,
+                    logger=MagicMock(),
                 )
 
                 result = await memory.get_recent_messages(
@@ -526,7 +532,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 memory = await PgsqlMessageMemory.create_instance_from_pool(
-                    pool=pool_mock
+                    pool=pool_mock,
+                    logger=MagicMock(),
                 )
 
                 search_function = str(function)
@@ -653,7 +660,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                     fetch_all=True,
                 )
                 memory = await PgsqlMessageMemory.create_instance_from_pool(
-                    pool=pool_mock
+                    pool=pool_mock,
+                    logger=MagicMock(),
                 )
                 search_partitions = [
                     TextPartition(data="", total_tokens=1, embeddings=rand(3))
@@ -758,7 +766,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 memory_store = await PgsqlRawMemory.create_instance_from_pool(
-                    pool=pool_mock
+                    pool=pool_mock,
+                    logger=MagicMock(),
                 )
 
                 search_function = str(function)


### PR DESCRIPTION
## Summary
- require a logger for BasePgsqlMemory and subclasses
- log query execution time in BasePgsqlMemory
- pass logger through PgsqlMessageMemory and PgsqlRawMemory helpers
- adapt MemoryManager and CLI to supply loggers
- update tests for new logger argument

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_684f0813c1a48323b0890dc075f804dd