### PR TITLE
Add device move tests for vision models

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1322,7 +1322,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             modality=Modality.VISION_OBJECT_DETECTION,
         )
         lm.assert_awaited_once_with("img.png", threshold=0.5)
-        theme.display_image_entities.assert_called_once_with(lm.return_value)
+        theme.display_image_entities.assert_called_once_with(
+            lm.return_value, sort=True
+        )
         tg_patch.assert_not_called()
         self.assertEqual(
             console.print.call_args.args[0],
@@ -1448,7 +1450,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         theme._ = lambda s: s
         theme.icons = {"user_input": ">"}
         theme.model.return_value = "panel"
-        theme.display_image_labels.return_value = "table"
+        theme.display_image_entity.return_value = "table"
         hub = MagicMock()
         hub.can_access.return_value = True
         hub.model.return_value = "hub_model"
@@ -1496,11 +1498,11 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             modality=Modality.VISION_IMAGE_CLASSIFICATION,
         )
         lm.assert_awaited_once_with("img.png")
-        theme.display_image_labels.assert_called_once_with(lm.return_value)
+        theme.display_image_entity.assert_called_once_with(lm.return_value)
         tg_patch.assert_not_called()
         self.assertEqual(
             console.print.call_args.args[0],
-            theme.display_image_labels.return_value,
+            theme.display_image_entity.return_value,
         )
 
     async def test_run_vision_image_to_text(self):

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -755,18 +755,24 @@ class FancyThemeMoreTests(unittest.TestCase):
     def test_display_image_entities(self):
         align = self.theme.display_image_entities(
             [
-                ImageEntity(label="cat", score=0.9, box=[0.0, 1.0, 2.0, 3.0]),
-                ImageEntity(label="dog", score=None, box=None),
-            ]
+                ImageEntity(label="cat", score=0.5, box=[0.0, 1.0, 2.0, 3.0]),
+                ImageEntity(label="dog", score=0.9, box=None),
+            ],
+            sort=True,
         )
         table = align.renderable
         self.assertEqual(table.row_count, 2)
-        self.assertEqual(table.columns[0]._cells[0], "cat")
-        self.assertEqual(table.columns[0]._cells[1], "dog")
+        # dog should be first due to higher score
+        self.assertEqual(table.columns[0]._cells[0], "dog")
+        self.assertEqual(table.columns[0]._cells[1], "cat")
         self.assertEqual(table.columns[1]._cells[0], "[score]0.90[/score]")
-        self.assertEqual(table.columns[1]._cells[1], "-")
-        self.assertEqual(table.columns[2]._cells[0], "0.00, 1.00, 2.00, 3.00")
-        self.assertEqual(table.columns[2]._cells[1], "-")
+        self.assertEqual(table.columns[1]._cells[1], "[score]0.50[/score]")
+
+    def test_display_image_entity(self):
+        align = self.theme.display_image_entity(ImageEntity(label="cat"))
+        table = align.renderable
+        self.assertEqual(table.row_count, 1)
+        self.assertEqual(table.columns[0]._cells[0], "cat")
 
     def test_display_image_labels(self):
         align = self.theme.display_image_labels(["cat", "dog"])

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -129,7 +129,10 @@ class DummyTheme(Theme):
     ):
         raise NotImplementedError()
 
-    def display_image_entities(self, entities):
+    def display_image_entities(self, entities, sort: bool):
+        raise NotImplementedError()
+
+    def display_image_entity(self, entity):
         raise NotImplementedError()
 
     def display_image_labels(self, labels):
@@ -205,7 +208,8 @@ class ThemeAbstractMethodsTestCase(unittest.TestCase):
             lambda: self.theme.memory_search_matches("id", "ns", []),
             lambda: self.theme.tokenizer_config(None),
             lambda: self.theme.tokenizer_tokens([]),
-            lambda: self.theme.display_image_entities([]),
+            lambda: self.theme.display_image_entities([], False),
+            lambda: self.theme.display_image_entity(None),
             lambda: self.theme.welcome("u", "n", "v", "lic", None),
         ]
         for call in methods:
@@ -347,7 +351,8 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.memory_search_matches(self.theme, "id", "ns", []),
             lambda: Theme.tokenizer_config(self.theme, None),
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
-            lambda: Theme.display_image_entities(self.theme, []),
+            lambda: Theme.display_image_entities(self.theme, [], False),
+            lambda: Theme.display_image_entity(self.theme, None),
             lambda: Theme.display_image_labels(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),
         ]

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -15,6 +15,18 @@ from unittest import TestCase, IsolatedAsyncioTestCase, main
 from unittest.mock import MagicMock, patch, PropertyMock
 
 
+class DummyInputs(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        self.to_called_with = None
+
+    def to(self, device):
+        self.to_called_with = device
+        return self
+
+
 class PTMWithGenerate(PreTrainedModel):
     def generate(self, *args, **kwargs):
         raise NotImplementedError
@@ -86,7 +98,7 @@ class VisionEncoderDecoderModelCallTestCase(IsolatedAsyncioTestCase):
             patch("avalan.model.vision.image.Image.open") as image_open_mock,
         ):
             processor_instance = MagicMock()
-            processor_instance.return_value = {"pixel_values": "t"}
+            processor_instance.return_value = DummyInputs(pixel_values="t")
             processor_mock.return_value = processor_instance
 
             model_instance = MagicMock(spec=PTMWithGenerate)
@@ -123,6 +135,10 @@ class VisionEncoderDecoderModelCallTestCase(IsolatedAsyncioTestCase):
             )
             model_instance.generate.assert_called_once_with(
                 **processor_instance.return_value
+            )
+            self.assertEqual(
+                processor_instance.return_value.to_called_with,
+                model._device,
             )
 
 


### PR DESCRIPTION
## Summary
- ensure inputs are moved to device across vision models
- update CLI tests for new image display behaviour
- exercise sorting of image entities

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_686fe02f5ac483238526d63d91cc37fa