### PR TITLE
Integrate ModelManager with EngineAgent

### DIFF
--- a/src/avalan/agent/engine.py
+++ b/src/avalan/agent/engine.py
@@ -2,16 +2,21 @@ from abc import ABC, abstractmethod
 from ..agent import Specification
 from ..entities import (
     EngineMessage,
+    EngineUri,
     GenerationSettings,
     Input,
     Message,
     MessageRole,
+    Modality,
+    Operation,
+    OperationParameters,
+    OperationTextParameters,
 )
 from ..memory.manager import MemoryManager
 from ..model import TextGenerationResponse
 from ..model.engine import Engine
-from ..model.nlp.text.vendor import TextGenerationVendorModel
 from ..tool.manager import ToolManager
+from ..model.manager import ModelManager
 from ..event import Event, EventType
 from ..event.manager import EventManager
 from dataclasses import replace
@@ -26,6 +31,8 @@ class EngineAgent(ABC):
     _memory: MemoryManager
     _tool: ToolManager
     _event_manager: EventManager
+    _model_manager: ModelManager
+    _engine_uri: EngineUri
     _last_output: TextGenerationResponse | None = None
     _last_prompt: tuple[Input, str | None] | None = None
 
@@ -42,6 +49,10 @@ class EngineAgent(ABC):
     @property
     def engine(self) -> Engine:
         return self._model
+
+    @property
+    def engine_uri(self) -> EngineUri:
+        return self._engine_uri
 
     @property
     def output(self) -> TextGenerationResponse | None:
@@ -80,6 +91,8 @@ class EngineAgent(ABC):
         memory: MemoryManager,
         tool: ToolManager,
         event_manager: EventManager,
+        model_manager: ModelManager,
+        engine_uri: EngineUri,
         *args,
         name: str | None = None,
         id: UUID | None = None,
@@ -90,6 +103,8 @@ class EngineAgent(ABC):
         self._memory = memory
         self._tool = tool
         self._event_manager = event_manager
+        self._model_manager = model_manager
+        self._engine_uri = engine_uri
 
     async def __call__(
         self, specification: Specification, input: str, **kwargs
@@ -275,11 +290,18 @@ class EngineAgent(ABC):
 
         # Have model generate output from input
 
-        model_settings = dict(
-            system_prompt=system_prompt, settings=settings, tool=self._tool
+        operation = Operation(
+            generation_settings=settings,
+            input=input,
+            modality=Modality.TEXT_GENERATION,
+            parameters=OperationParameters(
+                text=OperationTextParameters(
+                    system_prompt=system_prompt,
+                    skip_special_tokens=skip_special_tokens,
+                )
+            ),
+            requires_input=True,
         )
-        if not isinstance(self._model, TextGenerationVendorModel):
-            model_settings["skip_special_tokens"] = skip_special_tokens
 
         await self._event_manager.trigger(
             Event(
@@ -293,7 +315,12 @@ class EngineAgent(ABC):
                 },
             )
         )
-        output = await self._model(input, **model_settings)
+        output = await self._model_manager(
+            self._engine_uri,
+            Modality.TEXT_GENERATION,
+            self._model,
+            operation,
+        )
         await self._event_manager.trigger(
             Event(
                 type=EventType.MODEL_EXECUTE_AFTER,

--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -255,7 +255,9 @@ class Orchestrator:
                     self._memory,
                     self._tool,
                     self._event_manager,
+                    self._model_manager,
                     self._renderer,
+                    environment.engine_uri,
                     name=self._name,
                     id=self._id,
                 )

--- a/src/avalan/agent/renderer.py
+++ b/src/avalan/agent/renderer.py
@@ -2,7 +2,9 @@ from ..agent import Role, Specification
 from ..agent.engine import EngineAgent
 from ..memory.manager import MemoryManager
 from ..model.engine import Engine
+from ..model.manager import ModelManager
 from ..tool.manager import ToolManager
+from ..entities import EngineUri
 from ..event.manager import EventManager
 from jinja2 import (
     Environment as TemplateEnvironment,
@@ -67,7 +69,9 @@ class TemplateEngineAgent(EngineAgent):
         memory: MemoryManager,
         tool: ToolManager,
         event_manager: EventManager,
+        model_manager: ModelManager,
         renderer: Renderer,
+        engine_uri: EngineUri,
         *args,
         name: str | None = None,
         id: UUID | None = None,
@@ -77,6 +81,8 @@ class TemplateEngineAgent(EngineAgent):
             memory,
             tool,
             event_manager,
+            model_manager,
+            engine_uri,
             name=name,
             id=id,
         )

--- a/tests/agent/additional_coverage_test.py
+++ b/tests/agent/additional_coverage_test.py
@@ -53,6 +53,16 @@ class EngineAgentCoverageTestCase(unittest.IsolatedAsyncioTestCase):
             self.memory,
             self.tool,
             self.event_manager,
+            MagicMock(spec=ModelManager),
+            EngineUri(
+                host=None,
+                port=None,
+                user=None,
+                password=None,
+                vendor=None,
+                model_id="m",
+                params={},
+            ),
         )
         with self.assertRaises(NotImplementedError):
             agent._prepare_call(Specification(role=None, goal=None), "hi")
@@ -63,6 +73,16 @@ class EngineAgentCoverageTestCase(unittest.IsolatedAsyncioTestCase):
             self.memory,
             self.tool,
             self.event_manager,
+            MagicMock(spec=ModelManager),
+            EngineUri(
+                host=None,
+                port=None,
+                user=None,
+                password=None,
+                vendor=None,
+                model_id="m",
+                params={},
+            ),
         )
         agent._last_output = "value"
         self.assertEqual(agent.output, "value")

