### PR TITLE
Fix reasoning parser hang when tags split across tokens

### DIFF
--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -106,4 +106,15 @@ class ReasoningParser:
         return result
 
     async def flush(self) -> Iterable[Any]:
-        return []
+        result: list[Any] = []
+        if self._pending_tag:
+            as_reasoning = self._thinking
+            for t in self._pending_tag:
+                if as_reasoning:
+                    self._token_count += 1
+                    result.append(ReasoningToken(t))
+                else:
+                    result.append(t)
+            self._pending_tag.clear()
+            self._pending_length = 0
+        return result

--- a/src/avalan/model/response/text.py
+++ b/src/avalan/model/response/text.py
@@ -109,54 +109,61 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
     async def __anext__(self) -> Token | TokenDetail | str:
         assert self._output
 
-        if self._parser_queue and not self._parser_queue.empty():
-            return self._parser_queue.get()
+        while True:
+            if self._parser_queue and not self._parser_queue.empty():
+                return self._parser_queue.get()
 
-        try:
-            token = await self._output.__anext__()
-        except StopAsyncIteration:
-            await self._trigger_consumed()
-            raise
+            try:
+                token = await self._output.__anext__()
+            except StopAsyncIteration:
+                if self._reasoning_parser:
+                    for it in await self._reasoning_parser.flush():
+                        self._parser_queue.put(it)
+                    if not self._parser_queue.empty():
+                        continue
+                await self._trigger_consumed()
+                raise
 
-        token_str = token if isinstance(token, str) else token.token
-        self._buffer.write(token_str)
+            token_str = token if isinstance(token, str) else token.token
+            self._buffer.write(token_str)
 
-        if not self._reasoning_parser:
-            return token
+            if not self._reasoning_parser:
+                return token
 
-        try:
-            items = await self._reasoning_parser.push(token_str)
-        except ReasoningTokenLimitExceeded:
-            await self._trigger_consumed()
-            raise StopAsyncIteration
-        for it in items:
-            if isinstance(it, ReasoningToken):
-                token_id = (
-                    token.id
-                    if isinstance(token, (Token, TokenDetail))
-                    else it.id
-                )
-                parsed = ReasoningToken(
-                    token=it.token, id=token_id, probability=it.probability
-                )
-            elif isinstance(token, ToolCallToken):
-                parsed = ToolCallToken(token=str(it), id=token.id)
-            elif isinstance(token, TokenDetail):
-                parsed = TokenDetail(
-                    id=token.id,
-                    token=it if isinstance(it, str) else it.token,
-                    probability=token.probability,
-                    tokens=token.tokens,
-                    probability_distribution=token.probability_distribution,
-                    step=token.step,
-                )
-            elif isinstance(token, Token):
-                parsed = Token(id=token.id, token=str(it))
-            else:
-                parsed = it
-            self._parser_queue.put(parsed)
+            try:
+                items = await self._reasoning_parser.push(token_str)
+            except ReasoningTokenLimitExceeded:
+                await self._trigger_consumed()
+                raise StopAsyncIteration
+            for it in items:
+                if isinstance(it, ReasoningToken):
+                    token_id = (
+                        token.id
+                        if isinstance(token, (Token, TokenDetail))
+                        else it.id
+                    )
+                    parsed = ReasoningToken(
+                        token=it.token, id=token_id, probability=it.probability
+                    )
+                elif isinstance(token, ToolCallToken):
+                    parsed = ToolCallToken(token=str(it), id=token.id)
+                elif isinstance(token, TokenDetail):
+                    parsed = TokenDetail(
+                        id=token.id,
+                        token=it if isinstance(it, str) else it.token,
+                        probability=token.probability,
+                        tokens=token.tokens,
+                        probability_distribution=token.probability_distribution,
+                        step=token.step,
+                    )
+                elif isinstance(token, Token):
+                    parsed = Token(id=token.id, token=str(it))
+                else:
+                    parsed = it
+                self._parser_queue.put(parsed)
 
-        return self._parser_queue.get()
+            if not self._parser_queue.empty():
+                return self._parser_queue.get()
 
     async def to_str(self) -> str:
         if not self._use_async_generator:

--- a/tests/agent/reasoning_parser_extra_test.py
+++ b/tests/agent/reasoning_parser_extra_test.py
@@ -11,6 +11,12 @@ class ReasoningParserExtraTestCase(IsolatedAsyncioTestCase):
         await parser.push("</think>")
         self.assertEqual(await parser.flush(), [])
 
+    async def test_flush_returns_pending_tokens(self) -> None:
+        parser = ReasoningParser(reasoning_settings=ReasoningSettings())
+        await parser.push("<")
+        await parser.push("thi")
+        self.assertEqual(await parser.flush(), ["<", "thi"])
+
     async def test_set_thinking_affects_state(self):
         parser = ReasoningParser(reasoning_settings=ReasoningSettings())
         self.assertFalse(parser.is_thinking)


### PR DESCRIPTION
## Summary
- ensure ReasoningParser flushes pending tokens
- loop in TextGenerationResponse to avoid blocking on empty queue and flush pending tokens when the generator ends
- test partial pending token flush behaviour

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688a593703248323b4f1dcdc3c42209b