### PR TITLE
Add multi-token tag support

### DIFF
--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -21,6 +21,7 @@ class ReasoningParser:
         self._prefixes = prefixes or ["Think:"]
         self._thinking = False
         self._token_count = 0
+        self._pending_tag: list[str] = []
 
     def set_thinking(self, thinking: bool) -> None:
         self._thinking = thinking
@@ -36,11 +37,46 @@ class ReasoningParser:
             self._token_count += 1
             return [ReasoningToken(t)]
 
-        if token_clean in (self._start_tag, self._end_tag) or any(
-            token_clean.startswith(p) for p in self._prefixes
+        def flush_pending(as_reasoning: bool) -> list[Any]:
+            result: list[Any] = []
+            if self._pending_tag:
+                for t in self._pending_tag:
+                    result.extend(wrap(t) if as_reasoning else [t])
+                self._pending_tag.clear()
+            return result
+
+        expecting_tag = self._end_tag if self._thinking else self._start_tag
+
+        result: list[Any] = []
+        if self._pending_tag:
+            candidate = (
+                "".join(t.strip() for t in self._pending_tag) + token_clean
+            )
+            if expecting_tag.startswith(candidate):
+                self._pending_tag.append(token)
+                if candidate == expecting_tag:
+                    self._thinking = expecting_tag == self._start_tag
+                    result.extend(flush_pending(True))
+                    return result
+                return result
+            result.extend(flush_pending(False))
+
+        if token_clean in (self._start_tag, self._end_tag) or (
+            not self._thinking
+            and any(token_clean.startswith(p) for p in self._prefixes)
         ):
             self._thinking = token_clean != self._end_tag
-            return wrap(token)
+            result.extend(flush_pending(True))
+            result.extend(wrap(token))
+            return result
+
+        if expecting_tag.startswith(token_clean):
+            self._pending_tag.append(token)
+            if token_clean == expecting_tag:
+                self._thinking = expecting_tag == self._start_tag
+                result.extend(flush_pending(True))
+                return result
+            return result
 
         if self._thinking:
             within_budget = (
@@ -48,12 +84,15 @@ class ReasoningParser:
                 or self._token_count < self._settings.max_new_tokens
             )
             if within_budget:
-                return wrap(token)
+                result.extend(wrap(token))
+                return result
             if self._settings.stop_on_max_new_tokens:
                 raise ReasoningTokenLimitExceeded
-            return [token]
+            result.append(token)
+            return result
 
-        return [token]
+        result.append(token)
+        return result
 
     async def flush(self) -> Iterable[Any]:
         return []

--- a/tests/agent/reasoning_parser_split_tag_test.py
+++ b/tests/agent/reasoning_parser_split_tag_test.py
@@ -1,0 +1,25 @@
+from unittest import IsolatedAsyncioTestCase
+
+from avalan.entities import ReasoningSettings, ReasoningToken
+from avalan.model.response.parsers.reasoning import ReasoningParser
+
+
+class ReasoningParserSplitTagTestCase(IsolatedAsyncioTestCase):
+    async def test_split_start_and_end_tags(self) -> None:
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
+        outputs = []
+        for text in ["<", "think", ">", "a", "b", "<", "/think", ">"]:
+            outputs.extend(await parser.push(text))
+        self.assertTrue(all(isinstance(t, ReasoningToken) for t in outputs))
+        self.assertEqual(
+            [t.token for t in outputs],
+            ["<", "think", ">", "a", "b", "<", "/think", ">"],
+        )
+        self.assertFalse(parser.is_thinking)
+
+    async def test_unmatched_partial_tag(self) -> None:
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
+        outputs = []
+        for t in ["<", "unknown", ">"]:
+            outputs.extend(await parser.push(t))
+        self.assertEqual(outputs, ["<", "unknown", ">"])


### PR DESCRIPTION
## Summary
- improve `ReasoningParser` to handle start/end tags spanning multiple tokens
- test split tag logic

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688a4a8dea9c8323af2124461134e15d