### PR TITLE
Add tool call filters and transformers

### DIFF
--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+from collections.abc import Callable
 from numpy import ndarray
 from torch import dtype, Tensor
 from typing import Literal
@@ -524,6 +525,23 @@ class ToolManagerSettings:
     tool_format: ToolFormat | None = None
     avoid_repetition: bool = False
     maximum_depth: int | None = None
+    filters: (
+        list[
+            Callable[
+                [ToolCall, ToolCallContext],
+                tuple[ToolCall, ToolCallContext] | None,
+            ]
+        ]
+        | None
+    ) = None
+    transformers: (
+        list[
+            Callable[
+                [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
+            ]
+        ]
+        | None
+    ) = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -129,6 +129,13 @@ class ToolManager(ContextDecorator):
         if not tool:
             return None
 
+        if self._settings.filters:
+            for f in self._settings.filters:
+                modified = f(call, context)
+                if modified is not None:
+                    assert isinstance(modified, tuple) and len(modified) == 2
+                    call, context = modified
+
         is_native_tool = isinstance(tool, Tool)
 
         result = (
@@ -144,6 +151,12 @@ class ToolManager(ContextDecorator):
                 )
             )
         )
+
+        if self._settings.transformers:
+            for t in self._settings.transformers:
+                transformed = t(call, context, result)
+                if transformed is not None:
+                    result = transformed
 
         return ToolCallResult(
             id=uuid4(),


### PR DESCRIPTION
## Summary
- extend `ToolManagerSettings` with filters and transformers
- allow pre-call filtering and post-call result transformation in `ToolManager`
- test filters, transformers, and combined behavior

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686dd013d4548323a529d0bb83ea34f0