### PR TITLE
Update vision engine settings and models

### DIFF
--- a/docs/examples/vision_text_to_image.py
+++ b/docs/examples/vision_text_to_image.py
@@ -1,13 +1,13 @@
 from asyncio import run
 from avalan.entities import TransformerEngineSettings
-from avalan.model.vision.diffusion import TextToImageDiffusionModel
+from avalan.model.vision.diffusion import TextToImageModel
 from os.path import isfile
 from sys import argv, exit
 
 
 async def example(prompt: str, path: str) -> None:
     print("Loading model... ", end="", flush=True)
-    with TextToImageDiffusionModel(
+    with TextToImageModel(
         "stabilityai/stable-diffusion-xl-base-1.0",
         settings=TransformerEngineSettings(
             refiner_model_id="stabilityai/stable-diffusion-xl-refiner-1.0",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -166,6 +166,14 @@ class BetaSchedule(StrEnum):
 
 
 @dataclass(frozen=True, kw_only=True)
+class QuantizationSettings:
+    load_in_4bit: bool
+    bnb_4bit_quant_type: Literal["nf4"]
+    bnb_4bit_use_double_quant: bool
+    bnb_4bit_compute_dtype: type
+
+
+@dataclass(frozen=True, kw_only=True)
 class EngineSettings:
     auto_load_model: bool = True
     auto_load_tokenizer: bool = True
@@ -179,6 +187,14 @@ class EngineSettings:
     tokenizer_name_or_path: str | None = None
     subfolder: str | None = None
     tokenizer_subfolder: str | None = None
+    access_token: str | None = None
+    base_url: str | None = None
+    revision: str | None = None
+    quantization: QuantizationSettings | None = None
+    weight_type: WeightType = "auto"
+    base_model_id: str | None = None
+    checkpoint: str | None = None
+    refiner_model_id: str | None = None
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -694,14 +710,6 @@ class ToolManagerSettings:
 
 
 @dataclass(frozen=True, kw_only=True)
-class QuantizationSettings:
-    load_in_4bit: bool
-    bnb_4bit_quant_type: Literal["nf4"]
-    bnb_4bit_use_double_quant: bool
-    bnb_4bit_compute_dtype: type
-
-
-@dataclass(frozen=True, kw_only=True)
 class TextPartition:
     data: str
     total_tokens: int
@@ -710,21 +718,13 @@ class TextPartition:
 
 @dataclass(frozen=True, kw_only=True)
 class TransformerEngineSettings(EngineSettings):
-    access_token: str | None = None
     attention: AttentionImplementation | None = None
-    base_url: str | None = None
     loader_class: TextGenerationLoaderClass | None = "auto"
     local_files_only: bool = False
     low_cpu_mem_usage: bool = False
-    quantization: QuantizationSettings | None = None
-    revision: str | None = None
     special_tokens: list[str] | None = None
     state_dict: dict[str, Tensor] = None
     tokens: list[str] | None = None
-    weight_type: WeightType = "auto"
-    base_model_id: str | None = None
-    checkpoint: str | None = None
-    refiner_model_id: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -34,7 +34,7 @@ from ..model.vision.image import (
     ImageToTextModel,
     VisionEncoderDecoderModel,
 )
-from ..model.vision.diffusion import TextToImageDiffusionModel
+from ..model.vision.diffusion import TextToImageModel
 from ..model.vision.animation import TextToAnimationModel
 from ..model.vision.segmentation import SemanticSegmentationModel
 from ..secrets import KeyringSecrets
@@ -686,7 +686,7 @@ class ModelManager(ContextDecorator):
                 case Modality.VISION_ENCODER_DECODER:
                     model = VisionEncoderDecoderModel(**model_load_args)
                 case Modality.VISION_TEXT_TO_IMAGE:
-                    model = TextToImageDiffusionModel(**model_load_args)
+                    model = TextToImageModel(**model_load_args)
                 case Modality.VISION_TEXT_TO_ANIMATION:
                     model = TextToAnimationModel(**model_load_args)
                 case Modality.VISION_SEMANTIC_SEGMENTATION:

--- a/src/avalan/model/vision/animation.py
+++ b/src/avalan/model/vision/animation.py
@@ -1,13 +1,12 @@
 from ...compat import override
 from ...entities import (
     BetaSchedule,
-    Input,
     TimestepSpacing,
     TransformerEngineSettings,
 )
 from ...model import TextGenerationVendor
 from ...model.engine import Engine
-from ...model.transformer import TransformerModel
+from ...model.vision import BaseVisionModel
 from dataclasses import replace
 from diffusers import (
     AnimateDiffPipeline,
@@ -20,17 +19,11 @@ from diffusers.utils import export_to_gif
 from huggingface_hub import hf_hub_download
 from logging import Logger
 from safetensors.torch import load_file
-from torch import inference_mode, Tensor
-from transformers import (
-    PreTrainedModel,
-    PreTrainedTokenizer,
-    PreTrainedTokenizerFast,
-)
-from transformers.tokenization_utils_base import BatchEncoding
-from typing import Literal
+from torch import inference_mode
+from transformers import PreTrainedModel
 
 
-class TextToAnimationModel(TransformerModel):
+class TextToAnimationModel(BaseVisionModel):
     _schedulers: dict[tuple[TimestepSpacing, BetaSchedule], SchedulerMixin] = (
         {}
     )
@@ -64,27 +57,6 @@ class TextToAnimationModel(TransformerModel):
         ).to(self._device)
 
         return pipe
-
-    @override
-    @property
-    def uses_tokenizer(self) -> bool:
-        return False
-
-    @override
-    def _load_tokenizer(
-        self, tokenizer_name_or_path: str | None, use_fast: bool
-    ) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
-        raise NotImplementedError()
-
-    @override
-    def _tokenize_input(
-        self,
-        input: Input,
-        context: str | None = None,
-        tensor_format: Literal["pt"] = "pt",
-        **kwargs,
-    ) -> dict[str, Tensor] | BatchEncoding | Tensor:
-        raise NotImplementedError()
 
     @override
     async def __call__(

--- a/src/avalan/model/vision/diffusion.py
+++ b/src/avalan/model/vision/diffusion.py
@@ -1,27 +1,21 @@
 from ...compat import override
 from ...entities import (
-    Input,
     TransformerEngineSettings,
     VisionColorModel,
     VisionImageFormat,
 )
 from ...model import TextGenerationVendor
 from ...model.engine import Engine
-from ...model.transformer import TransformerModel
+from ...model.vision import BaseVisionModel
 from dataclasses import replace
 from diffusers import DiffusionPipeline
 from logging import Logger
-from torch import inference_mode, Tensor
-from transformers import (
-    PreTrainedModel,
-    PreTrainedTokenizer,
-    PreTrainedTokenizerFast,
-)
-from transformers.tokenization_utils_base import BatchEncoding
+from torch import inference_mode
+from transformers import PreTrainedModel
 from typing import Literal
 
 
-class TextToImageDiffusionModel(TransformerModel):
+class TextToImageModel(BaseVisionModel):
     _base: DiffusionPipeline
 
     def __init__(
@@ -62,27 +56,6 @@ class TextToImageDiffusionModel(TransformerModel):
         self._base = base
 
         return refiner
-
-    @override
-    @property
-    def uses_tokenizer(self) -> bool:
-        return False
-
-    @override
-    def _load_tokenizer(
-        self, tokenizer_name_or_path: str | None, use_fast: bool
-    ) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
-        raise NotImplementedError()
-
-    @override
-    def _tokenize_input(
-        self,
-        input: Input,
-        context: str | None = None,
-        tensor_format: Literal["pt"] = "pt",
-        **kwargs,
-    ) -> dict[str, Tensor] | BatchEncoding | Tensor:
-        raise NotImplementedError()
 
     @override
     async def __call__(

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -29,7 +29,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.VISION_IMAGE_TO_TEXT: "ImageToTextModel",
             Modality.VISION_IMAGE_TEXT_TO_TEXT: "ImageTextToTextModel",
             Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
-            Modality.VISION_TEXT_TO_IMAGE: "TextToImageDiffusionModel",
+            Modality.VISION_TEXT_TO_IMAGE: "TextToImageModel",
             Modality.VISION_TEXT_TO_ANIMATION: "TextToAnimationModel",
             Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
         }

--- a/tests/model/vision/animation_test.py
+++ b/tests/model/vision/animation_test.py
@@ -200,7 +200,7 @@ class TextToAnimationModelBaseMethodsTestCase(TestCase):
             model = TextToAnimationModel("id", settings)
         self.assertFalse(model.uses_tokenizer)
 
-    def test_load_tokenizer_not_implemented(self) -> None:
+    def test_load_tokenizer_not_supported(self) -> None:
         settings = TransformerEngineSettings(
             auto_load_model=False,
             auto_load_tokenizer=False,
@@ -216,27 +216,7 @@ class TextToAnimationModelBaseMethodsTestCase(TestCase):
             ),
         ):
             model = TextToAnimationModel("id", settings)
-        with self.assertRaises(NotImplementedError):
-            model._load_tokenizer(None, True)
-
-    def test_tokenize_input_not_implemented(self) -> None:
-        settings = TransformerEngineSettings(
-            auto_load_model=False,
-            auto_load_tokenizer=False,
-            base_model_id="base",
-            checkpoint="c",
-        )
-        with (
-            patch.object(Engine, "get_default_device", return_value="cpu"),
-            patch.object(
-                TextToAnimationModel,
-                "_load_model",
-                return_value=MagicMock(spec=DiffusionPipeline),
-            ),
-        ):
-            model = TextToAnimationModel("id", settings)
-        with self.assertRaises(NotImplementedError):
-            model._tokenize_input("in")
+        self.assertFalse(hasattr(model, "_load_tokenizer"))
 
 
 if __name__ == "__main__":

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -1,5 +1,5 @@
 from avalan.entities import TransformerEngineSettings
-from avalan.model.vision.diffusion import TextToImageDiffusionModel
+from avalan.model.vision.diffusion import TextToImageModel
 from avalan.entities import VisionColorModel, VisionImageFormat
 from avalan.model.engine import Engine
 from diffusers import DiffusionPipeline
@@ -9,15 +9,13 @@ from unittest import TestCase, IsolatedAsyncioTestCase, main
 from unittest.mock import MagicMock, patch, call
 
 
-class TextToImageDiffusionModelInstantiationTestCase(TestCase):
+class TextToImageModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
     refiner_id = "refiner/model"
 
     def test_missing_refiner(self) -> None:
         with self.assertRaises(AssertionError):
-            TextToImageDiffusionModel(
-                self.model_id, TransformerEngineSettings()
-            )
+            TextToImageModel(self.model_id, TransformerEngineSettings())
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)
@@ -37,7 +35,7 @@ class TextToImageDiffusionModelInstantiationTestCase(TestCase):
             settings = TransformerEngineSettings(
                 refiner_model_id=self.refiner_id
             )
-            model = TextToImageDiffusionModel(
+            model = TextToImageModel(
                 self.model_id,
                 settings,
                 logger=logger_mock,
@@ -67,7 +65,7 @@ class TextToImageDiffusionModelInstantiationTestCase(TestCase):
             refiner_instance.to.assert_called_once_with("cpu")
 
 
-class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
+class TextToImageModelCallTestCase(IsolatedAsyncioTestCase):
     model_id = "dummy/model"
     refiner_id = "refiner/model"
 
@@ -96,7 +94,7 @@ class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
             settings = TransformerEngineSettings(
                 refiner_model_id=self.refiner_id
             )
-            model = TextToImageDiffusionModel(
+            model = TextToImageModel(
                 self.model_id,
                 settings,
                 logger=logger_mock,
@@ -128,30 +126,17 @@ class TextToImageDiffusionModelCallTestCase(IsolatedAsyncioTestCase):
             inf_mock.assert_called_once_with()
 
 
-class TextToImageDiffusionModelBaseMethodsTestCase(TestCase):
-    def test_load_tokenizer_not_implemented(self) -> None:
+class TextToImageModelBaseMethodsTestCase(TestCase):
+    def test_load_tokenizer_not_supported(self) -> None:
         settings = TransformerEngineSettings(
             auto_load_model=False,
             auto_load_tokenizer=False,
             refiner_model_id="ref",
         )
         with patch.object(Engine, "get_default_device", return_value="cpu"):
-            model = TextToImageDiffusionModel("id", settings)
+            model = TextToImageModel("id", settings)
 
-        with self.assertRaises(NotImplementedError):
-            model._load_tokenizer(None, True)
-
-    def test_tokenize_input_not_implemented(self) -> None:
-        settings = TransformerEngineSettings(
-            auto_load_model=False,
-            auto_load_tokenizer=False,
-            refiner_model_id="ref",
-        )
-        with patch.object(Engine, "get_default_device", return_value="cpu"):
-            model = TextToImageDiffusionModel("id", settings)
-
-        with self.assertRaises(NotImplementedError):
-            model._tokenize_input("in")
+        self.assertFalse(hasattr(model, "_load_tokenizer"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- consolidate common engine settings
- rename `TextToImageDiffusionModel` to `TextToImageModel`
- refactor animation and image diffusion models to derive from `BaseVisionModel`
- update docs and tests for renamed models

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687a2f5b552c8323b6015d05a4440578