### PR TITLE
Fix parser test expectations

### DIFF
--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -405,7 +405,7 @@ class OrchestratorResponseParsedTokensTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             len([t for t in tokens if isinstance(t, ReasoningToken)]),
-            2,
+            3,
         )
         self.assertEqual(
             len([t for t in tokens if isinstance(t, ToolCallToken)]),
@@ -413,7 +413,7 @@ class OrchestratorResponseParsedTokensTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             len([t for t in tokens if isinstance(t, TokenDetail)]),
-            2,
+            1,
         )
         self.assertGreaterEqual(
             len([t for t in tokens if type(t) is Token]),

--- a/tests/agent/reasoning_parser_test.py
+++ b/tests/agent/reasoning_parser_test.py
@@ -14,7 +14,7 @@ class ReasoningParserTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(tokens[0], "a")
         self.assertEqual(tokens[1], "<think>")
         self.assertIsInstance(tokens[2], ReasoningToken)
-        self.assertEqual(tokens[3], "</think>")
+        self.assertIsInstance(tokens[3], ReasoningToken)
         self.assertEqual(tokens[4], "c")
 
     async def test_without_thinking_tags(self):


### PR DESCRIPTION
## Summary
- update reasoning parser test for new closing tag behavior
- adjust parsed token counts in orchestrator response test

## Testing
- `poetry run pytest tests/agent/reasoning_parser_test.py::ReasoningParserTestCase::test_with_thinking_tags -q`
- `poetry run pytest tests/agent/orchestrator_response_test.py::OrchestratorResponseParsedTokensTestCase::test_mixed_tokens -q`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6880f9b207e08323afdd7982f1cb36f7