### PR TITLE
Implement FlowManager

### DIFF
--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -31,6 +31,8 @@ class EventType(StrEnum):
     MODEL_EXECUTE_AFTER = "model_execute_after"
     MODEL_MANAGER_CALL_BEFORE = "model_manager_call_before"
     MODEL_MANAGER_CALL_AFTER = "model_manager_call_after"
+    FLOW_MANAGER_CALL_BEFORE = "flow_manager_call_before"
+    FLOW_MANAGER_CALL_AFTER = "flow_manager_call_after"
     START = "start"
     STREAM_END = "stream_end"
     TOKEN_GENERATED = "token_generated"

--- a/src/avalan/flow/manager.py
+++ b/src/avalan/flow/manager.py
@@ -1,0 +1,43 @@
+from logging import Logger
+from time import perf_counter
+from typing import Any
+
+from ..agent.loader import OrchestratorLoader
+from ..event import Event, EventType
+from .flow import Flow
+
+
+class FlowManager:
+    """Manage execution of a :class:`Flow`."""
+
+    _loader: OrchestratorLoader
+    _logger: Logger
+
+    def __init__(
+        self, orchestrator_loader: OrchestratorLoader, logger: Logger
+    ) -> None:
+        self._loader = orchestrator_loader
+        self._logger = logger
+
+    async def __call__(self, flow: Flow) -> Any:
+        """Execute ``flow`` and return its result."""
+        start = perf_counter()
+        await self._loader.event_manager.trigger(
+            Event(
+                type=EventType.FLOW_MANAGER_CALL_BEFORE,
+                payload={"flow": flow},
+                started=start,
+            )
+        )
+        result = flow.execute()
+        end = perf_counter()
+        await self._loader.event_manager.trigger(
+            Event(
+                type=EventType.FLOW_MANAGER_CALL_AFTER,
+                payload={"flow": flow, "result": result},
+                started=start,
+                finished=end,
+                elapsed=end - start,
+            )
+        )
+        return result

--- a/tests/flow/manager_test.py
+++ b/tests/flow/manager_test.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from avalan.flow.flow import Flow
+from avalan.flow.node import Node
+from avalan.flow.manager import FlowManager
+from avalan.event import EventType
+from avalan.agent.loader import OrchestratorLoader
+
+
+class FlowManagerCallTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_call_triggers_events(self):
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        loader = MagicMock(spec=OrchestratorLoader)
+        loader.event_manager = MagicMock()
+        loader.event_manager.trigger = AsyncMock()
+        manager = FlowManager(loader, logger=MagicMock())
+
+        result = await manager(flow)
+
+        self.assertEqual(result, 1)
+        called_types = [
+            c.args[0].type
+            for c in loader.event_manager.trigger.await_args_list
+        ]
+        self.assertIn(EventType.FLOW_MANAGER_CALL_BEFORE, called_types)
+        self.assertIn(EventType.FLOW_MANAGER_CALL_AFTER, called_types)
+        before = next(
+            c.args[0]
+            for c in loader.event_manager.trigger.await_args_list
+            if c.args[0].type == EventType.FLOW_MANAGER_CALL_BEFORE
+        )
+        after = next(
+            c.args[0]
+            for c in loader.event_manager.trigger.await_args_list
+            if c.args[0].type == EventType.FLOW_MANAGER_CALL_AFTER
+        )
+        self.assertIsNone(before.finished)
+        self.assertIsNone(before.elapsed)
+        self.assertEqual(after.started, before.started)
+        self.assertIsNotNone(after.finished)
+        self.assertIsNotNone(after.elapsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `FlowManager` for executing flows with event tracking
- define `FLOW_MANAGER_CALL_BEFORE` and `FLOW_MANAGER_CALL_AFTER` events
- test that FlowManager triggers events with timing info
- make FlowManager take an `OrchestratorLoader` instead of individual managers

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68752de9582883239268b050b0ecae8d