### PR TITLE
Move response parsers

### DIFF
--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -16,8 +16,8 @@ from ....event.manager import EventManager
 from ....model.response.text import TextGenerationResponse
 from ....tool.manager import ToolManager
 from ....cli import CommandAbortException
-from .parsers import StreamParser
-from .parsers.tool import ToolCallParser
+from avalan.model.response.parsers import StreamParser
+from avalan.model.response.parsers.tool import ToolCallParser
 from queue import Queue
 from inspect import iscoroutine
 from time import perf_counter

--- a/src/avalan/agent/orchestrator/response/parsers/__init__.py
+++ b/src/avalan/agent/orchestrator/response/parsers/__init__.py
@@ -1,7 +1,0 @@
-from typing import Any, Iterable, Protocol
-
-
-class StreamParser(Protocol):
-    async def push(self, token_str: str) -> Iterable[Any]: ...
-
-    async def flush(self) -> Iterable[Any]: ...

--- a/src/avalan/model/response/parsers/__init__.py
+++ b/src/avalan/model/response/parsers/__init__.py
@@ -1,0 +1,7 @@
+from typing import Any, Iterable, Protocol
+
+
+class StreamParser(Protocol):
+    async def push(self, token_str: str) -> Iterable[Any]: ...
+
+    async def flush(self) -> Iterable[Any]: ...

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -4,10 +4,10 @@ from io import StringIO
 from time import perf_counter
 from typing import Any, Iterable
 
-from .....entities import ToolCallToken
-from .....event import Event, EventType
-from .....event.manager import EventManager
-from .....tool.manager import ToolManager
+from ....entities import ToolCallToken
+from ....event import Event, EventType
+from ....event.manager import EventManager
+from ....tool.manager import ToolManager
 
 
 class ToolCallParser:

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -19,7 +19,7 @@ from avalan.model import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import (
     ReasoningParser,
 )
-from avalan.agent.orchestrator.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallParser
 
 from unittest import IsolatedAsyncioTestCase
 from dataclasses import dataclass

--- a/tests/agent/tool_call_parser_test.py
+++ b/tests/agent/tool_call_parser_test.py
@@ -1,4 +1,4 @@
-from avalan.agent.orchestrator.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallParser
 from avalan.entities import ToolCallToken
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- move StreamParser and ToolCallParser into model.response.parsers
- fix imports and update tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_687fdf9a956c83238ce74ceb3d972ef1