### PR TITLE
Add tokenizer tests for diffusion model

### DIFF
--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -132,5 +132,31 @@ class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
             inf_mock.assert_called_once_with()
 
 
+class TextToImageDiffusionModelBaseMethodsTestCase(TestCase):
+    def test_load_tokenizer_not_implemented(self) -> None:
+        settings = TransformerEngineSettings(
+            auto_load_model=False,
+            auto_load_tokenizer=False,
+            refiner_model_id="ref",
+        )
+        with patch.object(Engine, "get_default_device", return_value="cpu"):
+            model = TextToImageDiffusionModel("id", settings)
+
+        with self.assertRaises(NotImplementedError):
+            model._load_tokenizer(None, True)
+
+    def test_tokenize_input_not_implemented(self) -> None:
+        settings = TransformerEngineSettings(
+            auto_load_model=False,
+            auto_load_tokenizer=False,
+            refiner_model_id="ref",
+        )
+        with patch.object(Engine, "get_default_device", return_value="cpu"):
+            model = TextToImageDiffusionModel("id", settings)
+
+        with self.assertRaises(NotImplementedError):
+            model._tokenize_input("in")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add tests for `_load_tokenizer` and `_tokenize_input` in `TextToImageDiffusionModel`

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6876b8272b208323b82d7a20e7f4f4f4