### PR TITLE
Add requires_input to Operation

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1052,7 +1052,10 @@ class CLI:
         model_run_parser.add_argument(
             "--text-max-length",
             type=int,
-            help="The maximum length the generated tokens can have. Corresponds to the length of the input prompt + max_new_tokens",
+            help=(
+                "The maximum length the generated tokens can have. Corresponds"
+                " to the length of the input prompt + max_new_tokens"
+            ),
         )
         model_run_parser.add_argument(
             "--text-num-beams",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -535,6 +535,7 @@ class Operation:
     input: Input | None
     modality: Modality
     parameters: OperationParameters
+    requires_input: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -89,14 +89,17 @@ class ModelManager(ContextDecorator):
         engine_uri: EngineUri,
         modality: Modality,
         model: ModelType,
-        operation: Operation
+        operation: Operation,
     ):
         stopping_criteria = (
             KeywordStoppingCriteria(
                 operation.parameters["text"].stop_on_keywords,
                 model.tokenizer,
             )
-            if operation.parameters and "text" in operation.parameters and operation.parameters["text"] and operation.parameters["text"].stop_on_keywords
+            if operation.parameters
+            and "text" in operation.parameters
+            and operation.parameters["text"]
+            and operation.parameters["text"].stop_on_keywords
             else None
         )
 
@@ -110,9 +113,7 @@ class ModelManager(ContextDecorator):
 
                 return await model(
                     path=operation.parameters["audio"].path,
-                    sampling_rate=operation.parameters[
-                        "audio"
-                    ].sampling_rate,
+                    sampling_rate=operation.parameters["audio"].sampling_rate,
                 )
 
             case Modality.AUDIO_TEXT_TO_SPEECH:
@@ -132,9 +133,7 @@ class ModelManager(ContextDecorator):
                     reference_text=operation.parameters[
                         "audio"
                     ].reference_text,
-                    sampling_rate=operation.parameters[
-                        "audio"
-                    ].sampling_rate,
+                    sampling_rate=operation.parameters["audio"].sampling_rate,
                 )
 
             case Modality.TEXT_GENERATION:
