### PR TITLE
Add tests for _resample_mono

### DIFF
--- a/tests/model/audio/base_audio_model_test.py
+++ b/tests/model/audio/base_audio_model_test.py
@@ -78,3 +78,66 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
         resample_patch.assert_not_called()
         audio_wave.mean.assert_called_once_with(0)
         mean.numpy.assert_called_once_with()
+
+    def test_resample_mono_stereo_resample(self):
+        model = DummyAudioModel(
+            None,
+            EngineSettings(auto_load_model=False),
+            logger=MagicMock(spec=Logger),
+        )
+
+        audio_wave = MagicMock()
+        audio_wave.shape = (2, 10)
+        audio_wave.squeeze = MagicMock()
+
+        mean = MagicMock()
+        audio_wave.mean.return_value = mean
+        unsqueezed = MagicMock()
+        mean.unsqueeze.return_value = unsqueezed
+
+        resampled = MagicMock()
+        resampled.squeeze.return_value = "wave"
+
+        with (
+            patch(
+                "avalan.model.audio.load", return_value=(audio_wave, 8000)
+            ) as load_patch,
+            patch(
+                "avalan.model.audio.resample", return_value=resampled
+            ) as resample_patch,
+        ):
+            result = model._resample_mono("a.wav", 16000)
+
+        self.assertEqual(result, "wave")
+        load_patch.assert_called_once_with("a.wav")
+        audio_wave.mean.assert_called_once_with(dim=0)
+        audio_wave.squeeze.assert_not_called()
+        mean.unsqueeze.assert_called_once_with(0)
+        resample_patch.assert_called_once_with(unsqueezed, 8000, 16000)
+        resampled.squeeze.assert_called_once_with(0)
+
+    def test_resample_mono_mono_no_change(self):
+        model = DummyAudioModel(
+            None,
+            EngineSettings(auto_load_model=False),
+            logger=MagicMock(spec=Logger),
+        )
+
+        audio_wave = MagicMock()
+        audio_wave.shape = (1, 10)
+        audio_wave.mean = MagicMock()
+        audio_wave.squeeze.return_value = "wave"
+
+        with (
+            patch(
+                "avalan.model.audio.load", return_value=(audio_wave, 16000)
+            ) as load_patch,
+            patch("avalan.model.audio.resample") as resample_patch,
+        ):
+            result = model._resample_mono("a.wav", 16000)
+
+        self.assertEqual(result, "wave")
+        load_patch.assert_called_once_with("a.wav")
+        audio_wave.squeeze.assert_called_once_with(0)
+        audio_wave.mean.assert_not_called()
+        resample_patch.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure BaseAudioModel `_resample_mono` converts stereo to mono and resamples
- ensure `_resample_mono` skips resampling on mono audio

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687e7a3a527c832388436e46fa24cc55