### PR TITLE
Add sequence classification CLI support

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -169,6 +169,7 @@ async def model_run(
             Modality.AUDIO_TEXT_TO_SPEECH,
             Modality.TEXT_GENERATION,
             Modality.TEXT_QUESTION_ANSWERING,
+            Modality.TEXT_SEQUENCE_CLASSIFICATION,
             Modality.TEXT_TOKEN_CLASSIFICATION,
             Modality.VISION_IMAGE_TEXT_TO_TEXT,
         ]
@@ -272,6 +273,11 @@ async def model_run(
                     context=args.text_context,
                     system_prompt=system_prompt,
                 )
+                console.print(output)
+            elif modality == Modality.TEXT_SEQUENCE_CLASSIFICATION:
+                assert input_string
+
+                output = await lm(input_string)
                 console.print(output)
             elif modality == Modality.TEXT_TOKEN_CLASSIFICATION:
                 assert input_string

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -76,6 +76,7 @@ class Modality(StrEnum):
     EMBEDDING = "embedding"
     TEXT_GENERATION = "text_generation"
     TEXT_QUESTION_ANSWERING = "text_question_answering"
+    TEXT_SEQUENCE_CLASSIFICATION = "text_sequence_classification"
     TEXT_TOKEN_CLASSIFICATION = "text_token_classification"
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -12,6 +12,7 @@ from ..model.hubs.huggingface import HuggingfaceHub
 from ..model.nlp.sentence import SentenceTransformerModel
 from ..model.nlp.text.generation import TextGenerationModel
 from ..model.nlp.question import QuestionAnsweringModel
+from ..model.nlp.sequence import SequenceClassificationModel
 from ..model.nlp.token import TokenClassificationModel
 from ..model.audio import SpeechRecognitionModel, TextToSpeechModel
 from ..model.vision.detection import ObjectDetectionModel
@@ -187,6 +188,8 @@ class ModelManager(ContextDecorator):
                     model = SemanticSegmentationModel(**model_load_args)
                 case Modality.TEXT_QUESTION_ANSWERING:
                     model = QuestionAnsweringModel(**model_load_args)
+                case Modality.TEXT_SEQUENCE_CLASSIFICATION:
+                    model = SequenceClassificationModel(**model_load_args)
                 case Modality.TEXT_TOKEN_CLASSIFICATION:
                     model = TokenClassificationModel(**model_load_args)
                 case _:

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1408,6 +1408,86 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         theme.display_token_labels.assert_called_once_with([lm.return_value])
         self.assertEqual(console.print.call_args.args[0], "table")
 
+    async def test_run_text_sequence_classification(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="lbl")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_SEQUENCE_CLASSIFICATION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_SEQUENCE_CLASSIFICATION,
+        )
+        lm.assert_awaited_once_with("hi")
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "lbl")
+
     async def test_run_vision_object_detection(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -15,6 +15,9 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
         modalities = {
             Modality.TEXT_GENERATION: "TextGenerationModel",
             Modality.TEXT_QUESTION_ANSWERING: "QuestionAnsweringModel",
+            Modality.TEXT_SEQUENCE_CLASSIFICATION: (
+                "SequenceClassificationModel"
+            ),
             Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
             Modality.EMBEDDING: "SentenceTransformerModel",
             Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",


### PR DESCRIPTION
## Summary
- add `TEXT_SEQUENCE_CLASSIFICATION` Modality
- support running sequence classification models from the CLI
- load SequenceClassificationModel in `ModelManager`
- test CLI `model_run` for sequence classification
- test loading sequence classification modality

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6870daaa78fc83239079a0709724fe40