### PR TITLE
Add S3Vectors message memory

### DIFF
--- a/src/avalan/memory/permanent/s3vectors/__init__.py
+++ b/src/avalan/memory/permanent/s3vectors/__init__.py
@@ -1,0 +1,49 @@
+from abc import ABC
+from asyncio import to_thread as _to_thread
+from logging import Logger
+from typing import Any, Callable
+
+
+async def to_thread(func: Callable[..., Any], **kwargs: Any) -> Any:
+    """Run *func* in a thread."""
+    return await _to_thread(func, **kwargs)
+
+
+class S3VectorsMemory(ABC):
+    """Common logic for S3Vectors based memories."""
+
+    _bucket: str
+    _collection: str
+    _client: Any
+    _logger: Logger
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        collection: str,
+        client: Any,
+        logger: Logger,
+        **kwargs: Any,
+    ) -> None:
+        self._bucket = bucket
+        self._collection = collection
+        self._client = client
+        self._logger = logger
+
+    async def _call_client(
+        self, func: Callable[..., Any], **kwargs: Any
+    ) -> Any:
+        return await to_thread(func, **kwargs)
+
+    async def _put_object(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.put_object, **kwargs)
+
+    async def _get_object(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.get_object, **kwargs)
+
+    async def _put_vector(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.put_vector, **kwargs)
+
+    async def _query_vector(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.query_vector, **kwargs)

