### PR TITLE
Add Elasticsearch memory support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -870,6 +870,53 @@ files = [
 ]
 
 [[package]]
+name = "elastic-transport"
+version = "8.17.1"
+description = "Transport classes and utilities shared among Python Elastic client libraries"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"memory\" or extra == \"test\" or extra == \"all\""
+files = [
+    {file = "elastic_transport-8.17.1-py3-none-any.whl", hash = "sha256:192718f498f1d10c5e9aa8b9cf32aed405e469a7f0e9d6a8923431dbb2c59fb8"},
+    {file = "elastic_transport-8.17.1.tar.gz", hash = "sha256:5edef32ac864dca8e2f0a613ef63491ee8d6b8cfb52881fa7313ba9290cac6d2"},
+]
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.26.2,<3"
+
+[package.extras]
+develop = ["aiohttp", "furo", "httpx", "opentelemetry-api", "opentelemetry-sdk", "orjson", "pytest", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "pytest-mock", "requests", "respx", "sphinx (>2)", "sphinx-autodoc-typehints", "trustme"]
+
+[[package]]
+name = "elasticsearch"
+version = "9.0.2"
+description = "Python client for Elasticsearch"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"memory\" or extra == \"test\" or extra == \"all\""
+files = [
+    {file = "elasticsearch-9.0.2-py3-none-any.whl", hash = "sha256:47cac1f0e5e7be8d8c6751a5d7818d416adfc11eac72f1b59e145930a87de880"},
+    {file = "elasticsearch-9.0.2.tar.gz", hash = "sha256:290e790153500d9f3cb66d74918ac70e9f96b5cd88147213859edca6ab5013f5"},
+]
+
+[package.dependencies]
+elastic-transport = ">=8.15.1,<9"
+python-dateutil = "*"
+typing-extensions = "*"
+
+[package.extras]
+async = ["aiohttp (>=3,<4)"]
+dev = ["aiohttp", "black", "build", "coverage", "isort", "jinja2", "mapbox-vector-tile", "mypy", "nltk", "nox", "numpy", "orjson", "pandas", "pyarrow", "pyright", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "python-dateutil", "pyyaml (>=5.4)", "requests (>=2,<3)", "sentence-transformers", "simsimd", "tqdm", "twine", "types-python-dateutil", "types-tqdm", "unasync"]
+docs = ["sphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme (>=2.0)"]
+orjson = ["orjson (>=3)"]
+pyarrow = ["pyarrow (>=1)"]
+requests = ["requests (>=2.4.0,!=2.32.2,<3.0.0)"]
+vectorstore-mmr = ["numpy (>=1)", "simsimd (>=3)"]
+
+[[package]]
 name = "faiss-cpu"
 version = "1.11.0"
 description = "A library for efficient similarity search and clustering of dense vectors."
@@ -5382,15 +5429,15 @@ type = ["pytest-mypy"]
 
 [extras]
 agent = ["jinja2"]
