### PR TITLE
Add tests for Elasticsearch memories

### DIFF
--- a/tests/memory/permanent/elasticsearch_init_test.py
+++ b/tests/memory/permanent/elasticsearch_init_test.py
@@ -1,0 +1,11 @@
+from avalan.memory.permanent.elasticsearch import to_thread
+from unittest import IsolatedAsyncioTestCase
+
+
+class ToThreadTestCase(IsolatedAsyncioTestCase):
+    async def test_to_thread_runs_function(self):
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        result = await to_thread(add, a=1, b=2)
+        self.assertEqual(result, 3)


### PR DESCRIPTION
## Summary
- test `to_thread` helper
- add search_memories edge case tests for ElasticsearchRawMemory
- cover missing hits in ElasticsearchMessageMemory
- cover missing `_source` in search_messages

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6879855374788323ba0558c3b028710e