### PR TITLE
Add default attention CLI tests

### DIFF
--- a/tests/cli/default_attention_test.py
+++ b/tests/cli/default_attention_test.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch
+
+from avalan.cli.__main__ import CLI
+
+
+class DefaultAttentionTestCase(unittest.TestCase):
+    def test_cuda_flash(self):
+        with (
+            patch("avalan.cli.__main__.is_available", return_value=True),
+            patch(
+                "avalan.cli.__main__.is_flash_attn_2_available",
+                return_value=True,
+            ),
+            patch(
+                "avalan.cli.__main__.is_torch_flex_attn_available",
+                return_value=False,
+            ),
+        ):
+            self.assertEqual(
+                CLI._default_attention("cuda"), "flash_attention_2"
+            )
+
+    def test_cuda_flex(self):
+        with (
+            patch("avalan.cli.__main__.is_available", return_value=True),
+            patch(
+                "avalan.cli.__main__.is_flash_attn_2_available",
+                return_value=False,
+            ),
+            patch(
+                "avalan.cli.__main__.is_torch_flex_attn_available",
+                return_value=True,
+            ),
+        ):
+            self.assertEqual(CLI._default_attention("cuda"), "flex_attention")
+
+    def test_mps_sdpa(self):
+        with patch("torch.backends.mps.is_available", return_value=True):
+            self.assertEqual(CLI._default_attention("mps"), "sdpa")
+
+    def test_none_cuda_unavailable(self):
+        with patch("avalan.cli.__main__.is_available", return_value=False):
+            self.assertIsNone(CLI._default_attention("cuda"))
+
+    def test_none_cpu(self):
+        self.assertIsNone(CLI._default_attention("cpu"))
+
+    def test_exception_ignored(self):
+        with patch(
+            "avalan.cli.__main__.is_available", side_effect=RuntimeError
+        ):
+            self.assertIsNone(CLI._default_attention("cuda"))


### PR DESCRIPTION
## Summary
- add tests for CLI `_default_attention` ensuring default attention is set correctly depending on device

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6882623553788323ba4c14c251049258