### PR TITLE
Add test for confirm-all coroutine

### DIFF
--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -580,3 +580,69 @@ class OrchestratorResponseConfirmTestCase(IsolatedAsyncioTestCase):
                 pass
 
         tool.assert_not_awaited()
+
+    async def test_confirm_all_with_coroutine(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+
+        async def outer_gen():
+            for ch in "call":
+                yield ch
+
+        outer_response = TextGenerationResponse(
+            lambda: outer_gen(), use_async_generator=True
+        )
+
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.get_calls.side_effect = lambda text: (
+            [ToolCall(id=uuid4(), name="calc", arguments=None)]
+            if text == "call"
+            else None
+        )
+
+        async def tool_exec(call, context: ToolCallContext):
+            return ToolCallResult(
+                id=uuid4(),
+                call=call,
+                name=call.name,
+                arguments=call.arguments,
+                result="2",
+            )
+
+        tool.side_effect = tool_exec
+
+        async def inner_gen():
+            yield "r"
+
+        inner_response = TextGenerationResponse(
+            lambda: inner_gen(), use_async_generator=True
+        )
+        agent.return_value = inner_response
+
+        async def confirm(_call: ToolCall) -> str:
+            return "a"
+
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            outer_response,
+            agent,
+            operation,
+            {},
+            tool=tool,
+            event_manager=event_manager,
+            tool_confirm=confirm,
+        )
+
+        self.assertFalse(resp._tool_confirm_all)
+
+        async for _ in resp:
+            pass
+
+        self.assertTrue(resp._tool_confirm_all)
+        tool.assert_awaited()


### PR DESCRIPTION
## Summary
- add coverage for OrchestratorResponse.__anext__ when confirming all tool calls with a coroutine

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68683e1df1dc8323bb2dfcbb0f26948f