### PR TITLE
Handle backend on inline serve

### DIFF
--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -5,7 +5,7 @@ from ...agent.orchestrator.response.orchestrator_response import (
 )
 from ...cli import get_input, has_input, confirm_tool_call
 from ...cli.commands.model import token_generation
-from ...entities import OrchestratorSettings, ToolCall
+from ...entities import Backend, OrchestratorSettings, ToolCall
 from ...event import EventStats
 from ...model.hubs.huggingface import HuggingfaceHub
 from ...model.nlp.text.vendor import TextGenerationVendorModel
@@ -84,7 +84,9 @@ def get_orchestrator_settings(
             if v is not None
         },
         uri=engine_uri,
-        engine_config=None,
+        engine_config={
+            "backend": getattr(args, "backend", Backend.TRANSFORMERS.value)
+        },
         call_options={
             "max_new_tokens": call_tokens,
             "skip_special_tokens": args.run_skip_special_tokens,

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -27,7 +27,7 @@ from avalan.event import Event, EventType
 from avalan.memory.permanent import VectorFunction
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
-from avalan.entities import GenerationSettings, ReasoningSettings
+from avalan.entities import ReasoningSettings
 from avalan.model.response.parsers.tool import ToolCallParser
 from avalan.entities import ReasoningToken, Token, TokenDetail, ToolCallToken
 
@@ -47,6 +47,7 @@ class CliAgentMessageSearchTestCase(unittest.IsolatedAsyncioTestCase):
             tool_events=2,
             tool=None,
             run_max_new_tokens=100,
+            backend="transformers",
         )
         self.console = MagicMock()
         status_cm = MagicMock()
@@ -190,6 +191,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             prefix_openai="oa",
             prefix_mcp="mcp",
             reload=False,
+            backend="transformers",
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -228,6 +230,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             prefix_openai="oa",
             prefix_mcp="mcp",
             reload=False,
+            backend="transformers",
             engine_uri="uri",
             role="assistant",
             name=None,
@@ -295,6 +298,7 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             prefix_openai="oa",
             prefix_mcp="mcp",
             reload=False,
+            backend="transformers",
             engine_uri=None,
             role=None,
             name=None,
@@ -344,6 +348,7 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
             run_max_new_tokens=None,
             run_skip_special_tokens=True,
             tool=None,
+            backend="transformers",
             no_repl=False,
             quiet=False,
         )
@@ -392,6 +397,7 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
             tool_browser_engine=None,
             tool_browser_search=None,
             tool_browser_search_context=None,
+            backend="transformers",
             no_repl=False,
             quiet=False,
         )
@@ -431,6 +437,7 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
             tool_browser_engine="chromium",
             tool_browser_search=True,
             tool_browser_search_context=5,
+            backend="transformers",
             no_repl=False,
             quiet=False,
         )
@@ -496,6 +503,7 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
             display_tools=False,
             display_tools_events=2,
             tools_confirm=False,
+            backend="transformers",
         )
         self.console = MagicMock()
         status_cm = MagicMock()
@@ -1193,6 +1201,7 @@ class CliAgentInitEarlyReturnTestCase(unittest.IsolatedAsyncioTestCase):
             run_max_new_tokens=10,
             run_skip_special_tokens=True,
             tool=None,
+            backend="transformers",
             no_repl=False,
             quiet=False,
         )

--- a/tests/cli/get_orchestrator_settings_test.py
+++ b/tests/cli/get_orchestrator_settings_test.py
@@ -14,6 +14,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             task=None,
             instructions=None,
             engine_uri="ai://m",
+            backend="transformers",
             run_max_new_tokens=10,
             run_skip_special_tokens=False,
             memory_recent=None,
@@ -31,6 +32,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
         self.assertTrue(result.memory_recent)
         self.assertEqual(result.uri, "ai://m")
         self.assertEqual(result.call_options["max_new_tokens"], 10)
+        self.assertEqual(result.engine_config, {"backend": "transformers"})
         self.assertEqual(result.agent_config, {"name": "a", "role": "r"})
         self.assertEqual(result.tools, [])
         self.assertEqual(
@@ -45,6 +47,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             task="t",
             instructions="i",
             engine_uri="old",
+            backend="transformers",
             run_max_new_tokens=5,
             run_skip_special_tokens=True,
             memory_recent=False,
@@ -83,6 +86,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
         self.assertEqual(result.permanent_memory, {"ns": "dsn2"})
         self.assertEqual(result.tools, ["b"])
         self.assertEqual(result.sentence_model_id, "m")
+        self.assertEqual(result.engine_config, {"backend": "transformers"})
 
     def test_chat_template_settings(self):
         args = Namespace(
@@ -91,6 +95,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             task=None,
             instructions=None,
             engine_uri="ai://m",
+            backend="transformers",
             run_max_new_tokens=10,
             run_skip_special_tokens=False,
             memory_recent=None,
@@ -109,3 +114,4 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
         self.assertTrue(
             result.call_options["chat_template_settings"]["enable_thinking"]
         )
+        self.assertEqual(result.engine_config, {"backend": "transformers"})


### PR DESCRIPTION
## Summary
- pass backend when building orchestrator settings
- update tests for backend option

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68879573117c83239ade3a1d8353cfd8