@@ -148,9 +147,7 @@ class ModelManager(ContextDecorator):
                         ].system_prompt,
                         settings=operation.generation_settings,
                         stopping_criterias=(
-                            [stopping_criteria]
-                            if stopping_criteria
-                            else None
+                            [stopping_criteria] if stopping_criteria else None
                         ),
                         manual_sampling=operation.parameters[
                             "text"
@@ -179,9 +176,7 @@ class ModelManager(ContextDecorator):
                 return await model(
                     operation.input,
                     context=operation.parameters["text"].context,
-                    system_prompt=operation.parameters[
-                        "text"
-                    ].system_prompt,
+                    system_prompt=operation.parameters["text"].system_prompt,
                 )
 
             case Modality.TEXT_SEQUENCE_CLASSIFICATION:
@@ -205,9 +200,7 @@ class ModelManager(ContextDecorator):
 
                 return await model(
                     operation.input,
-                    system_prompt=operation.parameters[
-                        "text"
-                    ].system_prompt,
+                    system_prompt=operation.parameters["text"].system_prompt,
                 )
 
             case Modality.TEXT_TRANSLATION:
@@ -244,8 +237,7 @@ class ModelManager(ContextDecorator):
                 return await model(operation.parameters["vision"].path)
 
             case (
-                Modality.VISION_IMAGE_TO_TEXT
-                | Modality.VISION_ENCODER_DECODER
+                Modality.VISION_IMAGE_TO_TEXT | Modality.VISION_ENCODER_DECODER
             ):
                 assert (
                     operation.parameters["vision"]
@@ -268,9 +260,7 @@ class ModelManager(ContextDecorator):
                 return await model(
                     operation.parameters["vision"].path,
                     operation.input,
-                    system_prompt=operation.parameters[
-                        "vision"
-                    ].system_prompt,
+                    system_prompt=operation.parameters["vision"].system_prompt,
                     settings=operation.generation_settings,
                     width=operation.parameters["vision"].width,
                 )
@@ -279,8 +269,7 @@ class ModelManager(ContextDecorator):
                 assert (
                     operation.parameters["vision"]
                     and operation.parameters["vision"].path
-                    and operation.parameters["vision"].threshold
-                    is not None
+                    and operation.parameters["vision"].threshold is not None
                 )
 
                 return await model(
@@ -297,9 +286,7 @@ class ModelManager(ContextDecorator):
                 return await model(operation.parameters["vision"].path)
 
             case _:
-                raise NotImplementedError(
-                    f"Modality {modality} not supported"
-                )
+                raise NotImplementedError(f"Modality {modality} not supported")
 
     @staticmethod
     def get_operation_from_arguments(
@@ -321,6 +308,17 @@ class ModelManager(ContextDecorator):
             use_cache=args.use_cache,
         )
         system_prompt = args.system or None
+
+        requires_input = modality in {
+            Modality.AUDIO_TEXT_TO_SPEECH,
+            Modality.TEXT_GENERATION,
+            Modality.TEXT_QUESTION_ANSWERING,
+            Modality.TEXT_SEQUENCE_CLASSIFICATION,
+            Modality.TEXT_SEQUENCE_TO_SEQUENCE,
+            Modality.TEXT_TRANSLATION,
+            Modality.TEXT_TOKEN_CLASSIFICATION,
+            Modality.VISION_IMAGE_TEXT_TO_TEXT,
+        }
 
         match modality:
             case Modality.AUDIO_SPEECH_RECOGNITION:
@@ -445,6 +443,7 @@ class ModelManager(ContextDecorator):
             input=input_string,
             modality=modality,
             parameters=parameters,
+            requires_input=requires_input,
         )
 
         return operation

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1,6 +1,6 @@
 from avalan.cli.commands import get_model_settings
 from avalan.cli.commands import model as model_cmds
-from avalan.entities import Modality, ImageEntity, Operation
+from avalan.entities import Modality, ImageEntity
 from avalan.event.manager import EventManager
 from avalan.event import Event, EventType
 from types import SimpleNamespace
@@ -1026,6 +1026,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 model_cmds, "ModelManager", return_value=manager
             ) as mm_patch,
+            patch(
+                "avalan.cli.commands.model.ModelManager.get_operation_from_arguments",
+                new=RealModelManager.get_operation_from_arguments,
+            ),
             patch.object(
                 model_cmds,
                 "get_model_settings",
@@ -2409,6 +2413,10 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 model_cmds, "ModelManager", return_value=manager
             ) as mm_patch,
+            patch(
+                "avalan.cli.commands.model.ModelManager.get_operation_from_arguments",
+                new=RealModelManager.get_operation_from_arguments,
+            ),
             patch.object(
                 model_cmds,
                 "get_model_settings",
@@ -2479,17 +2487,15 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.__exit__.return_value = False
         manager.parse_uri.return_value = engine_uri
         manager.load = MagicMock(return_value=load_cm)
-        manager.get_operation_from_arguments.return_value = Operation(
-            generation_settings=None,
-            input=None,
-            modality="bad",
-            parameters=None,
-        )
 
         with (
             patch.object(
                 model_cmds, "ModelManager", return_value=manager
             ) as mm_patch,
+            patch(
+                "avalan.cli.commands.model.ModelManager.get_operation_from_arguments",
+                new=RealModelManager.get_operation_from_arguments,
+            ),
             patch.object(
                 model_cmds,
                 "get_model_settings",

--- a/tests/model/model_manager_operation_test.py
+++ b/tests/model/model_manager_operation_test.py
@@ -57,30 +57,36 @@ class ModelManagerGetOperationTestCase(unittest.TestCase):
 
     def test_all_modalities(self):
         cases = {
-            Modality.AUDIO_SPEECH_RECOGNITION: self._check_audio,
-            Modality.AUDIO_TEXT_TO_SPEECH: self._check_audio,
-            Modality.TEXT_QUESTION_ANSWERING: self._check_text,
-            Modality.TEXT_SEQUENCE_CLASSIFICATION: (
-                lambda op: self.assertIsNone(op.parameters)
+            Modality.AUDIO_SPEECH_RECOGNITION: (self._check_audio, False),
+            Modality.AUDIO_TEXT_TO_SPEECH: (self._check_audio, True),
+            Modality.EMBEDDING: (
+                lambda op: self.assertIsNone(op.parameters),
+                False,
             ),
-            Modality.TEXT_SEQUENCE_TO_SEQUENCE: self._check_text,
-            Modality.TEXT_TRANSLATION: self._check_text,
-            Modality.TEXT_TOKEN_CLASSIFICATION: self._check_text,
-            Modality.TEXT_GENERATION: self._check_text,
-            Modality.VISION_IMAGE_CLASSIFICATION: self._check_vision,
-            Modality.VISION_IMAGE_TO_TEXT: self._check_vision,
-            Modality.VISION_IMAGE_TEXT_TO_TEXT: self._check_vision,
-            Modality.VISION_ENCODER_DECODER: self._check_vision,
-            Modality.VISION_OBJECT_DETECTION: self._check_vision,
-            Modality.VISION_SEMANTIC_SEGMENTATION: self._check_vision,
+            Modality.TEXT_QUESTION_ANSWERING: (self._check_text, True),
+            Modality.TEXT_SEQUENCE_CLASSIFICATION: (
+                lambda op: self.assertIsNone(op.parameters),
+                True,
+            ),
+            Modality.TEXT_SEQUENCE_TO_SEQUENCE: (self._check_text, True),
+            Modality.TEXT_TRANSLATION: (self._check_text, True),
+            Modality.TEXT_TOKEN_CLASSIFICATION: (self._check_text, True),
+            Modality.TEXT_GENERATION: (self._check_text, True),
+            Modality.VISION_IMAGE_CLASSIFICATION: (self._check_vision, False),
+            Modality.VISION_IMAGE_TO_TEXT: (self._check_vision, False),
+            Modality.VISION_IMAGE_TEXT_TO_TEXT: (self._check_vision, True),
+            Modality.VISION_ENCODER_DECODER: (self._check_vision, False),
+            Modality.VISION_OBJECT_DETECTION: (self._check_vision, False),
+            Modality.VISION_SEMANTIC_SEGMENTATION: (self._check_vision, False),
         }
-        for modality, checker in cases.items():
+        for modality, (checker, expected_requires_input) in cases.items():
             with self.subTest(modality=modality):
                 op = self.manager.get_operation_from_arguments(
                     modality, self.args, "i"
                 )
                 self.assertEqual(op.modality, modality)
                 checker(op)
+                self.assertEqual(op.requires_input, expected_requires_input)
 
     def test_unknown_modality(self):
         op = self.manager.get_operation_from_arguments(
@@ -88,3 +94,4 @@ class ModelManagerGetOperationTestCase(unittest.TestCase):
         )
         self.assertEqual(op.modality, FakeModality.UNKNOWN)
         self.assertIsNone(op.parameters)
+        self.assertFalse(op.requires_input)


### PR DESCRIPTION
## Summary
- add optional `requires_input` to `Operation`
- determine `requires_input` in `ModelManager.get_operation_from_arguments`
- adjust CLI to use new `requires_input` logic
- test `requires_input` for every modality
- streamline user input update with `dataclasses.replace`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6871c59429308323bb3e3215cd3dad00