### PR TITLE
Add audio classification call test

### DIFF
--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -45,6 +45,21 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
         model = DummyModel()
         cases = [
             (
+                Modality.AUDIO_CLASSIFICATION,
+                Operation(
+                    generation_settings=self.settings,
+                    input=None,
+                    modality=Modality.AUDIO_CLASSIFICATION,
+                    parameters=OperationParameters(
+                        audio=OperationAudioParameters(
+                            path="a.wav",
+                            sampling_rate=16000,
+                        )
+                    ),
+                ),
+                ((), {"path": "a.wav", "sampling_rate": 16000}),
+            ),
+            (
                 Modality.AUDIO_SPEECH_RECOGNITION,
                 Operation(
                     generation_settings=self.settings,


### PR DESCRIPTION
## Summary
- cover `ModelManager.__call__` when modality is `AUDIO_CLASSIFICATION`

## Testing
- `make lint` *(fails: reformatting many files)*
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687e713f6544832397848a101539d9d7