### PR TITLE
Move weight helpers to Engine

### DIFF
--- a/src/avalan/model/nlp/__init__.py
+++ b/src/avalan/model/nlp/__init__.py
@@ -1,45 +1,16 @@
 from abc import ABC
-from ...entities import GenerationSettings, WeightType
+from ...entities import GenerationSettings, WeightType as WeightType
 from ...model.transformer import TransformerModel
 from contextlib import nullcontext
 from torch import (
-    dtype,
-    bool as tbool,
-    bfloat16,
-    float16,
-    float32,
-    float64,
-    int8,
-    int16,
-    int32,
-    int64,
     inference_mode,
     Tensor,
-    uint8,
 )
 from transformers import AsyncTextIteratorStreamer
 from transformers.generation import StoppingCriteria
-from typing import Final, Literal
 
 
 class BaseNLPModel(TransformerModel, ABC):
-    _WEIGHTS: Final[dict[str, Literal["auto"] | dtype]] = {
-        "bool": tbool,
-        "bf16": bfloat16,
-        "f16": float16,
-        "fp16": float16,
-        "f32": float32,
-        "fp32": float32,
-        "f64": float64,
-        "fp64": float64,
-        "i8": int8,
-        "i16": int16,
-        "i32": int32,
-        "i64": int64,
-        "ui8": uint8,
-        "auto": "auto",
-    }
-
     def _generate_output(
         self,
         inputs: dict[str, Tensor] | Tensor,
@@ -115,7 +86,3 @@ class BaseNLPModel(TransformerModel, ABC):
                 )
             )
         return outputs
