### PR TITLE
Ensure message event context

### DIFF
--- a/src/avalan/agent/engine.py
+++ b/src/avalan/agent/engine.py
@@ -173,6 +173,19 @@ class EngineAgent(ABC):
                             "model_type": self._model.model_type,
                             "model_id": self._model.model_id,
                             "message": previous_message,
+                            "participant_id": getattr(
+                                self._memory, "participant_id", None
+                            ),
+                            "session_id": (
+                                getattr(
+                                    self._memory, "permanent_message", None
+                                )
+                                and getattr(
+                                    self._memory.permanent_message,
+                                    "session_id",
+                                    None,
+                                )
+                            ),
                         },
                     )
                 )
@@ -190,6 +203,19 @@ class EngineAgent(ABC):
                             "model_type": self._model.model_type,
                             "model_id": self._model.model_id,
                             "message": previous_message,
+                            "participant_id": getattr(
+                                self._memory, "participant_id", None
+                            ),
+                            "session_id": (
+                                getattr(
+                                    self._memory, "permanent_message", None
+                                )
+                                and getattr(
+                                    self._memory.permanent_message,
+                                    "session_id",
+                                    None,
+                                )
+                            ),
                         },
                     )
                 )
@@ -201,6 +227,17 @@ class EngineAgent(ABC):
                         "model_type": self._model.model_type,
                         "model_id": self._model.model_id,
                         "message": new_message,
+                        "participant_id": getattr(
+                            self._memory, "participant_id", None
+                        ),
+                        "session_id": (
+                            getattr(self._memory, "permanent_message", None)
+                            and getattr(
+                                self._memory.permanent_message,
+                                "session_id",
+                                None,
+                            )
+                        ),
                     },
                 )
             )
@@ -218,6 +255,17 @@ class EngineAgent(ABC):
                         "model_type": self._model.model_type,
                         "model_id": self._model.model_id,
                         "message": new_message,
+                        "participant_id": getattr(
+                            self._memory, "participant_id", None
+                        ),
+                        "session_id": (
+                            getattr(self._memory, "permanent_message", None)
+                            and getattr(
+                                self._memory.permanent_message,
+                                "session_id",
+                                None,
+                            )
+                        ),
                     },
                 )
             )

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -146,7 +146,15 @@ class MemoryManager:
                 await self._event_manager.trigger(
                     Event(
                         type=EventType.MEMORY_PERMANENT_MESSAGE_ADD,
-                        payload={"message": engine_message},
+                        payload={
+                            "message": engine_message,
+                            "participant_id": self._participant_id,
+                            "session_id": (
+                                self._permanent_message_memory.session_id
+                                if self._permanent_message_memory
+                                else None
+                            ),
+                        },
                         started=start,
                     )
                 )
@@ -161,7 +169,15 @@ class MemoryManager:
                 await self._event_manager.trigger(
                     Event(
                         type=EventType.MEMORY_PERMANENT_MESSAGE_ADDED,
-                        payload={"message": engine_message},
+                        payload={
+                            "message": engine_message,
+                            "participant_id": self._participant_id,
+                            "session_id": (
+                                self._permanent_message_memory.session_id
+                                if self._permanent_message_memory
+                                else None
+                            ),
+                        },
                         started=start,
                         finished=end,
                         ellapsed=end - start,
@@ -187,7 +203,10 @@ class MemoryManager:
                 await self._event_manager.trigger(
                     Event(
                         type=EventType.MEMORY_PERMANENT_MESSAGE_SESSION_CONTINUE,
-                        payload={"session_id": session_id},
+                        payload={
+                            "session_id": session_id,
+                            "participant_id": self._participant_id,
+                        },
                         started=start,
                     )
                 )
@@ -219,7 +238,10 @@ class MemoryManager:
             await self._event_manager.trigger(
                 Event(
                     type=EventType.MEMORY_PERMANENT_MESSAGE_SESSION_CONTINUED,
-                    payload={"session_id": session_id},
+                    payload={
+                        "session_id": session_id,
+                        "participant_id": self._participant_id,
+                    },
                     started=start,
                     finished=end,
                     ellapsed=end - start,
@@ -234,7 +256,7 @@ class MemoryManager:
                 await self._event_manager.trigger(
                     Event(
                         type=EventType.MEMORY_PERMANENT_MESSAGE_SESSION_START,
-                        payload={},
+                        payload={"participant_id": self._participant_id},
                         started=start,
                     )
                 )
@@ -252,7 +274,10 @@ class MemoryManager:
                 Event(
                     type=EventType.MEMORY_PERMANENT_MESSAGE_SESSION_STARTED,
                     payload={
-                        "session_id": self._permanent_message_memory.session_id
+                        "session_id": (
+                            self._permanent_message_memory.session_id
+                        ),
+                        "participant_id": self._participant_id,
                     },
                     started=start,
                     finished=end,

--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -369,6 +369,7 @@ class MemoryManagerEventTestCase(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.tp = AsyncMock()
         self.pm = AsyncMock(spec=PermanentMessageMemory)
+        self.pm.session_id = uuid4()
         self.rm = RecentMessageMemory()
         self.event_manager = MagicMock(spec=EventManager)
         self.event_manager.trigger = AsyncMock()
@@ -403,6 +404,14 @@ class MemoryManagerEventTestCase(IsolatedAsyncioTestCase):
                 for c in self.event_manager.trigger.await_args_list
             )
         )
+        self.assertTrue(
+            any(
+                c.args[0].type == EventType.MEMORY_PERMANENT_MESSAGE_ADD
+                and c.args[0].payload.get("participant_id")
+                == self.manager.participant_id
+                for c in self.event_manager.trigger.await_args_list
+            )
+        )
 
     async def test_continue_session_triggers_events(self):
         session_id = uuid4()
@@ -425,6 +434,15 @@ class MemoryManagerEventTestCase(IsolatedAsyncioTestCase):
                 for c in self.event_manager.trigger.await_args_list
             )
         )
+        self.assertTrue(
+            any(
+                c.args[0].type
+                == EventType.MEMORY_PERMANENT_MESSAGE_SESSION_CONTINUE
+                and c.args[0].payload.get("participant_id")
+                == self.manager.participant_id
+                for c in self.event_manager.trigger.await_args_list
+            )
+        )
 
     async def test_start_session_triggers_events(self):
         await self.manager.start_session()
@@ -443,6 +461,15 @@ class MemoryManagerEventTestCase(IsolatedAsyncioTestCase):
                 c.args[0].type
                 == EventType.MEMORY_PERMANENT_MESSAGE_SESSION_STARTED
                 and c.args[0].ellapsed is not None
+                for c in self.event_manager.trigger.await_args_list
+            )
+        )
+        self.assertTrue(
+            any(
+                c.args[0].type
+                == EventType.MEMORY_PERMANENT_MESSAGE_SESSION_START
+                and c.args[0].payload.get("participant_id")
+                == self.manager.participant_id
                 for c in self.event_manager.trigger.await_args_list
             )
         )


### PR DESCRIPTION
## Summary
- include participant and session context in message events
- add assertions checking payload context in unit tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6869512b777c8323b694d35d49a5875b