### PR TITLE
Add SequenceToSequence CLI support

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -170,6 +170,7 @@ async def model_run(
             Modality.TEXT_GENERATION,
             Modality.TEXT_QUESTION_ANSWERING,
             Modality.TEXT_SEQUENCE_CLASSIFICATION,
+            Modality.TEXT_SEQUENCE_TO_SEQUENCE,
             Modality.TEXT_TOKEN_CLASSIFICATION,
             Modality.VISION_IMAGE_TEXT_TO_TEXT,
         ]
@@ -287,6 +288,25 @@ async def model_run(
                     assert input_string
 
                     output = await lm(input_string)
+                    console.print(output)
+
+                case Modality.TEXT_SEQUENCE_TO_SEQUENCE:
+                    assert input_string
+
+                    stopping_criteria = (
+                        KeywordStoppingCriteria(
+                            args.stop_on_keyword, lm.tokenizer
+                        )
+                        if args.stop_on_keyword
+                        else None
+                    )
+                    output = await lm(
+                        input_string,
+                        settings=settings,
+                        stopping_criterias=(
+                            [stopping_criteria] if stopping_criteria else None
+                        ),
+                    )
                     console.print(output)
 
                 case Modality.TEXT_TOKEN_CLASSIFICATION:

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -77,6 +77,7 @@ class Modality(StrEnum):
     TEXT_GENERATION = "text_generation"
     TEXT_QUESTION_ANSWERING = "text_question_answering"
     TEXT_SEQUENCE_CLASSIFICATION = "text_sequence_classification"
+    TEXT_SEQUENCE_TO_SEQUENCE = "text_sequence_to_sequence"
     TEXT_TOKEN_CLASSIFICATION = "text_token_classification"
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -12,7 +12,10 @@ from ..model.hubs.huggingface import HuggingfaceHub
 from ..model.nlp.sentence import SentenceTransformerModel
 from ..model.nlp.text.generation import TextGenerationModel
 from ..model.nlp.question import QuestionAnsweringModel
-from ..model.nlp.sequence import SequenceClassificationModel
+from ..model.nlp.sequence import (
+    SequenceClassificationModel,
+    SequenceToSequenceModel,
+)
 from ..model.nlp.token import TokenClassificationModel
 from ..model.audio import SpeechRecognitionModel, TextToSpeechModel
 from ..model.vision.detection import ObjectDetectionModel
@@ -190,6 +193,8 @@ class ModelManager(ContextDecorator):
                     model = QuestionAnsweringModel(**model_load_args)
                 case Modality.TEXT_SEQUENCE_CLASSIFICATION:
                     model = SequenceClassificationModel(**model_load_args)
+                case Modality.TEXT_SEQUENCE_TO_SEQUENCE:
+                    model = SequenceToSequenceModel(**model_load_args)
                 case Modality.TEXT_TOKEN_CLASSIFICATION:
                     model = TokenClassificationModel(**model_load_args)
                 case _:

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1488,6 +1488,95 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "lbl")
 
+    async def test_run_text_sequence_to_sequence(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=["stop"],
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="summary")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+        lm.tokenizer = MagicMock()
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_SEQUENCE_TO_SEQUENCE,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_SEQUENCE_TO_SEQUENCE,
+        )
+        lm.assert_awaited_once()
+        kw = lm.await_args.kwargs
+        self.assertIsInstance(kw["settings"], model_cmds.GenerationSettings)
+        self.assertEqual(kw["settings"].max_new_tokens, args.max_new_tokens)
+        self.assertIsNotNone(kw["stopping_criterias"])
+        self.assertIsInstance(
+            kw["stopping_criterias"][0], model_cmds.KeywordStoppingCriteria
+        )
+        self.assertEqual(kw["stopping_criterias"][0]._keywords, ["stop"])
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "summary")
+
     async def test_run_vision_object_detection(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -18,6 +18,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.TEXT_SEQUENCE_CLASSIFICATION: (
                 "SequenceClassificationModel"
             ),
+            Modality.TEXT_SEQUENCE_TO_SEQUENCE: "SequenceToSequenceModel",
             Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
             Modality.EMBEDDING: "SentenceTransformerModel",
             Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
@@ -57,6 +58,15 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             with self.assertRaises(NotImplementedError):
                 manager.load_engine(
                     uri, settings, Modality.TEXT_QUESTION_ANSWERING
+                )
+
+    def test_load_engine_sequence_to_sequence_remote(self):
+        with ModelManager(self.hub, self.logger) as manager:
+            uri = manager.parse_uri("ai://openai/s2s")
+            settings = TransformerEngineSettings()
+            with self.assertRaises(NotImplementedError):
+                manager.load_engine(
+                    uri, settings, Modality.TEXT_SEQUENCE_TO_SEQUENCE
                 )
 
 


### PR DESCRIPTION
## Summary
- add `TEXT_SEQUENCE_TO_SEQUENCE` modality
- handle sequence-to-sequence calls in the CLI
- load `SequenceToSequenceModel` via `ModelManager`
- test new modality for `model_run` and `ModelManager.load_engine`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6870f6da052c8323b8fa74b9bcb94a80