### PR TITLE
Add semantic segmentation CLI and label display

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -228,6 +228,14 @@ async def model_run(
                     theme.display_image_entities(output),
                 )
                 return
+            elif modality == Modality.VISION_SEMANTIC_SEGMENTATION:
+                assert args.path
+
+                output = await lm(args.path)
+                console.print(
+                    theme.display_image_labels(output),
+                )
+                return
             elif modality == Modality.TEXT_GENERATION:
                 display_tokens = args.display_tokens or 0
                 dtokens_pick = 10 if display_tokens > 0 else 0

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -290,6 +290,10 @@ class Theme(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def display_image_labels(self, labels: list[str]) -> RenderableType:
+        raise NotImplementedError()
+
+    @abstractmethod
     async def tokens(
         self,
         model_id: str,

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -1564,6 +1564,20 @@ class FancyTheme(Theme):
 
         return Align(table, align="center")
 
+    def display_image_labels(self, labels: list[str]) -> RenderableType:
+        _ = self._
+        table = Table(
+            Column(header=_("Label"), justify="left"),
+            show_footer=False,
+            show_header=True,
+            show_edge=True,
+            show_lines=True,
+            border_style="gray58",
+        )
+        for label in labels:
+            table.add_row(label)
+        return Align(table, align="center")
+
     async def tokens(
         self,
         model_id: str,

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1329,6 +1329,93 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             theme.display_image_entities.return_value,
         )
 
+    async def test_run_vision_semantic_segmentation(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="img.png",
+            vision_threshold=0.5,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        theme.display_image_labels.return_value = "table"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value=["lbl1", "lbl2"])
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.VISION_SEMANTIC_SEGMENTATION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_SEMANTIC_SEGMENTATION,
+        )
+        lm.assert_awaited_once_with("img.png")
+        theme.display_image_labels.assert_called_once_with(lm.return_value)
+        tg_patch.assert_not_called()
+        self.assertEqual(
+            console.print.call_args.args[0],
+            theme.display_image_labels.return_value,
+        )
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -768,6 +768,13 @@ class FancyThemeMoreTests(unittest.TestCase):
         self.assertEqual(table.columns[2]._cells[0], "0.00, 1.00, 2.00, 3.00")
         self.assertEqual(table.columns[2]._cells[1], "-")
 
+    def test_display_image_labels(self):
+        align = self.theme.display_image_labels(["cat", "dog"])
+        table = align.renderable
+        self.assertEqual(table.row_count, 2)
+        self.assertEqual(table.columns[0]._cells[0], "cat")
+        self.assertEqual(table.columns[0]._cells[1], "dog")
+
     def test_fill_model_config_table(self):
         cfg = ModelConfig(
             architectures=["a"],

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -132,6 +132,9 @@ class DummyTheme(Theme):
     def display_image_entities(self, entities):
         raise NotImplementedError()
 
+    def display_image_labels(self, labels):
+        raise NotImplementedError()
+
     async def tokens(self, *args, **kwargs):
         raise NotImplementedError()
 
@@ -345,6 +348,7 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.tokenizer_config(self.theme, None),
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
             lambda: Theme.display_image_entities(self.theme, []),
+            lambda: Theme.display_image_labels(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),
         ]
 


### PR DESCRIPTION
## Summary
- support `Modality.VISION_SEMANTIC_SEGMENTATION` in `model_run`
- display object detection results using entity tables
- expose `Theme.display_image_labels` and implement in `FancyTheme`
- test new CLI branch and theme methods

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_686fac2274188323a431e5e7adedd773