### PR TITLE
Fix CLI settings tests and diffusion refiner check

### DIFF
--- a/src/avalan/model/vision/diffusion.py
+++ b/src/avalan/model/vision/diffusion.py
@@ -31,6 +31,7 @@ class TextToImageDiffusionModel(TransformerModel):
         logger: Logger | None = None,
     ):
         settings = settings or TransformerEngineSettings()
+        assert settings.refiner_model_id
         settings = replace(settings, enable_eval=False)
         super().__init__(model_id, settings, logger)
 

--- a/tests/cli/get_model_settings_test.py
+++ b/tests/cli/get_model_settings_test.py
@@ -42,6 +42,8 @@ class GetModelSettingsTestCase(unittest.TestCase):
             "low_cpu_mem_usage": True,
             "quiet": False,
             "revision": "rev",
+            "base_model_id": None,
+            "checkpoint": None,
             "special_tokens": ["<s>"],
             "tokenizer": "tok",
             "tokens": ["t"],

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -53,6 +53,8 @@ class CliModelTestCase(TestCase):
             "low_cpu_mem_usage": True,
             "quiet": False,
             "revision": "rev",
+            "base_model_id": None,
+            "checkpoint": None,
             "special_tokens": ["<s>"],
             "tokenizer": "tok",
             "tokens": ["t"],


### PR DESCRIPTION
## Summary
- update `get_model_settings` tests for new `base_model_id` and `checkpoint`
- restore refiner ID assertion in `TextToImageDiffusionModel`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68797c04969c8323a095889658492363