### PR TITLE
Fix reasoning stop limit

### DIFF
--- a/src/avalan/model/response/text.py
+++ b/src/avalan/model/response/text.py
@@ -126,7 +126,10 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
 
             if (
                 not self._reasoning_parser
-                or self._reasoning_parser.is_thinking_budget_exhausted
+                or (
+                    self._reasoning_parser.is_thinking_budget_exhausted
+                    and not self._reasoning_parser.is_thinking
+                )
             ):
                 return token
 


### PR DESCRIPTION
## Summary
- ensure thinking budget doesn't bypass reasoning within <think> blocks
- fix stop-on-limit test

## Testing
- `poetry run pytest tests/model/reasoning_stop_on_limit_test.py::TextGenerationStopOnLimitTestCase::test_stop_on_limit -vv -s`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688a9da178d08323a607988b1a8d7dc8