### PR TITLE
Add vision object detection CLI support

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -963,6 +963,15 @@ class CLI:
             ),
         )
         model_run_parser.add_argument(
+            "--vision-threshold",
+            default=0.3,
+            type=float,
+            help=(
+                "Score threshold for object detection. "
+                "Only applicable to vision modalities."
+            ),
+        )
+        model_run_parser.add_argument(
             "--do-sample",
             default=True,
             action="store_true",

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -217,6 +217,17 @@ async def model_run(
                 )
                 console.print(output)
                 return
+            elif modality == Modality.VISION_OBJECT_DETECTION:
+                assert args.path and args.vision_threshold is not None
+
+                output = await lm(
+                    args.path,
+                    threshold=args.vision_threshold,
+                )
+                console.print(
+                    theme.display_image_entities(output),
+                )
+                return
             elif modality == Modality.TEXT_GENERATION:
                 display_tokens = args.display_tokens or 0
                 dtokens_pick = 10 if display_tokens > 0 else 0

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -13,6 +13,7 @@ from ...entities import (
     Token,
     TokenizerConfig,
     User,
+    ImageEntity,
 )
 from ...event import Event, EventStats
 from ...memory.partitioner.text import TextPartition
@@ -279,6 +280,12 @@ class Theme(ABC):
         special_tokens: list[str] | None,
         current_dtoken: Token | None = None,
         dtokens_selected: list[Token] = [],
+    ) -> RenderableType:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def display_image_entities(
+        self, entities: list[ImageEntity]
     ) -> RenderableType:
         raise NotImplementedError()
 

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -13,6 +13,7 @@ from ...entities import (
     Token,
     TokenizerConfig,
     User,
+    ImageEntity,
 )
 from ...event import Event, EventStats, EventType, TOOL_TYPES
 from ...memory.partitioner.text import TextPartition
@@ -1532,6 +1533,36 @@ class FancyTheme(Theme):
             Align(columns, align="center"),
             box=box.MINIMAL,
         )
+
+    def display_image_entities(
+        self, entities: list[ImageEntity]
+    ) -> RenderableType:
+        _ = self._
+        table = Table(
+            Column(header=_("Label"), justify="left"),
+            Column(header=_("Score"), justify="right"),
+            Column(header=_("Box"), justify="left"),
+            show_footer=False,
+            show_header=True,
+            show_edge=True,
+            show_lines=True,
+            border_style="gray58",
+        )
+
+        for entity in entities:
+            score = (
+                self._f("score", f"{entity.score:.2f}")
+                if entity.score is not None
+                else "-"
+            )
+            box = (
+                ", ".join(f"{v:.2f}" for v in entity.box)
+                if entity.box
+                else "-"
+            )
+            table.add_row(entity.label, score, box)
+
+        return Align(table, align="center")
 
     async def tokens(
         self,

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1,6 +1,6 @@
 from avalan.cli.commands import get_model_settings
 from avalan.cli.commands import model as model_cmds
-from avalan.entities import Modality
+from avalan.entities import Modality, ImageEntity
 from avalan.event.manager import EventManager
 from avalan.event import Event, EventType
 from types import SimpleNamespace
@@ -1237,6 +1237,97 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         lm.assert_awaited_once_with(path="in.wav", sampling_rate=16_000)
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "transcript")
+
+    async def test_run_vision_object_detection(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="img.png",
+            vision_threshold=0.5,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        theme.display_image_entities.return_value = "table"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(
+            return_value=[
+                ImageEntity(label="lbl", score=0.9, box=[0, 1, 2, 3])
+            ]
+        )
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.VISION_OBJECT_DETECTION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_OBJECT_DETECTION,
+        )
+        lm.assert_awaited_once_with("img.png", threshold=0.5)
+        theme.display_image_entities.assert_called_once_with(lm.return_value)
+        tg_patch.assert_not_called()
+        self.assertEqual(
+            console.print.call_args.args[0],
+            theme.display_image_entities.return_value,
+        )
 
     async def test_run_invalid_modality_raises(self):
         args = Namespace(

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -25,6 +25,7 @@ from avalan.entities import (
     Token,
     TokenDetail,
     TokenizerConfig,
+    ImageEntity,
     User,
 )
 from avalan.memory.permanent import Memory, MemoryType
@@ -750,6 +751,22 @@ class FancyThemeMoreTests(unittest.TestCase):
         table = align.renderable
         headers = table.columns[0]._cells
         self.assertIn("Truncate dimension", headers)
+
+    def test_display_image_entities(self):
+        align = self.theme.display_image_entities(
+            [
+                ImageEntity(label="cat", score=0.9, box=[0.0, 1.0, 2.0, 3.0]),
+                ImageEntity(label="dog", score=None, box=None),
+            ]
+        )
+        table = align.renderable
+        self.assertEqual(table.row_count, 2)
+        self.assertEqual(table.columns[0]._cells[0], "cat")
+        self.assertEqual(table.columns[0]._cells[1], "dog")
+        self.assertEqual(table.columns[1]._cells[0], "[score]0.90[/score]")
+        self.assertEqual(table.columns[1]._cells[1], "-")
+        self.assertEqual(table.columns[2]._cells[0], "0.00, 1.00, 2.00, 3.00")
+        self.assertEqual(table.columns[2]._cells[1], "-")
 
     def test_fill_model_config_table(self):
         cfg = ModelConfig(

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -129,6 +129,9 @@ class DummyTheme(Theme):
     ):
         raise NotImplementedError()
 
+    def display_image_entities(self, entities):
+        raise NotImplementedError()
+
     async def tokens(self, *args, **kwargs):
         raise NotImplementedError()
 
@@ -199,6 +202,7 @@ class ThemeAbstractMethodsTestCase(unittest.TestCase):
             lambda: self.theme.memory_search_matches("id", "ns", []),
             lambda: self.theme.tokenizer_config(None),
             lambda: self.theme.tokenizer_tokens([]),
+            lambda: self.theme.display_image_entities([]),
             lambda: self.theme.welcome("u", "n", "v", "lic", None),
         ]
         for call in methods:

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -344,6 +344,7 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.memory_search_matches(self.theme, "id", "ns", []),
             lambda: Theme.tokenizer_config(self.theme, None),
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
+            lambda: Theme.display_image_entities(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),
         ]
 


### PR DESCRIPTION
## Summary
- support object detection models from the CLI
- add vision threshold option
- display image entities in FancyTheme
- adjust theme test coverage
- test running vision object detection

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686f22a467f08323a4d6d6a241e6b06e