### PR TITLE
Fix template message expectations

### DIFF
--- a/tests/model/model_init_test.py
+++ b/tests/model/model_init_test.py
@@ -103,9 +103,9 @@ class StreamVendorTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             tmpl,
             [
-                {"role": MessageRole.SYSTEM, "content": "sys"},
-                {"role": MessageRole.USER, "content": "hi"},
-                {"role": MessageRole.TOOL, "content": "t"},
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": {"type": "text", "text": "hi"}},
+                {"role": "tool", "content": {"type": "text", "text": "t"}},
             ],
         )
 


### PR DESCRIPTION
## Summary
- update expected values in vendor template message test

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688bb2a4fa4883238111fb99c34f4ef9