### PR TITLE
Use assertion for agent proxy engine requirement

### DIFF
--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -625,15 +625,13 @@ async def agent_proxy(
 ) -> None:
     args.name = getattr(args, "name", "Proxy") or "Proxy"
     args.memory_recent = getattr(args, "memory_recent", True) or True
-    args.memory_permanent_message = getattr(
-        args, 
-        "memory_permanent_message", 
-        None
-    ) or "postgresql://avalan:password@localhost:5432/avalan"
+    args.memory_permanent_message = (
+        getattr(args, "memory_permanent_message", None)
+        or "postgresql://avalan:password@localhost:5432/avalan"
+    )
     args.specifications_file = None
-    
-    if not getattr(args, "engine_uri", None):
-        raise SystemExit("--engine-uri is required")
+
+    assert getattr(args, "engine_uri", None), "--engine-uri is required"
 
     await agent_serve(args, hub, logger, name, version)
 


### PR DESCRIPTION
## Summary
- ensure `agent_proxy` asserts that an engine URI is provided

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_688d7ba26c9c832389aa6dd253469ff3