### PR TITLE
Add text token classification

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -169,6 +169,7 @@ async def model_run(
             Modality.AUDIO_TEXT_TO_SPEECH,
             Modality.TEXT_GENERATION,
             Modality.TEXT_QUESTION_ANSWERING,
+            Modality.TEXT_TOKEN_CLASSIFICATION,
             Modality.VISION_IMAGE_TEXT_TO_TEXT,
         ]
 
@@ -272,6 +273,14 @@ async def model_run(
                     system_prompt=system_prompt,
                 )
                 console.print(output)
+            elif modality == Modality.TEXT_TOKEN_CLASSIFICATION:
+                assert input_string
+
+                output = await lm(
+                    input_string,
+                    system_prompt=system_prompt,
+                )
+                console.print(theme.display_token_labels([output]))
             elif modality == Modality.TEXT_GENERATION:
                 display_tokens = args.display_tokens or 0
                 dtokens_pick = 10 if display_tokens > 0 else 0

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -298,6 +298,12 @@ class Theme(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def display_token_labels(
+        self, token_labels: list[dict[str, str]]
+    ) -> RenderableType:
+        raise NotImplementedError()
+
+    @abstractmethod
     async def tokens(
         self,
         model_id: str,

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -1550,7 +1550,10 @@ class FancyTheme(Theme):
         )
 
         if sort:
-            entities.sort(key=lambda e: e.score if e.score is not None else -inf, reverse=True)
+            entities.sort(
+                key=lambda e: e.score if e.score is not None else -inf,
+                reverse=True,
+            )
 
         for entity in entities:
             score = (
@@ -1592,6 +1595,24 @@ class FancyTheme(Theme):
         )
         for label in labels:
             table.add_row(label)
+        return Align(table, align="center")
+
+    def display_token_labels(
+        self, token_labels: list[dict[str, str]]
+    ) -> RenderableType:
+        _ = self._
+        table = Table(
+            Column(header=_("Token"), justify="left"),
+            Column(header=_("Label"), justify="left"),
+            show_footer=False,
+            show_header=True,
+            show_edge=True,
+            show_lines=True,
+            border_style="gray58",
+        )
+        for pair in token_labels:
+            for token, label in pair.items():
+                table.add_row(token, label)
         return Align(table, align="center")
 
     async def tokens(

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -76,6 +76,7 @@ class Modality(StrEnum):
     EMBEDDING = "embedding"
     TEXT_GENERATION = "text_generation"
     TEXT_QUESTION_ANSWERING = "text_question_answering"
+    TEXT_TOKEN_CLASSIFICATION = "text_token_classification"
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"
     VISION_IMAGE_TO_TEXT = "vision_image_to_text"

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -12,6 +12,7 @@ from ..model.hubs.huggingface import HuggingfaceHub
 from ..model.nlp.sentence import SentenceTransformerModel
 from ..model.nlp.text.generation import TextGenerationModel
 from ..model.nlp.question import QuestionAnsweringModel
+from ..model.nlp.token import TokenClassificationModel
 from ..model.audio import SpeechRecognitionModel, TextToSpeechModel
 from ..model.vision.detection import ObjectDetectionModel
 from ..model.vision.image import (
@@ -102,6 +103,7 @@ class ModelManager(ContextDecorator):
         SentenceTransformerModel
         | TextGenerationModel
         | QuestionAnsweringModel
+        | TokenClassificationModel
         | SpeechRecognitionModel
         | TextToSpeechModel
         | ObjectDetectionModel
@@ -146,6 +148,7 @@ class ModelManager(ContextDecorator):
         SentenceTransformerModel
         | TextGenerationModel
         | QuestionAnsweringModel
+        | TokenClassificationModel
         | SpeechRecognitionModel
         | TextToSpeechModel
         | ObjectDetectionModel
@@ -184,6 +187,8 @@ class ModelManager(ContextDecorator):
                     model = SemanticSegmentationModel(**model_load_args)
                 case Modality.TEXT_QUESTION_ANSWERING:
                     model = QuestionAnsweringModel(**model_load_args)
+                case Modality.TEXT_TOKEN_CLASSIFICATION:
+                    model = TokenClassificationModel(**model_load_args)
                 case _:
                     model = TextGenerationModel(**model_load_args)
         elif (

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -54,7 +54,9 @@ class TokenClassificationModel(BaseNLPModel):
         return inputs
 
     @override
-    async def __call__(self, input: str) -> dict[str, str]:
+    async def __call__(
+        self, input: str, *, system_prompt: str | None = None
+    ) -> dict[str, str]:
         assert self._tokenizer, (
             f"Model {self._model} can't be executed "
             + "without a tokenizer loaded first"
@@ -63,7 +65,9 @@ class TokenClassificationModel(BaseNLPModel):
             f"Model {self._model} can't be executed, it "
             + "needs to be loaded first"
         )
-        inputs = self._tokenize_input(input, system_prompt=None, context=None)
+        inputs = self._tokenize_input(
+            input, system_prompt=system_prompt, context=None
+        )
         with inference_mode():
             outputs = self._model(**inputs)
             # logits shape (1, seq_len, num_labels)

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1323,6 +1323,91 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "answer")
 
+    async def test_run_text_token_classification(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system="sys",
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        theme.display_token_labels.return_value = "table"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value={"t": "L"})
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_TOKEN_CLASSIFICATION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_TOKEN_CLASSIFICATION,
+        )
+        lm.assert_awaited_once_with(
+            "hi",
+            system_prompt="sys",
+        )
+        tg_patch.assert_not_called()
+        theme.display_token_labels.assert_called_once_with([lm.return_value])
+        self.assertEqual(console.print.call_args.args[0], "table")
+
     async def test_run_vision_object_detection(self):
         args = Namespace(
             model="id",

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -781,6 +781,13 @@ class FancyThemeMoreTests(unittest.TestCase):
         self.assertEqual(table.columns[0]._cells[0], "cat")
         self.assertEqual(table.columns[0]._cells[1], "dog")
 
+    def test_display_token_labels(self):
+        align = self.theme.display_token_labels([{"tok": "LBL"}])
+        table = align.renderable
+        self.assertEqual(table.row_count, 1)
+        self.assertEqual(table.columns[0]._cells[0], "tok")
+        self.assertEqual(table.columns[1]._cells[0], "LBL")
+
     def test_fill_model_config_table(self):
         cfg = ModelConfig(
             architectures=["a"],

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -138,6 +138,9 @@ class DummyTheme(Theme):
     def display_image_labels(self, labels):
         raise NotImplementedError()
 
+    def display_token_labels(self, labels):
+        raise NotImplementedError()
+
     async def tokens(self, *args, **kwargs):
         raise NotImplementedError()
 
@@ -354,6 +357,7 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.display_image_entities(self.theme, [], False),
             lambda: Theme.display_image_entity(self.theme, None),
             lambda: Theme.display_image_labels(self.theme, []),
+            lambda: Theme.display_token_labels(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),
         ]
 

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -15,6 +15,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
         modalities = {
             Modality.TEXT_GENERATION: "TextGenerationModel",
             Modality.TEXT_QUESTION_ANSWERING: "QuestionAnsweringModel",
+            Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
             Modality.EMBEDDING: "SentenceTransformerModel",
             Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
             Modality.AUDIO_TEXT_TO_SPEECH: "TextToSpeechModel",
@@ -45,6 +46,15 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
                         Model.return_value
                     )
                     self.assertIs(result, Model.return_value)
+
+    def test_load_engine_question_answering_remote(self):
+        with ModelManager(self.hub, self.logger) as manager:
+            uri = manager.parse_uri("ai://openai/qa")
+            settings = TransformerEngineSettings()
+            with self.assertRaises(NotImplementedError):
+                manager.load_engine(
+                    uri, settings, Modality.TEXT_QUESTION_ANSWERING
+                )
 
 
 class ModelManagerLoadModalitiesTestCase(TestCase):


### PR DESCRIPTION
## Summary
- support TokenClassificationModel in CLI with new modality `TEXT_TOKEN_CLASSIFICATION`
- extend entities with the modality
- pass system_prompt through TokenClassificationModel
- add display_token_labels to themes
- load TokenClassificationModel via ModelManager
- update unit tests for new functionality

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68706e35c0388323ae86007c1109f1ab