### PR TITLE
Add reasoning settings

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1329,6 +1329,17 @@ class CLI:
             help="If specified, assume model response starts with reasoning",
         )
         model_run_parser.add_argument(
+            "--no-reasoning",
+            action="store_true",
+            default=False,
+            help="Disable reasoning parser",
+        )
+        model_run_parser.add_argument(
+            "--reasoning-max-new-tokens",
+            type=int,
+            help="Maximum number of reasoning tokens",
+        )
+        model_run_parser.add_argument(
             "--stop_on_keyword",
             type=str,
             action="append",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -224,6 +224,12 @@ class EngineUri:
 
 
 @dataclass(frozen=True, kw_only=True)
+class ReasoningSettings:
+    max_new_tokens: int | None = None
+    enabled: bool = True
+
+
+@dataclass(frozen=True, kw_only=True)
 class GenerationSettings:
     # Generation length ------------------------------------------------------
     # The minimum numbers of tokens to generate, ignoring the number of tokens
@@ -353,6 +359,7 @@ class GenerationSettings:
             "return_dict": True,
         }
     )
+    reasoning: ReasoningSettings = field(default_factory=ReasoningSettings)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -2,6 +2,7 @@ from ..entities import (
     AttentionImplementation,
     EngineUri,
     GenerationSettings,
+    ReasoningSettings,
     Input,
     Modality,
     Operation,
@@ -488,6 +489,10 @@ class ModelManager(ContextDecorator):
             top_k=args.top_k,
             top_p=args.top_p,
             use_cache=args.use_cache,
+            reasoning=ReasoningSettings(
+                max_new_tokens=getattr(args, "reasoning_max_new_tokens", None),
+                enabled=not getattr(args, "no_reasoning", False),
+            ),
         )
         system_prompt = args.system or None
 

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -170,6 +170,7 @@ class TextGenerationModel(BaseNLPModel):
         return TextGenerationResponse(
             output_fn,
             inputs=inputs,
+            generation_settings=generation_settings,
             pick=pick,
             settings=generation_settings,
             stopping_criterias=stopping_criterias,

--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -123,6 +123,7 @@ class MlxLmModel(TextGenerationModel):
         return TextGenerationResponse(
             output_fn,
             inputs=inputs,
+            generation_settings=generation_settings,
             settings=generation_settings,
             skip_special_tokens=skip_special_tokens,
             use_async_generator=settings.use_async_generator,

--- a/src/avalan/model/nlp/text/vendor/__init__.py
+++ b/src/avalan/model/nlp/text/vendor/__init__.py
@@ -94,8 +94,10 @@ class TextGenerationVendorModel(TextGenerationModel, ABC):
             tool=tool,
             use_async_generator=settings.use_async_generator,
         )
+        gen_settings = settings or GenerationSettings()
         return TextGenerationResponse(
             streamer,
-            settings=settings or GenerationSettings(),
-            use_async_generator=settings.use_async_generator,
+            generation_settings=gen_settings,
+            settings=gen_settings,
+            use_async_generator=gen_settings.use_async_generator,
         )

--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -1,4 +1,4 @@
-from ....entities import ReasoningToken
+from ....entities import ReasoningSettings, ReasoningToken
 from typing import Any, Iterable
 
 
@@ -6,14 +6,17 @@ class ReasoningParser:
     def __init__(
         self,
         *,
+        reasoning_settings: ReasoningSettings,
         start_tag: str = "<think>",
         end_tag: str = "</think>",
         prefixes: list[str] | None = None,
     ) -> None:
+        self._settings = reasoning_settings
         self._start_tag = start_tag
         self._end_tag = end_tag
         self._prefixes = prefixes or ["Think:"]
         self._thinking = False
+        self._token_count = 0
 
     def set_thinking(self, thinking: bool) -> None:
         self._thinking = thinking
@@ -26,15 +29,24 @@ class ReasoningParser:
         token_clean = token_str.strip()
         if token_clean == self._start_tag:
             self._thinking = True
+            self._token_count += 1
             return [ReasoningToken(token_str)]
         if token_clean == self._end_tag:
             self._thinking = False
+            self._token_count += 1
             return [ReasoningToken(token_str)]
         if any(token_clean.startswith(p) for p in self._prefixes):
             self._thinking = True
+            self._token_count += 1
             return [ReasoningToken(token_str)]
         if self._thinking:
-            return [ReasoningToken(token_str)]
+            if (
+                self._settings.max_new_tokens is None
+                or self._token_count < self._settings.max_new_tokens
+            ):
+                self._token_count += 1
+                return [ReasoningToken(token_str)]
+            return [token_str]
         return [token_str]
 
     async def flush(self) -> Iterable[Any]:

--- a/tests/agent/orchestrator_response_step_test.py
+++ b/tests/agent/orchestrator_response_step_test.py
@@ -9,6 +9,7 @@ from avalan.entities import (
     MessageRole,
     Token,
     TransformerEngineSettings,
+    GenerationSettings,
 )
 from avalan.model import TextGenerationResponse
 from unittest import IsolatedAsyncioTestCase
@@ -43,8 +44,12 @@ def _dummy_response() -> TextGenerationResponse:
         yield "a"
         yield Token(id=1, token="b")
 
+    settings = GenerationSettings()
     return TextGenerationResponse(
-        lambda: output_gen(), use_async_generator=True
+        lambda **_: output_gen(),
+        use_async_generator=True,
+        generation_settings=settings,
+        settings=settings,
     )
 
 

--- a/tests/agent/reasoning_parser_extra_test.py
+++ b/tests/agent/reasoning_parser_extra_test.py
@@ -1,17 +1,18 @@
 from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.entities import ReasoningSettings
 from unittest import IsolatedAsyncioTestCase
 
 
 class ReasoningParserExtraTestCase(IsolatedAsyncioTestCase):
     async def test_flush_returns_empty(self):
-        parser = ReasoningParser()
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
         await parser.push("<think>")
         await parser.push("a")
         await parser.push("</think>")
         self.assertEqual(await parser.flush(), [])
 
     async def test_set_thinking_affects_state(self):
-        parser = ReasoningParser()
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
         self.assertFalse(parser.is_thinking)
         parser.set_thinking(True)
         self.assertTrue(parser.is_thinking)

--- a/tests/agent/reasoning_parser_test.py
+++ b/tests/agent/reasoning_parser_test.py
@@ -1,13 +1,13 @@
 from avalan.model.response.parsers.reasoning import (
     ReasoningParser,
 )
-from avalan.entities import ReasoningToken
+from avalan.entities import ReasoningToken, ReasoningSettings
 from unittest import IsolatedAsyncioTestCase
 
 
 class ReasoningParserTestCase(IsolatedAsyncioTestCase):
     async def test_with_thinking_tags(self):
-        parser = ReasoningParser()
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
         tokens = []
         for t in ["a", "<think>", "b", "</think>", "c"]:
             tokens.extend(await parser.push(t))
@@ -21,14 +21,16 @@ class ReasoningParserTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(tokens[4], "c")
 
     async def test_without_thinking_tags(self):
-        parser = ReasoningParser()
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
         tokens = []
         for t in ["x", "y"]:
             tokens.extend(await parser.push(t))
         self.assertEqual(tokens, ["x", "y"])
 
     async def test_with_prefixes(self):
-        parser = ReasoningParser(prefixes=["Thought:"])
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(), prefixes=["Thought:"]
+        )
         tokens = []
         for t in ["Thought:", "d", "e"]:
             tokens.extend(await parser.push(t))
