### PR TITLE
Move reasoning parser & queue parsing

### DIFF
--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Iterable
 
-from .....entities import ReasoningToken
+from ....entities import ReasoningToken
 
 
 class ReasoningParser:

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -16,7 +16,7 @@ from avalan.event import Event, EventType
 from avalan.event.manager import EventManager
 from avalan.agent.engine import EngineAgent
 from avalan.model import TextGenerationResponse
-from avalan.agent.orchestrator.response.parsers.reasoning import (
+from avalan.model.response.parsers.reasoning import (
     ReasoningParser,
 )
 from avalan.agent.orchestrator.response.parsers.tool import ToolCallParser

--- a/tests/agent/reasoning_parser_test.py
+++ b/tests/agent/reasoning_parser_test.py
@@ -1,4 +1,4 @@
-from avalan.agent.orchestrator.response.parsers.reasoning import (
+from avalan.model.response.parsers.reasoning import (
     ReasoningParser,
 )
 from avalan.entities import ReasoningToken


### PR DESCRIPTION
## Summary
- relocate `ReasoningParser` under `model.response.parsers`
- add reasoning parser queue to `TextGenerationResponse`
- support optional reasoning parsing in text response
- update imports in tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687fdacbda9c8323a332c4da89108591