### PR TITLE
Add namespace scoping for tool filters and transformers

### DIFF
--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -589,6 +589,22 @@ class ToolCallResult(ToolCall):
 
 
 @dataclass(frozen=True, kw_only=True)
+class ToolFilter:
+    func: Callable[
+        [ToolCall, ToolCallContext], tuple[ToolCall, ToolCallContext] | None
+    ]
+    namespace: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class ToolTransformer:
+    func: Callable[
+        [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
+    ]
+    namespace: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
 class ToolManagerSettings:
     eos_token: str | None = None
     tool_format: ToolFormat | None = None
@@ -600,6 +616,7 @@ class ToolManagerSettings:
                 [ToolCall, ToolCallContext],
                 tuple[ToolCall, ToolCallContext] | None,
             ]
+            | ToolFilter
         ]
         | None
     ) = None
@@ -608,6 +625,7 @@ class ToolManagerSettings:
             Callable[
                 [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
             ]
+            | ToolTransformer
         ]
         | None
     ) = None


### PR DESCRIPTION
## Summary
- add `ToolFilter` and `ToolTransformer` dataclasses with optional namespace
- support namespace filtering logic in `ToolManager`
- test scoping logic for filters and transformers
- made `_matches_namespace` a static method
- removed forward annotations import

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6873bc4021088323a5d049bc21aefd8d