### PR TITLE
Fix CLI model run assertions

### DIFF
--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -86,11 +86,11 @@ class ModelManager(ContextDecorator):
     def __call__(self, model: ModelType, operation: Operation):
         pass
 
+    @staticmethod
     def get_operation_from_arguments(
-        self,
         modality: Modality,
         args: Namespace,
-        input_string: Input | None
+        input_string: Input | None,
     ) -> Operation:
         settings = GenerationSettings(
             do_sample=args.do_sample,
@@ -167,8 +167,7 @@ class ModelManager(ContextDecorator):
                         manual_sampling=args.display_tokens or 0,
                         pick_tokens=(
                             10
-                            if args.display_tokens
-                            and args.display_tokens > 0
+                            if args.display_tokens and args.display_tokens > 0
                             else 0
                         ),
                         stop_on_keywords=args.stop_on_keyword,
@@ -186,8 +185,7 @@ class ModelManager(ContextDecorator):
                 )
 
             case (
-                Modality.VISION_IMAGE_TO_TEXT
-                | Modality.VISION_ENCODER_DECODER
+                Modality.VISION_IMAGE_TO_TEXT | Modality.VISION_ENCODER_DECODER
             ):
                 parameters = OperationParameters(
                     vision=OperationVisionParameters(
@@ -209,7 +207,11 @@ class ModelManager(ContextDecorator):
                 parameters = OperationParameters(
                     vision=OperationVisionParameters(
                         path=args.path,
-                        threshold=args.image_threshold,
+                        threshold=getattr(
+                            args,
+                            "vision_threshold",
+                            getattr(args, "image_threshold", None),
+                        ),
                     )
                 )
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from argparse import Namespace
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, AsyncMock, patch, call, ANY
+from avalan.model.manager import ModelManager as RealModelManager
 import asyncio
 from unittest import IsolatedAsyncioTestCase, main, TestCase
 
@@ -843,6 +844,11 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                 model_cmds, "ModelManager", return_value=manager
             ) as mm_patch,
             patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ),
+            patch.object(
                 model_cmds,
                 "get_model_settings",
                 return_value={
@@ -924,24 +930,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_GENERATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_GENERATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1112,26 +1125,35 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                 manager.parse_uri.return_value = engine_uri
                 manager.load.return_value = load_cm
 
-                with (
-                    patch.object(
-                        model_cmds, "ModelManager", return_value=manager
-                    ) as mm_patch,
-                    patch.object(
-                        model_cmds,
-                        "get_model_settings",
-                        return_value={
-                            "engine_uri": engine_uri,
-                            "modality": Modality.AUDIO_TEXT_TO_SPEECH,
-                        },
-                    ) as gms_patch,
-                    patch.object(model_cmds, "get_input", return_value="hi"),
-                    patch.object(
-                        model_cmds, "token_generation", new_callable=AsyncMock
-                    ) as tg_patch,
-                ):
-                    await model_cmds.model_run(
-                        args, console, theme, hub, 5, logger
-                    )
+                with patch.object(
+                    model_cmds, "ModelManager", return_value=manager
+                ) as mm_patch:
+                    with patch.object(
+                        model_cmds.ModelManager,
+                        "get_operation_from_arguments",
+                        side_effect=RealModelManager.get_operation_from_arguments,
+                    ):
+                        with (
+                            patch.object(
+                                model_cmds,
+                                "get_model_settings",
+                                return_value={
+                                    "engine_uri": engine_uri,
+                                    "modality": Modality.AUDIO_TEXT_TO_SPEECH,
+                                },
+                            ) as gms_patch,
+                            patch.object(
+                                model_cmds, "get_input", return_value="hi"
+                            ),
+                            patch.object(
+                                model_cmds,
+                                "token_generation",
+                                new_callable=AsyncMock,
+                            ) as tg_patch,
+                        ):
+                            await model_cmds.model_run(
+                                args, console, theme, hub, 5, logger
+                            )
 
                 mm_patch.assert_called_once_with(hub, logger)
                 manager.parse_uri.assert_called_once_with("id")
@@ -1208,24 +1230,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.AUDIO_SPEECH_RECOGNITION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.AUDIO_SPEECH_RECOGNITION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1289,24 +1318,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_QUESTION_ANSWERING,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_QUESTION_ANSWERING,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1374,24 +1410,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_TOKEN_CLASSIFICATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_TOKEN_CLASSIFICATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1458,24 +1501,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_SEQUENCE_CLASSIFICATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_SEQUENCE_CLASSIFICATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1539,24 +1589,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_SEQUENCE_TO_SEQUENCE,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_SEQUENCE_TO_SEQUENCE,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1630,24 +1687,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.TEXT_TRANSLATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.TEXT_TRANSLATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1728,24 +1792,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_OBJECT_DETECTION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_OBJECT_DETECTION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1817,24 +1888,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_SEMANTIC_SEGMENTATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_SEMANTIC_SEGMENTATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1904,24 +1982,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_IMAGE_CLASSIFICATION,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_IMAGE_CLASSIFICATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -1990,24 +2075,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_IMAGE_TO_TEXT,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_IMAGE_TO_TEXT,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -2072,24 +2164,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_ENCODER_DECODER,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_ENCODER_DECODER,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")
@@ -2155,24 +2254,31 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri.return_value = engine_uri
         manager.load.return_value = load_cm
 
-        with (
-            patch.object(
-                model_cmds, "ModelManager", return_value=manager
-            ) as mm_patch,
-            patch.object(
-                model_cmds,
-                "get_model_settings",
-                return_value={
-                    "engine_uri": engine_uri,
-                    "modality": Modality.VISION_IMAGE_TEXT_TO_TEXT,
-                },
-            ) as gms_patch,
-            patch.object(model_cmds, "get_input", return_value="hi"),
-            patch.object(
-                model_cmds, "token_generation", new_callable=AsyncMock
-            ) as tg_patch,
-        ):
-            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_IMAGE_TEXT_TO_TEXT,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
 
         mm_patch.assert_called_once_with(hub, logger)
         manager.parse_uri.assert_called_once_with("id")


### PR DESCRIPTION
## Summary
- make `ModelManager.get_operation_from_arguments` a static method
- call the static version directly when building operations
- adjust input assertions in CLI model run
- update CLI model run tests to patch the static method

## Testing
- `make lint`
- `poetry run pytest -vv -s`


------
https://chatgpt.com/codex/tasks/task_e_687166155030832393f152743634b6de