### PR TITLE
Add reasoning parser coverage test

### DIFF
--- a/tests/agent/reasoning_parser_limit_test.py
+++ b/tests/agent/reasoning_parser_limit_test.py
@@ -1,0 +1,24 @@
+from unittest import IsolatedAsyncioTestCase
+
+from avalan.entities import ReasoningSettings, ReasoningToken
+from avalan.model.response.parsers.reasoning import ReasoningParser
+
+
+class ReasoningParserLimitTestCase(IsolatedAsyncioTestCase):
+    async def test_token_limit_switches_to_plain_output(self) -> None:
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(max_new_tokens=2)
+        )
+        outputs = []
+        for text in ["<think>", "a", "b", "c", "</think>", "d"]:
+            outputs.extend(await parser.push(text))
+        self.assertIsInstance(outputs[0], ReasoningToken)
+        self.assertEqual(outputs[0].token, "<think>")
+        self.assertIsInstance(outputs[1], ReasoningToken)
+        self.assertEqual(outputs[1].token, "a")
+        self.assertEqual(outputs[2], "b")
+        self.assertEqual(outputs[3], "c")
+        self.assertIsInstance(outputs[4], ReasoningToken)
+        self.assertEqual(outputs[4].token, "</think>")
+        self.assertEqual(outputs[5], "d")
+        self.assertFalse(parser.is_thinking)


### PR DESCRIPTION
## Summary
- ensure ReasoningParser returns plain strings after max tokens are reached
- verify parser clears its thinking state

## Testing
- `poetry run pytest --verbose -s tests/agent/reasoning_parser_limit_test.py`
- `poetry run pytest --verbose -s`
- `poetry run coverage run -m pytest tests/agent/reasoning_parser_test.py tests/agent/reasoning_parser_extra_test.py tests/agent/reasoning_parser_limit_test.py`
- `poetry run coverage report | grep reasoning.py`

------
https://chatgpt.com/codex/tasks/task_e_688406d72c4083239bd21d188c8c3d3c