### PR TITLE
Add reasoning max token stop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,9 @@ The response includes the model reasoning, and its final answer:
 
 Nvidia's Nemotron reasoning model solves the same problem easily and doesn't require the `--start-thinking` flag, since it automatically produces think tags. It does so more verbosely, though (**852** output tokens versus DeepSeek's **216** output tokens), since it detects ambiguity in the `and then that result` part of the prompt and ends up revisiting the essential principles of mathematics, to the point of realizing it's overthinking 🤓
 
+> [!TIP]
+> Endless reasoning rants can be stopped by using `--reasoning-max-new-tokens` and `--reasoning-stop-on-max-new-tokens`.
+
 ```bash
 echo 'What is (4 + 6) and then that result times 5, divided by 2?' | \
     avalan model run "nvidia/OpenReasoning-Nemotron-14B" \

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1340,6 +1340,12 @@ class CLI:
             help="Maximum number of reasoning tokens",
         )
         model_run_parser.add_argument(
+            "--reasoning-stop-on-max-new-tokens",
+            action="store_true",
+            default=False,
+            help="Stop reasoning when maximum tokens are produced",
+        )
+        model_run_parser.add_argument(
             "--stop_on_keyword",
             type=str,
             action="append",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -227,6 +227,7 @@ class EngineUri:
 class ReasoningSettings:
     max_new_tokens: int | None = None
     enabled: bool = True
+    stop_on_max_new_tokens: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -492,6 +492,11 @@ class ModelManager(ContextDecorator):
             reasoning=ReasoningSettings(
                 max_new_tokens=getattr(args, "reasoning_max_new_tokens", None),
                 enabled=not getattr(args, "no_reasoning", False),
+                stop_on_max_new_tokens=getattr(
+                    args,
+                    "reasoning_stop_on_max_new_tokens",
+                    False,
+                ),
             ),
         )
         system_prompt = args.system or None

--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -1,8 +1,9 @@
-from ....entities import ReasoningSettings, ReasoningToken
 from typing import Any, Iterable
 
+from ....entities import ReasoningSettings, ReasoningToken
 
-class ReasoningTokenLimitedException(Exception):
+
+class ReasoningTokenLimitExceeded(Exception):
     """Raised when the reasoning token limit is reached."""
 
 
@@ -50,6 +51,8 @@ class ReasoningParser:
             ):
                 self._token_count += 1
                 return [ReasoningToken(token_str)]
+            if self._settings.stop_on_max_new_tokens:
+                raise ReasoningTokenLimitExceeded
             return [token_str]
         return [token_str]
 

--- a/tests/agent/reasoning_parser_limit_test.py
+++ b/tests/agent/reasoning_parser_limit_test.py
@@ -1,7 +1,10 @@
 from unittest import IsolatedAsyncioTestCase
 
 from avalan.entities import ReasoningSettings, ReasoningToken
-from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.model.response.parsers.reasoning import (
+    ReasoningParser,
+    ReasoningTokenLimitExceeded,
+)
 
 
 class ReasoningParserLimitTestCase(IsolatedAsyncioTestCase):
@@ -22,3 +25,15 @@ class ReasoningParserLimitTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(outputs[4].token, "</think>")
         self.assertEqual(outputs[5], "d")
         self.assertFalse(parser.is_thinking)
+
+    async def test_token_limit_raises_exception(self) -> None:
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(
+                max_new_tokens=2,
+                stop_on_max_new_tokens=True,
+            )
+        )
+        await parser.push("<think>")
+        await parser.push("a")
+        with self.assertRaises(ReasoningTokenLimitExceeded):
+            await parser.push("b")

--- a/tests/model/reasoning_stop_on_limit_test.py
+++ b/tests/model/reasoning_stop_on_limit_test.py
@@ -1,0 +1,34 @@
+from avalan.model.response.text import TextGenerationResponse
+from avalan.entities import (
+    GenerationSettings,
+    ReasoningSettings,
+    ReasoningToken,
+)
+from unittest import IsolatedAsyncioTestCase
+
+
+class TextGenerationStopOnLimitTestCase(IsolatedAsyncioTestCase):
+    async def test_stop_on_limit(self) -> None:
+        async def gen():
+            for t in ("<think>", "a", "b", "</think>"):
+                yield t
+
+        settings = GenerationSettings(
+            reasoning=ReasoningSettings(
+                max_new_tokens=2,
+                stop_on_max_new_tokens=True,
+            )
+        )
+        resp = TextGenerationResponse(
+            lambda **_: gen(),
+            use_async_generator=True,
+            generation_settings=settings,
+            settings=settings,
+        )
+        it = resp.__aiter__()
+        first = await it.__anext__()
+        second = await it.__anext__()
+        self.assertIsInstance(first, ReasoningToken)
+        self.assertIsInstance(second, ReasoningToken)
+        with self.assertRaises(StopAsyncIteration):
+            await it.__anext__()


### PR DESCRIPTION
## Summary
- allow stopping reasoning when max tokens is reached
- expose `--reasoning-stop-on-max-new-tokens` CLI flag
- raise `ReasoningTokenLimitExceeded` in parser when limit reached
- stop `TextGenerationResponse` iteration on that exception
- document reasoning token stop tip in README
- test stopping behavior

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6884319f21508323bcada9ca910b7601