### PR TITLE
Add parallel device tests

### DIFF
--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -205,6 +205,88 @@ class CliCallTestCase(IsolatedAsyncioTestCase):
         main_mock.assert_awaited_once()
         destroy.assert_called_once()
 
+    async def test_call_parallel_child_keeps_non_cuda_device(self):
+        with (
+            patch.dict("os.environ", {"LOCAL_RANK": "1"}, clear=False),
+            patch.object(
+                sys,
+                "argv",
+                ["prog", "--parallel", "colwise", "--device", "cpu"],
+            ),
+            patch(
+                "avalan.cli.__main__.translation", return_value=self.translator
+            ),
+            patch(
+                "avalan.cli.__main__.FancyTheme",
+                return_value=MagicMock(get_styles=lambda: {}),
+            ),
+            patch("avalan.cli.__main__.Console", return_value=MagicMock()),
+            patch.object(CLI, "_needs_hf_token", return_value=False),
+            patch("avalan.cli.__main__.HuggingfaceHub"),
+            patch("avalan.cli.__main__.destroy_process_group"),
+            patch("avalan.cli.__main__.set_device") as set_device_mock,
+            patch.object(CLI, "_main", AsyncMock()) as main_mock,
+        ):
+            await self.cli()
+        main_mock.assert_awaited_once()
+        self.assertEqual(main_mock.await_args.args[0].device, "cpu")
+        set_device_mock.assert_not_called()
+
+    async def test_call_parallel_child_sets_rank_on_cuda_device(self):
+        rank = 2
+        with (
+            patch.dict("os.environ", {"LOCAL_RANK": str(rank)}, clear=False),
+            patch.object(
+                sys,
+                "argv",
+                ["prog", "--parallel", "colwise", "--device", "cuda"],
+            ),
+            patch(
+                "avalan.cli.__main__.translation", return_value=self.translator
+            ),
+            patch(
+                "avalan.cli.__main__.FancyTheme",
+                return_value=MagicMock(get_styles=lambda: {}),
+            ),
+            patch("avalan.cli.__main__.Console", return_value=MagicMock()),
+            patch.object(CLI, "_needs_hf_token", return_value=False),
+            patch("avalan.cli.__main__.HuggingfaceHub"),
+            patch("avalan.cli.__main__.destroy_process_group"),
+            patch("avalan.cli.__main__.set_device") as set_device_mock,
+            patch.object(CLI, "_main", AsyncMock()) as main_mock,
+        ):
+            await self.cli()
+        main_mock.assert_awaited_once()
+        self.assertEqual(main_mock.await_args.args[0].device, f"cuda:{rank}")
+        set_device_mock.assert_called_once_with(rank)
+
+    async def test_call_parallel_child_leaves_explicit_cuda_device(self):
+        with (
+            patch.dict("os.environ", {"LOCAL_RANK": "0"}, clear=False),
+            patch.object(
+                sys,
+                "argv",
+                ["prog", "--parallel", "colwise", "--device", "cuda:1"],
+            ),
+            patch(
+                "avalan.cli.__main__.translation", return_value=self.translator
+            ),
+            patch(
+                "avalan.cli.__main__.FancyTheme",
+                return_value=MagicMock(get_styles=lambda: {}),
+            ),
+            patch("avalan.cli.__main__.Console", return_value=MagicMock()),
+            patch.object(CLI, "_needs_hf_token", return_value=False),
+            patch("avalan.cli.__main__.HuggingfaceHub"),
+            patch("avalan.cli.__main__.destroy_process_group"),
+            patch("avalan.cli.__main__.set_device") as set_device_mock,
+            patch.object(CLI, "_main", AsyncMock()) as main_mock,
+        ):
+            await self.cli()
+        main_mock.assert_awaited_once()
+        self.assertEqual(main_mock.await_args.args[0].device, "cuda:1")
+        set_device_mock.assert_not_called()
+
 
 class CliMainDispatchTestCase(IsolatedAsyncioTestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- test that GPU device selection is correct when using `--parallel` with `LOCAL_RANK`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6866eea71a108323ad580451d0a93f8c