### PR TITLE
Unify audio resampling logic

### DIFF
--- a/tests/model/audio/base_audio_model_test.py
+++ b/tests/model/audio/base_audio_model_test.py
@@ -3,7 +3,7 @@ from avalan.model import TokenizerNotSupportedException
 from avalan.model.audio import BaseAudioModel
 from logging import Logger
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from typing import Literal
 
 
@@ -30,3 +30,43 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
             model._load_tokenizer(None)
         with self.assertRaises(TokenizerNotSupportedException):
             model._load_tokenizer_with_tokens(None)
+
+    def test_resample(self):
+        model = DummyAudioModel(
+            None,
+            EngineSettings(auto_load_model=False),
+            logger=MagicMock(spec=Logger),
+        )
+        audio_wave = MagicMock()
+        squeezed = MagicMock()
+        squeezed.numpy.return_value = "audio"
+        audio_wave.squeeze.return_value = squeezed
+        resampler = MagicMock(return_value=audio_wave)
+        with (
+            patch("avalan.model.audio.load", return_value=(audio_wave, 8000)),
+            patch(
+                "avalan.model.audio.Resample", return_value=resampler
+            ) as res_patch,
+        ):
+            result = model._resample("a.wav", 16000)
+        self.assertEqual(result, "audio")
+        res_patch.assert_called_once_with(orig_freq=8000, new_freq=16000)
+        resampler.assert_called_once_with(audio_wave)
+
+    def test_resample_no_change(self):
+        model = DummyAudioModel(
+            None,
+            EngineSettings(auto_load_model=False),
+            logger=MagicMock(spec=Logger),
+        )
+        audio_wave = MagicMock()
+        squeezed = MagicMock()
+        squeezed.numpy.return_value = "audio"
+        audio_wave.squeeze.return_value = squeezed
+        with (
+            patch("avalan.model.audio.load", return_value=(audio_wave, 16000)),
+            patch("avalan.model.audio.Resample") as res_patch,
+        ):
+            result = model._resample("a.wav", 16000)
+        self.assertEqual(result, "audio")
+        res_patch.assert_not_called()

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -144,8 +144,7 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 DiaForConditionalGeneration, "from_pretrained"
             ) as model_mock,
-            patch("avalan.model.audio.load") as load_mock,
-            patch("avalan.model.audio.functional.resample") as resample_mock,
+            patch.object(TextToSpeechModel, "_resample") as resample_method,
             patch(
                 "avalan.model.audio.inference_mode", return_value=nullcontext()
             ) as inf_mock,
@@ -163,13 +162,9 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             model_instance.generate = MagicMock(return_value=outputs)
             model_mock.return_value = model_instance
 
-            reference_audio = MagicMock()
             resampled_audio = MagicMock()
-            mean_mock = MagicMock()
-            resampled_audio.mean.return_value = mean_mock
-            mean_mock.numpy.return_value = "voice"
-            load_mock.return_value = (reference_audio, 22050)
-            resample_mock.return_value = resampled_audio
+            resampled_audio.mean.return_value = "voice"
+            resample_method.return_value = resampled_audio
 
             settings = EngineSettings()
             model = TextToSpeechModel(
@@ -186,10 +181,7 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             )
 
             self.assertEqual(result, "file.wav")
-            load_mock.assert_called_once_with("ref.wav")
-            resample_mock.assert_called_once_with(
-                reference_audio, 22050, 16000
-            )
+            resample_method.assert_called_once_with("ref.wav", 16000)
             resampled_audio.mean.assert_called_once_with(0)
             processor_instance.assert_called_with(
                 text="ref\nhi",
@@ -220,8 +212,7 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 DiaForConditionalGeneration, "from_pretrained"
             ) as model_mock,
-            patch("avalan.model.audio.load") as load_mock,
-            patch("avalan.model.audio.functional.resample") as resample_mock,
+            patch.object(TextToSpeechModel, "_resample") as resample_method,
             patch(
                 "avalan.model.audio.inference_mode", return_value=nullcontext()
             ) as inf_mock,
@@ -239,11 +230,9 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             model_instance.generate = MagicMock(return_value=outputs)
             model_mock.return_value = model_instance
 
-            reference_audio = MagicMock()
-            mean_mock = MagicMock()
-            reference_audio.mean.return_value = mean_mock
-            mean_mock.numpy.return_value = "voice"
-            load_mock.return_value = (reference_audio, 16000)
+            resampled_audio = MagicMock()
+            resampled_audio.mean.return_value = "voice"
+            resample_method.return_value = resampled_audio
 
             settings = EngineSettings()
             model = TextToSpeechModel(
@@ -260,9 +249,8 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             )
 
             self.assertEqual(result, "file.wav")
-            load_mock.assert_called_once_with("ref.wav")
-            resample_mock.assert_not_called()
-            reference_audio.mean.assert_called_once_with(0)
+            resample_method.assert_called_once_with("ref.wav", 16000)
+            resampled_audio.mean.assert_called_once_with(0)
             processor_instance.assert_called_with(
                 text="ref\nhi",
                 audio="voice",


### PR DESCRIPTION
## Summary
- move audio resampling code to `BaseAudioModel._resample`
- reuse `_resample` in speech recognition and text to speech models
- update tests accordingly and add coverage for `_resample`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686ecf36f03c8323851dce78158333d2