### PR TITLE
Refactor vision CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ echo "Transcribe the text on this image, keeping format" | \
     avalan model run "ai://local/google/gemma-3-12b-it" \
         --modality vision_image_text_to_text \
         --path docs/examples/typewritten_partial_sheet.jpg \
+        --vision-width 512 \
         --max-new-tokens 1024
 ```
 
@@ -246,7 +247,8 @@ Detect objects in an image and list them with accuracy scores:
 ```bash
 avalan model run "facebook/detr-resnet-50" \
     --modality vision_object_detection \
-    --path docs/examples/kitchen.jpg
+    --path docs/examples/kitchen.jpg \
+    --vision-threshold 0.3
 ```
 
 Results are sorted by accuracy and include bounding boxes:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2088,8 +2088,8 @@ DISPLAY_PROBABILITIES_SAMPLE_MINIMUM]
                         [--audio-reference-path AUDIO_REFERENCE_PATH]
                         [--audio-reference-text AUDIO_REFERENCE_TEXT]
                         [--audio-sampling-rate AUDIO_SAMPLING_RATE]
-                        [--image-threshold IMAGE_THRESHOLD]
-                        [--image-width IMAGE_WIDTH] [--do-sample]
+                        [--vision-threshold VISION_THRESHOLD]
+                        [--vision-width VISION_WIDTH] [--do-sample]
                         [--enable-gradient-calculation] [--use-cache]
                         [--max-new-tokens MAX_NEW_TOKENS]
                         [--modality 
@@ -2207,10 +2207,10 @@ gather,local_packed_rowwise,sequence_parallel,replicate}
   --audio-sampling-rate AUDIO_SAMPLING_RATE
                         Sampling rate to use for audio generation. Only
                         applicable to audio modalities.
-  --image-threshold IMAGE_THRESHOLD
+  --vision-threshold VISION_THRESHOLD
                         Score threshold for object detection. Only applicable
                         to vision modalities.
-  --image-width IMAGE_WIDTH
+  --vision-width VISION_WIDTH
                         Resize input image to this width before processing.
                         Only applicable to vision image text to text modality.
   --do-sample           Tell if the token generation process should be

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -975,7 +975,8 @@ class CLI:
             ),
         )
         model_run_parser.add_argument(
-            "--image-threshold",
+            "--vision-threshold",
+            dest="vision_threshold",
             default=0.3,
             type=float,
             help=(
@@ -984,7 +985,8 @@ class CLI:
             ),
         )
         model_run_parser.add_argument(
-            "--image-width",
+            "--vision-width",
+            dest="vision_width",
             type=int,
             help=(
                 "Resize input image to this width before processing. "

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -85,7 +85,7 @@ class Modality(StrEnum):
     VISION_OBJECT_DETECTION = "vision_object_detection"
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"
     VISION_IMAGE_TO_TEXT = "vision_image_to_text"
-    VISION_IMAGE_TEXT_TO_IMAGE = "vision_image_text_to_image"
+    VISION_TEXT_TO_IMAGE = "vision_text_to_image"
     VISION_IMAGE_TEXT_TO_TEXT = "vision_image_text_to_text"
     VISION_ENCODER_DECODER = "vision_encoder_decoder"
     VISION_SEMANTIC_SEGMENTATION = "vision_semantic_segmentation"

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -453,7 +453,11 @@ class ModelManager(ContextDecorator):
                     vision=OperationVisionParameters(
                         path=args.path,
                         system_prompt=system_prompt,
-                        width=args.image_width,
+                        width=getattr(
+                            args,
+                            "vision_width",
+                            getattr(args, "image_width", None),
+                        ),
                     )
                 )
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2284,7 +2284,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             display_tools_events=2,
             path="img.png",
             vision_threshold=0.5,
-            image_width=42,
+            vision_width=42,
         )
         console = MagicMock()
         theme = MagicMock()

--- a/tests/model/model_manager_operation_test.py
+++ b/tests/model/model_manager_operation_test.py
@@ -29,7 +29,7 @@ class ModelManagerGetOperationTestCase(unittest.TestCase):
             skip_special_tokens=False,
             system=None,
             display_tokens=0,
-            image_width=256,
+            vision_width=256,
             vision_threshold=0.5,
             do_sample=False,
             enable_gradient_calculation=False,


### PR DESCRIPTION
## Summary
- rename `VISION_IMAGE_TEXT_TO_IMAGE` to `VISION_TEXT_TO_IMAGE`
- rename `--image-threshold` to `--vision-threshold`
- rename `--image-width` to `--vision-width`
- update examples and CLI docs
- adjust tests and manager for new option names

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6876df5ece708323ade113c3ec9a2b1a