### PR TITLE
Fix tests broken after API update

### DIFF
--- a/tests/cli/get_model_settings_test.py
+++ b/tests/cli/get_model_settings_test.py
@@ -47,6 +47,7 @@ class GetModelSettingsTestCase(unittest.TestCase):
             "tokens": ["t"],
             "subfolder": "model_sub",
             "tokenizer_subfolder": "tok_sub",
+            "refiner_model_id": None,
             "trust_remote_code": True,
             "weight_type": "fp16",
         }

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -58,6 +58,7 @@ class CliModelTestCase(TestCase):
             "tokens": ["t"],
             "subfolder": None,
             "tokenizer_subfolder": None,
+            "refiner_model_id": None,
             "trust_remote_code": True,
             "weight_type": "fp16",
         }

--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -110,6 +110,7 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
                         "manual_sampling": False,
                         "pick": 0,
                         "skip_special_tokens": False,
+                        "tool": None,
                     },
                 ),
             ),

--- a/tests/model/nlp/text_test.py
+++ b/tests/model/nlp/text_test.py
@@ -113,7 +113,7 @@ class TextGenerationModelTestCase(TestCase):
                 auto_model_mock.assert_called_once_with(
                     model_id,
                     cache_dir=None,
-                    subfolder=None,
+                    subfolder="",
                     attn_implementation=None,
                     trust_remote_code=False,
                     torch_dtype="auto",


### PR DESCRIPTION
## Summary
- update expected fields in CLI tests for `refiner_model_id`
- adjust model manager test to include tool parameter
- reflect updated subfolder argument when loading models

## Testing
- `poetry run pytest --verbose -s tests/cli/get_model_settings_test.py tests/cli/model_test.py tests/model/model_manager_call_test.py tests/model/nlp/text_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e2d8a70083238a747d95a317f21d