### PR TITLE
Add CLI and loader agent creation tests

### DIFF
--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -381,6 +381,10 @@ async def agent_run(
                 agent_id=agent_id or uuid4(),
                 memory_recent=memory_recent,
                 tools=args.tool,
+                max_new_tokens=getattr(args, "run_max_new_tokens", None),
+                temperature=getattr(args, "run_temperature", None),
+                top_k=getattr(args, "run_top_k", None),
+                top_p=getattr(args, "run_top_p", None),
             )
             logger.debug("Loading agent from inline settings")
             browser_settings = get_tool_settings(

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -1241,6 +1241,151 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIs(model_manager.passed_tool, tool_manager)
         self.assertIs(DummyEngine.last_tool, tool_manager)
 
+    async def test_run_engine_uri_only_generates_id(self):
+        self.args.specifications_file = None
+        self.args.engine_uri = "engine"
+        self.args.role = None
+        self.args.id = None
+
+        uid = uuid4()
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value=None),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_settings",
+                new=AsyncMock(return_value=self.orch),
+            ) as fs_patch,
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(),
+            ) as ff_patch,
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ),
+            patch("avalan.cli.commands.agent.uuid4", return_value=uid),
+        ):
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+
+        fs_patch.assert_awaited_once()
+        ff_patch.assert_not_called()
+        settings = fs_patch.call_args.args[0]
+        self.assertEqual(settings.agent_id, uid)
+        self.assertEqual(settings.uri, "engine")
+
+    async def test_run_engine_uri_with_id(self):
+        self.args.specifications_file = None
+        self.args.engine_uri = "engine"
+        self.args.role = None
+        self.args.id = "custom"
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value=None),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_settings",
+                new=AsyncMock(return_value=self.orch),
+            ) as fs_patch,
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(),
+            ) as ff_patch,
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ),
+        ):
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+
+        fs_patch.assert_awaited_once()
+        ff_patch.assert_not_called()
+        settings = fs_patch.call_args.args[0]
+        self.assertEqual(settings.agent_id, "custom")
+
+    async def test_run_engine_uri_with_name(self):
+        self.args.specifications_file = None
+        self.args.engine_uri = "engine"
+        self.args.role = "assistant"
+        self.args.name = "Agent"
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value=None),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_settings",
+                new=AsyncMock(return_value=self.orch),
+            ) as fs_patch,
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(),
+            ) as ff_patch,
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ),
+        ):
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+
+        fs_patch.assert_awaited_once()
+        ff_patch.assert_not_called()
+        settings = fs_patch.call_args.args[0]
+        self.assertEqual(settings.agent_config["name"], "Agent")
+
+    async def test_run_engine_uri_with_generation_settings(self):
+        self.args.specifications_file = None
+        self.args.engine_uri = "engine"
+        self.args.role = "assistant"
+        self.args.run_temperature = 0.5
+        self.args.run_top_p = 0.9
+        self.args.run_top_k = 5
+        self.args.run_max_new_tokens = 42
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value=None),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_settings",
+                new=AsyncMock(return_value=self.orch),
+            ) as fs_patch,
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ),
+        ):
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+
+        fs_patch.assert_awaited_once()
+        settings = fs_patch.call_args.args[0]
+        self.assertEqual(settings.call_options["temperature"], 0.5)
+        self.assertEqual(settings.call_options["top_p"], 0.9)
+        self.assertEqual(settings.call_options["top_k"], 5)
+        self.assertEqual(settings.call_options["max_new_tokens"], 42)
+
 
 class CliAgentInitNoRoleTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_agent_init_accepts_no_role(self):


### PR DESCRIPTION
## Summary
- add tests for agent creation via CLI and toml loader
- support generation settings in `agent_run`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_688d437c36048323b8d1ba908b9f6d10