### PR TITLE
Add AudioClassification tests

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1361,6 +1361,7 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         theme.display_audio_labels.assert_called_once_with(
             manager.return_value
         )
+        tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args_list[-1].args[0], "table")
 
     async def test_run_text_question_answering(self):

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -22,6 +22,7 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             Modality.TEXT_TRANSLATION: "TranslationModel",
             Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
             Modality.EMBEDDING: "SentenceTransformerModel",
+            Modality.AUDIO_CLASSIFICATION: "AudioClassificationModel",
             Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
             Modality.AUDIO_TEXT_TO_SPEECH: "TextToSpeechModel",
             Modality.VISION_OBJECT_DETECTION: "ObjectDetectionModel",
@@ -79,6 +80,15 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
             settings = TransformerEngineSettings()
             with self.assertRaises(NotImplementedError):
                 manager.load_engine(uri, settings, Modality.TEXT_TRANSLATION)
+
+    def test_load_engine_audio_classification_remote(self):
+        with ModelManager(self.hub, self.logger) as manager:
+            uri = manager.parse_uri("ai://openai/ac")
+            settings = TransformerEngineSettings()
+            with self.assertRaises(NotImplementedError):
+                manager.load_engine(
+                    uri, settings, Modality.AUDIO_CLASSIFICATION
+                )
 
 
 class ModelManagerLoadModalitiesTestCase(TestCase):


### PR DESCRIPTION
## Summary
- ensure `ModelManager.load_engine` can load audio classification engines
- verify remote loading raises `NotImplementedError`
- fix lint in CLI audio classification test

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_687e7545ed188323b9db374ee9b896a0