### PR TITLE
Add S3VectorsRawMemory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ cpu = [
   "accelerate==1.8.1",
 ]
 memory = [
+  "boto3==1.39.3",
   "faiss-cpu==1.11.0",
   "markitdown[pdf]==0.1.2",
   "markdownify==1.1.0",

--- a/src/avalan/memory/permanent/s3vectors/raw.py
+++ b/src/avalan/memory/permanent/s3vectors/raw.py
@@ -1,0 +1,181 @@
+from ....deploy.aws import AsyncClient
+from ....memory.partitioner.text import TextPartition
+from ....memory.permanent import (
+    Memory,
+    MemoryType,
+    PermanentMemory,
+    PermanentMemoryPartition,
+    VectorFunction,
+)
+from asyncio import to_thread
+from datetime import datetime, timezone
+from json import dumps, loads
+from logging import Logger
+from typing import Any
+from uuid import UUID, uuid4
+
+from boto3 import client as boto_client
+
+
+class S3VectorsRawMemory(PermanentMemory):
+    _bucket: str
+    _collection: str
+    _client: Any
+    _logger: Logger
+
+    def __init__(
+        self,
+        bucket: str,
+        collection: str,
+        *,
+        client: Any,
+        logger: Logger,
+    ) -> None:
+        self._bucket = bucket
+        self._collection = collection
+        self._client = client
+        self._logger = logger
+        super().__init__(sentence_model=None)
+
+    @classmethod
+    async def create_instance(
+        cls,
+        bucket: str,
+        collection: str,
+        *,
+        logger: Logger,
+        aws_client: Any | None = None,
+    ) -> "S3VectorsRawMemory":
+        if aws_client is None:
+            aws_client = boto_client("s3vectors")
+        memory = cls(
+            bucket=bucket,
+            collection=collection,
+            client=AsyncClient(aws_client),
+            logger=logger,
+        )
+        return memory
+
+    async def append_with_partitions(
+        self,
+        namespace: str,
+        participant_id: UUID,
+        *,
+        memory_type: MemoryType,
+        data: str,
+        identifier: str,
+        partitions: list[TextPartition],
+        symbols: dict | None = None,
+        model_id: str | None = None,
+    ) -> None:
+        assert (
+            namespace and participant_id and data and identifier and partitions
+        )
+        now_utc = datetime.now(timezone.utc)
+        entry_id = uuid4()
+        entry = Memory(
+            id=entry_id,
+            model_id=model_id,
+            type=memory_type,
+            participant_id=participant_id,
+            namespace=namespace,
+            identifier=identifier,
+            data=data,
+            partitions=len(partitions),
+            symbols=symbols,
+            created_at=now_utc,
+        )
+        await to_thread(
+            self._client.put_object,
+            Bucket=self._bucket,
+            Key=f"{self._collection}/{entry.id}.json",
+            Body=dumps(
+                {
+                    "id": str(entry.id),
+                    "model_id": entry.model_id,
+                    "type": str(entry.type),
+                    "participant_id": str(entry.participant_id),
+                    "namespace": entry.namespace,
+                    "identifier": entry.identifier,
+                    "data": entry.data,
+                    "partitions": entry.partitions,
+                    "symbols": entry.symbols,
+                    "created_at": entry.created_at.isoformat(),
+                }
+            ).encode(),
+        )
+        for idx, p in enumerate(partitions):
+            row = PermanentMemoryPartition(
+                participant_id=entry.participant_id,
+                memory_id=entry.id,
+                partition=idx + 1,
+                data=p.data,
+                embedding=p.embeddings,
+                created_at=now_utc,
+            )
+            await to_thread(
+                self._client.put_vector,
+                Bucket=self._bucket,
+                Collection=self._collection,
+                Id=f"{row.memory_id}:{row.partition}",
+                Vector=row.embedding.tolist(),
+                Metadata={
+                    "memory_id": str(row.memory_id),
+                    "participant_id": str(row.participant_id),
+                    "namespace": namespace,
+                },
+            )
+
+    async def search_memories(
+        self,
+        *,
+        search_partitions: list[TextPartition],
+        participant_id: UUID,
+        namespace: str,
+        function: VectorFunction,
+        limit: int | None = None,
+    ) -> list[Memory]:
+        assert participant_id and namespace and search_partitions
+        query = search_partitions[0].embeddings.tolist()
+        response = await to_thread(
+            self._client.query_vector,
+            Bucket=self._bucket,
+            Collection=self._collection,
+            QueryVector=query,
+            TopK=limit or 10,
+            Function=str(function),
+            Filter={
+                "memory_id": "*",
+                "participant_id": str(participant_id),
+                "namespace": namespace,
+            },
+        )
+        results = []
+        for item in response.get("Items", []):
+            mem_id = item.get("Metadata", {}).get("memory_id")
+            if not mem_id:
+                continue
+            obj = await to_thread(
+                self._client.get_object,
+                Bucket=self._bucket,
+                Key=f"{self._collection}/{mem_id}.json",
+            )
+            meta = loads(obj["Body"].read().decode())
+            results.append(
+                Memory(
+                    id=UUID(meta["id"]),
+                    model_id=meta["model_id"],
+                    type=MemoryType(meta["type"]),
+                    participant_id=UUID(meta["participant_id"]),
+                    namespace=meta["namespace"],
+                    identifier=meta["identifier"],
+                    data=meta["data"],
+                    partitions=meta["partitions"],
+                    symbols=meta["symbols"],
+                    created_at=datetime.fromisoformat(meta["created_at"]),
+                )
+            )
+        return results
+
+    async def search(self, query: str) -> list[Memory] | None:
+        raise NotImplementedError()

--- a/tests/memory/permanent/s3vectors_raw_memory_test.py
+++ b/tests/memory/permanent/s3vectors_raw_memory_test.py
@@ -1,0 +1,95 @@
+from avalan.memory.partitioner.text import TextPartition
+from avalan.memory.permanent import MemoryType
+from avalan.memory.permanent.s3vectors.raw import S3VectorsRawMemory
+from datetime import datetime, timezone
+import numpy as np
+from uuid import uuid4, UUID
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class S3VectorsRawMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_create_instance(self):
+        client = MagicMock()
+        memory = await S3VectorsRawMemory.create_instance(
+            bucket="b", collection="c", logger=MagicMock(), aws_client=client
+        )
+        self.assertIsInstance(memory, S3VectorsRawMemory)
+        self.assertIs(memory._client._client, client)
+
+    async def test_append_with_partitions(self):
+        memory = S3VectorsRawMemory(
+            bucket="b", collection="c", client=AsyncMock(), logger=MagicMock()
+        )
+        part1 = TextPartition(
+            data="a", embeddings=np.array([0.1]), total_tokens=1
+        )
+        part2 = TextPartition(
+            data="b", embeddings=np.array([0.2]), total_tokens=1
+        )
+        mem_id = UUID("11111111-1111-1111-1111-111111111111")
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.uuid4",
+                return_value=mem_id,
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            await memory.append_with_partitions(
+                "ns",
+                uuid4(),
+                memory_type=MemoryType.RAW,
+                data="d",
+                identifier="id",
+                partitions=[part1, part2],
+                symbols={},
+                model_id="m",
+            )
+        self.assertTrue(memory._client.put_object.called)
+        self.assertEqual(memory._client.put_vector.call_count, 2)
+
+    async def test_search_memories(self):
+        mem_id = UUID("11111111-1111-1111-1111-111111111111")
+        part = TextPartition(
+            data="x", embeddings=np.array([0.3]), total_tokens=1
+        )
+        client = MagicMock()
+        client.query_vector.return_value = {
+            "Items": [{"Metadata": {"memory_id": str(mem_id)}}]
+        }
+        client.get_object.return_value = {
+            "Body": MagicMock(
+                read=MagicMock(
+                    return_value=(
+                        b'{"id": "%s", "model_id": "m", "type": "raw", '
+                        b'"participant_id": "%s", "namespace": "ns", '
+                        b'"identifier": "id", "data": "d", "partitions": 1, '
+                        b'"symbols": {}, "created_at": "%s"}'
+                    )
+                    % (
+                        str(mem_id).encode(),
+                        str(mem_id).encode(),
+                        datetime.now(timezone.utc).isoformat().encode(),
+                    )
+                )
+            )
+        }
+        memory = S3VectorsRawMemory(
+            bucket="b", collection="c", client=client, logger=MagicMock()
+        )
+        with patch(
+            "avalan.memory.permanent.s3vectors.raw.to_thread",
+            AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+        ):
+            result = await memory.search_memories(
+                search_partitions=[part],
+                participant_id=mem_id,
+                namespace="ns",
+                function=MemoryType.RAW,  # type: ignore[arg-type]
+                limit=1,
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, mem_id)


### PR DESCRIPTION
## Summary
- support S3 Vectors via new `S3VectorsRawMemory`
- add boto3 dependency to memory extras
- test new memory store

## Testing
- `poetry run ruff format src/avalan/memory/permanent/s3vectors/raw.py tests/memory/permanent/s3vectors_raw_memory_test.py >/tmp/ruff_format.log && tail -n 20 /tmp/ruff_format.log`
- `poetry run black --preview --enable-unstable-feature=string_processing src/avalan/memory/permanent/s3vectors/raw.py tests/memory/permanent/s3vectors_raw_memory_test.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `poetry run ruff check --fix src/avalan/memory/permanent/s3vectors/raw.py tests/memory/permanent/s3vectors_raw_memory_test.py >/tmp/ruff_check.log && tail -n 20 /tmp/ruff_check.log`
- `poetry run pytest --verbose -s >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6878690052648323afb2b693dba95c6e