### PR TITLE
Fix CLI modality defaults

### DIFF
--- a/src/avalan/cli/commands/__init__.py
+++ b/src/avalan/cli/commands/__init__.py
@@ -20,7 +20,7 @@ def get_model_settings(
         disable_loading_progress_bar=args.disable_loading_progress_bar,
         modality=(
             modality
-            or args.modality
+            or getattr(args, "modality", None)
             or (
                 Modality.EMBEDDING
                 if hasattr(args, "sentence_transformer")

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -143,7 +143,11 @@ async def model_run(
     with ModelManager(hub, logger) as manager:
         engine_uri = manager.parse_uri(args.model)
         model_settings = get_model_settings(
-            args, hub, logger, engine_uri
+            args,
+            hub,
+            logger,
+            engine_uri,
+            modality=Modality.TEXT_GENERATION,
         )
 
         if not args.quiet:
@@ -199,7 +203,7 @@ async def model_run(
                     max_new_tokens=settings.max_new_tokens,
                     reference_path=args.audio_reference_path,
                     reference_text=args.audio_reference_text,
-                    sampling_rate=args.audio_sampling_rate
+                    sampling_rate=args.audio_sampling_rate,
                 )
                 console.print(f"Audio generated in {output}")
                 return
@@ -209,7 +213,9 @@ async def model_run(
 
                 if engine_uri.is_local:
                     stopping_criteria = (
-                        KeywordStoppingCriteria(args.stop_on_keyword, lm.tokenizer)
+                        KeywordStoppingCriteria(
+                            args.stop_on_keyword, lm.tokenizer
+                        )
                         if args.stop_on_keyword
                         else None
                     )
@@ -222,7 +228,8 @@ async def model_run(
                         ),
                         manual_sampling=display_tokens,
                         pick=dtokens_pick,
-                        skip_special_tokens=args.quiet or args.skip_special_tokens,
+                        skip_special_tokens=args.quiet
+                        or args.skip_special_tokens,
                     )
                 else:
                     output_generator = lm(

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -845,7 +845,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 model_cmds,
                 "get_model_settings",
-                return_value={"engine_uri": engine_uri},
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_GENERATION,
+                },
             ) as gms_patch,
             patch.object(model_cmds, "get_input", return_value=None),
             patch.object(
@@ -859,7 +862,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         gms_patch.assert_called_once_with(
             args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
-        manager.load.assert_called_once_with(engine_uri=engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_GENERATION,
+        )
         lm.assert_not_called()
         tg_patch.assert_not_called()
         hub.can_access.assert_called_once_with("id")
@@ -927,7 +933,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 model_cmds,
                 "get_model_settings",
-                return_value={"engine_uri": engine_uri},
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_GENERATION,
+                },
             ) as gms_patch,
             patch.object(model_cmds, "get_input", return_value="hi"),
             patch.object(
@@ -941,7 +950,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         gms_patch.assert_called_once_with(
             args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
-        manager.load.assert_called_once_with(engine_uri=engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_GENERATION,
+        )
 
         lm.assert_awaited_once()
         call_kwargs = lm.await_args.kwargs
@@ -1015,7 +1027,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 model_cmds,
                 "get_model_settings",
-                return_value={"engine_uri": engine_uri},
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_GENERATION,
+                },
             ) as gms_patch,
             patch.object(model_cmds, "get_input", return_value="hi"),
             patch.object(
@@ -1029,7 +1044,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         gms_patch.assert_called_once_with(
             args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
         )
-        manager.load.assert_called_once_with(engine_uri=engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_GENERATION,
+        )
         lm.assert_awaited_once()
         tg_patch.assert_awaited_once()
 


### PR DESCRIPTION
## Summary
- handle missing `modality` attribute gracefully
- pass explicit modality when running models
- update tests for new modality parameter

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686e97b6970c83239dd27b341cbf3610