### PR TITLE
Fix initial model run tests

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -13,6 +13,7 @@ from ...model import TextGenerationResponse
 from ...model.hubs.huggingface import HuggingfaceHub
 from ...model.manager import ModelManager
 from ...entities import GenerationSettings  # noqa: F401
+from ...model.criteria import KeywordStoppingCriteria  # noqa: F401
 from ...model.nlp.sentence import SentenceTransformerModel
 from ...model.nlp.text.generation import TextGenerationModel
 from ...secrets import KeyringSecrets
@@ -197,12 +198,7 @@ async def model_run(
                 args,
                 input_string,
             )
-            output = await manager(
-                engine_uri,
-                modality,
-                model,
-                operation
-            )
+            output = await manager(engine_uri, modality, model, operation)
 
             if modality in {
                 Modality.AUDIO_SPEECH_RECOGNITION,

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1392,11 +1392,18 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
+        manager = AsyncMock()
         manager.__enter__.return_value = manager
         manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
 
         with patch.object(
             model_cmds, "ModelManager", return_value=manager
@@ -1483,11 +1490,18 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
+        manager = AsyncMock()
         manager.__enter__.return_value = manager
         manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
 
         with patch.object(
             model_cmds, "ModelManager", return_value=manager
@@ -1571,11 +1585,18 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         load_cm.__enter__.return_value = lm
         load_cm.__exit__.return_value = False
 
-        manager = MagicMock()
+        manager = AsyncMock()
         manager.__enter__.return_value = manager
         manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
-        manager.load.return_value = load_cm
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
 
         with patch.object(
             model_cmds, "ModelManager", return_value=manager


### PR DESCRIPTION
## Summary
- re-import `KeywordStoppingCriteria`
- make model tests use async manager mocks

## Testing
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_text_sequence_classification -vv -s`
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_text_token_classification -vv -s`
- `poetry run pytest tests/cli/model_test.py::CliModelRunTestCase::test_run_text_sequence_to_sequence -vv -s`
- `poetry run pytest --verbose -s` *(fails: 7 failed, 647 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871947c17948323921035b296a96f77