### PR TITLE
Add engine run events

### DIFF
--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -36,6 +36,8 @@ class EventType(StrEnum):
     INPUT_TOKEN_COUNT_BEFORE = "input_token_count_before"
     INPUT_TOKEN_COUNT_AFTER = "input_token_count_after"
     TOKEN_GENERATED = "token_generated"
+    ENGINE_RUN_BEFORE = "engine_run_before"
+    ENGINE_RUN_AFTER = "engine_run_after"
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
## Summary
- fire ENGINE_RUN_BEFORE and ENGINE_RUN_AFTER around `EngineAgent` calls
- record execution timing for ENGINE_RUN_AFTER
- test that Orchestrator triggers these events

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_685133a478988323aa63b356432e3c4a