### PR TITLE
Add tests for TextGenerationSingleStream

### DIFF
--- a/tests/model/text_generation_single_stream_test.py
+++ b/tests/model/text_generation_single_stream_test.py
@@ -1,0 +1,30 @@
+from unittest import IsolatedAsyncioTestCase
+from avalan.model.stream import TextGenerationSingleStream
+
+
+class TextGenerationSingleStreamTestCase(IsolatedAsyncioTestCase):
+    async def test_iteration_and_reset(self) -> None:
+        stream = TextGenerationSingleStream("hello")
+        iterator = stream.__aiter__()
+        self.assertIs(iterator, stream)
+        self.assertEqual(await iterator.__anext__(), "hello")
+        with self.assertRaises(StopAsyncIteration):
+            await iterator.__anext__()
+
+        iterator2 = stream()
+        self.assertIs(iterator2, stream)
+        self.assertEqual(await iterator2.__anext__(), "hello")
+        with self.assertRaises(StopAsyncIteration):
+            await iterator2.__anext__()
+
+    async def test_async_for_and_property(self) -> None:
+        stream = TextGenerationSingleStream("foo")
+        tokens = []
+        async for token in stream():
+            tokens.append(token)
+        self.assertEqual(tokens, ["foo"])
+        with self.assertRaises(StopAsyncIteration):
+            await stream.__anext__()
+        iterator = stream.__aiter__()
+        self.assertEqual(stream.content, "foo")
+        self.assertEqual(await iterator.__anext__(), "foo")


### PR DESCRIPTION
## Summary
- add coverage tests for `TextGenerationSingleStream`

## Testing
- `poetry run pytest --verbose -s`
- `poetry run pytest --cov=src/avalan/model/stream.py --cov-report=json`

------
https://chatgpt.com/codex/tasks/task_e_688d10269a0883239107d3ad391f1336