### PR TITLE
Add CLI speech recognition support

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -207,6 +207,15 @@ async def model_run(
                 )
                 console.print(f"Audio generated in {output}")
                 return
+            elif modality == Modality.AUDIO_SPEECH_RECOGNITION:
+                assert args.audio_path and args.audio_sampling_rate
+
+                output = await lm(
+                    path=args.audio_path,
+                    sampling_rate=args.audio_sampling_rate,
+                )
+                console.print(output)
+                return
             elif modality == Modality.TEXT_GENERATION:
                 display_tokens = args.display_tokens or 0
                 dtokens_pick = 10 if display_tokens > 0 else 0

--- a/src/avalan/model/audio.py
+++ b/src/avalan/model/audio.py
@@ -69,11 +69,11 @@ class SpeechRecognitionModel(BaseAudioModel):
     @override
     async def __call__(
         self,
-        audio_source: str,
-        sampling_rate: int,
+        path: str,
+        sampling_rate: int = 16_000,
         tensor_format: Literal["pt"] = "pt",
     ) -> str:
-        audio = self._resample(audio_source, sampling_rate)
+        audio = self._resample(path, sampling_rate)
         inputs = self._processor(
             audio,
             sampling_rate=sampling_rate,

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1166,6 +1166,94 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                     "Audio generated in gen.wav",
                 )
 
+    async def test_run_audio_speech_recognition(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            audio_path="in.wav",
+            audio_sampling_rate=16_000,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="transcript")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.AUDIO_SPEECH_RECOGNITION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(
+            args,
+            hub,
+            logger,
+            engine_uri,
+            modality=Modality.TEXT_GENERATION,
+        )
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.AUDIO_SPEECH_RECOGNITION,
+        )
+        lm.assert_awaited_once_with(path="in.wav", sampling_rate=16_000)
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "transcript")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",


### PR DESCRIPTION
## Summary
- rename `SpeechRecognitionModel.__call__` parameter to `path` and default the sampling rate to 16k
- extend CLI `model_run` to handle `AUDIO_SPEECH_RECOGNITION`
- add tests for the new CLI behaviour

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686ed9a21d7c8323a4a32c41af388b3c