### PR TITLE
Change audio path CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Run a speech recognition model:
 ```bash
 avalan model run "facebook/wav2vec2-base-960h" \
     --modality audio_speech_recognition \
-    --audio-path oprah.wav \
+    --path oprah.wav \
     --audio-sampling-rate 16000
 ```
 
@@ -219,7 +219,7 @@ Create an audio speech from your prompt by cloning Oprah's voice, using an
 echo "[S1] Leo Messi is the greatest football player of all times." | \
     avalan model run "nari-labs/Dia-1.6B-0626" \
             --modality audio_text_to_speech \
-            --audio-path example.wav \
+            --path example.wav \
             --audio-reference-path docs/examples/oprah.wav \
             --audio-reference-text "[S1] And then I grew up and had the esteemed honor of meeting her. And wasn't that a surprise. Here was this petite, almost delicate lady who was the personification of grace and goodness."
 ```

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -47,7 +47,16 @@ import gettext
 from gettext import translation
 from importlib.util import find_spec
 from locale import getlocale
-from logging import basicConfig, DEBUG, Filter, getLogger, INFO, Logger, LogRecord, WARNING
+from logging import (
+    basicConfig,
+    DEBUG,
+    Filter,
+    getLogger,
+    INFO,
+    Logger,
+    LogRecord,
+    WARNING,
+)
 from os import getenv, environ
 from subprocess import run
 from os.path import join
@@ -920,7 +929,7 @@ class CLI:
             ),
         )
         model_run_parser.add_argument(
-            "--audio-path",
+            "--path",
             type=str,
             help=(
                 "Path where to store generated audio. "

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -142,12 +142,7 @@ async def model_run(
 
     with ModelManager(hub, logger) as manager:
         engine_uri = manager.parse_uri(args.model)
-        model_settings = get_model_settings(
-            args,
-            hub,
-            logger,
-            engine_uri
-        )
+        model_settings = get_model_settings(args, hub, logger, engine_uri)
 
         if not args.quiet:
             if engine_uri.is_local:
@@ -172,7 +167,7 @@ async def model_run(
 
         requires_input = modality in [
             Modality.AUDIO_TEXT_TO_SPEECH,
-            Modality.TEXT_GENERATION
+            Modality.TEXT_GENERATION,
         ]
 
         with manager.load(**model_settings) as lm:
@@ -201,10 +196,10 @@ async def model_run(
             )
 
             if modality == Modality.AUDIO_TEXT_TO_SPEECH:
-                assert args.audio_path and args.audio_sampling_rate
+                assert args.path and args.audio_sampling_rate
 
                 output = await lm(
-                    path=args.audio_path,
+                    path=args.path,
                     prompt=input_string,
                     max_new_tokens=settings.max_new_tokens,
                     reference_path=args.audio_reference_path,
@@ -214,10 +209,10 @@ async def model_run(
                 console.print(f"Audio generated in {output}")
                 return
             elif modality == Modality.AUDIO_SPEECH_RECOGNITION:
-                assert args.audio_path and args.audio_sampling_rate
+                assert args.path and args.audio_sampling_rate
 
                 output = await lm(
-                    path=args.audio_path,
+                    path=args.path,
                     sampling_rate=args.audio_sampling_rate,
                 )
                 console.print(output)

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1069,7 +1069,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             display_events=False,
             display_tools=False,
             display_tools_events=2,
-            audio_path="out.wav",
+            path="out.wav",
             audio_sampling_rate=16_000,
         )
 
@@ -1180,7 +1180,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             display_events=False,
             display_tools=False,
             display_tools_events=2,
-            audio_path="in.wav",
+            path="in.wav",
             audio_sampling_rate=16_000,
         )
         console = MagicMock()


### PR DESCRIPTION
## Summary
- rename `--audio-path` CLI option to `--path`
- update implementation and tests to use the new option
- reflect the new flag in README examples

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686f1c4743088323b05e1c43ec5305eb