@@ -41,7 +43,9 @@ class ReasoningParserTestCase(IsolatedAsyncioTestCase):
 
 
     async def test_without_prefixes(self):
-        parser = ReasoningParser(prefixes=["Thought:"])
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(), prefixes=["Thought:"]
+        )
         tokens = []
         for t in ["hello", "world"]:
             tokens.extend(await parser.push(t))

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -27,6 +27,7 @@ from avalan.event import Event, EventType
 from avalan.memory.permanent import VectorFunction
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.entities import GenerationSettings, ReasoningSettings
 from avalan.model.response.parsers.tool import ToolCallParser
 from avalan.entities import ReasoningToken, Token, TokenDetail, ToolCallToken
 
@@ -1290,7 +1291,7 @@ class CliAgentMixedTokensTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_agent_run_mixed_tokens(self):
         async def complex_generator():
-            rp = ReasoningParser()
+            rp = ReasoningParser(reasoning_settings=ReasoningSettings())
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
@@ -1340,8 +1341,12 @@ class CliAgentMixedTokensTestCase(unittest.IsolatedAsyncioTestCase):
             input_token_count = 1
 
             def __init__(self):
+                settings = GenerationSettings()
                 self._resp = TextGenerationResponse(
-                    lambda: complex_generator(), use_async_generator=True
+                    lambda **_: complex_generator(),
+                    use_async_generator=True,
+                    generation_settings=settings,
+                    settings=settings,
                 )
 
             def __aiter__(self_inner):

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, AsyncMock, patch, call, ANY
 from avalan.model.manager import ModelManager as RealModelManager
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.entities import GenerationSettings, ReasoningSettings
 from avalan.model.response.parsers.tool import ToolCallParser
 import asyncio
 from unittest import IsolatedAsyncioTestCase, main, TestCase
