### PR TITLE
Fix tests for vision encoder decoder and CLI input

### DIFF
--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -5,6 +5,7 @@ from rich.prompt import Confirm, Prompt
 from rich.syntax import Syntax
 from json import dumps
 from ..entities import ToolCall
+from io import UnsupportedOperation
 from select import select
 from sys import stdin
 
@@ -37,8 +38,11 @@ def confirm_tool_call(console: Console, call: ToolCall) -> str:
 
 
 def has_input(console: Console) -> bool:
-    stdin_ready, __, __ = select([stdin], [], [], 0.0)
-    return bool(stdin_ready)
+    try:
+        stdin_ready, __, __ = select([stdin], [], [], 0.0)
+        return bool(stdin_ready)
+    except UnsupportedOperation:
+        return False
 
 
 def get_input(

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -2551,7 +2551,11 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             engine_uri=engine_uri,
             modality=Modality.VISION_ENCODER_DECODER,
         )
-        lm.assert_awaited_once_with("img.png", skip_special_tokens=False)
+        lm.assert_awaited_once_with(
+            "img.png",
+            prompt=None,
+            skip_special_tokens=False,
+        )
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "caption")
 

--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -262,7 +262,7 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
                         )
                     ),
                 ),
-                (("img.png",), {"skip_special_tokens": True}),
+                (("img.png",), {"prompt": None, "skip_special_tokens": True}),
             ),
             (
                 Modality.VISION_IMAGE_TEXT_TO_TEXT,

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -119,6 +119,7 @@ class ImageToTextModelCallTestCase(IsolatedAsyncioTestCase):
 
             image_instance = MagicMock()
             image_open_mock.return_value = image_instance
+            image_instance.convert.return_value = image_instance
 
             model = ImageToTextModel(
                 self.model_id,
@@ -133,6 +134,7 @@ class ImageToTextModelCallTestCase(IsolatedAsyncioTestCase):
             processor_instance.assert_called_with(
                 images=image_instance, return_tensors="pt"
             )
+            image_instance.convert.assert_called_once_with("RGB")
             model_instance.generate.assert_called_once_with(
                 **processor_instance.return_value
             )

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -119,6 +119,7 @@ class VisionEncoderDecoderModelCallTestCase(IsolatedAsyncioTestCase):
 
             image_instance = MagicMock()
             image_open_mock.return_value = image_instance
+            image_instance.convert.return_value = image_instance
 
             model = VisionEncoderDecoderModel(
                 self.model_id,
@@ -126,13 +127,14 @@ class VisionEncoderDecoderModelCallTestCase(IsolatedAsyncioTestCase):
                 logger=logger_mock,
             )
 
-            caption = await model("img.jpg")
+            caption = await model("img.jpg", None)
 
             self.assertEqual(caption, "caption")
             image_open_mock.assert_called_once_with("img.jpg")
             processor_instance.assert_called_with(
                 images=image_instance, return_tensors="pt"
             )
+            image_instance.convert.assert_called_once_with("RGB")
             model_instance.generate.assert_called_once_with(
                 **processor_instance.return_value
             )


### PR DESCRIPTION
## Summary
- prevent unsupported stdin from raising errors
- update tests for vision image handling
- adapt tests for new vision encoder decoder prompt

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687ebdbbc2b88323afbe6756169aedc3