### PR TITLE
Implement tool call confirmation

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -132,6 +132,7 @@ class Orchestrator:
         return self._event_manager
 
     async def __call__(self, input: Input, **kwargs) -> OrchestratorResponse:
+        tool_confirm = kwargs.pop("tool_confirm", None)
         if self.is_finished:
             self._operation_step = 0
 
@@ -216,6 +217,7 @@ class Orchestrator:
             engine_args,
             event_manager=self._event_manager,
             tool=self._tool,
+            tool_confirm=tool_confirm,
             agent_id=self._id,
             participant_id=self._memory.participant_id,
             session_id=(

--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -2,6 +2,9 @@ from contextlib import nullcontext
 from rich.console import Console
 from rich.padding import Padding
 from rich.prompt import Confirm, Prompt
+from rich.syntax import Syntax
+from json import dumps
+from ..entities import ToolCall
 from select import select
 from sys import stdin
 
@@ -16,6 +19,21 @@ class CommandAbortException(BaseException):
 
 def confirm(console: Console, prompt: str) -> bool:
     return Confirm.ask(prompt)
+
+
+def confirm_tool_call(console: Console, call: ToolCall) -> str:
+    """Return user's decision on executing ``call``."""
+    console.print(
+        Syntax(
+            dumps({"name": call.name, "arguments": call.arguments}, indent=2),
+            "json",
+        )
+    )
+    return Prompt.ask(
+        "Execute tool call? ([y]es/[a]ll/[n]o)",
+        choices=["y", "a", "n"],
+        default="n",
+    )
 
 
 def has_input(console: Console) -> bool:

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -558,6 +558,11 @@ class CLI:
                 "with input piping)"
             ),
         )