@@ -4381,7 +4382,7 @@ class CliToolCallTokenTestCase(IsolatedAsyncioTestCase):
 class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):
     async def test_model_run_mixed_tokens(self):
         async def complex_generator():
-            rp = ReasoningParser()
+            rp = ReasoningParser(reasoning_settings=ReasoningSettings())
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
@@ -4427,8 +4428,12 @@ class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):
                         else:
                             yield p
 
+        settings = GenerationSettings()
         response = TextGenerationResponse(
-            lambda: complex_generator(), use_async_generator=True
+            lambda **_: complex_generator(),
+            use_async_generator=True,
+            generation_settings=settings,
+            settings=settings,
         )
 
         args = Namespace(

--- a/tests/model/model_init_test.py
+++ b/tests/model/model_init_test.py
@@ -1,4 +1,5 @@
 from avalan.model.response.text import TextGenerationResponse
+from avalan.entities import GenerationSettings
 from avalan.model.stream import TextGenerationStream
 from avalan.model.vendor import (
     TextGenerationVendor,
@@ -25,6 +26,8 @@ class TextGenerationResponseTestCase(IsolatedAsyncioTestCase):
             lambda **_: gen(),
             use_async_generator=True,
             inputs={"input_ids": [[1, 2, 3]]},
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
         )
         resp.add_done_callback(done)
 
@@ -37,14 +40,18 @@ class TextGenerationResponseTestCase(IsolatedAsyncioTestCase):
 
     async def test_to_json_valid_and_invalid(self):
         resp = TextGenerationResponse(
-            lambda: 'prefix ```json\n{"a": 1}\n``` suffix',
+            lambda **_: 'prefix ```json\n{"a": 1}\n``` suffix',
             use_async_generator=False,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
         )
         self.assertEqual(await resp.to_json(), '{"a": 1}')
 
         invalid = TextGenerationResponse(
-            lambda: '```json {"a": } ```',
+            lambda **_: '```json {"a": } ```',
             use_async_generator=False,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
         )
         with self.assertRaises(InvalidJsonResponseException):
             await invalid.to_json()

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -89,7 +89,7 @@ class MlxLmModelTestCase(IsolatedAsyncioTestCase):
         stream_mock.assert_not_called()
         self.assertIsInstance(resp, TextGenerationResponse)
         self.assertIs(resp._output_fn, stream_mock)
-        self.assertEqual(resp._kwargs["inputs"], {"input_ids": [[1]]})
+        self.assertEqual(resp.input_token_count, 1)
         self.assertFalse(resp._kwargs["settings"].do_sample)
         self.assertTrue(resp._use_async_generator)
 
@@ -242,7 +242,7 @@ class MlxLmModelAdditionalTestCase(IsolatedAsyncioTestCase):
         str_mock.assert_not_called()
         self.assertIsInstance(resp, TextGenerationResponse)
         self.assertIs(resp._output_fn, str_mock)
-        self.assertEqual(resp._kwargs["inputs"], {"input_ids": [[1]]})
+        self.assertEqual(resp.input_token_count, 1)
         self.assertFalse(resp._kwargs["settings"].do_sample)
         self.assertFalse(resp._use_async_generator)
 

--- a/tests/model/nlp/text_generation_call_test.py
+++ b/tests/model/nlp/text_generation_call_test.py
@@ -36,7 +36,7 @@ class TextGenerationModelCallTestCase(IsolatedAsyncioTestCase):
             chat_template_settings=settings.chat_template_settings,
         )
         self.assertIs(response._output_fn, string_output)
