### PR TITLE
Fix QA inference mode

### DIFF
--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -3,7 +3,7 @@ from ...entities import Input
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.engine import Engine
-from torch import argmax
+from torch import argmax, inference_mode
 from transformers import AutoModelForQuestionAnswering, PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
 from typing import Literal
@@ -76,7 +76,8 @@ class QuestionAnsweringModel(BaseNLPModel):
             system_prompt=system_prompt,
             context=context,
         )
-        outputs = self._model(**inputs)
+        with inference_mode():
+            outputs = self._model(**inputs)
         start_answer_logits = outputs.start_logits
         end_answer_logits = outputs.end_logits
         start = argmax(start_answer_logits)

--- a/tests/model/nlp/question_test.py
+++ b/tests/model/nlp/question_test.py
@@ -9,6 +9,7 @@ from logging import Logger
 from torch import tensor
 from transformers import PreTrainedModel, PreTrainedTokenizerFast
 from unittest import TestCase, IsolatedAsyncioTestCase, main
+from contextlib import nullcontext
 from unittest.mock import patch, MagicMock, PropertyMock
 
 
@@ -107,6 +108,10 @@ class QuestionAnsweringModelCallTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 QuestionAnsweringModel, "_tokenize_input"
             ) as tokenize_mock,
+            patch(
+                "avalan.model.nlp.question.inference_mode",
+                return_value=nullcontext(),
+            ) as inference_mode_mock,
         ):
             tokenizer_instance = TruthyMagicMock(spec=PreTrainedTokenizerFast)
             tokenizer_instance.decode.return_value = "ans"
@@ -160,6 +165,7 @@ class QuestionAnsweringModelCallTestCase(IsolatedAsyncioTestCase):
             tokenizer_instance.decode.assert_called_with(
                 called_tensor, skip_special_tokens=True
             )
+            inference_mode_mock.assert_called_once_with()
 
     async def test_call_with_system_prompt(self):
         logger_mock = MagicMock(spec=Logger)
@@ -172,6 +178,10 @@ class QuestionAnsweringModelCallTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 QuestionAnsweringModel, "_tokenize_input"
             ) as tokenize_mock,
+            patch(
+                "avalan.model.nlp.question.inference_mode",
+                return_value=nullcontext(),
+            ) as inference_mode_mock,
         ):
             tokenizer_instance = TruthyMagicMock(spec=PreTrainedTokenizerFast)
             tokenizer_instance.decode.return_value = "ans"
@@ -219,6 +229,7 @@ class QuestionAnsweringModelCallTestCase(IsolatedAsyncioTestCase):
                 system_prompt="sp",
                 context="ctx",
             )
+            inference_mode_mock.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap model call in `QuestionAnsweringModel.__call__` inside `inference_mode`
- check `inference_mode` usage in tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6870727b3a5c8323bdd5c671b9dcbbfa