### PR TITLE
Fix text to video tests

### DIFF
--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -362,40 +362,31 @@ class ModelManager(ContextDecorator):
                 assert (
                     operation.input
                     and operation.parameters["vision"]
-                    and operation.parameters["vision"].negative_prompt
-                    and operation.parameters["vision"].reference_path
                     and operation.parameters["vision"].path
-                    and operation.parameters["vision"].height
-                    and operation.parameters["vision"].width
                 )
+
+                vision = operation.parameters["vision"]
+                kwargs = {
+                    "reference_path": vision.reference_path,
+                    "negative_prompt": vision.negative_prompt,
+                    "height": vision.height,
+                    "downscale": vision.downscale,
+                    "frames": vision.frames,
+                    "denoise_strength": vision.denoise_strength,
+                    "inference_steps": vision.inference_steps,
+                    "decode_timestep": vision.decode_timestep,
+                    "noise_scale": vision.noise_scale,
+                    "frames_per_second": vision.frames_per_second,
+                }
+                if vision.width is not None:
+                    kwargs["width"] = vision.width
+                if vision.n_steps is not None:
+                    kwargs["steps"] = vision.n_steps
 
                 result = await model(
                     operation.input,
-                    operation.parameters[
-                        "vision"
-                    ].negative_prompt,
-                    operation.parameters[
-                        "vision"
-                    ].reference_path,
-                    operation.parameters["vision"].path,
-                    decode_timestep=operation.parameters[
-                        "vision"
-                    ].decode_timestep,
-                    denoise_strength=operation.parameters[
-                        "vision"
-                    ].denoise_strength,
-                    downscale=operation.parameters["vision"].downscale,
-                    fps=operation.parameters[
-                        "vision"
-                    ].frames_per_second,
-                    frames=operation.parameters["vision"].frames,
-                    height=operation.parameters["vision"].height,
-                    inference_steps=operation.parameters[
-                        "vision"
-                    ].inference_steps,
-                    noise_scale=operation.parameters["vision"].noise_scale,
-                    width=operation.parameters["vision"].width,
-                    steps=operation.parameters["vision"].n_steps,
+                    vision.path,
+                    **kwargs,
                 )
 
             case Modality.VISION_SEMANTIC_SEGMENTATION:


### PR DESCRIPTION
## Summary
- adjust `ModelManager.__call__` for VISION_TEXT_TO_VIDEO modality
- ensure optional video parameters are passed only when available

## Testing
- `poetry run pytest -k "text_to_video or supported_modalities" -vv`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687a987ab35c83238d571756200c327d