### PR TITLE
Add FancyTheme events tests

### DIFF
--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -2015,6 +2015,9 @@ class FancyTheme(Theme):
         only_tools: bool,
     ) -> list[str] | None:
         _, _n = self._, self._n
+        if not events or events_limit == 0:
+            return None
+
         event_log: list[str] | None = _lf(
             [
                 (
@@ -2074,8 +2077,6 @@ class FancyTheme(Theme):
                 )
                 for event in events
             ]
-            if events and events_limit is None or events_limit
-            else None
         )
 
         if event_log and events_limit:

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -754,3 +754,46 @@ class FancyThemeMoreTests(unittest.TestCase):
         self.assertEqual(FancyTheme._percentage(0.5), "50%")
         self.assertEqual(FancyTheme._percentage(0.123), "12.3%")
         self.assertEqual(FancyTheme._percentage(1), "100%")
+
+
+class FancyThemeEventsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.theme = FancyTheme(
+            lambda s: s, lambda s, p, n: s if n == 1 else p
+        )
+
+    def test_no_events(self):
+        self.assertIsNone(self.theme.events([]))
+        self.assertIsNone(self.theme.events([], events_limit=0))
+
+    def test_single_event(self):
+        event = Event(type=EventType.START)
+        panel = self.theme.events([event])
+        self.assertEqual(panel.height, 4)
+        self.assertIn("EventType.START", str(panel.renderable))
+
+        panel = self.theme.events([event], events_limit=1)
+        self.assertEqual(panel.height, 3)
+        self.assertIn("EventType.START", str(panel.renderable))
+
+    def test_multiple_events_with_limit(self):
+        e1 = Event(type=EventType.START)
+        e2 = Event(type=EventType.END)
+
+        panel = self.theme.events([e1, e2])
+        text = str(panel.renderable)
+        self.assertEqual(panel.height, 4)
+        self.assertIn("EventType.START", text)
+        self.assertIn("EventType.END", text)
+
+        panel = self.theme.events([e1, e2], events_limit=1)
+        text = str(panel.renderable)
+        self.assertEqual(panel.height, 3)
+        self.assertNotIn("EventType.START", text)
+        self.assertIn("EventType.END", text)
+
+        panel = self.theme.events([e1, e2], events_limit=2)
+        text = str(panel.renderable)
+        self.assertEqual(panel.height, 4)
+        self.assertIn("EventType.START", text)
+        self.assertIn("EventType.END", text)


### PR DESCRIPTION
## Summary
- handle empty events in FancyTheme._events_log
- add tests for FancyTheme.events covering empty, single and multiple events cases

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_685060a8844c8323b671293afec4ca7b