### PR TITLE
Add subfolder args to engine settings

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -115,6 +115,18 @@ class CLI:
             ),
         )
         global_parser.add_argument(
+            "--subfolder",
+            type=str,
+            help="Subfolder inside model repository to load the model from",
+        )
+        global_parser.add_argument(
+            "--tokenizer-subfolder",
+            type=str,
+            help=(
+                "Subfolder inside model repository to load the tokenizer from"
+            ),
+        )
+        global_parser.add_argument(
             "--device",
             type=str,
             required=False,

--- a/src/avalan/cli/commands/__init__.py
+++ b/src/avalan/cli/commands/__init__.py
@@ -44,6 +44,12 @@ def get_model_settings(
         tokens=(
             args.token if args.token and isinstance(args.token, list) else None
         ),
+        subfolder=args.subfolder if hasattr(args, "subfolder") else None,
+        tokenizer_subfolder=(
+            args.tokenizer_subfolder
+            if hasattr(args, "tokenizer_subfolder")
+            else None
+        ),
         trust_remote_code=(
             args.trust_remote_code
             if hasattr(args, "trust_remote_code")

--- a/src/avalan/cli/commands/tokenizer.py
+++ b/src/avalan/cli/commands/tokenizer.py
@@ -25,6 +25,8 @@ async def tokenize(
         settings=TransformerEngineSettings(
             device=args.device,
             cache_dir=hub.cache_dir,
+            subfolder=getattr(args, "subfolder", None),
+            tokenizer_subfolder=getattr(args, "tokenizer_subfolder", None),
             tokenizer_name_or_path=tokenizer_name_or_path,
             tokens=(
                 args.token

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -122,6 +122,8 @@ class EngineSettings:
     parallel: ParallelStrategy | dict[str, ParallelStrategy] | None = None
     trust_remote_code: bool = False
     tokenizer_name_or_path: str | None = None
+    subfolder: str | None = None
+    tokenizer_subfolder: str | None = None
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/src/avalan/model/audio.py
+++ b/src/avalan/model/audio.py
@@ -52,6 +52,7 @@ class SpeechRecognitionModel(BaseAudioModel):
             trust_remote_code=self._settings.trust_remote_code,
             # default behavior in transformers v4.48
             use_fast=True,
+            subfolder=self._settings.tokenizer_subfolder,
         )
         model = AutoModelForCTC.from_pretrained(
             self._model_id,
@@ -61,6 +62,7 @@ class SpeechRecognitionModel(BaseAudioModel):
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
             ignore_mismatched_sizes=True,
+            subfolder=self._settings.subfolder,
         )
         return model
 
@@ -90,12 +92,14 @@ class TextToSpeechModel(BaseAudioModel):
         self._processor = AutoProcessor.from_pretrained(
             self._model_id,
             trust_remote_code=self._settings.trust_remote_code,
+            subfolder=self._settings.tokenizer_subfolder,
         )
         model = DiaForConditionalGeneration.from_pretrained(
             self._model_id,
             trust_remote_code=self._settings.trust_remote_code,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            subfolder=self._settings.subfolder,
         )
         return model
 

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -22,6 +22,7 @@ class QuestionAnsweringModel(BaseNLPModel):
         model = AutoModelForQuestionAnswering.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
+            subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
             torch_dtype=BaseNLPModel._get_weight_type(

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -28,6 +28,7 @@ class SequenceClassificationModel(BaseNLPModel):
         model = AutoModelForSequenceClassification.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
+            subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
             torch_dtype=BaseNLPModel._get_weight_type(
@@ -93,6 +94,7 @@ class SequenceToSequenceModel(BaseNLPModel):
         model = AutoModelForSeq2SeqLM.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
+            subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
             torch_dtype=BaseNLPModel._get_weight_type(

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -80,6 +80,7 @@ class TextGenerationModel(BaseNLPModel):
         model = loader.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
+            subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
             state_dict=self._settings.state_dict,

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -21,6 +21,7 @@ class TokenClassificationModel(BaseNLPModel):
         model = AutoModelForTokenClassification.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
+            subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
             torch_dtype=BaseNLPModel._get_weight_type(

--- a/src/avalan/model/transformer.py
+++ b/src/avalan/model/transformer.py
@@ -109,7 +109,9 @@ class TransformerModel(Engine, ABC):
         self, tokenizer_name_or_path: str | None, use_fast: bool
     ) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
         return AutoTokenizer.from_pretrained(
-            tokenizer_name_or_path or self._model_id, use_fast=use_fast
+            tokenizer_name_or_path or self._model_id,
+            use_fast=use_fast,
+            subfolder=self._settings.tokenizer_subfolder,
         )
 
     def _load_tokenizer_with_tokens(

--- a/tests/cli/get_model_settings_test.py
+++ b/tests/cli/get_model_settings_test.py
@@ -23,6 +23,8 @@ class GetModelSettingsTestCase(unittest.TestCase):
             special_token=["<s>"],
             tokenizer="tok",
             token=["t"],
+            subfolder="model_sub",
+            tokenizer_subfolder="tok_sub",
             trust_remote_code=True,
             weight_type="fp16",
         )
@@ -43,6 +45,8 @@ class GetModelSettingsTestCase(unittest.TestCase):
             "special_tokens": ["<s>"],
             "tokenizer": "tok",
             "tokens": ["t"],
+            "subfolder": "model_sub",
+            "tokenizer_subfolder": "tok_sub",
             "trust_remote_code": True,
             "weight_type": "fp16",
         }

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -56,6 +56,8 @@ class CliModelTestCase(TestCase):
             "special_tokens": ["<s>"],
             "tokenizer": "tok",
             "tokens": ["t"],
+            "subfolder": None,
+            "tokenizer_subfolder": None,
             "trust_remote_code": True,
             "weight_type": "fp16",
         }

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -57,6 +57,7 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
                 self.model_id,
                 trust_remote_code=False,
                 use_fast=True,
+                subfolder=None,
             )
             model_mock.assert_called_once_with(
                 self.model_id,
@@ -66,6 +67,7 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
                 ignore_mismatched_sizes=True,
+                subfolder=None,
             )
 
 

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -53,12 +53,14 @@ class TextToSpeechModelInstantiationTestCase(TestCase):
             processor_mock.assert_called_once_with(
                 self.model_id,
                 trust_remote_code=False,
+                subfolder=None,
             )
             model_mock.assert_called_once_with(
                 self.model_id,
                 trust_remote_code=False,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                subfolder=None,
             )
 
 

--- a/tests/model/nlp/question_test.py
+++ b/tests/model/nlp/question_test.py
@@ -79,6 +79,7 @@ class QuestionAnsweringModelInstantiationTestCase(TestCase):
             model_mock.assert_called_once_with(
                 self.model_id,
                 cache_dir=None,
+                subfolder=None,
                 attn_implementation=None,
                 trust_remote_code=False,
                 torch_dtype="auto",
@@ -91,6 +92,7 @@ class QuestionAnsweringModelInstantiationTestCase(TestCase):
             tokenizer_mock.assert_called_once_with(
                 self.model_id,
                 use_fast=True,
+                subfolder=None,
             )
 
 

--- a/tests/model/nlp/sentence_test.py
+++ b/tests/model/nlp/sentence_test.py
@@ -101,6 +101,7 @@ class SentenceTransformerModelTestCase(IsolatedAsyncioTestCase):
                 auto_tokenizer_mock.assert_called_once_with(
                     self.model_id,
                     use_fast=True,
+                    subfolder=None,
                 )
 
     def test_token_count(self):

--- a/tests/model/nlp/sequence_test.py
+++ b/tests/model/nlp/sequence_test.py
@@ -78,6 +78,7 @@ class SequenceClassificationModelInstantiationTestCase(TestCase):
             auto_model_mock.assert_called_once_with(
                 self.model_id,
                 cache_dir=None,
+                subfolder=None,
                 attn_implementation=None,
                 trust_remote_code=False,
                 torch_dtype="auto",
@@ -90,6 +91,7 @@ class SequenceClassificationModelInstantiationTestCase(TestCase):
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id,
                 use_fast=True,
+                subfolder=None,
             )
 
 

--- a/tests/model/nlp/sequence_to_sequence_model_test.py
+++ b/tests/model/nlp/sequence_to_sequence_model_test.py
@@ -73,6 +73,7 @@ class SequenceToSequenceModelInstantiationTestCase(TestCase):
             auto_model_mock.assert_called_once_with(
                 self.model_id,
                 cache_dir=None,
+                subfolder=None,
                 attn_implementation=None,
                 trust_remote_code=False,
                 torch_dtype="auto",
@@ -85,6 +86,7 @@ class SequenceToSequenceModelInstantiationTestCase(TestCase):
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id,
                 use_fast=True,
+                subfolder=None,
             )
 
 

--- a/tests/model/nlp/text_test.py
+++ b/tests/model/nlp/text_test.py
@@ -67,7 +67,7 @@ class TextGenerationModelTestCase(TestCase):
                 )
                 self.assertIsInstance(model, TextGenerationModel)
                 auto_tokenizer_mock.assert_called_once_with(
-                    model_id, use_fast=True
+                    model_id, use_fast=True, subfolder=None
                 )
 
     def test_instantiation_with_load_model_and_tokenizer(self):
@@ -113,6 +113,7 @@ class TextGenerationModelTestCase(TestCase):
                 auto_model_mock.assert_called_once_with(
                     model_id,
                     cache_dir=None,
+                    subfolder=None,
                     attn_implementation=None,
                     trust_remote_code=False,
                     torch_dtype="auto",
@@ -126,7 +127,7 @@ class TextGenerationModelTestCase(TestCase):
                     tp_plan=None,
                 )
                 auto_tokenizer_mock.assert_called_once_with(
-                    model_id, use_fast=True
+                    model_id, use_fast=True, subfolder=None
                 )
 
 
@@ -211,7 +212,9 @@ class TextGenerationModelMethodsTestCase(TestCase):
                 ),
             )
 
-            auto_tok.assert_called_once_with("m", use_fast=True)
+            auto_tok.assert_called_once_with(
+                "m", use_fast=True, subfolder=None
+            )
             tokenizer.add_special_tokens.assert_called_once()
             args = tokenizer.add_special_tokens.call_args.args[0]
             self.assertIn("additional_special_tokens", args)
@@ -242,7 +245,9 @@ class TextGenerationModelMethodsTestCase(TestCase):
                 ),
             )
 
-            auto_tok.assert_called_once_with("m", use_fast=True)
+            auto_tok.assert_called_once_with(
+                "m", use_fast=True, subfolder=None
+            )
             tokenizer.add_tokens.assert_called_once_with(tokens)
 
 

--- a/tests/model/nlp/token_test.py
+++ b/tests/model/nlp/token_test.py
@@ -64,7 +64,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
             )
             self.assertIsInstance(model, TokenClassificationModel)
             auto_tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
             auto_model_mock.assert_not_called()
 
