### PR TITLE
Add ToolCallToken in parser

### DIFF
--- a/src/avalan/agent/orchestrator/response/parsers/tool.py
+++ b/src/avalan/agent/orchestrator/response/parsers/tool.py
@@ -4,6 +4,7 @@ from io import StringIO
 from time import perf_counter
 from typing import Any, Iterable
 
+from .....entities import ToolCallToken
 from .....event import Event, EventType
 from .....event.manager import EventManager
 from .....tool.manager import ToolManager
@@ -18,15 +19,46 @@ class ToolCallParser:
         self._tool_manager = tool_manager
         self._event_manager = event_manager
         self._buffer = StringIO()
+        self._tag_buffer = ""
+        self._inside_call = False
 
     async def push(self, token_str: str) -> Iterable[Any]:
         buffer_value = self._buffer.getvalue()
         should_check = self._tool_manager.is_potential_tool_call(
             buffer_value, token_str
         )
+
+        prev_inside = self._inside_call
+
         self._buffer.write(token_str)
+        self._tag_buffer += token_str
+        if len(self._tag_buffer) > 64:
+            self._tag_buffer = self._tag_buffer[-64:]
+
+        if not self._inside_call and (
+            "<tool_call" in self._tag_buffer
+            or "<tool " in self._tag_buffer
+            or "<tool>" in self._tag_buffer
+        ):
+            self._inside_call = True
+
+        if self._inside_call and (
+            "</tool_call>" in self._tag_buffer
+            or "</tool>" in self._tag_buffer
+            or "/>" in self._tag_buffer
+        ):
+            self._inside_call = False
+
+        start_triggered = not prev_inside and self._inside_call
+
+        item = (
+            ToolCallToken(token_str)
+            if prev_inside or start_triggered
+            else token_str
+        )
+
         if not should_check:
-            return [token_str]
+            return [item]
 
         if self._event_manager:
             await self._event_manager.trigger(
@@ -35,14 +67,16 @@ class ToolCallParser:
 
         calls = self._tool_manager.get_calls(self._buffer.getvalue())
         if not calls:
-            return [token_str]
+            return [item]
 
         event = Event(
             type=EventType.TOOL_PROCESS, payload=calls, started=perf_counter()
         )
 
         self._buffer = StringIO()
-        return [token_str, event]
+        self._tag_buffer = ""
+        self._inside_call = False
+        return [item, event]
 
     async def flush(self) -> Iterable[Any]:
         return []

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -679,6 +679,20 @@ class ReasoningToken(Token):
 
 
 @dataclass(frozen=True, kw_only=True)
+class ToolCallToken(Token):
+    """Token produced while the model emits a tool call."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        id: Tensor | int = -1,
+        probability: float | None = None,
+    ) -> None:
+        super().__init__(id=id, token=token, probability=probability)
+
+
+@dataclass(frozen=True, kw_only=True)
 class ToolCall:
     id: UUID
     name: str

--- a/tests/agent/tool_call_parser_test.py
+++ b/tests/agent/tool_call_parser_test.py
@@ -1,0 +1,25 @@
+from avalan.agent.orchestrator.response.parsers.tool import ToolCallParser
+from avalan.entities import ToolCallToken
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+class ToolCallParserTestCase(IsolatedAsyncioTestCase):
+    async def test_with_tool_call_tags(self):
+        manager = MagicMock()
+
+        def _get_calls(text: str):
+            return [MagicMock()] if "</tool_call>" in text else None
+
+        manager.is_potential_tool_call.return_value = True
+        manager.get_calls.side_effect = _get_calls
+
+        parser = ToolCallParser(manager, None)
+        tokens = []
+        for t in ["<tool_call>", "x", "</tool_call>", "y"]:
+            tokens.extend(await parser.push(t))
+
+        self.assertIsInstance(tokens[0], ToolCallToken)
+        self.assertIsInstance(tokens[1], ToolCallToken)
+        self.assertIsInstance(tokens[2], ToolCallToken)
+        self.assertEqual(tokens[-1], "y")


### PR DESCRIPTION
## Summary
- add `ToolCallToken` dataclass
- emit `ToolCallToken` from `ToolCallParser` when tool-call text is parsed
- test that `ToolCallParser` marks tokens inside `<tool_call>` tags

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687d5cf245c8832390f3c9ba48c02e0f