--- a/src/avalan/memory/permanent/s3vectors/message.py
+++ b/src/avalan/memory/permanent/s3vectors/message.py
@@ -1,0 +1,226 @@
+from datetime import datetime, timezone
+from json import dumps, loads
+from logging import Logger
+from typing import Any
+from uuid import UUID, uuid4
+
+from boto3 import client as boto_client
+from ....deploy.aws import AsyncClient
+
+from ....entities import (
+    EngineMessage,
+    EngineMessageScored,
+    Message,
+    MessageRole,
+)
+from ....memory.partitioner.text import TextPartition
+from ....memory.permanent import (
+    PermanentMessage,
+    PermanentMessageMemory,
+    PermanentMessagePartition,
+    VectorFunction,
+)
+from . import S3VectorsMemory
+
+
+class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
+    def __init__(
+        self,
+        bucket: str,
+        collection: str,
+        *,
+        client: Any,
+        logger: Logger,
+        sentence_model: Any | None = None,
+    ) -> None:
+        S3VectorsMemory.__init__(
+            self,
+            bucket=bucket,
+            collection=collection,
+            client=client,
+            logger=logger,
+        )
+        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)  # type: ignore[arg-type]
+
+    @classmethod
+    async def create_instance(
+        cls,
+        bucket: str,
+        collection: str,
+        *,
+        logger: Logger,
+        aws_client: Any | None = None,
+        sentence_model: Any | None = None,
+    ) -> "S3VectorsMessageMemory":
+        if aws_client is None:
+            aws_client = boto_client("s3vectors")
+        return cls(
+            bucket=bucket,
+            collection=collection,
+            client=AsyncClient(aws_client),
+            logger=logger,
+            sentence_model=sentence_model,
+        )
+
+    async def create_session(
+        self, *, agent_id: UUID, participant_id: UUID
+    ) -> UUID:
+        return uuid4()
+
+    async def continue_session_and_get_id(
+        self,
+        *,
+        agent_id: UUID,
+        participant_id: UUID,
+        session_id: UUID,
+    ) -> UUID:
+        return session_id
+
+    async def append_with_partitions(
+        self,
+        engine_message: EngineMessage,
+        *,
+        partitions: list[TextPartition],
+    ) -> None:
+        assert engine_message and partitions
+        now_utc = datetime.now(timezone.utc)
+        message_id = uuid4()
+        message = PermanentMessage(
+            id=message_id,
+            agent_id=engine_message.agent_id,
+            model_id=engine_message.model_id,
+            session_id=self._session_id,
+            author=engine_message.message.role,
+            data=engine_message.message.content,
+            partitions=len(partitions),
+            created_at=now_utc,
+        )
+        key = (
+            f"{self._collection}/{message.session_id}/{message.id}.json"
+            if message.session_id
+            else f"{self._collection}/{message.id}.json"
+        )
+        await self._put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=dumps(
+                {
+                    "id": str(message.id),
+                    "agent_id": str(message.agent_id),
+                    "model_id": message.model_id,
+                    "session_id": (
+                        str(message.session_id) if message.session_id else None
+                    ),
+                    "author": str(message.author),
+                    "data": message.data,
+                    "partitions": message.partitions,
+                    "created_at": message.created_at.isoformat(),
+                }
+            ).encode(),
+        )
+        for idx, part in enumerate(partitions):
+            row = PermanentMessagePartition(
+                agent_id=message.agent_id,
+                session_id=message.session_id,
+                message_id=message.id,
+                partition=idx + 1,
+                data=part.data,
+                embedding=part.embeddings,
+                created_at=now_utc,
+            )
+            await self._put_vector(
+                Bucket=self._bucket,
+                Collection=self._collection,
+                Id=f"{row.message_id}:{row.partition}",
+                Vector=row.embedding.tolist(),
+                Metadata={
+                    "message_id": str(row.message_id),
+                    "agent_id": str(row.agent_id),
+                    "session_id": (
+                        str(row.session_id) if row.session_id else None
+                    ),
+                },
+            )
+
+    async def get_recent_messages(
+        self,
+        session_id: UUID,
+        participant_id: UUID,
+        *,
+        limit: int | None = None,
+    ) -> list[EngineMessage]:
+        prefix = f"{self._collection}/{session_id}/"
+        response = await self._call_client(
+            self._client.list_objects_v2, Bucket=self._bucket, Prefix=prefix
+        )
+        objects = response.get("Contents", []) if response else []
+        objs = sorted(
+            objects, key=lambda o: o.get("LastModified"), reverse=True
+        )
+        messages: list[EngineMessage] = []
+        for obj in objs[: limit or len(objs)]:
+            data = await self._get_object(Bucket=self._bucket, Key=obj["Key"])
+            meta = loads(data["Body"].read().decode())
+            messages.append(
+                EngineMessage(
+                    agent_id=UUID(meta["agent_id"]),
+                    model_id=meta["model_id"],
+                    message=Message(
+                        role=MessageRole(meta["author"]), content=meta["data"]
+                    ),
+                )
+            )
+        return messages
+
+    async def search_messages(
+        self,
+        *,
+        agent_id: UUID,
+        function: VectorFunction,
+        limit: int | None = None,
+        participant_id: UUID,
+        search_partitions: list[TextPartition],
+        search_user_messages: bool,
+        session_id: UUID | None,
+        exclude_session_id: UUID | None,
+    ) -> list[EngineMessageScored]:
+        assert agent_id and participant_id and search_partitions
+        query = search_partitions[0].embeddings.tolist()
+        filt = {
+            "message_id": "*",
+            "agent_id": str(agent_id),
+            "participant_id": str(participant_id),
+        }
+        if session_id:
+            filt["session_id"] = str(session_id)
+        response = await self._query_vector(
+            Bucket=self._bucket,
+            Collection=self._collection,
+            QueryVector=query,
+            TopK=limit or 10,
+            Function=str(function),
+            Filter=filt,
+        )
+        results: list[EngineMessageScored] = []
+        for item in response.get("Items", []):
+            msg_id = item.get("Metadata", {}).get("message_id")
+            if not msg_id:
+                continue
+            key = (
+                f"{self._collection}/{session_id}/{msg_id}.json"
+                if session_id
+                else f"{self._collection}/{msg_id}.json"
+            )
+            obj = await self._get_object(Bucket=self._bucket, Key=key)
+            meta = loads(obj["Body"].read().decode())
+            results.append(
+                EngineMessageScored(
+                    agent_id=UUID(meta["agent_id"]),
+                    model_id=meta["model_id"],
+                    message=Message(
+                        role=MessageRole(meta["author"]), content=meta["data"]
+                    ),
+                    score=item.get("Score", 0.0),
+                )
+            )
+        return results

