### PR TITLE
Add text-to-animation CLI

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -239,6 +239,9 @@ async def model_run(
             elif modality == Modality.VISION_TEXT_TO_IMAGE:
                 console.print(output)
 
+            elif modality == Modality.VISION_TEXT_TO_ANIMATION:
+                console.print(output)
+
             else:
                 raise NotImplementedError(f"Modality {modality} not supported")
 

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -86,6 +86,7 @@ class Modality(StrEnum):
     VISION_IMAGE_CLASSIFICATION = "vision_image_classification"
     VISION_IMAGE_TO_TEXT = "vision_image_to_text"
     VISION_TEXT_TO_IMAGE = "vision_text_to_image"
+    VISION_TEXT_TO_ANIMATION = "vision_text_to_animation"
     VISION_IMAGE_TEXT_TO_TEXT = "vision_image_text_to_text"
     VISION_ENCODER_DECODER = "vision_encoder_decoder"
     VISION_SEMANTIC_SEGMENTATION = "vision_semantic_segmentation"

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2470,6 +2470,112 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "out.png")
 
+    async def test_run_vision_text_to_animation(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="out.gif",
+            vision_steps=4,
+            vision_timestep_spacing="trailing",
+            vision_beta_schedule="linear",
+            vision_guidance_scale=1.0,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="out.gif")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = AsyncMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
+
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_TEXT_TO_ANIMATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_TEXT_TO_ANIMATION,
+        )
+        lm.assert_awaited_once_with(
+            "hi",
+            "out.gif",
+            beta_schedule="linear",
+            guidance_scale=1.0,
+            steps=4,
+            timestep_spacing="trailing",
+        )
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "out.gif")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -30,6 +30,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.VISION_IMAGE_TEXT_TO_TEXT: "ImageTextToTextModel",
             Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
             Modality.VISION_TEXT_TO_IMAGE: "TextToImageDiffusionModel",
+            Modality.VISION_TEXT_TO_ANIMATION: "TextToAnimationModel",
             Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
         }
         for modality, class_name in modalities.items():


### PR DESCRIPTION
## Summary
- introduce `Modality.VISION_TEXT_TO_ANIMATION`
- wire `TextToAnimationModel` into ModelManager
- support text-to-animation output in CLI
- test ModelManager loading and CLI run for the new modality

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687986628e808323b56fab57e31f95b1