### PR TITLE
Add CLI support for vision diffusion

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -33,6 +33,8 @@ from ..entities import (
     DistanceType,
     Modality,
     ParallelStrategy,
+    VisionColorModel,
+    VisionImageFormat,
     TextGenerationLoaderClass,
     User,
     WeightType,
@@ -991,6 +993,46 @@ class CLI:
             help=(
                 "Resize input image to this width before processing. "
                 "Only applicable to vision image text to text modality."
+            ),
+        )
+        model_run_parser.add_argument(
+            "--vision-color-model",
+            default=VisionColorModel.RGB,
+            type=str,
+            choices=[m.value for m in VisionColorModel],
+            help=(
+                "Color model for image generation. "
+                "Only applicable to vision text to image modality."
+            ),
+        )
+        model_run_parser.add_argument(
+            "--vision-image-format",
+            default=VisionImageFormat.JPEG,
+            type=str,
+            choices=[f.value for f in VisionImageFormat],
+            help=(
+                "Image format to save generated image. "
+                "Only applicable to vision text to image modality."
+            ),
+        )
+        model_run_parser.add_argument(
+            "--vision-high-noise-frac",
+            dest="vision_high_noise_frac",
+            default=0.8,
+            type=float,
+            help=(
+                "High noise fraction for diffusion. "
+                "Only applicable to vision text to image modality."
+            ),
+        )
+        model_run_parser.add_argument(
+            "--vision-steps",
+            dest="vision_steps",
+            default=40,
+            type=int,
+            help=(
+                "Number of inference steps for diffusion. "
+                "Only applicable to vision text to image modality."
             ),
         )
         model_run_parser.add_argument(

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -236,6 +236,9 @@ async def model_run(
             elif modality == Modality.VISION_SEMANTIC_SEGMENTATION:
                 console.print(theme.display_image_labels(output))
 
+            elif modality == Modality.VISION_TEXT_TO_IMAGE:
+                console.print(output)
+
             else:
                 raise NotImplementedError(f"Modality {modality} not supported")
 

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -113,6 +113,45 @@ class ToolFormat(StrEnum):
     OPENAI = "openai"
 
 
+class VisionColorModel(StrEnum):
+    ONE = "1"
+    L = "L"
+    LA = "LA"
+    P = "P"
+    PA = "PA"
+    RGB = "RGB"
+    RGBA = "RGBA"
+    RGBX = "RGBX"
+    CMYK = "CMYK"
+    YCBCR = "YCbCr"
+    LAB = "LAB"
+    HSV = "HSV"
+    INTENSITY = "I"
+    FLOAT = "F"
+
+
+class VisionImageFormat(StrEnum):
+    BMP = "BMP"
+    DDS = "DDS"
+    EPS = "EPS"
+    GIF = "GIF"
+    ICNS = "ICNS"
+    ICO = "ICO"
+    IM = "IM"
+    JPEG = "JPEG"
+    JPEG2000 = "JPEG2000"
+    MSP = "MSP"
+    PCX = "PCX"
+    PNG = "PNG"
+    PPM = "PPM"
+    SGI = "SGI"
+    SPI = "SPI"
+    TGA = "TGA"
+    TIFF = "TIFF"
+    WEBP = "WEBP"
+    XBM = "XBM"
+
+
 @dataclass(frozen=True, kw_only=True)
 class EngineSettings:
     auto_load_model: bool = True
@@ -526,6 +565,10 @@ class OperationVisionParameters:
     system_prompt: str | None = None
     threshold: float | None = None
     width: int | None = None
+    color_model: VisionColorModel | None = None
+    high_noise_frac: float | None = None
+    image_format: VisionImageFormat | None = None
+    n_steps: int | None = None
 
 
 class OperationParameters(TypedDict, total=False):

--- a/src/avalan/model/vision/diffusion.py
+++ b/src/avalan/model/vision/diffusion.py
@@ -1,5 +1,10 @@
 from ...compat import override
-from ...entities import Input, TransformerEngineSettings
+from ...entities import (
+    Input,
+    TransformerEngineSettings,
+    VisionColorModel,
+    VisionImageFormat,
+)
 from ...model import TextGenerationVendor
 from ...model.nlp import BaseNLPModel
 from ...model.transformer import TransformerModel
@@ -87,48 +92,21 @@ class TextToImageDiffusionModel(TransformerModel):
         prompt: str,
         path: str,
         *,
-        color_model: Literal[
-            "1",
-            "L",
-            "LA",
-            "P",
-            "PA",
-            "RGB",
-            "RGBA",
-            "RGBX",
-            "CMYK",
-            "YCbCr",
-            "LAB",
-            "HSV",
-            "I",
-            "F",
-        ] = "RGB",
+        color_model: VisionColorModel = VisionColorModel.RGB,
         high_noise_frac: float = 0.8,
-        image_format: Literal[
-            "BMP",
-            "DDS",
-            "EPS",
-            "GIF",
-            "ICNS",
-            "ICO",
-            "IM",
-            "JPEG",
-            "JPEG2000",
-            "MSP",
-            "PCX",
-            "PNG",
-            "PPM",
-            "SGI",
-            "SPI",
-            "TGA",
-            "TIFF",
-            "WEBP",
-            "XBM",
-        ] = "JPEG",
+        image_format: VisionImageFormat = VisionImageFormat.JPEG,
         n_steps: int = 40,
         output_type: Literal["latent"] = "latent",
     ) -> str:
-        assert prompt and path
+        assert (
+            prompt
+            and path
+            and color_model
+            and high_noise_frac is not None
+            and image_format
+            and n_steps
+            and output_type
+        )
 
         with inference_mode():
             image = self._base(

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2361,6 +2361,112 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "txt")
 
+    async def test_run_vision_text_to_image(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="out.png",
+            vision_color_model="RGB",
+            vision_image_format="PNG",
+            vision_high_noise_frac=0.9,
+            vision_steps=50,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="out.png")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = AsyncMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
+
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_TEXT_TO_IMAGE,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_TEXT_TO_IMAGE,
+        )
+        lm.assert_awaited_once_with(
+            "hi",
+            "out.png",
+            color_model="RGB",
+            high_noise_frac=0.9,
+            image_format="PNG",
+            n_steps=50,
+        )
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "out.png")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -272,6 +272,32 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
                 (("img.png",), {"threshold": 0.5}),
             ),
             (
+                Modality.VISION_TEXT_TO_IMAGE,
+                Operation(
+                    generation_settings=self.settings,
+                    input="txt",
+                    modality=Modality.VISION_TEXT_TO_IMAGE,
+                    parameters=OperationParameters(
+                        vision=OperationVisionParameters(
+                            path="out.png",
+                            color_model="RGB",
+                            high_noise_frac=0.9,
+                            image_format="PNG",
+                            n_steps=10,
+                        )
+                    ),
+                ),
+                (
+                    ("txt", "out.png"),
+                    {
+                        "color_model": "RGB",
+                        "high_noise_frac": 0.9,
+                        "image_format": "PNG",
+                        "n_steps": 10,
+                    },
+                ),
+            ),
+            (
                 Modality.VISION_SEMANTIC_SEGMENTATION,
                 Operation(
                     generation_settings=self.settings,

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -29,6 +29,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.VISION_IMAGE_TO_TEXT: "ImageToTextModel",
             Modality.VISION_IMAGE_TEXT_TO_TEXT: "ImageTextToTextModel",
             Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
+            Modality.VISION_TEXT_TO_IMAGE: "TextToImageDiffusionModel",
             Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
         }
         for modality, class_name in modalities.items():

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -1,5 +1,6 @@
 from avalan.entities import TransformerEngineSettings
 from avalan.model.vision.diffusion import TextToImageDiffusionModel
+from avalan.entities import VisionColorModel, VisionImageFormat
 from avalan.model.nlp import BaseNLPModel
 from avalan.model.engine import Engine
 from diffusers import DiffusionPipeline
@@ -109,8 +110,8 @@ class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
             result = await model(
                 "prompt",
                 "out.jpg",
-                color_model="CMYK",
-                image_format="PNG",
+                color_model=VisionColorModel.CMYK,
+                image_format=VisionImageFormat.PNG,
                 n_steps=10,
             )
 


### PR DESCRIPTION
## Summary
- expose color model and image format enums for vision diffusion
- support TextToImageDiffusionModel in the CLI
- add ModelManager support for vision text-to-image
- print path for text-to-image results
- test ModelManager for new modality
- test model_run with vision text-to-image

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6876e717e664832387a3d98700a6dfb4