### PR TITLE
Add audio generation call test

### DIFF
--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -102,6 +102,21 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
                 ),
             ),
             (
+                Modality.AUDIO_GENERATION,
+                Operation(
+                    generation_settings=self.settings,
+                    input="song",
+                    modality=Modality.AUDIO_GENERATION,
+                    parameters=OperationParameters(
+                        audio=OperationAudioParameters(
+                            path="out.wav",
+                            sampling_rate=16000,
+                        )
+                    ),
+                ),
+                (("song", "out.wav", 1), {}),
+            ),
+            (
                 Modality.TEXT_GENERATION,
                 Operation(
                     generation_settings=self.settings,


### PR DESCRIPTION
## Summary
- cover ModelManager.__call__ when using audio generation modality

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687e8e0d09008323a56076a1636a4ea1