### PR TITLE
Rename EngineOperation to AgentOperation

### DIFF
--- a/src/avalan/agent/__init__.py
+++ b/src/avalan/agent/__init__.py
@@ -52,7 +52,7 @@ class EngineEnvironment:
 
 
 @dataclass(frozen=True, kw_only=True)
-class EngineOperation:
+class AgentOperation:
     specification: Specification
     environment: EngineEnvironment
     modality: Modality = Modality.TEXT_GENERATION

--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -2,7 +2,7 @@ from .. import (
     EngineEnvironment,
     InputType,
     NoOperationAvailableException,
-    EngineOperation,
+    AgentOperation,
 )
 from ..engine import EngineAgent
 from ...entities import (
@@ -32,7 +32,7 @@ from uuid import UUID, uuid4
 class Orchestrator:
     _id: UUID
     _name: str | None
-    _operations: list[EngineOperation]
+    _operations: list[AgentOperation]
     _renderer: Renderer
     _total_operations: int
     _logger: Logger
@@ -55,7 +55,7 @@ class Orchestrator:
         memory: MemoryManager,
         tool: ToolManager,
         event_manager: EventManager,
-        operations: EngineOperation | list[EngineOperation],
+        operations: AgentOperation | list[AgentOperation],
         *,
         call_options: dict | None = None,
         exit_memory: bool = True,
@@ -70,7 +70,7 @@ class Orchestrator:
         self._event_manager = event_manager
         self._operations = (
             [operations]
-            if isinstance(operations, EngineOperation)
+            if isinstance(operations, AgentOperation)
             else operations
         )
         self._id = id or uuid4()
@@ -122,7 +122,7 @@ class Orchestrator:
         return self._name
 
     @property
-    def operations(self) -> list[EngineOperation]:
+    def operations(self) -> list[AgentOperation]:
         return self._operations
 
     @property

--- a/src/avalan/agent/orchestrator/orchestrators/default.py
+++ b/src/avalan/agent/orchestrator/orchestrators/default.py
@@ -1,4 +1,4 @@
-from ....agent import EngineEnvironment, EngineOperation, Goal, Specification
+from ....agent import EngineEnvironment, AgentOperation, Goal, Specification
 from ....agent.orchestrator import Orchestrator
 from ....entities import EngineUri, Modality, TransformerEngineSettings
 from ....event.manager import EventManager
@@ -47,7 +47,7 @@ class DefaultOrchestrator(Orchestrator):
             memory,
             tool,
             event_manager,
-            EngineOperation(
+            AgentOperation(
                 specification=specification,
                 environment=EngineEnvironment(
                     engine_uri=engine_uri, settings=settings

--- a/src/avalan/agent/orchestrator/orchestrators/json.py
+++ b/src/avalan/agent/orchestrator/orchestrators/json.py
@@ -2,7 +2,7 @@ from ....agent import (
     EngineEnvironment,
     EngineUri,
     Goal,
-    EngineOperation,
+    AgentOperation,
     OutputType,
     Role,
     Specification,
@@ -113,7 +113,7 @@ class JsonOrchestrator(Orchestrator):
             memory,
             tool,
             event_manager,
-            EngineOperation(
+            AgentOperation(
                 specification=specification,
                 environment=EngineEnvironment(
                     engine_uri=engine_uri, settings=settings

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -1,4 +1,4 @@
-from ... import EngineOperation
+from ... import AgentOperation
 from ...engine import EngineAgent
 from ....entities import (
     Input,
@@ -29,7 +29,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     _response: TextGenerationResponse
     _response_iterator: AsyncIterator[Token | TokenDetail | Event] | None
     _engine_agent: EngineAgent
-    _operation: EngineOperation
+    _operation: AgentOperation
     _engine_args: dict
     _event_manager: EventManager | None
     _tool_manager: ToolManager | None
@@ -51,7 +51,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         input: Input,
         response: TextGenerationResponse,
         engine_agent: EngineAgent,
-        operation: EngineOperation,
+        operation: AgentOperation,
         engine_args: dict,
         event_manager: EventManager | None = None,
         tool: ToolManager | None = None,

--- a/tests/agent/additional_coverage_test.py
+++ b/tests/agent/additional_coverage_test.py
@@ -9,7 +9,7 @@ from avalan.agent.orchestrator.orchestrators.json import (
 )
 from avalan.agent import (
     EngineEnvironment,
-    EngineOperation,
+    AgentOperation,
     Specification,
     Role,
     OutputType,
@@ -103,7 +103,7 @@ class OrchestratorCoverageTestCase(unittest.IsolatedAsyncioTestCase):
             engine_uri=engine_uri,
             settings=TransformerEngineSettings(),
         )
-        self.operation = EngineOperation(
+        self.operation = AgentOperation(
             specification=Specification(role=None, goal=None),
             environment=self.environment,
         )

--- a/tests/agent/orchestrator_renderer_property_test.py
+++ b/tests/agent/orchestrator_renderer_property_test.py
@@ -1,7 +1,7 @@
 from avalan.agent import (
     EngineEnvironment,
     EngineUri,
-    EngineOperation,
+    AgentOperation,
     Specification,
 )
 from avalan.agent.orchestrator import Orchestrator
@@ -48,7 +48,7 @@ class RendererPropertyTestCase(TestCase):
         self.settings = TransformerEngineSettings()
 
     def test_renderer_on_orchestrator(self):
-        op = EngineOperation(
+        op = AgentOperation(
             specification=Specification(role=None, goal=None),
             environment=EngineEnvironment(
                 engine_uri=self.engine_uri, settings=self.settings

--- a/tests/agent/orchestrator_response_additional_test.py
+++ b/tests/agent/orchestrator_response_additional_test.py
@@ -2,7 +2,7 @@ from avalan.agent.engine import EngineAgent
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, EngineOperation, Specification
+from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
     Message,
@@ -28,7 +28,7 @@ class _DummyEngine:
         self.tokenizer = MagicMock()
 
 
-def _dummy_operation() -> EngineOperation:
+def _dummy_operation() -> AgentOperation:
     env = EngineEnvironment(
         engine_uri=EngineUri(
             host=None,
@@ -42,7 +42,7 @@ def _dummy_operation() -> EngineOperation:
         settings=TransformerEngineSettings(),
     )
     spec = Specification(role="assistant", goal=None)
-    return EngineOperation(specification=spec, environment=env)
+    return AgentOperation(specification=spec, environment=env)
 
 
 def _dummy_response(async_gen: bool = True) -> TextGenerationResponse:

--- a/tests/agent/orchestrator_response_more_test.py
+++ b/tests/agent/orchestrator_response_more_test.py
@@ -1,7 +1,7 @@
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, EngineOperation, Specification
+from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
     Message,
@@ -22,7 +22,7 @@ class _DummyEngine:
         self.tokenizer = MagicMock()
 
 
-def _dummy_operation() -> EngineOperation:
+def _dummy_operation() -> AgentOperation:
     env = EngineEnvironment(
         engine_uri=EngineUri(
             host=None,
@@ -36,7 +36,7 @@ def _dummy_operation() -> EngineOperation:
         settings=None,
     )
     spec = Specification(role="assistant", goal=None)
-    return EngineOperation(specification=spec, environment=env)
+    return AgentOperation(specification=spec, environment=env)
 
 
 def _empty_response() -> TextGenerationResponse:

--- a/tests/agent/orchestrator_response_step_test.py
+++ b/tests/agent/orchestrator_response_step_test.py
@@ -2,7 +2,7 @@ from avalan.agent.engine import EngineAgent
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, EngineOperation, Specification
+from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
     Message,
@@ -21,7 +21,7 @@ class _DummyEngine:
         self.tokenizer = MagicMock()
 
 
-def _dummy_operation() -> EngineOperation:
+def _dummy_operation() -> AgentOperation:
     env = EngineEnvironment(
         engine_uri=EngineUri(
             host=None,
@@ -35,7 +35,7 @@ def _dummy_operation() -> EngineOperation:
         settings=TransformerEngineSettings(),
     )
     spec = Specification(role="assistant", goal=None)
-    return EngineOperation(specification=spec, environment=env)
+    return AgentOperation(specification=spec, environment=env)
 
 
 def _dummy_response() -> TextGenerationResponse:

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -1,7 +1,7 @@
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, EngineOperation, Specification
+from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
     Message,
@@ -34,7 +34,7 @@ class _DummyEngine:
         self.tokenizer = MagicMock()
 
 
-def _dummy_operation() -> EngineOperation:
+def _dummy_operation() -> AgentOperation:
     env = EngineEnvironment(
         engine_uri=EngineUri(
             host=None,
@@ -48,7 +48,7 @@ def _dummy_operation() -> EngineOperation:
         settings=TransformerEngineSettings(),
     )
     spec = Specification(role="assistant", goal=None)
-    return EngineOperation(specification=spec, environment=env)
+    return AgentOperation(specification=spec, environment=env)
 
 
 def _dummy_response(async_gen=True):

--- a/tests/agent/orchestrator_test.py
+++ b/tests/agent/orchestrator_test.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from avalan.agent.orchestrator import Orchestrator
 from avalan.agent import (
-    EngineOperation,
+    AgentOperation,
     Specification,
     EngineEnvironment,
     InputType,
@@ -42,7 +42,7 @@ class OrchestratorCallTestCase(unittest.IsolatedAsyncioTestCase):
         self.spec = Specification(
             role=None, goal=None, input_type=InputType.TEXT
         )
-        self.operation = EngineOperation(
+        self.operation = AgentOperation(
             specification=self.spec, environment=self.environment
         )
         self.logger = MagicMock()
@@ -153,7 +153,7 @@ class OrchestratorAenterTestCase(unittest.IsolatedAsyncioTestCase):
             ),
             settings=TransformerEngineSettings(),
         )
-        op = EngineOperation(
+        op = AgentOperation(
             specification=Specification(role=None, goal=None), environment=env
         )
         model_manager = MagicMock(spec=ModelManager)

--- a/tests/cli/agent_run_math_tool_test.py
+++ b/tests/cli/agent_run_math_tool_test.py
@@ -6,7 +6,7 @@ from avalan.cli.commands import agent as agent_cmds
 from avalan.agent import (
     Specification,
     EngineEnvironment,
-    EngineOperation as AgentOperation,
+    AgentOperation,
 )
 from avalan.agent.engine import EngineAgent
 from avalan.entities import (


### PR DESCRIPTION
## Summary
- rename the `EngineOperation` dataclass to `AgentOperation`
- update orchestrator imports and logic
- fix tests to use new `AgentOperation` name

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68820f512efc832393e8728e5517a28a