### PR TITLE
Support additional model modalities

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -19,6 +19,7 @@ from ...event.manager import EventManager
 from ...memory.manager import MemoryManager
 from ...model.engine import Engine
 from ...model.manager import ModelManager
+from ...entities import Modality
 from ...tool.manager import ToolManager
 from contextlib import ExitStack
 from dataclasses import asdict
@@ -238,7 +239,9 @@ class Orchestrator:
                 model_ids.append(environment.engine_uri.model_id)
                 engine = (
                     self._model_manager.load_engine(
-                        environment.engine_uri, environment.settings
+                        environment.engine_uri,
+                        environment.settings,
+                        Modality.TEXT_GENERATION,
                     )
                     if environment.type == EngineType.TEXT_GENERATION
                     else None

--- a/src/avalan/cli/commands/__init__.py
+++ b/src/avalan/cli/commands/__init__.py
@@ -1,4 +1,4 @@
-from ...entities import EngineUri
+from ...entities import EngineUri, Modality
 from ...model.hubs.huggingface import HuggingfaceHub
 from argparse import Namespace
 from logging import Logger
@@ -9,7 +9,7 @@ def get_model_settings(
     hub: HuggingfaceHub,
     logger: Logger,
     engine_uri: EngineUri,
-    is_sentence_transformer: bool | None = None,
+    modality: Modality | None = None,
 ) -> dict:
     """Return settings used to load a model."""
     return dict(
@@ -18,9 +18,14 @@ def get_model_settings(
         attention=args.attention if hasattr(args, "attention") else None,
         device=args.device,
         disable_loading_progress_bar=args.disable_loading_progress_bar,
-        is_sentence_transformer=is_sentence_transformer
-        or (
-            hasattr(args, "sentence_transformer") and args.sentence_transformer
+        modality=(
+            modality
+            or (
+                Modality.EMBEDDING
+                if hasattr(args, "sentence_transformer")
+                and args.sentence_transformer
+                else Modality.TEXT_GENERATION
+            )
         ),
         loader_class=args.loader_class,
         low_cpu_mem_usage=args.low_cpu_mem_usage,

--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -2,8 +2,8 @@ from argparse import Namespace
 from asyncio import to_thread
 from ...cli import get_input
 from ...cli.commands import get_model_settings
+from ...entities import DistanceType, Modality, SearchMatch, Similarity
 from ...cli.commands.model import model_display
-from ...entities import DistanceType, SearchMatch, Similarity
 from ...memory.partitioner.text import TextPartitioner, TextPartition
 from ...memory.partitioner.code import CodePartitioner
 from ...memory.permanent import MemoryType
@@ -52,7 +52,7 @@ async def memory_document_index(
     with ModelManager(hub, logger) as manager:
         engine_uri = manager.parse_uri(args.model)
         model_settings = get_model_settings(
-            args, hub, logger, engine_uri, is_sentence_transformer=True
+            args, hub, logger, engine_uri, modality=Modality.EMBEDDING
         )
 
         with manager.load(**model_settings) as stm:
@@ -167,7 +167,7 @@ async def memory_embeddings(
     reverse_sort = sort_by in (DistanceType.COSINE, DistanceType.PEARSON)
 
     model_settings = get_model_settings(
-        args, hub, logger, model_id, is_sentence_transformer=True
+        args, hub, logger, model_id, modality=Modality.EMBEDDING
     )
     with ModelManager(hub, logger) as manager:
         with manager.load(**model_settings) as stm:
@@ -391,7 +391,7 @@ async def memory_search(
         return
 
     model_settings = get_model_settings(
-        args, hub, logger, model_id, is_sentence_transformer=True
+        args, hub, logger, model_id, modality=Modality.EMBEDDING
     )
 
     with ModelManager(hub, logger) as manager:

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -2,7 +2,7 @@ from ...agent.orchestrator import Orchestrator
 from ...event import Event, EventType, TOOL_TYPES
 from ...cli import get_input, confirm
 from ...cli.commands.cache import cache_delete, cache_download
-from ...entities import GenerationSettings, Model, Token, TokenDetail
+from ...entities import GenerationSettings, Model, Modality, Token, TokenDetail
 from ...event import EventStats
 from ...model import TextGenerationResponse
 from ...model.hubs.huggingface import HuggingfaceHub
@@ -39,7 +39,7 @@ def model_display(
     hub: HuggingfaceHub,
     logger: Logger,
     *vargs,
-    is_sentence_transformer: bool | None = None,
+    modality: Modality | None = None,
     load: bool | None = None,
     model: SentenceTransformerModel | TextGenerationModel | None = None,
     summary: bool | None = None,
@@ -71,7 +71,7 @@ def model_display(
                 hub,
                 logger,
                 engine_uri,
-                is_sentence_transformer=is_sentence_transformer,
+                modality=modality,
             )
             with manager.load(**model_settings) as lm:
                 logger.debug("Loaded model %s", lm.config.__repr__())
@@ -143,7 +143,7 @@ async def model_run(
     with ModelManager(hub, logger) as manager:
         engine_uri = manager.parse_uri(args.model)
         model_settings = get_model_settings(
-            args, hub, logger, engine_uri, is_sentence_transformer=False
+            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
 
         if not args.quiet:

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -51,6 +51,19 @@ WeightType = Literal[
     "ui8",
 ]
 
+
+class Modality(StrEnum):
+    AUDIO_SPEECH_RECOGNITION = "audio_speech_recognition"
+    AUDIO_TEXT_TO_SPEECH = "audio_text_to_speech"
+    EMBEDDING = "embedding"
+    TEXT_GENERATION = "text_generation"
+    VISION_OBJECT_DETECTION = "vision_object_detection"
+    VISION_IMAGE_CLASSIFICATION = "vision_image_classification"
+    VISION_IMAGE_TO_TEXT = "vision_image_to_text"
+    VISION_ENCODER_DECODER = "vision_encoder_decoder"
+    VISION_SEMANTIC_SEGMENTATION = "vision_semantic_segmentation"
+
+
 ToolValue = bool | float | int | str | None
 
 

--- a/tests/agent/default_orchestrator_test.py
+++ b/tests/agent/default_orchestrator_test.py
@@ -6,6 +6,7 @@ from avalan.event import EventType
 from avalan.entities import (
     EngineUri,
     MessageRole,
+    Modality,
     TransformerEngineSettings,
 )
 from avalan.agent.orchestrator.response.orchestrator_response import (
@@ -137,7 +138,9 @@ class DefaultOrchestratorTestCase(IsolatedAsyncioTestCase):
             settings=settings,
         ) as orch:
             model_manager.load_engine.assert_called_once_with(
-                engine_uri, settings
+                engine_uri,
+                settings,
+                Modality.TEXT_GENERATION,
             )
             Agent.assert_called_once()
             self.assertIs(orch.engine_agent, agent_mock)

--- a/tests/cli/get_model_settings_test.py
+++ b/tests/cli/get_model_settings_test.py
@@ -3,6 +3,7 @@ from argparse import Namespace
 from unittest.mock import MagicMock
 
 from avalan.cli.commands import get_model_settings
+from avalan.entities import Modality
 
 
 class GetModelSettingsTestCase(unittest.TestCase):
@@ -34,7 +35,7 @@ class GetModelSettingsTestCase(unittest.TestCase):
             "device": "cpu",
             "parallel": "colwise",
             "disable_loading_progress_bar": True,
-            "is_sentence_transformer": True,
+            "modality": Modality.EMBEDDING,
             "loader_class": "auto",
             "low_cpu_mem_usage": True,
             "quiet": False,
@@ -67,6 +68,6 @@ class GetModelSettingsTestCase(unittest.TestCase):
             MagicMock(),
             MagicMock(),
             engine_uri,
-            is_sentence_transformer=True,
+            modality=Modality.EMBEDDING,
         )
-        self.assertTrue(result["is_sentence_transformer"])
+        self.assertEqual(result["modality"], Modality.EMBEDDING)

--- a/tests/cli/memory_test.py
+++ b/tests/cli/memory_test.py
@@ -1,5 +1,5 @@
 from avalan.cli.commands import memory as memory_cmds
-from avalan.entities import DistanceType
+from avalan.entities import DistanceType, Modality
 from avalan.memory.permanent import MemoryType, VectorFunction
 from avalan.memory.partitioner.text import TextPartition
 from argparse import Namespace
@@ -105,7 +105,7 @@ class CliMemoryDocumentIndexTestCase(IsolatedAsyncioTestCase):
             self.hub,
             self.logger,
             "engine_uri",
-            is_sentence_transformer=True,
+            modality=Modality.EMBEDDING,
         )
         tp_patch.assert_called_once_with(
             model,
@@ -388,7 +388,7 @@ class CliMemoryEmbeddingsTestCase(IsolatedAsyncioTestCase):
             self.hub,
             self.logger,
             self.args.model,
-            is_sentence_transformer=True,
+            modality=Modality.EMBEDDING,
         )
         model.assert_awaited_once_with(["text", *self.args.compare])
         self.assertEqual(len(self.console.print.call_args_list), 2)

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1,5 +1,6 @@
-from avalan.cli.commands import model as model_cmds
 from avalan.cli.commands import get_model_settings
+from avalan.cli.commands import model as model_cmds
+from avalan.entities import Modality
 from avalan.event.manager import EventManager
 from avalan.event import Event, EventType
 from types import SimpleNamespace
@@ -46,7 +47,7 @@ class CliModelTestCase(TestCase):
             "device": "cpu",
             "parallel": None,
             "disable_loading_progress_bar": True,
-            "is_sentence_transformer": True,
+            "modality": Modality.EMBEDDING,
             "loader_class": "auto",
             "low_cpu_mem_usage": True,
             "quiet": False,
@@ -856,7 +857,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
         gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, is_sentence_transformer=False
+            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
         manager.load.assert_called_once_with(engine_uri=engine_uri)
         lm.assert_not_called()
@@ -938,7 +939,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
         gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, is_sentence_transformer=False
+            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
         manager.load.assert_called_once_with(engine_uri=engine_uri)
 
@@ -1026,7 +1027,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
         gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, is_sentence_transformer=False
+            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
         manager.load.assert_called_once_with(engine_uri=engine_uri)
         lm.assert_awaited_once()

--- a/tests/model/model_manager_extra_test.py
+++ b/tests/model/model_manager_extra_test.py
@@ -64,3 +64,16 @@ class ModelManagerExtraTestCase(TestCase):
             uri, get_mock.return_value, Modality.TEXT_GENERATION
         )
         self.assertEqual(result, "model")
+
+    def test_load_engine_invalid_modality(self):
+        manager = ModelManager(self.hub, self.logger)
+        uri = manager.parse_uri("ai://tok@openai/gpt-4o")
+        settings = TransformerEngineSettings()
+        with self.assertRaises(NotImplementedError):
+            manager.load_engine(uri, settings, "invalid")  # type: ignore[arg-type]
+
+    def test_load_invalid_modality(self):
+        manager = ModelManager(self.hub, self.logger)
+        uri = manager.parse_uri("ai://tok@openai/gpt-4o")
+        with self.assertRaises(NotImplementedError):
+            manager.load(uri, modality="invalid")  # type: ignore[arg-type]

--- a/tests/model/model_manager_extra_test.py
+++ b/tests/model/model_manager_extra_test.py
@@ -1,4 +1,4 @@
-from avalan.entities import EngineUri, TransformerEngineSettings
+from avalan.entities import EngineUri, Modality, TransformerEngineSettings
 from avalan.model.hubs.huggingface import HuggingfaceHub
 from avalan.model.manager import ModelManager
 from logging import Logger
@@ -60,5 +60,7 @@ class ModelManagerExtraTestCase(TestCase):
         self.assertEqual(args["base_url"], "url")
         self.assertEqual(args["attention"], "sd")
         self.assertTrue(args["trust_remote_code"])
-        load_mock.assert_called_once_with(uri, get_mock.return_value, None)
+        load_mock.assert_called_once_with(
+            uri, get_mock.return_value, Modality.TEXT_GENERATION
+        )
         self.assertEqual(result, "model")

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -1,0 +1,78 @@
+from avalan.entities import EngineUri, Modality, TransformerEngineSettings
+from avalan.model.hubs.huggingface import HuggingfaceHub
+from avalan.model.manager import ModelManager
+from logging import Logger
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+class ModelManagerLoadEngineModalitiesTestCase(TestCase):
+    def setUp(self):
+        self.hub = MagicMock(spec=HuggingfaceHub)
+        self.logger = MagicMock(spec=Logger)
+
+    def test_load_engine_local_modalities(self):
+        modalities = {
+            Modality.TEXT_GENERATION: "TextGenerationModel",
+            Modality.EMBEDDING: "SentenceTransformerModel",
+            Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
+            Modality.AUDIO_TEXT_TO_SPEECH: "TextToSpeechModel",
+            Modality.VISION_OBJECT_DETECTION: "ObjectDetectionModel",
+            Modality.VISION_IMAGE_CLASSIFICATION: "ImageClassificationModel",
+            Modality.VISION_IMAGE_TO_TEXT: "ImageTextToTextModel",
+            Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
+            Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
+        }
+        for modality, class_name in modalities.items():
+            with self.subTest(modality=modality):
+                with ModelManager(self.hub, self.logger) as manager:
+                    uri = manager.parse_uri(
+                        f"ai://local/{modality.name.lower()}"
+                    )
+                    settings = TransformerEngineSettings()
+                    manager._stack.enter_context = MagicMock()
+                    path = f"avalan.model.manager.{class_name}"
+                    with patch(path) as Model:
+                        result = manager.load_engine(uri, settings, modality)
+                    Model.assert_called_once_with(
+                        model_id=modality.name.lower(),
+                        settings=settings,
+                        logger=self.logger,
+                    )
+                    manager._stack.enter_context.assert_called_once_with(
+                        Model.return_value
+                    )
+                    self.assertIs(result, Model.return_value)
+
+
+class ModelManagerLoadModalitiesTestCase(TestCase):
+    def setUp(self):
+        self.hub = MagicMock(spec=HuggingfaceHub)
+        self.logger = MagicMock(spec=Logger)
+
+    def test_load_delegates_per_modality(self):
+        for modality in Modality:
+            with self.subTest(modality=modality):
+                engine_uri = EngineUri(
+                    host=None,
+                    port=None,
+                    user=None,
+                    password=None,
+                    vendor=None,
+                    model_id="m",
+                    params={},
+                )
+                with ModelManager(self.hub, self.logger) as manager:
+                    with (
+                        patch.object(
+                            manager, "get_engine_settings"
+                        ) as get_mock,
+                        patch.object(manager, "load_engine") as load_mock,
+                    ):
+                        get_mock.return_value = TransformerEngineSettings()
+                        load_mock.return_value = "model"
+                        result = manager.load(engine_uri, modality=modality)
+                    load_mock.assert_called_once_with(
+                        engine_uri, get_mock.return_value, modality
+                    )
+                    self.assertEqual(result, "model")

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -1,4 +1,4 @@
-from avalan.entities import EngineUri, TransformerEngineSettings
+from avalan.entities import EngineUri, Modality, TransformerEngineSettings
 from avalan.model.hubs.huggingface import HuggingfaceHub
 from avalan.model.manager import ModelManager
 from avalan.secrets import KeyringSecrets
@@ -282,7 +282,7 @@ class ManagerEngineSettingsTestCase(TestCase):
         ) as manager:
             uri = manager.parse_uri("ai://tok@openai/gpt-4o")
             settings = manager.get_engine_settings(
-                uri, is_sentence_transformer=True
+                uri, modality=Modality.EMBEDDING
             )
             self.assertIsNone(settings.access_token)
         self.secrets_mock.read.assert_not_called()
@@ -386,7 +386,11 @@ class ManagerLoadEngineTestCase(TestCase):
                             result = manager.load_engine(
                                 engine_uri,
                                 settings,
-                                is_sentence_transformer=is_sentence,
+                                (
+                                    Modality.EMBEDDING
+                                    if is_sentence
+                                    else Modality.TEXT_GENERATION
+                                ),
                             )
                             Model.assert_called_once_with(
                                 model_id=model_id,
@@ -408,7 +412,11 @@ class ManagerLoadEngineTestCase(TestCase):
                             result = manager.load_engine(
                                 engine_uri,
                                 settings,
-                                is_sentence_transformer=is_sentence,
+                                (
+                                    Modality.EMBEDDING
+                                    if is_sentence
+                                    else Modality.TEXT_GENERATION
+                                ),
                             )
 
                         Model.assert_called_once_with(


### PR DESCRIPTION
## Summary
- add new `Modality` enum for audio, embedding and vision modes
- update `ModelManager` to load models by modality
- adjust CLI helpers and commands to pass modality instead of sentence flag
- update orchestrator and tests for new API

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686d9038c8888323ac737ed50afb85c0