### PR TITLE
Add event manager hooks for memory operations

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -278,6 +278,11 @@ class OrchestratorLoader:
 
         logger.debug("Loading memory manager for agent %s", settings.agent_id)
 
+        event_manager = EventManager()
+        event_manager.add_listener(
+            lambda e: logger.debug("Event %s: %s", e.type, e.payload)
+        )
+
         memory = await MemoryManager.create_instance(
             agent_id=settings.agent_id,
             participant_id=participant_id,
@@ -285,6 +290,7 @@ class OrchestratorLoader:
             logger=logger,
             with_permanent_message_memory=settings.memory_permanent_message,
             with_recent_message_memory=settings.memory_recent,
+            event_manager=event_manager,
         )
 
         for namespace, dsn in (settings.permanent_memory or {}).items():
@@ -325,11 +331,6 @@ class OrchestratorLoader:
             settings=ToolManagerSettings(),
         )
         tool = await stack.enter_async_context(tool)
-
-        event_manager = EventManager()
-        event_manager.add_listener(
-            lambda e: logger.debug("Event %s: %s", e.type, e.payload)
-        )
 
         logger.debug(
             "Creating orchestrator %s #%s",

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -17,6 +17,20 @@ class EventType(StrEnum):
     CALL_PREPARE_AFTER = "call_prepare_after"
     MEMORY_APPEND_BEFORE = "memory_append_before"
     MEMORY_APPEND_AFTER = "memory_append_after"
+    MEMORY_PERMANENT_MESSAGE_ADD = "memory_permanent_message_add"
+    MEMORY_PERMANENT_MESSAGE_ADDED = "memory_permanent_message_added"
+    MEMORY_PERMANENT_MESSAGE_SESSION_CONTINUE = (
+        "memory_permanent_message_session_continue"
+    )
+    MEMORY_PERMANENT_MESSAGE_SESSION_CONTINUED = (
+        "memory_permanent_message_session_continued"
+    )
+    MEMORY_PERMANENT_MESSAGE_SESSION_START = (
+        "memory_permanent_message_session_start"
+    )
+    MEMORY_PERMANENT_MESSAGE_SESSION_STARTED = (
+        "memory_permanent_message_session_started"
+    )
     MODEL_EXECUTE_BEFORE = "model_execute_before"
     MODEL_EXECUTE_AFTER = "model_execute_after"
     INPUT_TOKEN_COUNT_BEFORE = "input_token_count_before"


### PR DESCRIPTION
## Summary
- extend `EventType` with memory permanent message events
- inject `EventManager` into `MemoryManager`
- fire events during permanent message operations
- wire loader to create an `EventManager` for the memory
- update tests for new events and add coverage

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6850167d71cc832390874b8caf17b628