--- a/tests/agent/engine_agent_event_test.py
+++ b/tests/agent/engine_agent_event_test.py
@@ -1,9 +1,15 @@
 from avalan.agent.engine import EngineAgent
-from avalan.entities import Message, MessageRole, GenerationSettings
+from avalan.entities import (
+    Message,
+    MessageRole,
+    GenerationSettings,
+    EngineUri,
+)
 from avalan.event import EventType
 from avalan.event.manager import EventManager
 from avalan.memory.manager import MemoryManager
 from avalan.tool.manager import ToolManager
+from avalan.model.manager import ModelManager
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -39,8 +45,25 @@ class EngineAgentEventTestCase(IsolatedAsyncioTestCase):
         tool = MagicMock(spec=ToolManager)
         event_manager = MagicMock(spec=EventManager)
         event_manager.trigger = AsyncMock()
-
-        agent = DummyAgent(DummyEngine(), memory, tool, event_manager)
+        model_manager = AsyncMock(spec=ModelManager)
+        model_manager.return_value = "out"
+        engine_uri = EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        )
+        agent = DummyAgent(
+            DummyEngine(),
+            memory,
+            tool,
+            event_manager,
+            model_manager,
+            engine_uri,
+        )
         await agent(MagicMock(), Message(role=MessageRole.USER, content="hi"))
 
         await agent.input_token_count()

--- a/tests/agent/template_engine_agent_test.py
+++ b/tests/agent/template_engine_agent_test.py
@@ -4,6 +4,8 @@ from avalan.event import EventType
 from avalan.memory.manager import MemoryManager
 from avalan.tool.manager import ToolManager
 from avalan.event.manager import EventManager
+from avalan.entities import EngineUri
+from avalan.model.manager import ModelManager
 from unittest import TestCase, IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock
 
@@ -11,12 +13,24 @@ from unittest.mock import MagicMock, AsyncMock
 class TemplateEngineAgentPrepareTestCase(TestCase):
     def setUp(self):
         self.renderer = Renderer()
+        self.model_manager = MagicMock(spec=ModelManager)
+        self.engine_uri = EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        )
         self.agent = TemplateEngineAgent(
             model=MagicMock(),
             memory=MagicMock(spec=MemoryManager),
             tool=MagicMock(spec=ToolManager),
             event_manager=MagicMock(spec=EventManager),
+            model_manager=self.model_manager,
             renderer=self.renderer,
+            engine_uri=self.engine_uri,
             name="Bob",
         )
 
@@ -86,12 +100,23 @@ class TemplateEngineAgentCallTestCase(IsolatedAsyncioTestCase):
         event_manager.trigger = AsyncMock()
         model = MagicMock()
 
+        engine_uri = EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        )
         agent = TemplateEngineAgent(
             model=model,
             memory=memory,
             tool=tool,
             event_manager=event_manager,
+            model_manager=MagicMock(spec=ModelManager),
             renderer=renderer,
+            engine_uri=engine_uri,
             name="Bob",
         )
 


### PR DESCRIPTION
## Summary
- inject `ModelManager` and `EngineUri` into `EngineAgent`
- delegate model execution through `ModelManager`
- update `TemplateEngineAgent` and orchestrator to pass new arguments
- adjust tests for new constructor and behaviour

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6872b2b1324883239c23c05e60e43bee