### PR TITLE
Add text translation modality

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1050,6 +1050,16 @@ class CLI:
             help="Context string for question answering",
         )
         model_run_parser.add_argument(
+            "--text-from-lang",
+            type=str,
+            help="Source language code for text translation",
+        )
+        model_run_parser.add_argument(
+            "--text-to-lang",
+            type=str,
+            help="Destination language code for text translation",
+        )
+        model_run_parser.add_argument(
             "--start-thinking",
             default=False,
             action="store_true",

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -171,6 +171,7 @@ async def model_run(
             Modality.TEXT_QUESTION_ANSWERING,
             Modality.TEXT_SEQUENCE_CLASSIFICATION,
             Modality.TEXT_SEQUENCE_TO_SEQUENCE,
+            Modality.TEXT_TRANSLATION,
             Modality.TEXT_TOKEN_CLASSIFICATION,
             Modality.VISION_IMAGE_TEXT_TO_TEXT,
         ]
@@ -306,6 +307,28 @@ async def model_run(
                         stopping_criterias=(
                             [stopping_criteria] if stopping_criteria else None
                         ),
+                    )
+                    console.print(output)
+
+                case Modality.TEXT_TRANSLATION:
+                    assert input_string
+
+                    stopping_criteria = (
+                        KeywordStoppingCriteria(
+                            args.stop_on_keyword, lm.tokenizer
+                        )
+                        if args.stop_on_keyword
+                        else None
+                    )
+                    output = await lm(
+                        input_string,
+                        source_language=args.text_from_lang,
+                        destination_language=args.text_to_lang,
+                        settings=settings,
+                        stopping_criterias=(
+                            [stopping_criteria] if stopping_criteria else None
+                        ),
+                        skip_special_tokens=args.skip_special_tokens,
                     )
                     console.print(output)
 

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -78,6 +78,7 @@ class Modality(StrEnum):
     TEXT_QUESTION_ANSWERING = "text_question_answering"
     TEXT_SEQUENCE_CLASSIFICATION = "text_sequence_classification"
     TEXT_SEQUENCE_TO_SEQUENCE = "text_sequence_to_sequence"
+    TEXT_TRANSLATION = "text_translation"
     TEXT_TOKEN_CLASSIFICATION = "text_token_classification"
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -15,6 +15,7 @@ from ..model.nlp.question import QuestionAnsweringModel
 from ..model.nlp.sequence import (
     SequenceClassificationModel,
     SequenceToSequenceModel,
+    TranslationModel,
 )
 from ..model.nlp.token import TokenClassificationModel
 from ..model.audio import SpeechRecognitionModel, TextToSpeechModel
@@ -195,6 +196,8 @@ class ModelManager(ContextDecorator):
                     model = SequenceClassificationModel(**model_load_args)
                 case Modality.TEXT_SEQUENCE_TO_SEQUENCE:
                     model = SequenceToSequenceModel(**model_load_args)
+                case Modality.TEXT_TRANSLATION:
+                    model = TranslationModel(**model_load_args)
                 case Modality.TEXT_TOKEN_CLASSIFICATION:
                     model = TokenClassificationModel(**model_load_args)
                 case _:

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1577,6 +1577,100 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "summary")
 
+    async def test_run_text_translation(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=["stop"],
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            text_from_lang="en_XX",
+            text_to_lang="fr_XX",
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="summary")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+        lm.tokenizer = MagicMock()
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = MagicMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri.return_value = engine_uri
+        manager.load.return_value = load_cm
+
+        with (
+            patch.object(
+                model_cmds, "ModelManager", return_value=manager
+            ) as mm_patch,
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_TRANSLATION,
+                },
+            ) as gms_patch,
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ) as tg_patch,
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.TEXT_TRANSLATION,
+        )
+        lm.assert_awaited_once()
+        kw = lm.await_args.kwargs
+        self.assertIsInstance(kw["settings"], model_cmds.GenerationSettings)
+        self.assertEqual(kw["settings"].max_new_tokens, args.max_new_tokens)
+        self.assertEqual(kw["source_language"], args.text_from_lang)
+        self.assertEqual(kw["destination_language"], args.text_to_lang)
+        self.assertEqual(kw["skip_special_tokens"], args.skip_special_tokens)
+        self.assertIsNotNone(kw["stopping_criterias"])
+        self.assertIsInstance(
+            kw["stopping_criterias"][0], model_cmds.KeywordStoppingCriteria
+        )
+        self.assertEqual(kw["stopping_criterias"][0]._keywords, ["stop"])
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "summary")
+
     async def test_run_vision_object_detection(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -19,6 +19,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
                 "SequenceClassificationModel"
             ),
             Modality.TEXT_SEQUENCE_TO_SEQUENCE: "SequenceToSequenceModel",
+            Modality.TEXT_TRANSLATION: "TranslationModel",
             Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
             Modality.EMBEDDING: "SentenceTransformerModel",
             Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
@@ -68,6 +69,13 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
                 manager.load_engine(
                     uri, settings, Modality.TEXT_SEQUENCE_TO_SEQUENCE
                 )
+
+    def test_load_engine_translation_remote(self):
+        with ModelManager(self.hub, self.logger) as manager:
+            uri = manager.parse_uri("ai://openai/translate")
+            settings = TransformerEngineSettings()
+            with self.assertRaises(NotImplementedError):
+                manager.load_engine(uri, settings, Modality.TEXT_TRANSLATION)
 
 
 class ModelManagerLoadModalitiesTestCase(TestCase):


### PR DESCRIPTION
## Summary
- introduce `TEXT_TRANSLATION` modality
- support translation in the CLI with `--text-from-lang` and `--text-to-lang`
- load `TranslationModel` in ModelManager
- run translation in `model_run`
- add unit tests for translation modality

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6870fc5e762083238a94a22d8242975a