### PR TITLE
Add image entity display tests

### DIFF
--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -25,6 +25,7 @@ from avalan.entities import (
     Token,
     TokenDetail,
     TokenizerConfig,
+    ImageEntity,
     User,
 )
 from avalan.memory.permanent import Memory, MemoryType
@@ -750,6 +751,22 @@ class FancyThemeMoreTests(unittest.TestCase):
         table = align.renderable
         headers = table.columns[0]._cells
         self.assertIn("Truncate dimension", headers)
+
+    def test_display_image_entities(self):
+        align = self.theme.display_image_entities(
+            [
+                ImageEntity(label="cat", score=0.9, box=[0.0, 1.0, 2.0, 3.0]),
+                ImageEntity(label="dog", score=None, box=None),
+            ]
+        )
+        table = align.renderable
+        self.assertEqual(table.row_count, 2)
+        self.assertEqual(table.columns[0]._cells[0], "cat")
+        self.assertEqual(table.columns[0]._cells[1], "dog")
+        self.assertEqual(table.columns[1]._cells[0], "[score]0.90[/score]")
+        self.assertEqual(table.columns[1]._cells[1], "-")
+        self.assertEqual(table.columns[2]._cells[0], "0.00, 1.00, 2.00, 3.00")
+        self.assertEqual(table.columns[2]._cells[1], "-")
 
     def test_fill_model_config_table(self):
         cfg = ModelConfig(

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -344,6 +344,7 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.memory_search_matches(self.theme, "id", "ns", []),
             lambda: Theme.tokenizer_config(self.theme, None),
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
+            lambda: Theme.display_image_entities(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),
         ]
 


### PR DESCRIPTION
## Summary
- ensure Theme.display_image_entities is covered
- verify FancyTheme.display_image_entities output table

## Testing
- `poetry run ruff format --preview tests/cli/theme_fancy_test.py tests/cli/theme_test.py`
- `poetry run black --preview --enable-unstable-feature=string_processing tests/cli/theme_fancy_test.py tests/cli/theme_test.py`
- `poetry run ruff check --fix tests/cli/theme_fancy_test.py tests/cli/theme_test.py`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686f272367888323ac0191d8c6a44f63