### PR TITLE
Fix async mock warning

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2487,7 +2487,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager = AsyncMock()
         manager.__enter__.return_value = manager
         manager.__exit__.return_value = False
-        manager.parse_uri.return_value = engine_uri
+        manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
         with (


### PR DESCRIPTION
## Summary
- resolve unawaited coroutine warning in model tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6874bdba21788323bad3a431997c0c23