-        self.assertEqual(response._kwargs["inputs"], tok_inputs)
+        self.assertEqual(response.input_token_count, len(tok_inputs["input_ids"][0]))
         self.assertTrue(response._kwargs["settings"].do_sample)
         self.assertEqual(
             response._kwargs["settings"].pad_token_id,

--- a/tests/model/text_generation_response_additional_test.py
+++ b/tests/model/text_generation_response_additional_test.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from unittest import IsolatedAsyncioTestCase
 from avalan.model.response.text import TextGenerationResponse
+from avalan.entities import GenerationSettings, ReasoningSettings
 
 
 @dataclass
@@ -10,9 +11,12 @@ class Example:
 
 class TextGenerationResponseAdditionalTestCase(IsolatedAsyncioTestCase):
     async def test_to_entity(self):
+        settings = GenerationSettings()
         resp = TextGenerationResponse(
-            lambda: '{"value": "ok"}',
+            lambda **_: '{"value": "ok"}',
             use_async_generator=False,
+            generation_settings=settings,
+            settings=settings,
         )
         result = await resp.to(Example)
         self.assertEqual(result, Example(value="ok"))
@@ -22,10 +26,12 @@ class TextGenerationResponseAdditionalTestCase(IsolatedAsyncioTestCase):
             for t in ("<think>", "a", "</think>"):
                 yield t
 
+        gs = GenerationSettings(reasoning=ReasoningSettings(enabled=False))
         resp = TextGenerationResponse(
-            lambda: gen(),
+            lambda **_: gen(),
             use_async_generator=True,
-            enable_reasoning_parser=False,
+            generation_settings=gs,
+            settings=gs,
         )
 
         tokens = []

--- a/tests/model/text_generation_response_extra_test.py
+++ b/tests/model/text_generation_response_extra_test.py
@@ -1,13 +1,20 @@
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
 from avalan.model.response.parsers.tool import ToolCallParser
-from avalan.entities import ReasoningToken, ToolCallToken, Token, TokenDetail
+from avalan.entities import (
+    GenerationSettings,
+    ReasoningSettings,
+    ReasoningToken,
+    ToolCallToken,
+    Token,
+    TokenDetail,
+)
 from unittest.mock import MagicMock
 from unittest import IsolatedAsyncioTestCase
 
 
 async def _complex_generator():
-    rp = ReasoningParser()
+    rp = ReasoningParser(reasoning_settings=ReasoningSettings())
     tm = MagicMock()
     tm.is_potential_tool_call.return_value = True
     tm.get_calls.return_value = None
@@ -50,8 +57,12 @@ async def _complex_generator():
 
 class TextGenerationResponseParsersTestCase(IsolatedAsyncioTestCase):
     async def test_mixed_tokens(self):
+        settings = GenerationSettings()
         resp = TextGenerationResponse(
-            lambda: _complex_generator(), use_async_generator=True
+            lambda **_: _complex_generator(),
+            use_async_generator=True,
+            generation_settings=settings,
+            settings=settings,
         )
 
         tokens = []


### PR DESCRIPTION
## Summary
- support configurable reasoning in `GenerationSettings` and `TextGenerationResponse`
- adapt reasoning parser to new settings
- expose reasoning flags on CLI
- update all calls and tests for new behaviour

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6883ff50e6988323b7ca11819b6089f8