### PR TITLE
Add image text to text modality support

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -972,6 +972,14 @@ class CLI:
             ),
         )
         model_run_parser.add_argument(
+            "--image-width",
+            type=int,
+            help=(
+                "Resize input image to this width before processing. "
+                "Only applicable to vision image text to text modality."
+            ),
+        )
+        model_run_parser.add_argument(
             "--do-sample",
             default=True,
             action="store_true",

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -168,6 +168,7 @@ async def model_run(
         requires_input = modality in [
             Modality.AUDIO_TEXT_TO_SPEECH,
             Modality.TEXT_GENERATION,
+            Modality.VISION_IMAGE_TEXT_TO_TEXT,
         ]
 
         with manager.load(**model_settings) as lm:
@@ -242,6 +243,18 @@ async def model_run(
                 output = await lm(
                     args.path,
                     skip_special_tokens=args.skip_special_tokens,
+                )
+                console.print(output)
+                return
+            elif modality == Modality.VISION_IMAGE_TEXT_TO_TEXT:
+                assert args.path
+
+                output = await lm(
+                    args.path,
+                    input_string,
+                    system_prompt=system_prompt,
+                    settings=settings,
+                    width=args.image_width,
                 )
                 console.print(output)
                 return

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -78,6 +78,7 @@ class Modality(StrEnum):
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"
     VISION_IMAGE_TO_TEXT = "vision_image_to_text"
+    VISION_IMAGE_TEXT_TO_TEXT = "vision_image_text_to_text"
     VISION_ENCODER_DECODER = "vision_encoder_decoder"
     VISION_SEMANTIC_SEGMENTATION = "vision_semantic_segmentation"
 

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -16,6 +16,7 @@ from ..model.vision.detection import ObjectDetectionModel
 from ..model.vision.image import (
     ImageClassificationModel,
     ImageTextToTextModel,
+    ImageToTextModel,
     VisionEncoderDecoderModel,
 )
 from ..model.vision.segmentation import SemanticSegmentationModel
@@ -171,6 +172,8 @@ class ModelManager(ContextDecorator):
                 case Modality.VISION_IMAGE_CLASSIFICATION:
                     model = ImageClassificationModel(**model_load_args)
                 case Modality.VISION_IMAGE_TO_TEXT:
+                    model = ImageToTextModel(**model_load_args)
+                case Modality.VISION_IMAGE_TEXT_TO_TEXT:
                     model = ImageTextToTextModel(**model_load_args)
                 case Modality.VISION_ENCODER_DECODER:
                     model = VisionEncoderDecoderModel(**model_load_args)

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -19,7 +19,8 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.AUDIO_TEXT_TO_SPEECH: "TextToSpeechModel",
             Modality.VISION_OBJECT_DETECTION: "ObjectDetectionModel",
             Modality.VISION_IMAGE_CLASSIFICATION: "ImageClassificationModel",
-            Modality.VISION_IMAGE_TO_TEXT: "ImageTextToTextModel",
+            Modality.VISION_IMAGE_TO_TEXT: "ImageToTextModel",
+            Modality.VISION_IMAGE_TEXT_TO_TEXT: "ImageTextToTextModel",
             Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
             Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
         }


### PR DESCRIPTION
## Summary
- support `VISION_IMAGE_TEXT_TO_TEXT` modality in `model_run`
- parse `--image-width` argument for resizing images
- load the new modality in `ModelManager`
- include constant in `Modality`
- test new modality and manager mapping
- fix image to text modality mapping

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686fc2c522108323bca6fa18c48930c0