### PR TITLE
Fix reasoning token detection

### DIFF
--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -11,6 +11,7 @@ from ...entities import (
     SentenceTransformerModelConfig,
     Similarity,
     Token,
+    ReasoningToken,
     TokenizerConfig,
     User,
     ImageEntity,
@@ -1674,6 +1675,12 @@ class FancyTheme(Theme):
             else:
                 wrapped.extend(wrapped_line)
                 wrapped.append(linesep)
+
+        _is_thinking = (
+            isinstance(tokens[-1], ReasoningToken)
+            if tokens
+            else start_thinking
+        )
 
         think_section = (
             think_wrapped[-(think_height - 2 * think_padding) :]


### PR DESCRIPTION
## Summary
- simplify thinking detection by checking last token instance
- drop `text_tokens` param from `tokens` logic and update callers
- clean up tests to match new `tokens` signature
- add tests to verify long line wrapping

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_687d60fca0d483239672a69ebb26449b