### PR TITLE
Fix tests after package upgrades

### DIFF
--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -444,7 +444,9 @@ class Engine(ABC):
                 name_or_path=self._tokenizer.name_or_path,
                 tokens=self._settings.tokens,
                 special_tokens=self._tokenizer.all_special_tokens,
-                tokenizer_model_max_length=self._tokenizer.model_max_length,
+                tokenizer_model_max_length=getattr(
+                    self._tokenizer, "model_max_length", 0
+                ),
                 fast=isinstance(self._tokenizer, PreTrainedTokenizerFast),
             )
 


### PR DESCRIPTION
## Summary
- avoid AttributeError by defaulting tokenizer model_max_length to 0

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6866e5df24a0832394d97737c9ecb5b0