### PR TITLE
Increase coverage for orchestrator

### DIFF
--- a/tests/agent/orchestrator_response_more_test.py
+++ b/tests/agent/orchestrator_response_more_test.py
@@ -1,0 +1,108 @@
+from avalan.agent.orchestrator.response.orchestrator_response import (
+    OrchestratorResponse,
+)
+from avalan.agent import EngineEnvironment, Operation, Specification
+from avalan.entities import (
+    EngineUri,
+    Message,
+    MessageRole,
+    Token,
+)
+from avalan.event import Event, EventType
+from avalan.tool.manager import ToolManager
+from avalan.model.response.text import TextGenerationResponse
+from avalan.agent.engine import EngineAgent
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self.model_id = "m"
+        self.tokenizer = MagicMock()
+
+
+def _dummy_operation() -> Operation:
+    env = EngineEnvironment(
+        engine_uri=EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        ),
+        settings=None,
+    )
+    spec = Specification(role="assistant", goal=None)
+    return Operation(specification=spec, environment=env)
+
+
+def _empty_response() -> TextGenerationResponse:
+    async def gen():
+        if False:
+            yield ""  # pragma: no cover - never executed
+
+    return TextGenerationResponse(lambda: gen(), use_async_generator=True)
+
+
+class OrchestratorResponseMoreCoverageTestCase(IsolatedAsyncioTestCase):
+    async def test_parser_queue_precedence(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+        )
+        resp.__aiter__()
+        resp._parser_queue.put("queued")
+        self.assertEqual(await resp.__anext__(), "queued")
+
+    async def test_flush_after_stop(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = False
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+        resp._tool_parser = MagicMock()
+        flushed = [Event(type=EventType.END), Token(id=1, token="x")]
+        resp._tool_parser.flush = AsyncMock(return_value=flushed)
+        resp.__aiter__()
+        self.assertEqual(await resp.__anext__(), flushed[1])
+        self.assertEqual(resp._tool_process_events.get_nowait(), flushed[0])
+
+    async def test_emit_parsed_event(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = False
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+        resp.__aiter__()
+        event = Event(type=EventType.END)
+        resp._tool_parser = MagicMock()
+        resp._tool_parser.push = AsyncMock(return_value=[event])
+        self.assertIs(await resp._emit("text"), event)

--- a/tests/cli/token_stream_start_thinking_test.py
+++ b/tests/cli/token_stream_start_thinking_test.py
@@ -1,0 +1,81 @@
+import asyncio
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import avalan.cli.commands.model as model_cmds
+
+
+class _Resp:
+    input_token_count = 1
+    can_think = True
+    is_thinking = False
+
+    def __init__(self) -> None:
+        self.thinking = None
+
+    def set_thinking(self, value: bool) -> None:
+        self.thinking = value
+
+    def __aiter__(self):
+        async def gen():
+            yield model_cmds.Token(id=1, token="A")
+
+        return gen()
+
+
+class TokenStreamStartThinkingTestCase(IsolatedAsyncioTestCase):
+    async def test_start_thinking(self):
+        args = Namespace(
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=True,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+        )
+        console = MagicMock()
+        console.width = 80
+        live = MagicMock()
+        logger = MagicMock()
+        stop_signal = asyncio.Event()
+        group = SimpleNamespace(renderables=[None])
+
+        async def fake_frames(*_, **__):
+            yield (None, "frame")
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_frames)
+
+        lm = SimpleNamespace(
+            model_id="m", tokenizer_config=None, input_token_count=lambda s: 1
+        )
+
+        resp = _Resp()
+
+        with patch("avalan.cli.commands.model.sleep", new=AsyncMock()):
+            await model_cmds._token_stream(
+                live=live,
+                group=group,
+                tokens_group_index=0,
+                args=args,
+                console=console,
+                theme=theme,
+                logger=logger,
+                orchestrator=None,
+                event_stats=None,
+                lm=lm,
+                input_string="hi",
+                response=resp,
+                display_tokens=1,
+                dtokens_pick=1,
+                refresh_per_second=1,
+                stop_signal=stop_signal,
+                tool_events_limit=None,
+                with_stats=True,
+            )
+
+        self.assertTrue(stop_signal.is_set())
+        self.assertTrue(resp.thinking)


### PR DESCRIPTION
## Summary
- add new unit tests for OrchestratorResponse
- test `_token_stream` start thinking behavior

## Testing
- `poetry run pytest --verbose -s`
- `poetry run pytest --cov=src --cov-report=json`

------
https://chatgpt.com/codex/tasks/task_e_68812824ee748323a16bd224ab308462