-
-    @staticmethod
-    def _get_weight_type(weight_type: WeightType) -> Literal["auto"] | dtype:
-        return BaseNLPModel._WEIGHTS.get(weight_type, "auto")

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -28,9 +28,7 @@ class QuestionAnsweringModel(BaseNLPModel):
             subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -43,9 +43,7 @@ class SentenceTransformerModel(BaseNLPModel):
             token=self._settings.access_token,
             model_kwargs={
                 "attn_implementation": self._settings.attention,
-                "torch_dtype": BaseNLPModel._get_weight_type(
-                    self._settings.weight_type
-                ),
+                "torch_dtype": Engine.weight(self._settings.weight_type),
                 "low_cpu_mem_usage": (
                     True if self._device else self._settings.low_cpu_mem_usage
                 ),

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -34,9 +34,7 @@ class SequenceClassificationModel(BaseNLPModel):
             subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,
@@ -102,9 +100,7 @@ class SequenceToSequenceModel(BaseNLPModel):
             subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -91,9 +91,7 @@ class TextGenerationModel(BaseNLPModel):
             low_cpu_mem_usage=(
                 True if self._device else self._settings.low_cpu_mem_usage
             ),
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             device_map=self._device,
             token=self._settings.access_token,
             quantization_config=bnb_config,

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -27,9 +27,7 @@ class TokenClassificationModel(BaseNLPModel):
             subfolder=self._settings.subfolder,
             attn_implementation=self._settings.attention,
             trust_remote_code=self._settings.trust_remote_code,
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             state_dict=self._settings.state_dict,
             local_files_only=self._settings.local_files_only,
             token=self._settings.access_token,

--- a/src/avalan/model/vision/animation.py
+++ b/src/avalan/model/vision/animation.py
@@ -6,7 +6,7 @@ from ...entities import (
     TransformerEngineSettings,
 )
 from ...model import TextGenerationVendor
-from ...model.nlp import BaseNLPModel
+from ...model.engine import Engine
 from ...model.transformer import TransformerModel
 from dataclasses import replace
 from diffusers import (
@@ -49,7 +49,7 @@ class TextToAnimationModel(TransformerModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        dtype = BaseNLPModel._get_weight_type(self._settings.weight_type)
+        dtype = Engine.weight(self._settings.weight_type)
         adapter = MotionAdapter().to(self._device, dtype)
         adapter.load_state_dict(
             load_file(

--- a/src/avalan/model/vision/diffusion.py
+++ b/src/avalan/model/vision/diffusion.py
@@ -6,7 +6,7 @@ from ...entities import (
     VisionImageFormat,
 )
 from ...model import TextGenerationVendor
-from ...model.nlp import BaseNLPModel
+from ...model.engine import Engine
 from ...model.transformer import TransformerModel
 from dataclasses import replace
 from diffusers import DiffusionPipeline
@@ -38,7 +38,7 @@ class TextToImageDiffusionModel(TransformerModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        dtype = BaseNLPModel._get_weight_type(self._settings.weight_type)
+        dtype = Engine.weight(self._settings.weight_type)
         dtype_variant = self._settings.weight_type
 
         base = DiffusionPipeline.from_pretrained(

--- a/src/avalan/model/vision/image.py
+++ b/src/avalan/model/vision/image.py
@@ -8,7 +8,6 @@ from ...entities import (
 )
 from ...model import TextGenerationVendor
 from ...model.engine import Engine
-from ...model.nlp import BaseNLPModel
 from ...model.vision import BaseVisionModel
 from diffusers import DiffusionPipeline
 from ...model.transformer import TransformerModel
@@ -129,9 +128,7 @@ class ImageTextToTextModel(ImageToTextModel):
         loader = self._loaders[self._settings.loader_class]
         model = loader.from_pretrained(
             self._model_id,
-            torch_dtype=BaseNLPModel._get_weight_type(
-                self._settings.weight_type
-            ),
+            torch_dtype=Engine.weight(self._settings.weight_type),
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
         )

--- a/tests/model/vision/animation_test.py
+++ b/tests/model/vision/animation_test.py
@@ -10,7 +10,6 @@ from avalan.entities import (
     TransformerEngineSettings,
 )
 from avalan.model.engine import Engine
-from avalan.model.nlp import BaseNLPModel
 from avalan.model.vision.animation import TextToAnimationModel
 from diffusers import AnimateDiffPipeline, DiffusionPipeline
 
@@ -21,9 +20,7 @@ class TextToAnimationModelInstantiationTestCase(TestCase):
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)
         with (
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ),
+            patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
                 "avalan.model.vision.animation.MotionAdapter"
@@ -73,9 +70,7 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
     async def test_call_all_parameter_combinations(self) -> None:
         logger_mock = MagicMock(spec=Logger)
         with (
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ),
+            patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
                 "avalan.model.vision.animation.MotionAdapter"
@@ -159,9 +154,7 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
     async def test_call_invalid_steps(self) -> None:
         logger_mock = MagicMock(spec=Logger)
         with (
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ),
+            patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
                 "avalan.model.vision.animation.MotionAdapter"

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -1,7 +1,6 @@
 from avalan.entities import TransformerEngineSettings
 from avalan.model.vision.diffusion import TextToImageDiffusionModel
 from avalan.entities import VisionColorModel, VisionImageFormat
-from avalan.model.nlp import BaseNLPModel
 from avalan.model.engine import Engine
 from diffusers import DiffusionPipeline
 from contextlib import nullcontext
@@ -26,9 +25,7 @@ class TextToImageDiffusionModelInstantiationTestCase(TestCase):
             patch.object(
                 DiffusionPipeline, "from_pretrained"
             ) as pipeline_mock,
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ),
+            patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
         ):
             base_instance = MagicMock(spec=DiffusionPipeline)
@@ -80,9 +77,7 @@ class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
             patch.object(
                 DiffusionPipeline, "from_pretrained"
             ) as pipeline_mock,
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ),
+            patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
                 "avalan.model.vision.diffusion.inference_mode",

--- a/tests/model/vision/image_text_to_text_model_test.py
+++ b/tests/model/vision/image_text_to_text_model_test.py
@@ -10,7 +10,7 @@ from avalan.model.vision.image import (
     ImageTextToTextModel,
 )
 from avalan.model.vision import BaseVisionModel
-from avalan.model.nlp import BaseNLPModel
+from avalan.model.engine import Engine
 from logging import Logger
 from transformers import (
     AutoTokenizer,
@@ -51,9 +51,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 AutoModelForImageTextToText, "from_pretrained"
             ) as model_mock,
             patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ) as wt_mock,
+            patch.object(Engine, "weight", return_value="dtype") as wt_mock,
         ):
             processor_instance = MagicMock()
             processor_mock.return_value = processor_instance
@@ -97,9 +95,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 AutoModelForImageTextToText, "from_pretrained"
             ) as model_mock,
             patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ) as wt_mock,
+            patch.object(Engine, "weight", return_value="dtype") as wt_mock,
         ):
             processor_instance = MagicMock()
             processor_mock.return_value = processor_instance
@@ -144,9 +140,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 Gemma3ForConditionalGeneration, "from_pretrained"
             ) as gemma_mock,
             patch.object(AutoTokenizer, "from_pretrained") as tokenizer_mock,
-            patch.object(
-                BaseNLPModel, "_get_weight_type", return_value="dtype"
-            ) as wt_mock,
+            patch.object(Engine, "weight", return_value="dtype") as wt_mock,
         ):
             processor_instance = MagicMock()
             processor_mock.return_value = processor_instance


### PR DESCRIPTION
## Summary
- centralize `_WEIGHTS` and `_get_weight_type` in `Engine`
- adjust NLP and vision models to use the new helpers
- update tests to patch the Engine methods

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_6879b6a2f45483239785001622f27e63