### PR TITLE
Refactor OrchestratorLoader

### DIFF
--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -142,7 +142,7 @@ class CliAgentMessageSearchTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(
                 agent_cmds.OrchestratorLoader,
-                "load_from_settings",
+                "from_settings",
                 new=AsyncMock(return_value=orch),
             ) as lfs,
             patch.object(
@@ -248,7 +248,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(
                 agent_cmds.OrchestratorLoader,
-                "load_from_settings",
+                "from_settings",
                 new=AsyncMock(return_value=orch),
             ) as lfs,
             patch.object(
@@ -667,7 +667,7 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(
                 agent_cmds.OrchestratorLoader,
-                "load_from_settings",
+                "from_settings",
                 new=AsyncMock(return_value=self.orch),
             ) as fs_patch,
             patch.object(
@@ -706,7 +706,7 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             patch.object(
                 agent_cmds.OrchestratorLoader,
-                "load_from_settings",
+                "from_settings",
                 new=AsyncMock(return_value=self.orch),
             ) as fs_patch,
             patch.object(


### PR DESCRIPTION
## Summary
- convert `OrchestratorLoader` to use an instance API
- rename `load_from_settings` to `from_settings`
- declare loader properties for type clarity

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68779335b43c83239c7494b9c0edbc83