### PR TITLE
Improve coverage for response classes

### DIFF
--- a/tests/agent/orchestrator_response_step_test.py
+++ b/tests/agent/orchestrator_response_step_test.py
@@ -1,0 +1,72 @@
+from avalan.agent.engine import EngineAgent
+from avalan.agent.orchestrator.response.orchestrator_response import (
+    OrchestratorResponse,
+)
+from avalan.agent import Operation, Specification, EngineEnvironment
+from avalan.entities import (
+    EngineUri,
+    Message,
+    MessageRole,
+    Token,
+    TransformerEngineSettings,
+)
+from avalan.model import TextGenerationResponse
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self.model_id = "m"
+        self.tokenizer = MagicMock()
+
+
+def _dummy_operation() -> Operation:
+    env = EngineEnvironment(
+        engine_uri=EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        ),
+        settings=TransformerEngineSettings(),
+    )
+    spec = Specification(role="assistant", goal=None)
+    return Operation(specification=spec, environment=env)
+
+
+def _dummy_response() -> TextGenerationResponse:
+    async def output_gen():
+        yield "a"
+        yield Token(id=1, token="b")
+
+    return TextGenerationResponse(
+        lambda: output_gen(), use_async_generator=True
+    )
+
+
+class OrchestratorResponseStepTestCase(IsolatedAsyncioTestCase):
+    async def test_step_counter(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _dummy_response(),
+            agent,
+            operation,
+            {},
+        )
+        resp.__aiter__()
+        await resp.__anext__()
+        self.assertEqual(resp._step, 1)
+        await resp.__anext__()
+        self.assertEqual(resp._step, 2)
+        with self.assertRaises(StopAsyncIteration):
+            await resp.__anext__()
+        resp.__aiter__()
+        self.assertEqual(resp._step, 0)

--- a/tests/model/text_generation_response_additional_test.py
+++ b/tests/model/text_generation_response_additional_test.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from unittest import IsolatedAsyncioTestCase
+from avalan.model.response.text import TextGenerationResponse
+
+
+@dataclass
+class Example:
+    value: str
+
+
+class TextGenerationResponseAdditionalTestCase(IsolatedAsyncioTestCase):
+    async def test_to_entity(self):
+        resp = TextGenerationResponse(
+            lambda: '{"value": "ok"}',
+            use_async_generator=False,
+        )
+        result = await resp.to(Example)
+        self.assertEqual(result, Example(value="ok"))
+
+    async def test_disable_reasoning_parser(self):
+        async def gen():
+            for t in ("<think>", "a", "</think>"):
+                yield t
+
+        resp = TextGenerationResponse(
+            lambda: gen(),
+            use_async_generator=True,
+            enable_reasoning_parser=False,
+        )
+
+        tokens = []
+        async for t in resp:
+            tokens.append(t)
+
+        self.assertEqual(tokens, ["<think>", "a", "</think>"])


### PR DESCRIPTION
## Summary
- add tests for TextGenerationResponse conversion and reasoning parser toggle
- add test for OrchestratorResponse step counter

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688114fb3b6c8323bb0732e92264d188