### PR TITLE
Add chat router test

### DIFF
--- a/tests/server/chat_router_unit_test.py
+++ b/tests/server/chat_router_unit_test.py
@@ -212,3 +212,7 @@ class ChatRouterUnitTest(IsolatedAsyncioTestCase):
         self.assertEqual(msg.content[0].text, "hi")
         self.assertIsInstance(msg.content[1], MessageContentImage)
         self.assertEqual(msg.content[1].image_url, {"url": "img"})
+
+    async def test_to_message_content_invalid_type(self) -> None:
+        with self.assertRaises(TypeError):
+            self.chat._to_message_content(123)


### PR DESCRIPTION
## Summary
- test invalid content for chat router

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68891bc36ca88323b58331768064722d