### PR TITLE
Fix audio resample tests

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -859,9 +859,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
-        gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
-        )
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
         manager.load.assert_called_once_with(
             engine_uri=engine_uri,
             modality=Modality.TEXT_GENERATION,
@@ -947,9 +945,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
-        gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
-        )
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
         manager.load.assert_called_once_with(
             engine_uri=engine_uri,
             modality=Modality.TEXT_GENERATION,
@@ -1041,9 +1037,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
-        gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
-        )
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
         manager.load.assert_called_once_with(
             engine_uri=engine_uri,
             modality=Modality.TEXT_GENERATION,
@@ -1142,11 +1136,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                 mm_patch.assert_called_once_with(hub, logger)
                 manager.parse_uri.assert_called_once_with("id")
                 gms_patch.assert_called_once_with(
-                    args,
-                    hub,
-                    logger,
-                    engine_uri,
-                    modality=Modality.TEXT_GENERATION,
+                    args, hub, logger, engine_uri
                 )
                 manager.load.assert_called_once_with(
                     engine_uri=engine_uri,
@@ -1239,13 +1229,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
-        gms_patch.assert_called_once_with(
-            args,
-            hub,
-            logger,
-            engine_uri,
-            modality=Modality.TEXT_GENERATION,
-        )
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
         manager.load.assert_called_once_with(
             engine_uri=engine_uri,
             modality=Modality.AUDIO_SPEECH_RECOGNITION,
@@ -1325,9 +1309,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
-        gms_patch.assert_called_once_with(
-            args, hub, logger, engine_uri, modality=Modality.TEXT_GENERATION
-        )
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
         manager.load.assert_called_once_with(
             engine_uri=engine_uri,
             modality=Modality.EMBEDDING,

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -162,9 +162,7 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             model_instance.generate = MagicMock(return_value=outputs)
             model_mock.return_value = model_instance
 
-            resampled_audio = MagicMock()
-            resampled_audio.mean.return_value = "voice"
-            resample_method.return_value = resampled_audio
+            resample_method.return_value = "voice"
 
             settings = EngineSettings()
             model = TextToSpeechModel(
@@ -182,7 +180,6 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
 
             self.assertEqual(result, "file.wav")
             resample_method.assert_called_once_with("ref.wav", 16000)
-            resampled_audio.mean.assert_called_once_with(0)
             processor_instance.assert_called_with(
                 text="ref\nhi",
                 audio="voice",
@@ -230,9 +227,7 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
             model_instance.generate = MagicMock(return_value=outputs)
             model_mock.return_value = model_instance
 
-            resampled_audio = MagicMock()
-            resampled_audio.mean.return_value = "voice"
-            resample_method.return_value = resampled_audio
+            resample_method.return_value = "voice"
 
             settings = EngineSettings()
             model = TextToSpeechModel(
@@ -250,7 +245,6 @@ class TextToSpeechModelReferenceTestCase(IsolatedAsyncioTestCase):
 
             self.assertEqual(result, "file.wav")
             resample_method.assert_called_once_with("ref.wav", 16000)
-            resampled_audio.mean.assert_called_once_with(0)
             processor_instance.assert_called_with(
                 text="ref\nhi",
                 audio="voice",


### PR DESCRIPTION
## Summary
- update BaseAudioModel resample tests
- fix TextToSpeechModel tests for new resample behaviour
- adjust CLI model tests after signature change

## Testing
- `poetry run pytest --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686ee6526e048323aa6c628dfc3981fc