### PR TITLE
Make agent role optional

### DIFF
--- a/src/avalan/agent/blueprint.toml
+++ b/src/avalan/agent/blueprint.toml
@@ -2,9 +2,11 @@
 {% if orchestrator.agent_config.get('name') %}
 name = "{{ orchestrator.agent_config['name'] }}"
 {% endif %}
+{% if orchestrator.agent_config.get('role') %}
 role = """
-{{ orchestrator.agent_config.get('role', '') | indent(4) }}
+{{ orchestrator.agent_config['role'] | indent(4) }}
 """
+{% endif %}
 {% if orchestrator.agent_config.get('task') %}
 task = """
 {{ orchestrator.agent_config['task'] | indent(4) }}

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -82,10 +82,6 @@ class OrchestratorLoader:
             ), "No uri defined in engine section of configuration"
 
             agent_config = config["agent"]
-            for setting in ["role"]:
-                assert (
-                    setting in agent_config
-                ), f"No {setting} defined in agent section of configuration"
 
             assert (
                 "engine" in config
@@ -120,9 +116,6 @@ class OrchestratorLoader:
                 f"Unknown type {config['agent']['type']} in agent section "
                 + "of configuration"
             )
-            assert (
-                "role" in agent_config
-            ), "No role defined in agent section of configuration"
 
             call_options = config["run"] if "run" in config else None
             if call_options and "chat" in call_options:
@@ -425,9 +418,6 @@ class OrchestratorLoader:
         assert (
             "task" in agent_config
         ), "No task defined in agent section of configuration"
-        assert (
-            "role" in agent_config
-        ), "No role defined in agent section of configuration"
 
         properties: list[Property] = []
         for property_name in config.get("json", []):
@@ -452,7 +442,7 @@ class OrchestratorLoader:
             properties,
             id=agent_id,
             name=agent_config["name"] if "name" in agent_config else None,
-            role=agent_config["role"],
+            role=agent_config.get("role"),
             task=agent_config["task"],
             instructions=agent_config["instructions"],
             rules=agent_config["rules"] if "rules" in agent_config else None,

--- a/src/avalan/agent/orchestrator/orchestrators/json.py
+++ b/src/avalan/agent/orchestrator/orchestrators/json.py
@@ -35,7 +35,9 @@ class Property:
 
 
 class JsonSpecification(Specification):
-    def __init__(self, output: type | list[Property], role: str, **kwargs):
+    def __init__(
+        self, output: type | list[Property], role: str | None = None, **kwargs
+    ):
         if not isinstance(output, list):
             annotations = getattr(output, "__annotations__", None)
             assert annotations
@@ -70,7 +72,8 @@ class JsonSpecification(Specification):
             **{"output_properties": properties},
         }
 
-        kwargs.setdefault("role", Role(persona=[role]))
+        if role is not None:
+            kwargs.setdefault("role", Role(persona=[role]))
         kwargs.setdefault("output_type", OutputType.JSON)
         kwargs.setdefault("template_vars", template_vars)
         super().__init__(**kwargs)
@@ -89,7 +92,7 @@ class JsonOrchestrator(Orchestrator):
         event_manager: EventManager,
         output: type | list[Property],
         *,
-        role: str,
+        role: str | None = None,
         task: str,
         instructions: str,
         name: str | None = None,

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -368,8 +368,8 @@ async def agent_run(
             )
         else:
             assert (
-                args.engine_uri and args.role
-            ), "--engine-uri and --role required when no specifications file"
+                args.engine_uri
+            ), "--engine-uri required when no specifications file"
             assert not args.specifications_file or not args.engine_uri
             memory_recent = (
                 args.memory_recent
@@ -575,7 +575,6 @@ async def agent_serve(
                 agent_id=uuid4(),
             )
         else:
-            assert args.role
             memory_recent = (
                 args.memory_recent if args.memory_recent is not None else True
             )
@@ -623,8 +622,6 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
     )
-    if not role:
-        return
 
     task = args.task or get_input(
         console,

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -1242,8 +1242,8 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIs(DummyEngine.last_tool, tool_manager)
 
 
-class CliAgentInitEarlyReturnTestCase(unittest.IsolatedAsyncioTestCase):
-    async def test_agent_init_returns_when_no_role(self):
+class CliAgentInitNoRoleTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_agent_init_accepts_no_role(self):
         args = Namespace(
             name="A",
             role=None,
@@ -1273,7 +1273,7 @@ class CliAgentInitEarlyReturnTestCase(unittest.IsolatedAsyncioTestCase):
             patch.object(agent_cmds.Prompt, "ask", return_value="A"),
         ):
             await agent_cmds.agent_init(args, console, theme)
-        console.print.assert_not_called()
+        console.print.assert_called_once()
 
 
 class CliAgentMixedTokensTestCase(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- allow omitting agent role in configuration and CLI
- remove role requirement from orchestrator loader and CLI commands
- update template to only include role when provided
- adjust JSON orchestrator and loader to handle missing roles
- update tests for optional role

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688d38dce6608323896c7cffa5651cdf