+        agent_run_parser.add_argument(
+            "--tools-confirm",
+            action="store_true",
+            help="Confirm tool calls before execution",
+        )
 
         CLI._add_agent_settings_arguments(agent_run_parser)
         CLI._add_tool_settings_arguments(

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -19,6 +19,7 @@ from unittest import IsolatedAsyncioTestCase
 from dataclasses import dataclass
 from avalan.tool.manager import ToolManager
 from avalan.entities import ToolCall, ToolCallResult
+from avalan.cli import CommandAbortException
 from io import StringIO
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -522,3 +523,60 @@ class OrchestratorResponsePotentialDetectionTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(tool.is_potential_tool_call.call_count, 6)
         self.assertEqual(items[0], "")
         self.assertEqual(items[-1], "r")
+
+
+class OrchestratorResponseConfirmTestCase(IsolatedAsyncioTestCase):
+    async def test_reject_tool_call(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+
+        async def outer_gen():
+            for ch in "call":
+                yield ch
+
+        outer_response = TextGenerationResponse(
+            lambda: outer_gen(), use_async_generator=True
+        )
+
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.get_calls.side_effect = lambda text: (
+            [ToolCall(id=uuid4(), name="calc", arguments=None)]
+            if text == "call"
+            else None
+        )
+
+        tool.side_effect = AsyncMock()
+
+        async def inner_gen():
+            yield "r"
+
+        inner_response = TextGenerationResponse(
+            lambda: inner_gen(), use_async_generator=True
+        )
+        agent.return_value = inner_response
+
+        def confirm(_call: ToolCall) -> str:
+            return "n"
+
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            outer_response,
+            agent,
+            operation,
+            {},
+            tool=tool,
+            event_manager=event_manager,
+            tool_confirm=confirm,
+        )
+
+        with self.assertRaises(CommandAbortException):
+            async for _ in resp:
+                pass
+
+        tool.assert_not_awaited()

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -580,3 +580,69 @@ class OrchestratorResponseConfirmTestCase(IsolatedAsyncioTestCase):
                 pass
 
         tool.assert_not_awaited()
+
+    async def test_confirm_all_with_coroutine(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+
+        async def outer_gen():
+            for ch in "call":
+                yield ch
+
+        outer_response = TextGenerationResponse(
+            lambda: outer_gen(), use_async_generator=True
+        )
+
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.get_calls.side_effect = lambda text: (
+            [ToolCall(id=uuid4(), name="calc", arguments=None)]
+            if text == "call"
+            else None
+        )
+
+        async def tool_exec(call, context: ToolCallContext):
+            return ToolCallResult(
+                id=uuid4(),
+                call=call,
+                name=call.name,
+                arguments=call.arguments,
+                result="2",
+            )
+
+        tool.side_effect = tool_exec
+
+        async def inner_gen():
+            yield "r"
+
+        inner_response = TextGenerationResponse(
+            lambda: inner_gen(), use_async_generator=True
+        )
+        agent.return_value = inner_response
+
+        async def confirm(_call: ToolCall) -> str:
+            return "a"
+
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            outer_response,
+            agent,
+            operation,
+            {},
+            tool=tool,
+            event_manager=event_manager,
+            tool_confirm=confirm,
+        )
+
+        self.assertFalse(resp._tool_confirm_all)
+
+        async for _ in resp:
+            pass
+
+        self.assertTrue(resp._tool_confirm_all)
+        tool.assert_awaited()

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -2,7 +2,11 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from argparse import Namespace
+from uuid import uuid4
+
 from rich.syntax import Syntax
+
+from avalan.entities import ToolCall
 from avalan.cli.commands import agent as agent_cmds
 from avalan.event import Event, EventType
 from avalan.memory.permanent import VectorFunction
@@ -982,6 +986,52 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         stats = fn.__closure__[0].cell_contents
         self.assertEqual(stats.total_triggers, 2)
         self.assertEqual(stats.triggers[EventType.START], 2)
+
+    async def test_run_tools_confirm_calls_callback(self):
+        self.args.tools_confirm = True
+        self.orch.tool = MagicMock(is_empty=False)
+        call_obj = ToolCall(id=uuid4(), name="calc", arguments={"a": 1})
+
+        class DummyOrchestratorResponse:
+            pass
+
+        async def orch_call(*args, tool_confirm=None, **kwargs):
+            self.assertIsNotNone(tool_confirm)
+            self.callback_result = tool_confirm(call_obj)
+            return DummyOrchestratorResponse()
+
+        self.orch.side_effect = orch_call
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value="hi"),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(return_value=self.orch),
+            ),
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg,
+            patch.object(
+                agent_cmds, "OrchestratorResponse", DummyOrchestratorResponse
+            ),
+            patch.object(
+                agent_cmds, "confirm_tool_call", return_value="y"
+            ) as ctc,
+        ):
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+
+        self.orch.assert_awaited_once_with(
+            "hi", use_async_generator=True, tool_confirm=unittest.mock.ANY
+        )
+        tg.assert_awaited_once()
+        ctc.assert_called_once_with(self.console, call_obj)
+        self.assertEqual(self.callback_result, "y")
 
 
 class CliAgentInitEarlyReturnTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -226,6 +226,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             display_events=False,
             display_tools=False,
             display_tools_events=2,
+            tools_confirm=False,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -292,6 +293,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             display_events=False,
             display_tools=False,
             display_tools_events=2,
+            tools_confirm=False,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -469,6 +471,7 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
             display_events=False,
             display_tools=False,
             display_tools_events=2,
+            tools_confirm=False,
         )
         self.console = MagicMock()
         status_cm = MagicMock()
@@ -574,7 +577,9 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
                 self.args, self.console, self.theme, self.hub, self.logger, 1
             )
 
-        self.orch.assert_awaited_once_with("hi", use_async_generator=True)
+        self.orch.assert_awaited_once_with(
+            "hi", use_async_generator=True, tool_confirm=None
+        )
         tg_patch.assert_awaited_once()
         self.orch.memory.continue_session.assert_awaited()
         self.console.print.assert_any_call("agent_panel")
@@ -633,7 +638,9 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
                 self.args, self.console, self.theme, self.hub, self.logger, 1
             )
 
-        self.orch.assert_awaited_once_with("hi", use_async_generator=True)
+        self.orch.assert_awaited_once_with(
+            "hi", use_async_generator=True, tool_confirm=None
+        )
         tg_patch.assert_awaited_once()
 
         self.assertEqual(len(self.console.status.call_args_list), 1)


### PR DESCRIPTION
## Summary
- add `--tools-confirm` option to agent run command
- prompt user for tool call confirmation
- abort tool execution when rejected
- support confirmation callback in orchestrator response
- test tool confirmation logic

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68683755d0948323993ddf683b63bbe0