### PR TITLE
Add attention mask setting for generation

### DIFF
--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -239,6 +239,8 @@ class GenerationSettings:
     enable_gradient_calculation: bool = False
     # Use async generator (token streaming)
     use_async_generator: bool = True
+    # Optional attention mask passed directly to ``generate``
+    attention_mask: Tensor | None = None
     # Parameters passed to tokenizer.apply_chat_template
     chat_template_settings: dict[str, object] | None = field(
         default_factory=lambda: {

--- a/src/avalan/model/nlp/__init__.py
+++ b/src/avalan/model/nlp/__init__.py
@@ -76,6 +76,9 @@ class BaseNLPModel(TransformerModel, ABC):
             "use_cache": settings.use_cache,
         }
 
+        if settings.attention_mask is not None:
+            generation_kwargs["attention_mask"] = settings.attention_mask
+
         if settings.forced_bos_token_id or settings.forced_eos_token_id:
             del generation_kwargs["bos_token_id"]
             del generation_kwargs["eos_token_id"]

--- a/tests/model/nlp/base_model_test.py
+++ b/tests/model/nlp/base_model_test.py
@@ -1,4 +1,5 @@
 from avalan.entities import GenerationSettings, TransformerEngineSettings
+import torch
 from avalan.model.nlp import BaseNLPModel
 from logging import Logger
 from contextlib import nullcontext
@@ -39,3 +40,24 @@ class BaseNLPModelGenerateTestCase(TestCase):
         self.assertNotIn("bos_token_id", kwargs)
         self.assertNotIn("eos_token_id", kwargs)
         self.assertIs(result, model._model.generate.return_value)
+
+    def test_generate_output_attention_mask(self):
+        model = DummyNLPModel(
+            "model",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+            logger=MagicMock(spec=Logger),
+        )
+        model._model = MagicMock()
+        model._tokenizer = MagicMock(eos_token_id=2)
+        mask = torch.tensor([[1, 1]])
+        settings = GenerationSettings(attention_mask=mask)
+        with patch(
+            "avalan.model.nlp.inference_mode", return_value=nullcontext()
+        ) as inf_mock:
+            model._generate_output({}, settings)
+        inf_mock.assert_called_once_with()
+        model._model.generate.assert_called_once()
+        _, kwargs = model._model.generate.call_args
+        self.assertIs(kwargs["attention_mask"], mask)


### PR DESCRIPTION
## Summary
- allow specifying `attention_mask` in `GenerationSettings`
- forward that mask to generation calls
- test that attention mask is propagated

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686aa31eddf08323aefb9af120b60def