### PR TITLE
Fix GPU device selection when using parallel CLI

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 import sys
 from asyncio import run as run_in_loop
 from asyncio.exceptions import CancelledError
-from torch.cuda import device_count, is_available
+from torch.cuda import device_count, is_available, set_device
 from torch.distributed import destroy_process_group
 from .. import license, name, site, version
 from ..cli import CommandAbortException, has_input
@@ -1286,6 +1286,12 @@ class CLI:
             ] + argv
             run(cmd, check=True)
             return
+
+        if args.parallel and "LOCAL_RANK" in environ:
+            rank = int(environ["LOCAL_RANK"])
+            if args.device.startswith("cuda") and ":" not in args.device:
+                args.device = f"cuda:{rank}"
+                set_device(rank)
 
         if args.version:
             print(f"{self._name} {self._version}")


### PR DESCRIPTION
## Summary
- set the CUDA device per spawned process when `--parallel` is used

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6866e91cccf48323a58fd53c832ac81a