### PR TITLE
Add text-to-video tests

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -3021,6 +3021,126 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "custom.mp4")
 
+    async def test_run_text_to_video_width_only(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="wide.mp4",
+            vision_reference_path=None,
+            vision_negative_prompt=None,
+            vision_height=None,
+            vision_width=320,
+            vision_downscale=2 / 3,
+            vision_frames=96,
+            vision_denoise_strength=0.4,
+            vision_inference_steps=10,
+            vision_decode_timestep=0.05,
+            vision_noise_scale=0.025,
+            vision_fps=24,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = AsyncMock(return_value="wide.mp4")
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = AsyncMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def call_side_effect(engine_uri, modality, model, operation):
+            return await RealModelManager.__call__(
+                manager, engine_uri, modality, model, operation
+            )
+
+        manager.side_effect = call_side_effect
+
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.VISION_TEXT_TO_VIDEO,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.VISION_TEXT_TO_VIDEO,
+        )
+        lm.assert_awaited_once_with(
+            "hi",
+            "wide.mp4",
+            reference_path=None,
+            negative_prompt=None,
+            height=None,
+            width=320,
+            downscale=2 / 3,
+            frames=96,
+            denoise_strength=0.4,
+            inference_steps=10,
+            decode_timestep=0.05,
+            noise_scale=0.025,
+            frames_per_second=24,
+        )
+        tg_patch.assert_not_called()
+        self.assertEqual(console.print.call_args.args[0], "wide.mp4")
+
     async def test_run_invalid_modality_raises(self):
         args = Namespace(
             model="id",

--- a/tests/model/vision/video_test.py
+++ b/tests/model/vision/video_test.py
@@ -1,0 +1,162 @@
+from avalan.entities import TransformerEngineSettings
+from avalan.model.engine import Engine
+from avalan.model.vision.video import TextToVideoModel
+from diffusers import DiffusionPipeline
+from contextlib import nullcontext
+from logging import Logger
+from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest.mock import MagicMock, call, patch, ANY
+
+
+class TextToVideoModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+    upsampler_id = "up/model"
+
+    def test_instantiation_with_load_model(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                DiffusionPipeline, "from_pretrained"
+            ) as pipeline_mock,
+            patch.object(Engine, "weight", return_value="dtype"),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+        ):
+            base_instance = MagicMock(spec=DiffusionPipeline)
+            base_instance.to.return_value = base_instance
+            base_instance.vae = MagicMock()
+            base_instance.vae.enable_tiling = MagicMock()
+            upsampler_instance = MagicMock(spec=DiffusionPipeline)
+            upsampler_instance.to.return_value = upsampler_instance
+            pipeline_mock.side_effect = [base_instance, upsampler_instance]
+
+            settings = TransformerEngineSettings(
+                upsampler_model_id=self.upsampler_id
+            )
+            model = TextToVideoModel(
+                self.model_id, settings, logger=logger_mock
+            )
+
+            self.assertIs(model.model, base_instance)
+            pipeline_mock.assert_has_calls(
+                [
+                    call(self.model_id, torch_dtype="dtype"),
+                    call(
+                        self.upsampler_id,
+                        vae=base_instance.vae,
+                        torch_dtype="dtype",
+                    ),
+                ]
+            )
+            base_instance.to.assert_called_once_with("cpu")
+            upsampler_instance.to.assert_called_once_with("cpu")
+            base_instance.vae.enable_tiling.assert_called_once_with()
+
+
+class TextToVideoModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+    upsampler_id = "up/model"
+
+    async def test_call(self) -> None:
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                DiffusionPipeline, "from_pretrained"
+            ) as pipeline_mock,
+            patch.object(Engine, "weight", return_value="dtype"),
+            patch.object(Engine, "get_default_device", return_value="cpu"),
+            patch("avalan.model.vision.video.load_image") as load_image_mock,
+            patch("avalan.model.vision.video.load_video", return_value="vid"),
+            patch("avalan.model.vision.video.export_to_video") as export_mock,
+            patch(
+                "avalan.model.vision.video.inference_mode",
+                return_value=nullcontext(),
+            ),
+            patch("avalan.model.vision.video.LTXVideoCondition") as cond_cls,
+        ):
+            base_instance = MagicMock(spec=DiffusionPipeline)
+            base_instance.to.return_value = base_instance
+            base_instance.vae = MagicMock()
+            base_instance.vae_spatial_compression_ratio = 2
+            first_out = MagicMock()
+            first_out.frames = ["latents"]
+            second_out = MagicMock()
+            frame = MagicMock()
+            second_out.frames = [[frame]]
+            base_instance.side_effect = [first_out, second_out]
+            upsampler_instance = MagicMock(spec=DiffusionPipeline)
+            upsampler_instance.to.return_value = upsampler_instance
+            upsampler_instance.return_value = MagicMock(frames=["upscaled"])
+            pipeline_mock.side_effect = [base_instance, upsampler_instance]
+
+            cond_instance = MagicMock()
+            cond_cls.return_value = cond_instance
+            load_image_mock.return_value = "img"
+
+            settings = TransformerEngineSettings(
+                upsampler_model_id=self.upsampler_id
+            )
+            model = TextToVideoModel(
+                self.model_id, settings, logger=logger_mock
+            )
+
+            result = await model(
+                "prompt",
+                "neg",
+                "ref.png",
+                "out.mp4",
+                width=512,
+                height=480,
+            )
+
+            self.assertEqual(result, "out.mp4")
+            load_image_mock.assert_called_once_with("ref.png")
+            export_mock.assert_called_with(
+                [frame.resize.return_value], "out.mp4", fps=24
+            )
+            base_instance.assert_has_calls(
+                [
+                    call(
+                        conditions=[cond_instance],
+                        prompt="prompt",
+                        negative_prompt="neg",
+                        width=340,
+                        height=320,
+                        num_frames=96,
+                        num_inference_steps=30,
+                        generator=ANY,
+                        output_type="latent",
+                    ),
+                    call(
+                        conditions=[cond_instance],
+                        prompt="prompt",
+                        negative_prompt="neg",
+                        width=680,
+                        height=640,
+                        num_frames=96,
+                        denoise_strength=0.4,
+                        num_inference_steps=10,
+                        latents=upsampler_instance.return_value.frames,
+                        decode_timestep=0.05,
+                        image_cond_noise_scale=0.025,
+                        generator=ANY,
+                        output_type="pil",
+                    ),
+                ]
+            )
+            upsampler_instance.assert_called_once_with(
+                latents=first_out.frames, output_type="latent"
+            )
+
+
+class TextToVideoModelRoundResolutionTestCase(TestCase):
+    def test_round_to_nearest_resolution(self) -> None:
+        self.assertEqual(
+            TextToVideoModel._round_to_nearest_resolution_acceptable_by_vae(
+                5, 7, 2
+            ),
+            (4, 6),
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- test TextToVideoModel instantiation and call behaviour
- test ModelManager model_run for text-to-video using width

## Testing
- `poetry run pytest tests/model/vision/video_test.py tests/cli/model_test.py::CliModelRunTestCase::test_run_text_to_video_width_only -q`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687aa1cb637883239a9d7ff3485afdb8