### PR TITLE
Add TextToAnimationModel tests

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2576,6 +2576,112 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "out.gif")
 
+    async def test_run_vision_text_to_animation_custom_options(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="anim.gif",
+            vision_steps=8,
+            vision_timestep_spacing="leading",
+            vision_beta_schedule="scaled_linear",
+            vision_guidance_scale=2.5,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="anim.gif")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = AsyncMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
+
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_TEXT_TO_ANIMATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_TEXT_TO_ANIMATION,
+        )
+        lm.assert_awaited_once_with(
+            "hi",
+            "anim.gif",
+            beta_schedule="scaled_linear",
+            guidance_scale=2.5,
+            steps=8,
+            timestep_spacing="leading",
+        )
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "anim.gif")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",

--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -299,6 +299,32 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
                 ),
             ),
             (
+                Modality.VISION_TEXT_TO_ANIMATION,
+                Operation(
+                    generation_settings=self.settings,
+                    input="txt",
+                    modality=Modality.VISION_TEXT_TO_ANIMATION,
+                    parameters=OperationParameters(
+                        vision=OperationVisionParameters(
+                            path="out.gif",
+                            n_steps=4,
+                            timestep_spacing="trailing",
+                            beta_schedule="linear",
+                            guidance_scale=1.0,
+                        )
+                    ),
+                ),
+                (
+                    ("txt", "out.gif"),
+                    {
+                        "beta_schedule": "linear",
+                        "guidance_scale": 1.0,
+                        "steps": 4,
+                        "timestep_spacing": "trailing",
+                    },
+                ),
+            ),
+            (
                 Modality.VISION_SEMANTIC_SEGMENTATION,
                 Operation(
                     generation_settings=self.settings,

--- a/tests/model/vision/animation_test.py
+++ b/tests/model/vision/animation_test.py
@@ -1,0 +1,250 @@
+import itertools
+from contextlib import nullcontext
+from logging import Logger
+from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest.mock import MagicMock, patch, call
+
+from avalan.entities import (
+    BetaSchedule,
+    TimestepSpacing,
+    TransformerEngineSettings,
+)
+from avalan.model.engine import Engine
+from avalan.model.nlp import BaseNLPModel
+from avalan.model.vision.animation import TextToAnimationModel
+from diffusers import AnimateDiffPipeline, DiffusionPipeline
+
+
+class TextToAnimationModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+
+    def test_instantiation_with_load_model(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                BaseNLPModel, "_get_weight_type", return_value="dtype"
+            ),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch(
+                "avalan.model.vision.animation.MotionAdapter"
+            ) as adapter_cls,
+            patch(
+                "avalan.model.vision.animation.hf_hub_download",
+                return_value="ckpt_path",
+            ) as download_mock,
+            patch(
+                "avalan.model.vision.animation.load_file",
+                return_value={"sd": 1},
+            ) as load_mock,
+            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+        ):
+            adapter_instance = MagicMock()
+            adapter_instance.to.return_value = adapter_instance
+            adapter_cls.return_value = adapter_instance
+
+            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance.to.return_value = pipe_instance
+            pipe_mock.return_value = pipe_instance
+
+            settings = TransformerEngineSettings(
+                base_model_id="base", checkpoint="ckpt"
+            )
+            model = TextToAnimationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+
+            self.assertIs(model.model, pipe_instance)
+            adapter_cls.assert_called_once_with()
+            adapter_instance.to.assert_called_once_with("cpu", "dtype")
+            download_mock.assert_called_once_with(self.model_id, "ckpt")
+            load_mock.assert_called_once_with("ckpt_path", device="cpu")
+            adapter_instance.load_state_dict.assert_called_once_with(
+                load_mock.return_value
+            )
+            pipe_mock.assert_called_once_with(
+                "base", motion_adapter=adapter_instance, torch_dtype="dtype"
+            )
+            pipe_instance.to.assert_called_once_with("cpu")
+
+
+class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+
+    async def test_call_all_parameter_combinations(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                BaseNLPModel, "_get_weight_type", return_value="dtype"
+            ),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch(
+                "avalan.model.vision.animation.MotionAdapter"
+            ) as adapter_cls,
+            patch(
+                "avalan.model.vision.animation.hf_hub_download",
+                return_value="ckpt",
+            ),
+            patch("avalan.model.vision.animation.load_file", return_value={}),
+            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+            patch(
+                "avalan.model.vision.animation.EulerDiscreteScheduler.from_config"
+            ) as scheduler_mock,
+            patch(
+                "avalan.model.vision.animation.export_to_gif"
+            ) as export_mock,
+            patch(
+                "avalan.model.vision.animation.inference_mode",
+                return_value=nullcontext(),
+            ),
+        ):
+            adapter_instance = MagicMock()
+            adapter_instance.to.return_value = adapter_instance
+            adapter_cls.return_value = adapter_instance
+
+            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance.to.return_value = pipe_instance
+            pipe_instance.scheduler = MagicMock(config="cfg")
+            output = MagicMock()
+            output.frames = [["frame"]]
+            pipe_instance.return_value = output
+            pipe_mock.return_value = pipe_instance
+
+            scheduler_instance = MagicMock()
+            scheduler_mock.return_value = scheduler_instance
+
+            settings = TransformerEngineSettings(
+                base_model_id="base", checkpoint="ckpt"
+            )
+            model = TextToAnimationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+
+            called = set()
+            for beta in BetaSchedule:
+                for spacing in TimestepSpacing:
+                    for steps in [1, 2, 4, 8]:
+                        config_before = pipe_instance.scheduler.config
+                        path = f"{steps}-{beta.value}-{spacing.value}.gif"
+                        result = await model(
+                            "prompt",
+                            path,
+                            beta_schedule=beta,
+                            guidance_scale=1.5,
+                            steps=steps,
+                            timestep_spacing=spacing,
+                        )
+                        self.assertEqual(result, path)
+                        export_mock.assert_called_with(output.frames[0], path)
+                        self.assertEqual(
+                            pipe_instance.call_args,
+                            call(
+                                prompt="prompt",
+                                guidance_scale=1.5,
+                                num_inference_steps=steps,
+                            ),
+                        )
+                        if (spacing, beta) not in called:
+                            scheduler_mock.assert_any_call(
+                                config_before,
+                                timestep_spacing=spacing,
+                                beta_schedule=beta,
+                            )
+                            called.add((spacing, beta))
+
+            self.assertEqual(
+                scheduler_mock.call_count,
+                len(list(itertools.product(BetaSchedule, TimestepSpacing))),
+            )
+
+    async def test_call_invalid_steps(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                BaseNLPModel, "_get_weight_type", return_value="dtype"
+            ),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch(
+                "avalan.model.vision.animation.MotionAdapter"
+            ) as adapter_cls,
+            patch(
+                "avalan.model.vision.animation.hf_hub_download",
+                return_value="ckpt",
+            ),
+            patch("avalan.model.vision.animation.load_file", return_value={}),
+            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+        ):
+            adapter_instance = MagicMock()
+            adapter_instance.to.return_value = adapter_instance
+            adapter_cls.return_value = adapter_instance
+            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance.to.return_value = pipe_instance
+            pipe_mock.return_value = pipe_instance
+
+            settings = TransformerEngineSettings(
+                base_model_id="base", checkpoint="ckpt"
+            )
+            model = TextToAnimationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+
+            with self.assertRaises(AssertionError):
+                await model("prompt", "out.gif", steps=3)
+
+
+class TextToAnimationModelBaseMethodsTestCase(TestCase):
+    def test_uses_tokenizer(self) -> None:
+        settings = TransformerEngineSettings(
+            base_model_id="base", checkpoint="c"
+        )
+        with (
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch.object(
+                TextToAnimationModel,
+                "_load_model",
+                return_value=MagicMock(spec=DiffusionPipeline),
+            ),
+        ):
+            model = TextToAnimationModel("id", settings)
+        self.assertFalse(model.uses_tokenizer)
+
+    def test_load_tokenizer_not_implemented(self) -> None:
+        settings = TransformerEngineSettings(
+            auto_load_model=False,
+            auto_load_tokenizer=False,
+            base_model_id="base",
+            checkpoint="c",
+        )
+        with (
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch.object(
+                TextToAnimationModel,
+                "_load_model",
+                return_value=MagicMock(spec=DiffusionPipeline),
+            ),
+        ):
+            model = TextToAnimationModel("id", settings)
+        with self.assertRaises(NotImplementedError):
+            model._load_tokenizer(None, True)
+
+    def test_tokenize_input_not_implemented(self) -> None:
+        settings = TransformerEngineSettings(
+            auto_load_model=False,
+            auto_load_tokenizer=False,
+            base_model_id="base",
+            checkpoint="c",
+        )
+        with (
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch.object(
+                TextToAnimationModel,
+                "_load_model",
+                return_value=MagicMock(spec=DiffusionPipeline),
+            ),
+        ):
+            model = TextToAnimationModel("id", settings)
+        with self.assertRaises(NotImplementedError):
+            model._tokenize_input("in")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- test TextToAnimationModel methods including parameter combinations
- test CLI model_run with vision_text_to_animation options
- test ModelManager call for vision text to animation

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68798eb0898c83239b391deb1ba88d68