@@ -103,6 +103,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
             auto_model_mock.assert_called_once_with(
                 self.model_id,
                 cache_dir=None,
+                subfolder=None,
                 attn_implementation=None,
                 trust_remote_code=False,
                 torch_dtype="auto",
@@ -113,7 +114,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
                 tp_plan=None,
             )
             auto_tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
 
     def test_instantiation_with_parallel(self):
@@ -151,6 +152,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
             auto_model_mock.assert_called_once_with(
                 self.model_id,
                 cache_dir=None,
+                subfolder=None,
                 attn_implementation=None,
                 trust_remote_code=False,
                 torch_dtype="auto",
@@ -220,7 +222,7 @@ class TokenClassificationModelCallTestCase(IsolatedAsyncioTestCase):
             model_instance.assert_called_once()
             tokenizer_mock.convert_ids_to_tokens.assert_called_once()
             auto_tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
             auto_model_mock.assert_called_once()
             inference_mode_mock.assert_called_once_with()
@@ -279,7 +281,7 @@ class TokenClassificationModelCallTestCase(IsolatedAsyncioTestCase):
             model_instance.assert_called_once()
             tokenizer_mock.convert_ids_to_tokens.assert_called_once()
             auto_tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
             auto_model_mock.assert_called_once()
             inference_mode_mock.assert_called_once_with()

--- a/tests/model/nlp/vllm_extra_test.py
+++ b/tests/model/nlp/vllm_extra_test.py
@@ -53,7 +53,9 @@ class VllmModelTestCase(IsolatedAsyncioTestCase):
                 model = VllmModel(self.model_id, settings)
 
         self.assertIs(model._model, llm_instance)
-        auto_tok.assert_called_once_with(self.model_id, use_fast=True)
+        auto_tok.assert_called_once_with(
+            self.model_id, use_fast=True, subfolder=None
+        )
         vllm_mock.LLM.assert_called_once()
 
     def test_supports_sample_generation(self):

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -78,7 +78,7 @@ class ImageToTextModelInstantiationTestCase(TestCase):
             )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
 
 

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -78,7 +78,7 @@ class VisionEncoderDecoderModelInstantiationTestCase(TestCase):
             )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(
-                self.model_id, use_fast=True
+                self.model_id, use_fast=True, subfolder=None
             )
 
 


### PR DESCRIPTION
## Summary
- extend `EngineSettings` with `subfolder` and `tokenizer_subfolder`
- expose new options through CLI
- use subfolder arguments when loading models and tokenizers
- adjust CLI helpers and tokenizer command
- update tests for the new parameters

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687268e6e418832391143a9991514e45