### PR TITLE
Add vision image-to-text CLI modality

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -236,6 +236,15 @@ async def model_run(
                     theme.display_image_labels(output),
                 )
                 return
+            elif modality == Modality.VISION_IMAGE_TO_TEXT:
+                assert args.path
+
+                output = await lm(
+                    args.path,
+                    skip_special_tokens=args.skip_special_tokens,
+                )
+                console.print(output)
+                return
             elif modality == Modality.VISION_IMAGE_CLASSIFICATION:
                 assert args.path
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1503,6 +1503,88 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             theme.display_image_labels.return_value,
         )
 
+    async def test_run_vision_image_to_text(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="img.png",
+            vision_threshold=0.5,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="caption")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.VISION_IMAGE_TO_TEXT,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_IMAGE_TO_TEXT,
+        )
+        lm.assert_awaited_once_with("img.png", skip_special_tokens=False)
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "caption")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",


### PR DESCRIPTION
## Summary
- add CLI run mode for `Modality.VISION_IMAGE_TO_TEXT`
- output image-to-text strings directly to the console
- test image-to-text mode in `model_run`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686fbb47504c832389fd54777ae28861