### PR TITLE
Add audio classification support

### DIFF
--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -54,15 +54,21 @@ from time import perf_counter
 from urllib.parse import urlparse, parse_qsl
 
 ModelType: TypeAlias = (
-    ImageClassificationModel
+    AudioClassificationModel
+    | ImageClassificationModel
     | ImageTextToTextModel
+    | ImageToTextModel
     | ObjectDetectionModel
     | QuestionAnsweringModel
     | SemanticSegmentationModel
     | SentenceTransformerModel
+    | SequenceClassificationModel
+    | SequenceToSequenceModel
     | SpeechRecognitionModel
     | TextGenerationModel
+    | TextToImageModel
     | TextToSpeechModel
+    | TranslationModel
     | TokenClassificationModel
     | VisionEncoderDecoderModel
     | TextToAnimationModel

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1267,6 +1267,102 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "transcript")
 
+    async def test_run_audio_classification(self):
+        args = Namespace(
+            model="id",
+            device="cpu",
+            max_new_tokens=1,
+            quiet=False,
+            skip_hub_access_check=False,
+            no_repl=True,
+            do_sample=False,
+            enable_gradient_calculation=False,
+            min_p=None,
+            repetition_penalty=1.0,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            use_cache=True,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=2,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=2,
+            path="audio.wav",
+            audio_sampling_rate=16_000,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+        theme.icons = {"user_input": ">"}
+        theme.model.return_value = "panel"
+        theme.display_audio_labels.return_value = "table"
+        hub = MagicMock()
+        hub.can_access.return_value = True
+        hub.model.return_value = "hub_model"
+        logger = MagicMock()
+
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        lm = MagicMock()
+        lm.config = MagicMock()
+        lm.config.__repr__ = lambda self=None: "cfg"
+
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = lm
+        load_cm.__exit__.return_value = False
+
+        manager = AsyncMock()
+        manager.__enter__.return_value = manager
+        manager.__exit__.return_value = False
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+        manager.return_value = {"ok": 1.0}
+
+        with patch.object(
+            model_cmds, "ModelManager", return_value=manager
+        ) as mm_patch:
+            with patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ):
+                with (
+                    patch.object(
+                        model_cmds,
+                        "get_model_settings",
+                        return_value={
+                            "engine_uri": engine_uri,
+                            "modality": Modality.AUDIO_CLASSIFICATION,
+                        },
+                    ) as gms_patch,
+                    patch.object(model_cmds, "get_input", return_value="hi"),
+                    patch.object(
+                        model_cmds, "token_generation", new_callable=AsyncMock
+                    ) as tg_patch,
+                ):
+                    await model_cmds.model_run(
+                        args, console, theme, hub, 5, logger
+                    )
+
+        mm_patch.assert_called_once_with(hub, logger)
+        manager.parse_uri.assert_called_once_with("id")
+        gms_patch.assert_called_once_with(args, hub, logger, engine_uri)
+        manager.load.assert_called_once_with(
+            engine_uri=engine_uri,
+            modality=Modality.AUDIO_CLASSIFICATION,
+        )
+        manager.assert_awaited_once()
+        operation = manager.await_args_list[0].args[3]
+        self.assertEqual(operation.parameters["audio"].path, "audio.wav")
+        self.assertEqual(operation.parameters["audio"].sampling_rate, 16_000)
+        theme.display_audio_labels.assert_called_once_with(
+            manager.return_value
+        )
+        self.assertEqual(console.print.call_args_list[-1].args[0], "table")
+
     async def test_run_text_question_answering(self):
         args = Namespace(
             model="id",

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -861,6 +861,15 @@ class FancyThemeMoreTests(unittest.TestCase):
         self.assertEqual(table.columns[0]._cells[0], "cat")
         self.assertEqual(table.columns[0]._cells[1], "dog")
 
+    def test_display_audio_labels(self):
+        align = self.theme.display_audio_labels({"dog": 0.9, "cat": 0.5})
+        table = align.renderable
+        self.assertEqual(table.row_count, 2)
+        self.assertEqual(table.columns[0]._cells[0], "dog")
+        self.assertEqual(table.columns[0]._cells[1], "cat")
+        self.assertEqual(table.columns[1]._cells[0], "[score]0.90[/score]")
+        self.assertEqual(table.columns[1]._cells[1], "[score]0.50[/score]")
+
     def test_display_token_labels(self):
         align = self.theme.display_token_labels([{"tok": "LBL"}])
         table = align.renderable

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -360,6 +360,7 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
             lambda: Theme.display_image_entities(self.theme, [], False),
             lambda: Theme.display_image_entity(self.theme, None),
+            lambda: Theme.display_audio_labels(self.theme, {}),
             lambda: Theme.display_image_labels(self.theme, []),
             lambda: Theme.display_token_labels(self.theme, []),
             lambda: Theme.welcome(self.theme, "u", "n", "v", "lic", None),

--- a/tests/model/audio/audio_classification_test.py
+++ b/tests/model/audio/audio_classification_test.py
@@ -1,0 +1,139 @@
+from avalan.entities import EngineSettings
+from avalan.model.engine import Engine
+from avalan.model.audio.classification import (
+    AudioClassificationModel,
+    AutoFeatureExtractor,
+    AutoModelForAudioClassification,
+)
+from contextlib import nullcontext
+from logging import Logger
+from transformers import PreTrainedModel
+from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest.mock import MagicMock, PropertyMock, patch
+
+
+class AudioClassificationModelInstantiationTestCase(TestCase):
+    model_id = "dummy/model"
+
+    def test_instantiation_no_load(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                AutoFeatureExtractor, "from_pretrained"
+            ) as extractor_mock,
+            patch.object(
+                AutoModelForAudioClassification, "from_pretrained"
+            ) as model_mock,
+        ):
+            settings = EngineSettings(auto_load_model=False)
+            model = AudioClassificationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+            self.assertIsInstance(model, AudioClassificationModel)
+            extractor_mock.assert_not_called()
+            model_mock.assert_not_called()
+
+    def test_instantiation_with_load_model(self):
+        logger_mock = MagicMock(spec=Logger)
+        with (
+            patch.object(
+                AutoFeatureExtractor, "from_pretrained"
+            ) as extractor_mock,
+            patch.object(
+                AutoModelForAudioClassification, "from_pretrained"
+            ) as model_mock,
+        ):
+            extractor_instance = MagicMock()
+            extractor_mock.return_value = extractor_instance
+
+            model_instance = MagicMock(spec=PreTrainedModel)
+            model_instance.to.return_value = model_instance
+            model_mock.return_value = model_instance
+
+            settings = EngineSettings()
+            model = AudioClassificationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+            self.assertIs(model.model, model_instance)
+            extractor_mock.assert_called_once_with(self.model_id)
+            model_mock.assert_called_once_with(
+                self.model_id,
+                device_map=Engine.get_default_device(),
+                tp_plan=None,
+                subfolder="",
+            )
+            model_instance.to.assert_called_once_with(model._device)
+
+
+class AudioClassificationModelCallTestCase(IsolatedAsyncioTestCase):
+    model_id = "dummy/model"
+
+    async def test_call(self):
+        logger_mock = MagicMock(spec=Logger)
+
+        class F(float):
+            def item(self):
+                return float(self)
+
+        with (
+            patch.object(
+                AutoFeatureExtractor, "from_pretrained"
+            ) as extractor_mock,
+            patch.object(
+                AutoModelForAudioClassification, "from_pretrained"
+            ) as model_mock,
+            patch.object(
+                AudioClassificationModel, "_resample_mono"
+            ) as resample_mock,
+            patch(
+                "avalan.model.audio.classification.inference_mode",
+                return_value=nullcontext(),
+            ) as inf_mock,
+        ):
+            extractor_instance = MagicMock()
+            extractor_call = MagicMock(return_value="inputs")
+            extractor_call.to.return_value = {"x": "X"}
+            extractor_instance.return_value = extractor_call
+            extractor_mock.return_value = extractor_instance
+
+            model_instance = MagicMock()
+            model_instance.to.return_value = model_instance
+            logits = MagicMock()
+            logits.softmax.return_value = [[F(0.2), F(0.8)]]
+            call_result = MagicMock(logits=logits)
+            model_instance.return_value = call_result
+            config_mock = MagicMock()
+            config_mock.id2label = {0: "A", 1: "B"}
+            type(model_instance).config = PropertyMock(
+                return_value=config_mock
+            )
+            model_mock.return_value = model_instance
+
+            resample_mock.return_value = "wave"
+
+            settings = EngineSettings(auto_load_model=False)
+            model = AudioClassificationModel(
+                self.model_id, settings, logger=logger_mock
+            )
+            model._model = model._load_model()
+
+            result = await model(
+                "file.wav", padding=False, sampling_rate=16000
+            )
+
+            self.assertEqual(result, {"B": 0.8, "A": 0.2})
+            resample_mock.assert_called_once_with("file.wav", 16000)
+            extractor_instance.assert_called_with(
+                "wave",
+                sampling_rate=16000,
+                return_tensors="pt",
+                padding=False,
+            )
+            extractor_call.to.assert_called_once_with(model._device)
+            model_instance.assert_called_once_with(**{"x": "X"})
+            logits.softmax.assert_called_once_with(dim=-1)
+            inf_mock.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand `ModelType` union to include more model classes
- add comprehensive audio classification model tests
- ensure CLI audio classification run requires necessary params
- cover audio label display helpers

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_687e67e3756883238757b9c0155bf3e5