### PR TITLE
Increase model module test coverage

### DIFF
--- a/tests/model/engine_additional_test.py
+++ b/tests/model/engine_additional_test.py
@@ -1,0 +1,48 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from avalan.entities import EngineSettings
+from avalan.model.engine import Engine, TokenizerNotSupportedException
+
+
+class DummyEngine(Engine):
+    def uses_tokenizer(self) -> bool:
+        return False
+
+    async def __call__(self, input, **kwargs):
+        return await super().__call__(input, **kwargs)
+
+    def _load_model(self):
+        return super()._load_model()
+
+
+class EngineAdditionalTestCase(IsolatedAsyncioTestCase):
+    async def test_base_call_raises(self):
+        engine = DummyEngine(
+            "id",
+            EngineSettings(auto_load_model=False, auto_load_tokenizer=False),
+        )
+        with self.assertRaises(NotImplementedError):
+            await engine("hi")
+
+    def test_base_load_model_raises(self):
+        engine = DummyEngine(
+            "id",
+            EngineSettings(auto_load_model=False, auto_load_tokenizer=False),
+        )
+        with self.assertRaises(NotImplementedError):
+            engine._load_model()
+
+    def test_load_tokenizer_with_tokens_raises(self):
+        engine = DummyEngine(
+            "id",
+            EngineSettings(auto_load_model=False, auto_load_tokenizer=False),
+        )
+        with self.assertRaises(TokenizerNotSupportedException):
+            engine._load_tokenizer_with_tokens("tok")
+
+    def test_get_device_memory_cuda_unavailable(self):
+        with patch(
+            "avalan.model.engine.cuda.is_available", return_value=False
+        ):
+            self.assertEqual(Engine._get_device_memory("cuda"), 0)

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -111,7 +111,121 @@ class MlxLmModelTestCase(IsolatedAsyncioTestCase):
         )
 
 
-if __name__ == "__main__":
-    from unittest import main
+class MlxLmModelAdditionalTestCase(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        stub = types.ModuleType("mlx_lm")
+        stub.load = MagicMock(return_value=("model", "tokenizer"))
+        stub.generate = MagicMock(return_value="out")
+        self.patch = patch.dict(sys.modules, {"mlx_lm": stub})
+        self.patch.start()
+        from avalan.model.nlp.text import generation as gen_mod
 
-    main()
+        sys.modules["avalan.model"].TextGenerationModel = (
+            gen_mod.TextGenerationModel
+        )
+        importlib.reload(
+            importlib.import_module("avalan.model.nlp.text.mlxlm")
+        )
+        self.mod = importlib.import_module("avalan.model.nlp.text.mlxlm")
+        self.stub = stub
+
+    async def asyncTearDown(self) -> None:
+        self.patch.stop()
+        del sys.modules["avalan.model"].TextGenerationModel
+
+    async def test_init_disables_auto_tokenizer(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=True
+            ),
+        )
+        self.assertFalse(model._settings.auto_load_tokenizer)
+
+    def test_load_model_sets_tokenizer(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        out = model._load_model()
+        self.stub.load.assert_called_once_with("id")
+        self.assertEqual(out, "model")
+        self.assertEqual(model._tokenizer, "tokenizer")
+        self.assertTrue(model._loaded_tokenizer)
+
+    async def test_stream_generator(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        model._model = "m"
+        model._tokenizer = "tok"
+        self.stub.generate.side_effect = lambda *a, **kw: iter(["a", "b"])
+        chunks = []
+        async for c in model._stream_generator("p", GenerationSettings()):
+            chunks.append(c)
+        self.assertEqual(chunks, ["a", "b"])
+
+    def test_string_output(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        model._model = "m"
+        model._tokenizer = "tok"
+        self.stub.generate.return_value = "text"
+        out = model._string_output("p", GenerationSettings())
+        self.assertEqual(out, "text")
+        self.stub.generate.assert_called_with(
+            "m",
+            "tok",
+            "p",
+            temperature=1.0,
+            top_p=1.0,
+            top_k=50,
+            max_tokens=None,
+            stop=None,
+        )
+
+    async def test_call_string_path(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        model._model = "m"
+        model._tokenizer = MagicMock()
+        model._tokenizer.decode.return_value = "p"
+        with (
+            patch.object(
+                self.mod.TextGenerationModel,
+                "_tokenize_input",
+                return_value={"input_ids": [1]},
+            ) as tok_mock,
+            patch.object(
+                self.mod.MlxLmModel, "_string_output", return_value="out"
+            ) as str_mock,
+        ):
+            result = await model(
+                "hi",
+                settings=GenerationSettings(use_async_generator=False),
+            )
+        tok_mock.assert_called_once()
+        str_mock.assert_called_once_with("p", GenerationSettings(use_async_generator=False))
+        self.assertEqual(result, "out")
+
+    def test_supports_sample_generation(self) -> None:
+        model = self.mod.MlxLmModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        self.assertFalse(model.supports_sample_generation)


### PR DESCRIPTION
## Summary
- add Engine base class edge case tests
- expand MlxLm model tests
- extend Huggingface hub tests for edge cases

## Testing
- `poetry run ruff check tests/model/engine_additional_test.py tests/model/nlp/mlxlm_extra_test.py tests/model/hubs/huggingface_test.py`
- `poetry run pytest --cov=src --cov-report=json -q`

------
https://chatgpt.com/codex/tasks/task_e_685219d9c2608323a1ecac85f4f67491