### PR TITLE
Add coverage for ReasoningParser and text response

### DIFF
--- a/tests/agent/reasoning_parser_extra_test.py
+++ b/tests/agent/reasoning_parser_extra_test.py
@@ -9,3 +9,11 @@ class ReasoningParserExtraTestCase(IsolatedAsyncioTestCase):
         await parser.push("a")
         await parser.push("</think>")
         self.assertEqual(await parser.flush(), [])
+
+    async def test_set_thinking_affects_state(self):
+        parser = ReasoningParser()
+        self.assertFalse(parser.is_thinking)
+        parser.set_thinking(True)
+        self.assertTrue(parser.is_thinking)
+        parser.set_thinking(False)
+        self.assertFalse(parser.is_thinking)

--- a/tests/model/text_generation_response_full_test.py
+++ b/tests/model/text_generation_response_full_test.py
@@ -15,3 +15,28 @@ class TextGenerationResponseFullCoverageTestCase(IsolatedAsyncioTestCase):
         second = await resp.__anext__()
         self.assertEqual(first, "x")
         self.assertEqual(second, "a")
+
+    async def test_set_thinking_and_properties(self):
+        resp = TextGenerationResponse(lambda: _gen(), use_async_generator=True)
+        self.assertTrue(resp.can_think)
+        self.assertFalse(resp.is_thinking)
+        resp.set_thinking(True)
+        self.assertTrue(resp.is_thinking)
+        resp.set_thinking(False)
+        self.assertFalse(resp.is_thinking)
+
+    async def test_disabled_reasoning_parser_returns_raw_token(self):
+        async def gen():
+            yield "b"
+
+        resp = TextGenerationResponse(
+            lambda: gen(),
+            use_async_generator=True,
+            enable_reasoning_parser=False,
+        )
+        it = resp.__aiter__()
+        token = await it.__anext__()
+        self.assertEqual(token, "b")
+        self.assertFalse(resp.can_think)
+        resp.set_thinking(True)  # Should have no effect
+        self.assertFalse(resp.is_thinking)


### PR DESCRIPTION
## Summary
- test that `ReasoningParser` can toggle thinking state
- test `TextGenerationResponse` reasoning flags and disabling parser

## Testing
- `poetry run pytest --verbose -s`
- `make test-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6880ffe84c74832383bcb927ef99d67c