-all = ["RestrictedPython", "accelerate", "anthropic", "bitsandbytes", "boto3", "diffusers", "faiss-cpu", "fastapi", "google-genai", "huggingface-hub", "jinja2", "keyring", "litellm", "markdownify", "markitdown", "mcp", "mlx-lm", "openai", "pgvector", "pillow", "playwright", "protobuf", "psycopg", "pydantic", "pytest", "pytest-cov", "sentence-transformers", "sentencepiece", "soundfile", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn", "youtube-transcript-api"]
+all = ["RestrictedPython", "accelerate", "anthropic", "bitsandbytes", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "google-genai", "huggingface-hub", "jinja2", "keyring", "litellm", "markdownify", "markitdown", "mcp", "mlx-lm", "openai", "pgvector", "pillow", "playwright", "protobuf", "psycopg", "pydantic", "pytest", "pytest-cov", "sentence-transformers", "sentencepiece", "soundfile", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn", "youtube-transcript-api"]
 audio = ["soundfile", "torchaudio"]
 cpu = ["accelerate"]
-memory = ["boto3", "faiss-cpu", "markdownify", "markitdown", "pgvector", "psycopg", "sentence-transformers", "tree-sitter", "tree-sitter-python"]
+memory = ["boto3", "elasticsearch", "faiss-cpu", "markdownify", "markitdown", "pgvector", "psycopg", "sentence-transformers", "tree-sitter", "tree-sitter-python"]
 mlx = ["mlx-lm"]
 quantization = ["bitsandbytes"]
 secrets = ["boto3", "keyring"]
 server = ["fastapi", "mcp", "pydantic", "uvicorn"]
-test = ["RestrictedPython", "boto3", "diffusers", "faiss-cpu", "fastapi", "huggingface-hub", "keyring", "litellm", "markdownify", "markitdown", "mcp", "mlx-lm", "pgvector", "pillow", "playwright", "psycopg", "pydantic", "pytest", "pytest-cov", "sympy", "tiktoken", "torchaudio", "tree-sitter", "tree-sitter-python"]
+test = ["RestrictedPython", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "huggingface-hub", "keyring", "litellm", "markdownify", "markitdown", "mcp", "mlx-lm", "pgvector", "pillow", "playwright", "psycopg", "pydantic", "pytest", "pytest-cov", "sympy", "tiktoken", "torchaudio", "tree-sitter", "tree-sitter-python"]
 tool = ["RestrictedPython", "playwright", "sympy", "youtube-transcript-api"]
 translation = ["protobuf", "sentencepiece", "tiktoken"]
 vendors = ["anthropic", "google-genai", "litellm", "openai", "pillow", "tiktoken"]
@@ -5400,4 +5447,4 @@ vllm = ["vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.11,<3.14"
-content-hash = "cbde62212f90dadc2297adb51d5df53821bafae1e0355aa470bf524d2c487210"
+content-hash = "46cf1cce843d8eabcc18771eb242c704b50cd3d05245ce13989c5c7391eccdd9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ memory = [
   "sentence-transformers==5.0.0",
   "tree-sitter==0.24.0",
   "tree-sitter-python==0.23.6",
+  "elasticsearch==9.0.2",
 ]
 quantization = [
   "bitsandbytes==0.46.1",
@@ -99,6 +100,7 @@ test = [
   "torchaudio==2.7.1",
   "tree-sitter==0.24.0",
   "tree-sitter-python==0.23.6",
+  "elasticsearch==9.0.2",
 ]
 tool = [
   "playwright==1.53.0",
@@ -172,6 +174,7 @@ all = [
   "tree-sitter-python==0.23.6",
   "uvicorn==0.35.0",
   "youtube-transcript-api==1.0.0",
+  "elasticsearch==9.0.2",
 ]
 
 [tool.black]

--- a/src/avalan/memory/permanent/elasticsearch/__init__.py
+++ b/src/avalan/memory/permanent/elasticsearch/__init__.py
@@ -1,0 +1,49 @@
+from abc import ABC
+from asyncio import to_thread as _to_thread
+from inspect import iscoroutinefunction
+from logging import Logger
+from typing import Any, Callable
+
+
+async def to_thread(func: Callable[..., Any], **kwargs: Any) -> Any:
+    """Run *func* in a thread."""
+    return await _to_thread(func, **kwargs)
+
+
+class ElasticsearchMemory(ABC):
+    """Common logic for Elasticsearch based memories."""
+
+    _index: str
+    _client: Any
+    _logger: Logger
+
+    def __init__(
+        self,
+        *,
+        index: str,
+        client: Any,
+        logger: Logger,
+        **kwargs: Any,
+    ) -> None:
+        self._index = index
+        self._client = client
+        self._logger = logger
+
+    async def _call_client(
+        self, func: Callable[..., Any], **kwargs: Any
+    ) -> Any:
+        if iscoroutinefunction(func):
+            return await func(**kwargs)
+        return await to_thread(func, **kwargs)
+
+    async def _index_document(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.index, **kwargs)
+
+    async def _get_document(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.get, **kwargs)
+
+    async def _index_vector(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.index_vector, **kwargs)
+
+    async def _query_vector(self, **kwargs: Any) -> Any:
+        return await self._call_client(self._client.query_vector, **kwargs)

--- a/src/avalan/memory/permanent/elasticsearch/message.py
+++ b/src/avalan/memory/permanent/elasticsearch/message.py
@@ -1,0 +1,219 @@
+from datetime import datetime, timezone
+from logging import Logger
+from typing import Any
+from uuid import UUID, uuid4
+
+from elasticsearch import AsyncElasticsearch
+
+from ....entities import (
+    EngineMessage,
+    EngineMessageScored,
+    Message,
+    MessageRole,
+)
+from ....memory.partitioner.text import TextPartition
+from ....memory.permanent import (
+    PermanentMessage,
+    PermanentMessageMemory,
+    PermanentMessagePartition,
+    VectorFunction,
+)
+from . import ElasticsearchMemory
+
+
+class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
+    def __init__(
+        self,
+        index: str,
+        *,
+        client: Any,
+        logger: Logger,
+        sentence_model: Any | None = None,
+    ) -> None:
+        ElasticsearchMemory.__init__(
+            self, index=index, client=client, logger=logger
+        )
+        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)  # type: ignore[arg-type]
+
+    @classmethod
+    async def create_instance(
+        cls,
+        index: str,
+        *,
+        logger: Logger,
+        es_client: Any | None = None,
+        sentence_model: Any | None = None,
+    ) -> "ElasticsearchMessageMemory":
+        if es_client is None:
+            es_client = AsyncElasticsearch()
+        return cls(
+            index=index,
+            client=es_client,
+            logger=logger,
+            sentence_model=sentence_model,
+        )
+
+    async def create_session(
+        self, *, agent_id: UUID, participant_id: UUID
+    ) -> UUID:
+        return uuid4()
+
+    async def continue_session_and_get_id(
+        self,
+        *,
+        agent_id: UUID,
+        participant_id: UUID,
+        session_id: UUID,
+    ) -> UUID:
+        return session_id
+
+    async def append_with_partitions(
+        self,
+        engine_message: EngineMessage,
+        *,
+        partitions: list[TextPartition],
+    ) -> None:
+        assert engine_message and partitions
+        now_utc = datetime.now(timezone.utc)
+        message_id = uuid4()
+        message = PermanentMessage(
+            id=message_id,
+            agent_id=engine_message.agent_id,
+            model_id=engine_message.model_id,
+            session_id=self._session_id,
+            author=engine_message.message.role,
+            data=engine_message.message.content,
+            partitions=len(partitions),
+            created_at=now_utc,
+        )
+        key = (
+            f"{self._index}/{message.session_id}/{message.id}.json"
+            if message.session_id
+            else f"{self._index}/{message.id}.json"
+        )
+        await self._index_document(
+            index=self._index,
+            id=key,
+            document={
+                "id": str(message.id),
+                "agent_id": str(message.agent_id),
+                "model_id": message.model_id,
+                "session_id": (
+                    str(message.session_id) if message.session_id else None
+                ),
+                "author": str(message.author),
+                "data": message.data,
+                "partitions": message.partitions,
+                "created_at": message.created_at.isoformat(),
+            },
+        )
+        for idx, part in enumerate(partitions):
+            row = PermanentMessagePartition(
+                agent_id=message.agent_id,
+                session_id=message.session_id,
+                message_id=message.id,
+                partition=idx + 1,
+                data=part.data,
+                embedding=part.embeddings,
+                created_at=now_utc,
+            )
+            await self._index_vector(
+                index=self._index,
+                id=f"{row.message_id}:{row.partition}",
+                vector=row.embedding.tolist(),
+                metadata={
+                    "message_id": str(row.message_id),
+                    "agent_id": str(row.agent_id),
+                    "session_id": (
+                        str(row.session_id) if row.session_id else None
+                    ),
+                },
+            )
+
+    async def get_recent_messages(
+        self,
+        session_id: UUID,
+        participant_id: UUID,
+        *,
+        limit: int | None = None,
+    ) -> list[EngineMessage]:
+        response = await self._call_client(
+            self._client.search,
+            index=self._index,
+            body={
+                "query": {"term": {"session_id": str(session_id)}},
+                "sort": [{"created_at": {"order": "desc"}}],
+                "size": limit or 10,
+            },
+        )
+        hits = response.get("hits", {}).get("hits", []) if response else []
+        messages: list[EngineMessage] = []
+        for hit in hits:
+            meta = hit.get("_source")
+            if not meta:
+                continue
+            messages.append(
+                EngineMessage(
+                    agent_id=UUID(meta["agent_id"]),
+                    model_id=meta["model_id"],
+                    message=Message(
+                        role=MessageRole(meta["author"]),
+                        content=meta["data"],
+                    ),
+                )
+            )
+        return messages
+
+    async def search_messages(
+        self,
+        *,
+        agent_id: UUID,
+        function: VectorFunction,
+        limit: int | None = None,
+        participant_id: UUID,
+        search_partitions: list[TextPartition],
+        search_user_messages: bool,
+        session_id: UUID | None,
+        exclude_session_id: UUID | None,
+    ) -> list[EngineMessageScored]:
+        assert agent_id and participant_id and search_partitions
+        query = search_partitions[0].embeddings.tolist()
+        filt = {
+            "message_id": "*",
+            "agent_id": str(agent_id),
+            "participant_id": str(participant_id),
+        }
+        if session_id:
+            filt["session_id"] = str(session_id)
+        response = await self._query_vector(
+            index=self._index,
+            query_vector=query,
+            top_k=limit or 10,
+            function=str(function),
+            filter=filt,
+        )
+        results: list[EngineMessageScored] = []
+        for item in response.get("Items", []):
+            msg_id = item.get("Metadata", {}).get("message_id")
+            if not msg_id:
+                continue
+            key = (
+                f"{self._index}/{session_id}/{msg_id}.json"
+                if session_id
+                else f"{self._index}/{msg_id}.json"
+            )
+            obj = await self._get_document(index=self._index, id=key)
+            meta = obj.get("_source") if obj else None
+            if not meta:
+                continue
+            results.append(
+                EngineMessageScored(
+                    agent_id=UUID(meta["agent_id"]),
+                    model_id=meta["model_id"],
+                    message=Message(
+                        role=MessageRole(meta["author"]), content=meta["data"]
+                    ),
+                    score=item.get("Score", 0.0),
+                )
+            )
+        return results

--- a/src/avalan/memory/permanent/elasticsearch/raw.py
+++ b/src/avalan/memory/permanent/elasticsearch/raw.py
@@ -1,0 +1,162 @@
+from datetime import datetime, timezone
+from logging import Logger
+from typing import Any
+from uuid import UUID, uuid4
+
+from elasticsearch import AsyncElasticsearch
+
+from ....memory.partitioner.text import TextPartition
+from ....memory.permanent import (
+    Memory,
+    MemoryType,
+    PermanentMemory,
+    PermanentMemoryPartition,
+    VectorFunction,
+)
+from . import ElasticsearchMemory
+
+
+class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
+    _index: str
+    _client: Any
+    _logger: Logger
+
+    def __init__(
+        self,
+        index: str,
+        *,
+        client: Any,
+        logger: Logger,
+    ) -> None:
+        ElasticsearchMemory.__init__(
+            self, index=index, client=client, logger=logger
+        )
+        PermanentMemory.__init__(self, sentence_model=None)
+
+    @classmethod
+    async def create_instance(
+        cls,
+        index: str,
+        *,
+        logger: Logger,
+        es_client: Any | None = None,
+    ) -> "ElasticsearchRawMemory":
+        if es_client is None:
+            es_client = AsyncElasticsearch()
+        memory = cls(index=index, client=es_client, logger=logger)
+        return memory
+
+    async def append_with_partitions(
+        self,
+        namespace: str,
+        participant_id: UUID,
+        *,
+        memory_type: MemoryType,
+        data: str,
+        identifier: str,
+        partitions: list[TextPartition],
+        symbols: dict | None = None,
+        model_id: str | None = None,
+    ) -> None:
+        assert (
+            namespace and participant_id and data and identifier and partitions
+        )
+        now_utc = datetime.now(timezone.utc)
+        entry_id = uuid4()
+        entry = Memory(
+            id=entry_id,
+            model_id=model_id,
+            type=memory_type,
+            participant_id=participant_id,
+            namespace=namespace,
+            identifier=identifier,
+            data=data,
+            partitions=len(partitions),
+            symbols=symbols,
+            created_at=now_utc,
+        )
+        await self._index_document(
+            index=self._index,
+            id=str(entry.id),
+            document={
+                "id": str(entry.id),
+                "model_id": entry.model_id,
+                "type": str(entry.type),
+                "participant_id": str(entry.participant_id),
+                "namespace": entry.namespace,
+                "identifier": entry.identifier,
+                "data": entry.data,
+                "partitions": entry.partitions,
+                "symbols": entry.symbols,
+                "created_at": entry.created_at.isoformat(),
+            },
+        )
+        for idx, p in enumerate(partitions):
+            row = PermanentMemoryPartition(
+                participant_id=entry.participant_id,
+                memory_id=entry.id,
+                partition=idx + 1,
+                data=p.data,
+                embedding=p.embeddings,
+                created_at=now_utc,
+            )
+            await self._index_vector(
+                index=self._index,
+                id=f"{row.memory_id}:{row.partition}",
+                vector=row.embedding.tolist(),
+                metadata={
+                    "memory_id": str(row.memory_id),
+                    "participant_id": str(row.participant_id),
+                    "namespace": namespace,
+                },
+            )
+
+    async def search_memories(
+        self,
+        *,
+        search_partitions: list[TextPartition],
+        participant_id: UUID,
+        namespace: str,
+        function: VectorFunction,
+        limit: int | None = None,
+    ) -> list[Memory]:
+        assert participant_id and namespace and search_partitions
+        query = search_partitions[0].embeddings.tolist()
+        response = await self._query_vector(
+            index=self._index,
+            query_vector=query,
+            top_k=limit or 10,
+            function=str(function),
+            filter={
+                "memory_id": "*",
+                "participant_id": str(participant_id),
+                "namespace": namespace,
+            },
+        )
+        results: list[Memory] = []
+        for item in response.get("Items", []):
+            mem_id = item.get("Metadata", {}).get("memory_id")
+            if not mem_id:
+                continue
+            obj = await self._get_document(index=self._index, id=mem_id)
+            meta = obj.get("_source") if obj else None
+            if not meta:
+                continue
+            results.append(
+                Memory(
+                    id=UUID(meta["id"]),
+                    model_id=meta["model_id"],
+                    type=MemoryType(meta["type"]),
+                    participant_id=UUID(meta["participant_id"]),
+                    namespace=meta["namespace"],
+                    identifier=meta["identifier"],
+                    data=meta["data"],
+                    partitions=meta["partitions"],
+                    symbols=meta["symbols"],
+                    created_at=datetime.fromisoformat(meta["created_at"]),
+                )
+            )
+        return results
+
+    async def search(self, query: str) -> list[Memory] | None:
+        raise NotImplementedError()

--- a/src/avalan/memory/permanent/elasticsearch/raw.py
+++ b/src/avalan/memory/permanent/elasticsearch/raw.py
@@ -13,7 +13,7 @@ from ....memory.permanent import (
     PermanentMemoryPartition,
     VectorFunction,
 )
-from . import ElasticsearchMemory
+from . import ElasticsearchMemory, to_thread  # noqa: F401
 
 
 class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):

--- a/tests/memory/permanent/elasticsearch_init_test.py
+++ b/tests/memory/permanent/elasticsearch_init_test.py
@@ -1,0 +1,11 @@
+from avalan.memory.permanent.elasticsearch import to_thread
+from unittest import IsolatedAsyncioTestCase
+
+
+class ToThreadTestCase(IsolatedAsyncioTestCase):
+    async def test_to_thread_runs_function(self):
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        result = await to_thread(add, a=1, b=2)
+        self.assertEqual(result, 3)

--- a/tests/memory/permanent/elasticsearch_message_memory_test.py
+++ b/tests/memory/permanent/elasticsearch_message_memory_test.py
@@ -1,0 +1,235 @@
+import sys
+import types
+import importlib.machinery
+from unittest.mock import MagicMock
+
+# Stub elasticsearch before importing the module under test
+es_stub = types.ModuleType("elasticsearch")
+es_stub.AsyncElasticsearch = MagicMock()
+es_stub.__spec__ = importlib.machinery.ModuleSpec("elasticsearch", loader=None)
+sys.modules.setdefault("elasticsearch", es_stub)
+
+from avalan.memory.partitioner.text import TextPartition
+from avalan.memory.permanent.elasticsearch.message import (
+    ElasticsearchMessageMemory,
+)
+from avalan.entities import EngineMessage, Message, MessageRole
+from avalan.memory.permanent import VectorFunction
+from uuid import uuid4, UUID
+import numpy as np
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+
+class ElasticsearchMessageMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_create_instance(self):
+        client = MagicMock()
+        memory = await ElasticsearchMessageMemory.create_instance(
+            index="idx", logger=MagicMock(), es_client=client
+        )
+        self.assertIsInstance(memory, ElasticsearchMessageMemory)
+        self.assertIs(memory._client, client)
+
+    async def test_create_instance_no_client(self):
+        client = MagicMock()
+        with patch(
+            "avalan.memory.permanent.elasticsearch.message.AsyncElasticsearch",
+            return_value=client,
+        ) as es_patch:
+            memory = await ElasticsearchMessageMemory.create_instance(
+                index="idx", logger=MagicMock()
+            )
+        es_patch.assert_called_once_with()
+        self.assertIsInstance(memory, ElasticsearchMessageMemory)
+        self.assertIs(memory._client, client)
+
+    async def test_append_with_partitions(self):
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=AsyncMock(), logger=MagicMock()
+        )
+        memory._session_id = uuid4()
+        engine_message = EngineMessage(
+            agent_id=uuid4(),
+            model_id="m",
+            message=Message(role=MessageRole.USER, content="hi"),
+        )
+        part1 = TextPartition(
+            data="a", embeddings=np.array([0.1]), total_tokens=1
+        )
+        part2 = TextPartition(
+            data="b", embeddings=np.array([0.2]), total_tokens=1
+        )
+        msg_id = UUID("11111111-1111-1111-1111-111111111111")
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.message.uuid4",
+                return_value=msg_id,
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            await memory.append_with_partitions(
+                engine_message, partitions=[part1, part2]
+            )
+        self.assertTrue(memory._client.index.called)
+        self.assertEqual(memory._client.index_vector.call_count, 2)
+
+    async def test_get_recent_messages(self):
+        client = MagicMock()
+        session_id = uuid4()
+        client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_source": {
+                            "agent_id": str(uuid4()),
+                            "model_id": "m",
+                            "author": "user",
+                            "data": "hi",
+                        },
+                        "_id": f"{session_id}/m1.json",
+                    }
+                ]
+            }
+        }
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.get_recent_messages(
+                session_id=session_id, participant_id=uuid4(), limit=1
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].message.content, "hi")
+
+    async def test_search_messages(self):
+        client = MagicMock()
+        session_id = uuid4()
+        msg_id = uuid4()
+        part = TextPartition(
+            data="q", embeddings=np.array([0.3]), total_tokens=1
+        )
+        client.query_vector.return_value = {
+            "Items": [{"Metadata": {"message_id": str(msg_id)}, "Score": 0.5}]
+        }
+        client.get.return_value = {
+            "_source": {
+                "agent_id": str(uuid4()),
+                "model_id": "m",
+                "author": "user",
+                "data": "hi",
+            }
+        }
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.search_messages(
+                search_partitions=[part],
+                agent_id=uuid4(),
+                session_id=session_id,
+                participant_id=uuid4(),
+                function=VectorFunction.L2_DISTANCE,
+                limit=1,
+                search_user_messages=True,
+                exclude_session_id=None,
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].score, 0.5)
+
+    async def test_create_session(self):
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=MagicMock(), logger=MagicMock()
+        )
+        sid = UUID("22222222-2222-2222-2222-222222222222")
+        with patch(
+            "avalan.memory.permanent.elasticsearch.message.uuid4",
+            return_value=sid,
+        ):
+            result = await memory.create_session(
+                agent_id=uuid4(), participant_id=uuid4()
+            )
+        self.assertEqual(result, sid)
+
+    async def test_continue_session_and_get_id(self):
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=MagicMock(), logger=MagicMock()
+        )
+        sid = uuid4()
+        result = await memory.continue_session_and_get_id(
+            agent_id=uuid4(), participant_id=uuid4(), session_id=sid
+        )
+        self.assertEqual(result, sid)
+
+    async def test_search_messages_missing_metadata(self):
+        client = MagicMock()
+        msg_id1 = uuid4()
+        msg_id2 = uuid4()
+        part = TextPartition(
+            data="x", embeddings=np.array([0.1]), total_tokens=1
+        )
+        client.query_vector.return_value = {
+            "Items": [
+                {},
+                {"Metadata": {}},
+                {"Metadata": {"message_id": str(msg_id1)}, "Score": 0.1},
+                {"Metadata": {"message_id": str(msg_id2)}, "Score": 0.2},
+            ]
+        }
+        client.get.return_value = {
+            "_source": {
+                "agent_id": str(uuid4()),
+                "model_id": "m",
+                "author": "user",
+                "data": "hi",
+            }
+        }
+        memory = ElasticsearchMessageMemory(
+            index="idx", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.search_messages(
+                search_partitions=[part],
+                agent_id=uuid4(),
+                session_id=None,
+                participant_id=uuid4(),
+                function=VectorFunction.L2_DISTANCE,
+                limit=4,
+                search_user_messages=True,
+                exclude_session_id=None,
+            )
+        self.assertEqual(len(result), 2)
+        self.assertEqual(client.get.call_count, 2)

--- a/tests/memory/permanent/elasticsearch_raw_memory_test.py
+++ b/tests/memory/permanent/elasticsearch_raw_memory_test.py
@@ -1,0 +1,162 @@
+import sys
+import types
+import importlib.machinery
+from unittest.mock import MagicMock
+
+# Stub elasticsearch before importing the module under test
+es_stub = types.ModuleType("elasticsearch")
+es_stub.AsyncElasticsearch = MagicMock()
+es_stub.__spec__ = importlib.machinery.ModuleSpec("elasticsearch", loader=None)
+sys.modules.setdefault("elasticsearch", es_stub)
+
+from avalan.memory.partitioner.text import TextPartition
+from avalan.memory.permanent import MemoryType
+from avalan.memory.permanent.elasticsearch.raw import ElasticsearchRawMemory
+from datetime import datetime, timezone
+import numpy as np
+from uuid import uuid4, UUID
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+
+class ElasticsearchRawMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_create_instance(self):
+        client = MagicMock()
+        memory = await ElasticsearchRawMemory.create_instance(
+            index="idx", logger=MagicMock(), es_client=client
+        )
+        self.assertIsInstance(memory, ElasticsearchRawMemory)
+        self.assertIs(memory._client, client)
+
+    async def test_create_instance_no_client(self):
+        client = MagicMock()
+        with patch(
+            "avalan.memory.permanent.elasticsearch.raw.AsyncElasticsearch",
+            return_value=client,
+        ) as es_patch:
+            memory = await ElasticsearchRawMemory.create_instance(
+                index="idx", logger=MagicMock()
+            )
+        es_patch.assert_called_once_with()
+        self.assertIsInstance(memory, ElasticsearchRawMemory)
+        self.assertIs(memory._client, client)
+
+    async def test_append_with_partitions(self):
+        memory = ElasticsearchRawMemory(
+            index="idx", client=AsyncMock(), logger=MagicMock()
+        )
+        part1 = TextPartition(
+            data="a", embeddings=np.array([0.1]), total_tokens=1
+        )
+        part2 = TextPartition(
+            data="b", embeddings=np.array([0.2]), total_tokens=1
+        )
+        mem_id = UUID("11111111-1111-1111-1111-111111111111")
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.uuid4",
+                return_value=mem_id,
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            await memory.append_with_partitions(
+                "ns",
+                uuid4(),
+                memory_type=MemoryType.RAW,
+                data="d",
+                identifier="id",
+                partitions=[part1, part2],
+                symbols={},
+                model_id="m",
+            )
+        self.assertTrue(memory._client.index.called)
+        self.assertEqual(memory._client.index_vector.call_count, 2)
+
+    async def test_search_memories(self):
+        mem_id = UUID("11111111-1111-1111-1111-111111111111")
+        part = TextPartition(
+            data="x", embeddings=np.array([0.3]), total_tokens=1
+        )
+        client = MagicMock()
+        client.query_vector.return_value = {
+            "Items": [{"Metadata": {"memory_id": str(mem_id)}}]
+        }
+        client.get.return_value = {
+            "_source": {
+                "id": str(mem_id),
+                "model_id": "m",
+                "type": "raw",
+                "participant_id": str(mem_id),
+                "namespace": "ns",
+                "identifier": "id",
+                "data": "d",
+                "partitions": 1,
+                "symbols": {},
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+        }
+        memory = ElasticsearchRawMemory(
+            index="idx", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.search_memories(
+                search_partitions=[part],
+                participant_id=mem_id,
+                namespace="ns",
+                function=MemoryType.RAW,  # type: ignore[arg-type]
+                limit=1,
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, mem_id)
+
+    async def test_search_memories_missing_id(self):
+        part = TextPartition(
+            data="x", embeddings=np.array([0.4]), total_tokens=1
+        )
+        client = MagicMock()
+        client.query_vector.return_value = {"Items": [{"Metadata": {}}]}
+        memory = ElasticsearchRawMemory(
+            index="idx", client=client, logger=MagicMock()
+        )
+        with (
+            patch(
+                "avalan.memory.permanent.elasticsearch.raw.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+            patch(
+                "avalan.memory.permanent.elasticsearch.to_thread",
+                AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+            ),
+        ):
+            result = await memory.search_memories(
+                search_partitions=[part],
+                participant_id=uuid4(),
+                namespace="ns",
+                function=MemoryType.RAW,  # type: ignore[arg-type]
+                limit=1,
+            )
+        self.assertEqual(result, [])
+        client.get.assert_not_called()
+
+    async def test_search_not_implemented(self):
+        memory = ElasticsearchRawMemory(
+            index="idx", client=MagicMock(), logger=MagicMock()
+        )
+        with self.assertRaises(NotImplementedError):
+            await memory.search("q")


### PR DESCRIPTION
## Summary
- implement `ElasticsearchMemory` base class
- implement `ElasticsearchRawMemory` and `ElasticsearchMessageMemory`
- add unit tests for the new Elasticsearch memory classes
- add `elasticsearch` extra dependency

## Testing
- `ruff format src/avalan/memory/permanent/elasticsearch/message.py src/avalan/memory/permanent/elasticsearch/raw.py pyproject.toml`
- `ruff check src/avalan/memory/permanent/elasticsearch/message.py src/avalan/memory/permanent/elasticsearch/raw.py`
- `black src/avalan/memory/permanent/elasticsearch/message.py src/avalan/memory/permanent/elasticsearch/raw.py`


------
https://chatgpt.com/codex/tasks/task_e_687923669b408323888dd49e21a230e3