### PR TITLE
Fix unreachable return and extend tests

### DIFF
--- a/src/avalan/memory/permanent/pgsql/__init__.py
+++ b/src/avalan/memory/permanent/pgsql/__init__.py
@@ -74,7 +74,6 @@ class BasePgsqlMemory(MemoryStore[T]):
                 await cursor.close()
                 row = dict(result) if result is not None else None
                 return row[field] if row else None
-        return None
 
     async def _has_one(self, query: str, parameters: tuple) -> bool:
         async with self._database.connection() as connection:

--- a/tests/memory/permanent/pgsql_base_memory_test.py
+++ b/tests/memory/permanent/pgsql_base_memory_test.py
@@ -97,6 +97,19 @@ class BasePgsqlMemoryTestCase(IsolatedAsyncioTestCase):
         result = await memory._try_fetch_one(DummyEntity, "q", (1,))
         self.assertIsNone(result)
 
+    async def test_fetch_field(self):
+        pool, _, cursor = self.mock_query({"f": "v"})
+        memory = DummyBaseMemory(pool, logger=MagicMock())
+        result = await memory._fetch_field("f", "q", (1,))
+        cursor.execute.assert_awaited_once_with("q", (1,))
+        self.assertEqual(result, "v")
+
+        pool, _, cursor = self.mock_query(None)
+        memory = DummyBaseMemory(pool, logger=MagicMock())
+        result = await memory._fetch_field("f", "q", (2,))
+        cursor.execute.assert_awaited_once_with("q", (2,))
+        self.assertIsNone(result)
+
     async def test_update_and_fetch_one_and_field(self):
         pool = AsyncMock(spec=AsyncConnectionPool)
         memory = DummyBaseMemory(pool, logger=MagicMock())

--- a/tests/model/model_type_test.py
+++ b/tests/model/model_type_test.py
@@ -1,0 +1,19 @@
+from avalan.model.engine import Engine
+from unittest import TestCase
+
+
+class ModelTypePropertyTestCase(TestCase):
+    def test_subclasses_use_engine_property(self) -> None:
+        seen = set()
+        stack = [Engine]
+        subclasses = []
+        while stack:
+            parent = stack.pop()
+            for sub in parent.__subclasses__():
+                if sub not in seen:
+                    seen.add(sub)
+                    stack.append(sub)
+                    subclasses.append(sub)
+        for cls in subclasses:
+            with self.subTest(model=cls):
+                self.assertNotIn("model_type", cls.__dict__)

--- a/tests/model/transformer_extra_test.py
+++ b/tests/model/transformer_extra_test.py
@@ -1,0 +1,32 @@
+from avalan.entities import TransformerEngineSettings
+from avalan.model.transformer import TransformerModel
+from logging import Logger
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+
+class DummyTransformerModel(TransformerModel):
+    def _load_model(self):
+        return MagicMock()
+
+    def _tokenize_input(self, *args, **kwargs):
+        return super()._tokenize_input(*args, **kwargs)
+
+    async def __call__(self, *args, **kwargs):
+        return None
+
+
+class TransformerModelPropertyTestCase(TestCase):
+    def test_properties_and_tokenize(self) -> None:
+        model = DummyTransformerModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+            logger=MagicMock(spec=Logger),
+        )
+        self.assertFalse(model.supports_sample_generation)
+        self.assertFalse(model.supports_token_streaming)
+        self.assertTrue(model.uses_tokenizer)
+        with self.assertRaises(NotImplementedError):
+            model._tokenize_input("in")

--- a/tests/model/vision/base_vision_model_test.py
+++ b/tests/model/vision/base_vision_model_test.py
@@ -1,0 +1,27 @@
+from avalan.entities import EngineSettings
+from avalan.model.vision import BaseVisionModel
+from logging import Logger
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+from typing import Literal
+
+
+class DummyVisionModel(BaseVisionModel):
+    def _load_model(self):
+        return MagicMock()
+
+    async def __call__(
+        self, image_source: str | object, tensor_format: Literal["pt"] = "pt"
+    ):
+        return await super().__call__(image_source, tensor_format)
+
+
+class BaseVisionModelTestCase(IsolatedAsyncioTestCase):
+    async def test_call_not_implemented(self) -> None:
+        model = DummyVisionModel(
+            None,
+            EngineSettings(auto_load_model=False),
+            logger=MagicMock(spec=Logger),
+        )
+        with self.assertRaises(NotImplementedError):
+            await model("img")

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -142,5 +142,18 @@ class ImageToTextModelCallTestCase(IsolatedAsyncioTestCase):
             )
 
 
+class ImageToTextModelTokenizeInputTestCase(TestCase):
+    def test_tokenize_input_not_implemented(self) -> None:
+        model = ImageToTextModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+            logger=MagicMock(spec=Logger),
+        )
+        with self.assertRaises(NotImplementedError):
+            model._tokenize_input("in")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- drop unreachable None return in `_fetch_field`
- check base vision model calling behavior
- validate `_tokenize_input` for image-to-text model
- ensure all model subclasses rely on `Engine.model_type`
- add base transformer property tests
- cover fetch field logic in pgsql memory

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6874d07f193083238b9ae6245b7952a3