### PR TITLE
Add diffusion pipeline support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ test = [
   "mcp==1.10.1",
   "pgvector==0.4.1",
   "pillow==11.3.0",
+  "diffusers==0.27.2",
   "playwright==1.53.0",
   "psycopg[binary,pool]==3.2.9",
   "pydantic==2.11.7",
@@ -123,6 +124,7 @@ vendors = [
 vision = [
   "pillow==11.3.0",
   "torchvision==0.22.1",
+  "diffusers==0.27.2",
 ]
 vllm = [
   "vllm[cpu]==0.1.0",
@@ -147,6 +149,7 @@ all = [
   "openai==1.93.0",
   "litellm==1.40.0",
   "pillow==11.3.0",
+  "diffusers==0.27.2",
   "protobuf==6.31.0",
   "psycopg[binary,pool]==3.2.9",
   "pgvector==0.4.1",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -663,6 +663,7 @@ class TransformerEngineSettings(EngineSettings):
     state_dict: dict[str, Tensor] = None
     tokens: list[str] | None = None
     weight_type: WeightType = "auto"
+    refiner_model_id: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/model/audio.py
+++ b/src/avalan/model/audio.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from ..compat import override
 from ..model import TextGenerationVendor, TokenizerNotSupportedException
 from ..model.engine import Engine
+from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import argmax, inference_mode
 from torchaudio import load
@@ -46,7 +47,9 @@ class BaseAudioModel(Engine, ABC):
 
 
 class SpeechRecognitionModel(BaseAudioModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoProcessor.from_pretrained(
             self._model_id,
             trust_remote_code=self._settings.trust_remote_code,
@@ -88,7 +91,9 @@ class SpeechRecognitionModel(BaseAudioModel):
 
 
 class TextToSpeechModel(BaseAudioModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoProcessor.from_pretrained(
             self._model_id,
             trust_remote_code=self._settings.trust_remote_code,

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -43,7 +43,9 @@ class Engine(ABC):
     _loaded_model: bool = False
     _loaded_tokenizer: bool = False
     _tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast | None = None
-    _model: PreTrainedModel | TextGenerationVendor | None = None
+    _model: (
+        PreTrainedModel | TextGenerationVendor | DiffusionPipeline | None
+    ) = None
     _config: ModelConfig | SentenceTransformerModelConfig | None = None
     _tokenizer_config: TokenizerConfig | None = None
     _parameter_types: set[str] | None = None
@@ -122,7 +124,9 @@ class Engine(ABC):
         return self._config
 
     @property
-    def model(self) -> PreTrainedModel | TextGenerationVendor | None:
+    def model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline | None:
         return self._model
 
     @property
@@ -156,7 +160,9 @@ class Engine(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         raise NotImplementedError()
 
     def is_runnable(self, device: str | None = None) -> bool | None:
@@ -359,10 +365,14 @@ class Engine(ABC):
                     bos_token_id=getattr(mc, "bos_token_id", None),
                     bos_token=(
                         self._tokenizer.decode(mc.bos_token_id)
-                        if self._tokenizer and hasattr(mc, "bos_token_id") and mc.bos_token_id
+                        if self._tokenizer
+                        and hasattr(mc, "bos_token_id")
+                        and mc.bos_token_id
                         else None
                     ),
-                    decoder_start_token_id=getattr(mc, "decoder_start_token_id", None),
+                    decoder_start_token_id=getattr(
+                        mc, "decoder_start_token_id", None
+                    ),
                     eos_token_id=getattr(mc, "eos_token_id", None),
                     eos_token=(
                         self._tokenizer.decode(mc.eos_token_id)
@@ -404,7 +414,9 @@ class Engine(ABC):
                     ),
                     num_labels=getattr(mc, "num_labels", None),
                     output_attentions=getattr(mc, "output_attentions", None),
-                    output_hidden_states=getattr(mc, "output_hidden_states", None),
+                    output_hidden_states=getattr(
+                        mc, "output_hidden_states", None
+                    ),
                     pad_token_id=getattr(mc, "pad_token_id", None),
                     pad_token=(
                         self._tokenizer.decode(mc.pad_token_id)
@@ -420,11 +432,18 @@ class Engine(ABC):
                     ),
                     state_size=(
                         len(self._model.state_dict().keys())
-                        if hasattr(self._model, "state_dict") and self._model.state_dict
+                        if hasattr(self._model, "state_dict")
+                        and self._model.state_dict
                         else 0
                     ),
-                    task_specific_params=getattr(mc, "task_specific_params", None),
-                    torch_dtype=str(mc.torch_dtype) if hasattr(mc, "torch_dtype") else None,
+                    task_specific_params=getattr(
+                        mc, "task_specific_params", None
+                    ),
+                    torch_dtype=(
+                        str(mc.torch_dtype)
+                        if hasattr(mc, "torch_dtype")
+                        else None
+                    ),
                     vocab_size=(
                         mc.vocab_size if hasattr(mc, "vocab_size") else None
                     ),

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -3,6 +3,7 @@ from ...entities import Input
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
 from transformers import AutoModelForQuestionAnswering, PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
@@ -18,7 +19,9 @@ class QuestionAnsweringModel(BaseNLPModel):
     def supports_token_streaming(self) -> bool:
         return False
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         model = AutoModelForQuestionAnswering.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -3,6 +3,7 @@ from ...entities import Input
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from contextlib import nullcontext
 from numpy import ndarray
 from torch import inference_mode
@@ -28,7 +29,9 @@ class SentenceTransformerModel(BaseNLPModel):
         token_ids = self.tokenizer.encode(input, add_special_tokens=False)
         return len(token_ids)
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         from sentence_transformers import SentenceTransformer
 
         model = SentenceTransformer(

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -3,6 +3,7 @@ from ...entities import GenerationSettings, Input
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from dataclasses import replace
 from torch import argmax, inference_mode, softmax, Tensor
 from transformers import (
@@ -24,7 +25,9 @@ class SequenceClassificationModel(BaseNLPModel):
     def supports_token_streaming(self) -> bool:
         return False
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         model = AutoModelForSequenceClassification.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,
@@ -90,7 +93,9 @@ class SequenceToSequenceModel(BaseNLPModel):
     def supports_token_streaming(self) -> bool:
         return False
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         model = AutoModelForSeq2SeqLM.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -14,6 +14,7 @@ from ....entities import (
 from ....model import TextGenerationResponse, TextGenerationVendor
 from ....model.nlp import BaseNLPModel
 from ....model.engine import Engine
+from diffusers import DiffusionPipeline
 from ....tool.manager import ToolManager
 from dataclasses import replace
 from importlib.util import find_spec
@@ -58,7 +59,9 @@ class TextGenerationModel(BaseNLPModel):
     def supports_token_streaming(self) -> bool:
         return True
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert (
             self._settings.loader_class in self._loaders
         ), f"Unrecognized loader {self._settings.loader_class}"

--- a/src/avalan/model/nlp/text/vendor/__init__.py
+++ b/src/avalan/model/nlp/text/vendor/__init__.py
@@ -5,6 +5,7 @@ from .....entities import (
     TransformerEngineSettings,
 )
 from .....model import TextGenerationResponse, TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.generation import TextGenerationModel
 from .....tool.manager import ToolManager
 from dataclasses import replace
@@ -34,7 +35,9 @@ class TextGenerationVendorModel(TextGenerationModel, ABC):
         super().__init__(model_id, settings, logger)
 
     @abstractmethod
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         raise NotImplementedError()
 
     @property

--- a/src/avalan/model/nlp/text/vendor/anthropic.py
+++ b/src/avalan/model/nlp/text/vendor/anthropic.py
@@ -8,6 +8,7 @@ from .....entities import (
     TokenDetail,
 )
 from .....model import TextGenerationVendor, TextGenerationVendorStream
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.vendor import TextGenerationVendorModel
 from .....tool.manager import ToolManager
 from transformers import PreTrainedModel
@@ -77,7 +78,9 @@ class AnthropicClient(TextGenerationVendor):
 
 
 class AnthropicModel(TextGenerationVendorModel):
-    def _load_model(self) -> TextGenerationVendor | PreTrainedModel:
+    def _load_model(
+        self,
+    ) -> TextGenerationVendor | PreTrainedModel | DiffusionPipeline:
         assert self._settings.access_token
         return AnthropicClient(
             api_key=self._settings.access_token,

--- a/src/avalan/model/nlp/text/vendor/anyscale.py
+++ b/src/avalan/model/nlp/text/vendor/anyscale.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -12,7 +13,9 @@ class AnyScaleClient(OpenAIClient):
 
 
 class AnyScaleModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return AnyScaleClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/deepinfra.py
+++ b/src/avalan/model/nlp/text/vendor/deepinfra.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -12,7 +13,9 @@ class DeepInfraClient(OpenAIClient):
 
 
 class DeepInfraModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return DeepInfraClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/deepseek.py
+++ b/src/avalan/model/nlp/text/vendor/deepseek.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -11,7 +12,9 @@ class DeepSeekClient(OpenAIClient):
 
 
 class DeepSeekModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return DeepSeekClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/google.py
+++ b/src/avalan/model/nlp/text/vendor/google.py
@@ -3,6 +3,7 @@ from google.genai.types import GenerateContentResponse
 from .....compat import override
 from .....entities import GenerationSettings, Message, Token, TokenDetail
 from .....model import TextGenerationVendor, TextGenerationVendorStream
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.vendor import TextGenerationVendorModel
 from .....tool.manager import ToolManager
 from transformers import PreTrainedModel
@@ -55,6 +56,8 @@ class GoogleClient(TextGenerationVendor):
 
 
 class GoogleModel(TextGenerationVendorModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return GoogleClient(api_key=self._settings.access_token)

--- a/src/avalan/model/nlp/text/vendor/groq.py
+++ b/src/avalan/model/nlp/text/vendor/groq.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -12,7 +13,9 @@ class GroqClient(OpenAIClient):
 
 
 class GroqModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return GroqClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/huggingface.py
+++ b/src/avalan/model/nlp/text/vendor/huggingface.py
@@ -6,6 +6,7 @@ from .....entities import (
     TokenDetail,
 )
 from .....model import TextGenerationVendor, TextGenerationVendorStream
+from diffusers import DiffusionPipeline
 from . import TextGenerationVendorModel
 from .....tool.manager import ToolManager
 from huggingface_hub import AsyncInferenceClient
@@ -62,7 +63,9 @@ class HuggingfaceClient(TextGenerationVendor):
 
 
 class HuggingfaceModel(TextGenerationVendorModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return HuggingfaceClient(
             api_key=self._settings.access_token,

--- a/src/avalan/model/nlp/text/vendor/hyperbolic.py
+++ b/src/avalan/model/nlp/text/vendor/hyperbolic.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -12,7 +13,9 @@ class HyperbolicClient(OpenAIClient):
 
 
 class HyperbolicModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return HyperbolicClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/litellm.py
+++ b/src/avalan/model/nlp/text/vendor/litellm.py
@@ -1,6 +1,7 @@
 from .....compat import override
 from .....entities import GenerationSettings, Message, Token, TokenDetail
 from .....model import TextGenerationVendor, TextGenerationVendorStream
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.vendor import TextGenerationVendorModel
 from .....tool.manager import ToolManager
 from transformers import PreTrainedModel
@@ -70,7 +71,9 @@ class LiteLLMClient(TextGenerationVendor):
 
 
 class LiteLLMModel(TextGenerationVendorModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         return LiteLLMClient(
             api_key=self._settings.access_token,
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -6,6 +6,7 @@ from .....entities import (
     TokenDetail,
 )
 from .....model import TextGenerationVendor, TextGenerationVendorStream
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.vendor import TextGenerationVendorModel
 from .....tool.manager import ToolManager
 from openai import AsyncOpenAI, AsyncStream
@@ -49,7 +50,9 @@ class OpenAIClient(TextGenerationVendor):
 
 
 class OpenAIModel(TextGenerationVendorModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.base_url or self._settings.access_token
         return OpenAIClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/openrouter.py
+++ b/src/avalan/model/nlp/text/vendor/openrouter.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .....model.nlp.text.vendor.openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -19,7 +20,9 @@ class OpenRouterClient(OpenAIClient):
 
 
 class OpenRouterModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return OpenRouterClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/text/vendor/together.py
+++ b/src/avalan/model/nlp/text/vendor/together.py
@@ -1,4 +1,5 @@
 from .....model import TextGenerationVendor
+from diffusers import DiffusionPipeline
 from .openai import OpenAIClient, OpenAIModel
 from transformers import PreTrainedModel
 
@@ -12,7 +13,9 @@ class TogetherClient(OpenAIClient):
 
 
 class TogetherModel(OpenAIModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._settings.access_token
         return TogetherClient(
             base_url=self._settings.base_url,

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -2,6 +2,7 @@ from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
 from transformers import AutoModelForTokenClassification, PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
@@ -17,7 +18,9 @@ class TokenClassificationModel(BaseNLPModel):
     def supports_token_streaming(self) -> bool:
         return False
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         model = AutoModelForTokenClassification.from_pretrained(
             self._model_id,
             cache_dir=self._settings.cache_dir,

--- a/src/avalan/model/vision/detection.py
+++ b/src/avalan/model/vision/detection.py
@@ -4,6 +4,7 @@ from ...model import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from ...model.vision.image import ImageClassificationModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from logging import Logger
 from PIL import Image
 from torch import inference_mode, tensor
@@ -26,7 +27,9 @@ class ObjectDetectionModel(ImageClassificationModel):
         self._revision = revision
         super().__init__(model_id, settings, logger=logger)
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoImageProcessor.from_pretrained(
             self._model_id,
             revision=self._revision,

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -10,6 +10,7 @@ from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.vision import BaseVisionModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from ...model.transformer import TransformerModel
 from PIL import Image
 from torch import inference_mode, Tensor
@@ -30,7 +31,9 @@ from typing import Literal
 
 # model predicts one of the 1000 ImageNet classes
 class ImageClassificationModel(BaseVisionModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoImageProcessor.from_pretrained(
             self._model_id,
             # default behavior in transformers v4.48
@@ -61,7 +64,9 @@ class ImageClassificationModel(BaseVisionModel):
 
 
 class ImageToTextModel(TransformerModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoImageProcessor.from_pretrained(
             self._model_id,
             # default behavior in transformers v4.48
@@ -109,7 +114,9 @@ class ImageTextToTextModel(ImageToTextModel):
         "gemma3": Gemma3ForConditionalGeneration,
     }
 
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert (
             self._settings.loader_class in self._loaders
         ), f"Unrecognized loader {self._settings.loader_class}"
@@ -196,7 +203,9 @@ class ImageTextToTextModel(ImageToTextModel):
 
 
 class VisionEncoderDecoderModel(ImageToTextModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoImageProcessor.from_pretrained(
             self._model_id,
             use_fast=True,

--- a/src/avalan/model/vision/segmentation.py
+++ b/src/avalan/model/vision/segmentation.py
@@ -2,6 +2,7 @@ from ...compat import override
 from ...model import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from ...model.engine import Engine
+from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import inference_mode, unique
 from transformers import (
@@ -13,7 +14,9 @@ from typing import Literal
 
 
 class SemanticSegmentationModel(BaseVisionModel):
-    def _load_model(self) -> PreTrainedModel | TextGenerationVendor:
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = AutoImageProcessor.from_pretrained(
             self._model_id,
             # default behavior in transformers v4.48

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -1,0 +1,138 @@
+from avalan.entities import TransformerEngineSettings
+from avalan.model.vision.diffusion import TextToImageDiffusionModel
+from avalan.model.nlp import BaseNLPModel
+from avalan.model.engine import Engine
+from diffusers import DiffusionPipeline
+from contextlib import nullcontext
+from logging import Logger
+from unittest import TestCase, IsolatedAsyncioTestCase, main
+from unittest.mock import MagicMock, patch, call
+
+
+class TextToImageDiffusionModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+    refiner_id = "refiner/model"
+
+    def test_missing_refiner(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextToImageDiffusionModel(
+                self.model_id, TransformerEngineSettings()
+            )
+
+    def test_instantiation_with_load_model(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                DiffusionPipeline, "from_pretrained"
+            ) as pipeline_mock,
+            patch.object(
+                BaseNLPModel, "_get_weight_type", return_value="dtype"
+            ),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+        ):
+            base_instance = MagicMock()
+            base_instance.text_encoder_2 = "te2"
+            base_instance.vae = "vae"
+            refiner_instance = MagicMock()
+            pipeline_mock.side_effect = [base_instance, refiner_instance]
+
+            settings = TransformerEngineSettings(
+                refiner_model_id=self.refiner_id
+            )
+            model = TextToImageDiffusionModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+
+            self.assertIs(model.model, refiner_instance)
+            self.assertIs(model._base, base_instance)
+            pipeline_mock.assert_has_calls(
+                [
+                    call(
+                        self.model_id,
+                        torch_dtype="dtype",
+                        variant=settings.weight_type,
+                        use_safetensors=True,
+                    ),
+                    call(
+                        self.refiner_id,
+                        text_encoder_2=base_instance.text_encoder_2,
+                        vae=base_instance.vae,
+                        torch_dtype="dtype",
+                        use_safetensors=True,
+                        variant=settings.weight_type,
+                    ),
+                ]
+            )
+            base_instance.to.assert_called_once_with("cpu")
+            refiner_instance.to.assert_called_once_with("cpu")
+
+
+class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+    refiner_id = "refiner/model"
+
+    async def test_call(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                DiffusionPipeline, "from_pretrained"
+            ) as pipeline_mock,
+            patch.object(
+                BaseNLPModel, "_get_weight_type", return_value="dtype"
+            ),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch(
+                "avalan.model.vision.diffusion.inference_mode",
+                return_value=nullcontext(),
+            ) as inf_mock,
+        ):
+            base_instance = MagicMock()
+            base_instance.text_encoder_2 = "te2"
+            base_instance.vae = "vae"
+            base_instance.__call__.return_value = MagicMock(images="latent")
+            refiner_image = MagicMock()
+            refiner_instance = MagicMock()
+            refiner_instance.__call__.return_value = MagicMock(
+                images=[refiner_image]
+            )
+            pipeline_mock.side_effect = [base_instance, refiner_instance]
+
+            settings = TransformerEngineSettings(
+                refiner_model_id=self.refiner_id
+            )
+            model = TextToImageDiffusionModel(
+                self.model_id,
+                settings,
+                logger=logger_mock,
+            )
+
+            result = await model(
+                "prompt",
+                "out.jpg",
+                color_model="CMYK",
+                image_format="PNG",
+                n_steps=10,
+            )
+
+            self.assertEqual(result, "out.jpg")
+            base_instance.__call__.assert_called_once_with(
+                prompt="prompt",
+                num_inference_steps=10,
+                denoising_end=0.8,
+                output_type="latent",
+            )
+            refiner_instance.__call__.assert_called_once_with(
+                prompt="prompt",
+                num_inference_steps=10,
+                denoising_start=0.8,
+                image="latent",
+            )
+            refiner_image.convert.assert_called_once_with("CMYK")
+            refiner_image.save.assert_called_once_with("out.jpg", "PNG")
+            inf_mock.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support DiffusionPipeline for all Engine model loaders
- handle refiner model settings in `TextToImageDiffusionModel`
- allow full set of image modes and formats
- add tests for diffusion model
- include diffusers in vision, test and all extras

## Testing
- `make lint`
- `poetry run pytest --verbose -s` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_e_687555648124832385e82d4afda6cff7