### PR TITLE
Fix model run tests

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -833,11 +833,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
-        manager.__enter__.return_value = manager
-        manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager = RealModelManager(hub, logger)
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
 
         with (
             patch.object(
@@ -915,18 +913,15 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         logger = MagicMock()
 
         engine_uri = SimpleNamespace(model_id="id", is_local=True)
-        lm = MagicMock()
+        lm = AsyncMock(return_value="resp")
         lm.config = MagicMock()
         lm.config.__repr__ = lambda self=None: "cfg"
-        lm.return_value = "resp"
 
         load_cm = MagicMock()
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = AsyncMock(side_effect=NotImplementedError())
-        manager.__enter__.return_value = manager
-        manager.__exit__.return_value = False
+        manager = RealModelManager(hub, logger)
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
@@ -1023,11 +1018,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
-        manager.__enter__.return_value = manager
-        manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager = RealModelManager(hub, logger)
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
 
         with (
             patch.object(
@@ -1309,11 +1302,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
-        manager.__enter__.return_value = manager
-        manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager = RealModelManager(hub, logger)
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
 
         with patch.object(
             model_cmds, "ModelManager", return_value=manager


### PR DESCRIPTION
## Summary
- update tests to use real `ModelManager`
- adapt mocks for async model calls

## Testing
- `make lint`
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_local_model -q`
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_remote_model -q`
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_text_question_answering -q`
- `poetry run pytest --verbose -s` *(fails: test_run_text_sequence_classification, test_run_text_sequence_to_sequence, test_run_text_token_classification, test_run_text_translation, test_run_vision_encoder_decoder, test_run_vision_image_classification, test_run_vision_image_text_to_text, test_run_vision_image_to_text, test_run_vision_object_detection, test_run_vision_semantic_segmentation)*

------
https://chatgpt.com/codex/tasks/task_e_687191312064832386e09949f42faf9b