--- a/tests/memory/permanent/s3vectors_message_memory_test.py
+++ b/tests/memory/permanent/s3vectors_message_memory_test.py
@@ -1,0 +1,157 @@
+from avalan.memory.partitioner.text import TextPartition
+from avalan.memory.permanent.s3vectors.message import S3VectorsMessageMemory
+from avalan.entities import EngineMessage, Message, MessageRole
+from avalan.memory.permanent import VectorFunction
+from uuid import uuid4, UUID
+from datetime import datetime, timezone
+import numpy as np
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class S3VectorsMessageMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_create_instance(self):
+        client = MagicMock()
+        memory = await S3VectorsMessageMemory.create_instance(
+            bucket="b", collection="c", logger=MagicMock(), aws_client=client
+        )
+        self.assertIsInstance(memory, S3VectorsMessageMemory)
+        self.assertIs(memory._client._client, client)
+
+    async def test_create_instance_no_client(self):
+        client = MagicMock()
+        with patch(
+            "avalan.memory.permanent.s3vectors.message.boto_client",
+            return_value=client,
+        ) as boto_patch:
+            memory = await S3VectorsMessageMemory.create_instance(
+                bucket="b", collection="c", logger=MagicMock()
+            )
+        boto_patch.assert_called_once_with("s3vectors")
+        self.assertIsInstance(memory, S3VectorsMessageMemory)
+        self.assertIs(memory._client._client, client)
+
+    async def test_append_with_partitions(self):
+        memory = S3VectorsMessageMemory(
+            bucket="b", collection="c", client=AsyncMock(), logger=MagicMock()
+        )
+        memory._session_id = uuid4()
+        engine_message = EngineMessage(
+            agent_id=uuid4(),
+            model_id="m",
+            message=Message(role=MessageRole.USER, content="hi"),
+        )
+        part1 = TextPartition(
+            data="a", embeddings=np.array([0.1]), total_tokens=1
+        )
+        part2 = TextPartition(
+            data="b", embeddings=np.array([0.2]), total_tokens=1
+        )
+        msg_id = UUID("11111111-1111-1111-1111-111111111111")
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.message.uuid4",
+                return_value=msg_id,
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            await memory.append_with_partitions(
+                engine_message, partitions=[part1, part2]
+            )
+        self.assertTrue(memory._client.put_object.called)
+        self.assertEqual(memory._client.put_vector.call_count, 2)
+
+    async def test_get_recent_messages(self):
+        client = MagicMock()
+        session_id = uuid4()
+        client.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": f"c/{session_id}/m1.json",
+                    "LastModified": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                },
+                {
+                    "Key": f"c/{session_id}/m2.json",
+                    "LastModified": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                },
+            ]
+        }
+        client.get_object.return_value = {
+            "Body": MagicMock(
+                read=MagicMock(
+                    return_value=b'{"agent_id": "'
+                    + str(uuid4()).encode()
+                    + b'", "model_id": "m", "author": "user", "data": "hi"}'
+                )
+            )
+        }
+        memory = S3VectorsMessageMemory(
+            bucket="b", collection="c", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.get_recent_messages(
+                session_id=session_id, participant_id=uuid4(), limit=1
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].message.content, "hi")
+
+    async def test_search_messages(self):
+        client = MagicMock()
+        session_id = uuid4()
+        msg_id = uuid4()
+        part = TextPartition(
+            data="q", embeddings=np.array([0.3]), total_tokens=1
+        )
+        client.query_vector.return_value = {
+            "Items": [{"Metadata": {"message_id": str(msg_id)}, "Score": 0.5}]
+        }
+        client.get_object.return_value = {
+            "Body": MagicMock(
+                read=MagicMock(
+                    return_value=b'{"agent_id": "'
+                    + str(uuid4()).encode()
+                    + b'", "model_id": "m", "author": "user", "data": "hi"}'
+                )
+            )
+        }
+        memory = S3VectorsMessageMemory(
+            bucket="b", collection="c", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.search_messages(
+                search_partitions=[part],
+                agent_id=uuid4(),
+                session_id=session_id,
+                participant_id=uuid4(),
+                function=VectorFunction.L2_DISTANCE,
+                limit=1,
+                search_user_messages=True,
+                exclude_session_id=None,
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].score, 0.5)

--- a/tests/memory/permanent/s3vectors_raw_memory_test.py
+++ b/tests/memory/permanent/s3vectors_raw_memory_test.py
@@ -50,6 +50,10 @@ class S3VectorsRawMemoryTestCase(IsolatedAsyncioTestCase):
                 "avalan.memory.permanent.s3vectors.raw.to_thread",
                 AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
             ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
         ):
             await memory.append_with_partitions(
                 "ns",
@@ -93,9 +97,15 @@ class S3VectorsRawMemoryTestCase(IsolatedAsyncioTestCase):
         memory = S3VectorsRawMemory(
             bucket="b", collection="c", client=client, logger=MagicMock()
         )
-        with patch(
-            "avalan.memory.permanent.s3vectors.raw.to_thread",
-            AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
         ):
             result = await memory.search_memories(
                 search_partitions=[part],
@@ -116,9 +126,15 @@ class S3VectorsRawMemoryTestCase(IsolatedAsyncioTestCase):
         memory = S3VectorsRawMemory(
             bucket="b", collection="c", client=client, logger=MagicMock()
         )
-        with patch(
-            "avalan.memory.permanent.s3vectors.raw.to_thread",
-            AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+        with (
+            patch(
+                "avalan.memory.permanent.s3vectors.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.s3vectors.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
         ):
             result = await memory.search_memories(
                 search_partitions=[part],


### PR DESCRIPTION
## Summary
- support threaded client calls through `to_thread`
- implement S3VectorsMessageMemory with session and retrieval helpers
- cover message memory with new unit tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_6878f18df510832398e578d6a54e1530