### PR TITLE
Add YouTube transcript tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ tool = [
   "playwright==1.53.0",
   "RestrictedPython==8.0",
   "sympy==1.14.0",
+  "youtube-transcript-api==1.0.0",
 ]
 secrets = [
   "boto3==1.39.3",
@@ -159,6 +160,7 @@ all = [
   "tree-sitter==0.24.0",
   "tree-sitter-python==0.23.6",
   "uvicorn==0.35.0",
+  "youtube-transcript-api==1.0.0",
 ]
 
 [tool.black]

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -547,3 +547,39 @@ class User:
     name: str
     full_name: str | None = None
     access_token_name: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class GenericProxyConfig:
+    scheme: str
+    host: str
+    port: int
+    username: str | None = None
+    password: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        credentials = (
+            f"{self.username}:{self.password}@"
+            if self.username and self.password
+            else ""
+        )
+        url = f"{self.scheme}://{credentials}{self.host}:{self.port}"
+        return {"http": url, "https": url}
+
+
+@dataclass(frozen=True, kw_only=True)
+class WebshareProxyConfig:
+    host: str
+    port: int
+    username: str
+    password: str
+    scheme: str = "http"
+
+    def to_generic(self) -> GenericProxyConfig:
+        return GenericProxyConfig(
+            scheme=self.scheme,
+            host=self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+        )

--- a/src/avalan/tool/youtube.py
+++ b/src/avalan/tool/youtube.py
@@ -1,0 +1,65 @@
+from . import Tool, ToolSet
+from ..compat import override
+from ..entities import (
+    GenericProxyConfig,
+    ToolCallContext,
+    WebshareProxyConfig,
+)
+from contextlib import AsyncExitStack
+from typing import Iterable
+from importlib import import_module
+
+
+class YouTubeTranscriptTool(Tool):
+    """Return the transcript of a YouTube video."""
+
+    _proxy: GenericProxyConfig | WebshareProxyConfig | None
+
+    def __init__(
+        self,
+        *,
+        proxy: GenericProxyConfig | WebshareProxyConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self._proxy = proxy
+        self.__name__ = "transcript"
+
+    async def __call__(
+        self,
+        video_id: str,
+        *,
+        context: ToolCallContext,
+        languages: Iterable[str] | None = None,
+    ) -> list[str]:
+        proxies = None
+        if self._proxy:
+            proxy_cfg = (
+                self._proxy.to_generic()
+                if isinstance(self._proxy, WebshareProxyConfig)
+                else self._proxy
+            )
+            proxies = proxy_cfg.to_dict()
+        transcript_api = import_module(
+            "youtube_transcript_api"
+        ).YouTubeTranscriptApi
+        transcript = transcript_api.get_transcript(
+            video_id,
+            languages=list(languages) if languages else None,
+            proxies=proxies,
+        )
+        return [chunk.get("text", "") for chunk in transcript]
+
+
+class YouTubeToolSet(ToolSet):
+    @override
+    def __init__(
+        self,
+        *,
+        proxy: GenericProxyConfig | WebshareProxyConfig | None = None,
+        exit_stack: AsyncExitStack | None = None,
+        namespace: str | None = None,
+    ) -> None:
+        tools = [YouTubeTranscriptTool(proxy=proxy)]
+        super().__init__(
+            exit_stack=exit_stack, namespace=namespace, tools=tools
+        )

--- a/tests/tool/youtube_tool_test.py
+++ b/tests/tool/youtube_tool_test.py
@@ -1,0 +1,81 @@
+from avalan.entities import (
+    GenericProxyConfig,
+    ToolCallContext,
+    WebshareProxyConfig,
+)
+from avalan.tool.youtube import YouTubeToolSet, YouTubeTranscriptTool
+from unittest import IsolatedAsyncioTestCase, TestCase, main
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class YouTubeToolSetTestCase(TestCase):
+    def test_init(self):
+        toolset = YouTubeToolSet()
+        self.assertEqual(len(toolset.tools), 1)
+        self.assertIsInstance(toolset.tools[0], YouTubeTranscriptTool)
+
+
+class YouTubeTranscriptToolTestCase(IsolatedAsyncioTestCase):
+    async def test_call_no_proxy(self):
+        dummy_api = SimpleNamespace(
+            YouTubeTranscriptApi=SimpleNamespace(
+                get_transcript=MagicMock(
+                    return_value=[{"text": "a"}, {"text": "b"}]
+                )
+            )
+        )
+        with patch(
+            "avalan.tool.youtube.import_module", return_value=dummy_api
+        ) as imp:
+            tool = YouTubeTranscriptTool()
+            result = await tool(
+                "id", languages=["en"], context=ToolCallContext()
+            )
+            imp.assert_called_once_with("youtube_transcript_api")
+            dummy_api.YouTubeTranscriptApi.get_transcript.assert_called_once_with(
+                "id", languages=["en"], proxies=None
+            )
+            self.assertEqual(result, ["a", "b"])
+
+    async def test_call_with_generic_proxy(self):
+        dummy_api = SimpleNamespace(
+            YouTubeTranscriptApi=SimpleNamespace(
+                get_transcript=MagicMock(return_value=[])
+            )
+        )
+        with patch(
+            "avalan.tool.youtube.import_module", return_value=dummy_api
+        ):
+            proxy = GenericProxyConfig(
+                scheme="http", host="h", port=1, username="u", password="p"
+            )
+            tool = YouTubeTranscriptTool(proxy=proxy)
+            await tool("id2", context=ToolCallContext())
+            url = "http://u:p@h:1"
+            dummy_api.YouTubeTranscriptApi.get_transcript.assert_called_once_with(
+                "id2", languages=None, proxies={"http": url, "https": url}
+            )
+
+    async def test_call_with_webshare_proxy(self):
+        dummy_api = SimpleNamespace(
+            YouTubeTranscriptApi=SimpleNamespace(
+                get_transcript=MagicMock(return_value=[])
+            )
+        )
+        with patch(
+            "avalan.tool.youtube.import_module", return_value=dummy_api
+        ):
+            proxy = WebshareProxyConfig(
+                host="wh", port=2, username="w", password="pw"
+            )
+            tool = YouTubeTranscriptTool(proxy=proxy)
+            await tool("id3", context=ToolCallContext())
+            url = "http://w:pw@wh:2"
+            dummy_api.YouTubeTranscriptApi.get_transcript.assert_called_once_with(
+                "id3", languages=None, proxies={"http": url, "https": url}
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support YouTube transcripts via new `youtube` toolset
- allow proxy configuration via `GenericProxyConfig` and `WebshareProxyConfig`
- install `youtube-transcript-api` in the `tool` extra
- test YouTube transcript tool behaviour

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6868358d71908323af2170d6227daf2d