### PR TITLE
Enable slots for frozen dataclasses

### DIFF
--- a/src/avalan/agent/__init__.py
+++ b/src/avalan/agent/__init__.py
@@ -22,18 +22,18 @@ class OutputType(StrEnum):
     TEXT = "text"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Goal:
     task: str
     instructions: list[str]
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Role:
     persona: list[str]
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Specification:
     role: Role | None
     goal: Goal | None
@@ -45,13 +45,13 @@ class Specification:
     template_vars: dict | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class EngineEnvironment:
     engine_uri: EngineUri
     settings: EngineSettings | TransformerEngineSettings
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class AgentOperation:
     specification: Specification
     environment: EngineEnvironment

--- a/src/avalan/agent/orchestrator/orchestrators/json.py
+++ b/src/avalan/agent/orchestrator/orchestrators/json.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Annotated, get_args, get_origin
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Property:
     TYPE_MAP = {
         int: int.__name__,

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -175,7 +175,7 @@ class BetaSchedule(StrEnum):
     SQUAREDCOS_CAP_V2 = "squaredcos_cap_v2"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class QuantizationSettings:
     load_in_4bit: bool
     bnb_4bit_quant_type: Literal["nf4"]
@@ -183,7 +183,7 @@ class QuantizationSettings:
     bnb_4bit_compute_dtype: type
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class EngineSettings:
     auto_load_model: bool = True
     auto_load_tokenizer: bool = True
@@ -208,7 +208,7 @@ class EngineSettings:
     upsampler_model_id: str | None = None
 
 
-@dataclass(kw_only=True, frozen=True)
+@dataclass(kw_only=True, frozen=True, slots=True)
 class EngineUri:
     host: str | None
     port: int | None
@@ -223,14 +223,14 @@ class EngineUri:
         return not self.vendor or self.vendor == "local"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ReasoningSettings:
     max_new_tokens: int | None = None
     enabled: bool = True
     stop_on_max_new_tokens: bool = False
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ChatSettings:
     add_generation_prompt: bool = True
     tokenize: bool = True
@@ -239,7 +239,7 @@ class ChatSettings:
     enable_thinking: bool = True
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class GenerationSettings:
     # Generation length ------------------------------------------------------
     # The minimum numbers of tokens to generate, ignoring the number of tokens
@@ -369,7 +369,7 @@ class GenerationSettings:
     response_format: dict | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class GenericProxyConfig:
     scheme: str
     host: str
@@ -387,7 +387,7 @@ class GenericProxyConfig:
         return {"http": url, "https": url}
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class HubCacheFile:
     name: str
     path: str
@@ -396,7 +396,7 @@ class HubCacheFile:
     last_modified: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class HubCache:
     model_id: str
     path: str
@@ -407,7 +407,7 @@ class HubCache:
     total_revisions: int
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class HubCacheDeletion:
     model_id: str
     revisions: list[str]
@@ -418,20 +418,20 @@ class HubCacheDeletion:
     deletable_snapshots: list[str]
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ImageEntity:
     label: str
     score: float | None = None
     box: list[float] | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class MessageContentText:
     type: Literal["text"]
     text: str
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class MessageContentImage:
     type: Literal["image_url"]
     image_url: dict[str, str]
@@ -440,7 +440,7 @@ class MessageContentImage:
 MessageContent = MessageContentText | MessageContentImage
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Message:
     role: MessageRole
     content: str | MessageContent | list[MessageContent]
@@ -451,7 +451,7 @@ class Message:
 Input = str | list[str] | Message | list[Message]
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ReasoningOrchestratorResponse:
     """Result returned by :class:`ReasoningOrchestrator`."""
 
@@ -459,7 +459,7 @@ class ReasoningOrchestratorResponse:
     reasoning: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class EngineMessage:
     agent_id: UUID
     model_id: str
@@ -470,12 +470,12 @@ class EngineMessage:
         return self.message.role == MessageRole.ASSISTANT
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class EngineMessageScored(EngineMessage):
     score: float
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Model:
     id: str
     parameters: int | None
@@ -501,7 +501,7 @@ class Model:
     updated_at: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ModelConfig:
     # Model architectures that can be used with the model pretrained weights
     architectures: list[str] | None
@@ -569,7 +569,7 @@ class ModelConfig:
     tokenizer_class: str | None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class OrchestratorSettings:
     agent_id: UUID
     orchestrator_type: str | None
@@ -591,14 +591,14 @@ class OrchestratorSettings:
     log_events: bool
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SearchMatch:
     query: str
     match: str
     l2_distance: float
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class SentenceTransformerModelConfig:
     backend: Literal["torch", "onnx", "openvino"]
     similarity_function: SimilarityFunction | None
@@ -606,7 +606,7 @@ class SentenceTransformerModelConfig:
     transformer_model_config: ModelConfig
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Similarity:
     cosine_distance: float
     inner_product: float
@@ -615,7 +615,7 @@ class Similarity:
     pearson: float
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class OperationAudioParameters:
     path: str
     reference_path: str | None = None
@@ -623,7 +623,7 @@ class OperationAudioParameters:
     sampling_rate: int
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class OperationTextParameters:
     context: str | None = None
     labeled_only: bool | None = None
@@ -636,7 +636,7 @@ class OperationTextParameters:
     system_prompt: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class OperationVisionParameters:
     path: str
     reference_path: str | None = None
@@ -668,7 +668,7 @@ class OperationParameters(TypedDict, total=False):
     vision: OperationVisionParameters | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Operation:
     generation_settings: GenerationSettings | None
     input: Input | None
@@ -677,7 +677,7 @@ class Operation:
     requires_input: bool = False
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class TokenizerConfig:
     name_or_path: str
     tokens: list[str] | None
@@ -688,21 +688,21 @@ class TokenizerConfig:
     fast: bool = False
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Token:
     id: Tensor | int
     token: str
     probability: float | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class TokenDetail(Token):
     step: int | None = None
     probability_distribution: ProbabilityDistribution | None = None
     tokens: list[Token] | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ReasoningToken(Token):
     """Token produced while the model is reasoning."""
 
@@ -713,10 +713,10 @@ class ReasoningToken(Token):
         id: Tensor | int = -1,
         probability: float | None = None,
     ) -> None:
-        super().__init__(id=id, token=token, probability=probability)
+        Token.__init__(self, id=id, token=token, probability=probability)
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCallToken(Token):
     """Token produced while the model emits a tool call."""
 
@@ -727,17 +727,17 @@ class ToolCallToken(Token):
         id: Tensor | int = -1,
         probability: float | None = None,
     ) -> None:
-        super().__init__(id=id, token=token, probability=probability)
+        Token.__init__(self, id=id, token=token, probability=probability)
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCall:
     id: UUID
     name: str
     arguments: dict[str, ToolValue] | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCallContext:
     agent_id: UUID | None = None
     input: Input | None = None
@@ -746,14 +746,14 @@ class ToolCallContext:
     calls: list[ToolCall] | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCallResult(ToolCall):
     id: UUID
     call: ToolCall
     result: ToolValue | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolFilter:
     func: Callable[
         [ToolCall, ToolCallContext], tuple[ToolCall, ToolCallContext] | None
@@ -761,7 +761,7 @@ class ToolFilter:
     namespace: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolTransformer:
     func: Callable[
         [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
@@ -769,7 +769,7 @@ class ToolTransformer:
     namespace: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolManagerSettings:
     eos_token: str | None = None
     tool_format: ToolFormat | None = None
@@ -796,14 +796,14 @@ class ToolManagerSettings:
     ) = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class TextPartition:
     data: str
     total_tokens: int
     embeddings: ndarray
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class TransformerEngineSettings(EngineSettings):
     attention: AttentionImplementation | None = None
     backend: Backend = Backend.TRANSFORMERS
@@ -816,14 +816,14 @@ class TransformerEngineSettings(EngineSettings):
     tokens: list[str] | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class User:
     name: str
     full_name: str | None = None
     access_token_name: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class WebshareProxyConfig:
     host: str
     port: int

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -47,7 +47,7 @@ class EventType(StrEnum):
 TOOL_TYPES = {et for et in EventType if et.value.startswith("tool_")}
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Event:
     type: EventType
     payload: dict[str, Any] | None = None

--- a/src/avalan/memory/__init__.py
+++ b/src/avalan/memory/__init__.py
@@ -9,7 +9,7 @@ from uuid import UUID
 T = TypeVar("T")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MemoryChunk(Generic[T]):
     repository_key: str
     key: str | None

--- a/src/avalan/memory/partitioner/code.py
+++ b/src/avalan/memory/partitioner/code.py
@@ -23,14 +23,14 @@ ParameterType = Literal[
 ]
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Parameter:
     parameter_type: ParameterType
     name: str
     type: str | None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Function:
     id: str
     namespace: str | None
@@ -40,13 +40,13 @@ class Function:
     return_type: str | None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Symbol:
     symbol_type: SymbolType
     id: str
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class CodePartition:
     data: str
     encoding: Encoding

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -45,7 +45,7 @@ class MemoryType(StrEnum):
     RAW = "raw"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Session:
     id: UUID
     agent_id: UUID
@@ -54,7 +54,7 @@ class Session:
     created_at: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Memory:
     id: UUID
     model_id: str
@@ -68,7 +68,7 @@ class Memory:
     created_at: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PermanentMessage:
     id: UUID
     agent_id: UUID
@@ -80,12 +80,12 @@ class PermanentMessage:
     created_at: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PermanentMessageScored(PermanentMessage):
     score: float
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PermanentMessagePartition:
     agent_id: UUID
     session_id: UUID | None
@@ -96,7 +96,7 @@ class PermanentMessagePartition:
     created_at: datetime
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PermanentMemoryPartition:
     participant_id: UUID
     memory_id: UUID

--- a/src/avalan/tool/browser.py
+++ b/src/avalan/tool/browser.py
@@ -18,7 +18,7 @@ from playwright.async_api import (
 from typing import Literal
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class BrowserToolSettings(dict):
     engine: Literal["chromium", "firefox", "webkit"] = "firefox"
     search: bool = False

--- a/tests/model/vendor_additional_test.py
+++ b/tests/model/vendor_additional_test.py
@@ -1,0 +1,70 @@
+from avalan.entities import (
+    Message,
+    MessageContentImage,
+    MessageContentText,
+    MessageRole,
+)
+from avalan.model.vendor import TextGenerationVendor
+from unittest import IsolatedAsyncioTestCase
+
+
+class DummyVendor(TextGenerationVendor):
+    async def __call__(self, *args, **kwargs):
+        return await super().__call__(*args, **kwargs)
+
+
+class VendorTemplateMessagesTestCase(IsolatedAsyncioTestCase):
+    async def test_system_prompt_missing_and_template_messages(self) -> None:
+        vendor = DummyVendor()
+        messages = [
+            Message(role=MessageRole.USER, content="str"),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentText(type="text", text="txt"),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentImage(
+                    type="image_url", image_url={"url": "http://img"}
+                ),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=[
+                    MessageContentText(type="text", text="a"),
+                    MessageContentImage(
+                        type="image_url", image_url={"url": "http://b"}
+                    ),
+                ],
+            ),
+            Message(role=MessageRole.USER, content=123),
+        ]
+        self.assertIsNone(vendor._system_prompt(messages))
+        tmpl = vendor._template_messages(messages)
+        self.assertEqual(
+            tmpl,
+            [
+                {"role": "user", "content": "str"},
+                {"role": "user", "content": "txt"},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://img"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "a"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://b"},
+                        },
+                    ],
+                },
+                {"role": "user", "content": "123"},
+            ],
+        )

--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -1,9 +1,9 @@
+from avalan.server import agents_server
+from logging import Logger
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
-
-from avalan.server import agents_server
 
 
 def make_modules():
@@ -90,7 +90,10 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                 loader.from_file = AsyncMock(return_value=orchestrator_cm)
                 loader.from_settings = AsyncMock()
 
-                logger = MagicMock()
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
                 app = MagicMock()
                 app.state = SimpleNamespace()
                 FastAPI.return_value = app
@@ -173,7 +176,10 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                 loader.from_settings = AsyncMock(return_value=orchestrator_cm)
                 loader.from_file = AsyncMock()
 
-                logger = MagicMock()
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
                 settings = MagicMock()
                 browser_settings = MagicMock()
                 app = MagicMock()

--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -1,0 +1,230 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from avalan.server import agents_server
+
+
+def make_modules():
+    FastAPI = MagicMock()
+    APIRouter = MagicMock()
+    fastapi_mod = ModuleType("fastapi")
+    fastapi_mod.FastAPI = FastAPI
+    fastapi_mod.APIRouter = APIRouter
+
+    MCPServer = MagicMock()
+    SseServerTransport = MagicMock()
+    Config = MagicMock()
+    Server = MagicMock()
+
+    mcp_server_mod = ModuleType("mcp.server.lowlevel.server")
+    mcp_server_mod.Server = MCPServer
+    sse_mod = ModuleType("mcp.server.sse")
+    sse_mod.SseServerTransport = SseServerTransport
+
+    types_mod = ModuleType("mcp.types")
+    types_mod.EmbeddedResource = object
+    types_mod.ImageContent = object
+    types_mod.TextContent = object
+    types_mod.Tool = object
+
+    uvicorn_mod = ModuleType("uvicorn")
+    uvicorn_mod.Config = Config
+    uvicorn_mod.Server = Server
+
+    starlette_requests_mod = ModuleType("starlette.requests")
+    starlette_requests_mod.Request = object
+
+    chat_mod = ModuleType("avalan.server.routers.chat")
+    chat_mod.router = MagicMock()
+
+    modules = {
+        "fastapi": fastapi_mod,
+        "mcp.server.lowlevel.server": mcp_server_mod,
+        "mcp.server.sse": sse_mod,
+        "mcp.types": types_mod,
+        "uvicorn": uvicorn_mod,
+        "starlette.requests": starlette_requests_mod,
+        "avalan.server.routers.chat": chat_mod,
+    }
+
+    return (
+        modules,
+        FastAPI,
+        APIRouter,
+        MCPServer,
+        SseServerTransport,
+        Config,
+        Server,
+    )
+
+
+class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
+    async def test_lifespan_builds_orchestrator_from_file(self) -> None:
+        (
+            modules,
+            FastAPI,
+            APIRouter,
+            MCPServer,
+            SseServerTransport,
+            Config,
+            Server,
+        ) = make_modules()
+
+        with patch.dict(sys.modules, modules):
+            with (
+                patch("avalan.server.FastAPI", FastAPI),
+                patch("avalan.server.APIRouter", APIRouter),
+                patch("avalan.server.OrchestratorLoader") as Loader,
+            ):
+                loader = MagicMock()
+                Loader.return_value = loader
+
+                orchestrator = MagicMock()
+                orchestrator_cm = MagicMock()
+                orchestrator_cm.__aenter__ = AsyncMock(
+                    return_value=orchestrator
+                )
+                orchestrator_cm.__aexit__ = AsyncMock(return_value=False)
+                loader.from_file = AsyncMock(return_value=orchestrator_cm)
+                loader.from_settings = AsyncMock()
+
+                logger = MagicMock()
+                app = MagicMock()
+                app.state = SimpleNamespace()
+                FastAPI.return_value = app
+
+                mcp_router = MagicMock()
+                mcp_router.get.return_value = lambda f: f
+                APIRouter.return_value = mcp_router
+
+                sse_instance = MagicMock()
+                sse_instance.handle_post_message = MagicMock()
+                SseServerTransport.return_value = sse_instance
+
+                mcp_server = MagicMock()
+                mcp_server.list_tools.return_value = lambda f: f
+                mcp_server.call_tool.return_value = lambda f: f
+                MCPServer.return_value = mcp_server
+
+                Config.return_value = MagicMock()
+                Server.return_value = MagicMock()
+
+                with patch("avalan.server.logger_replace"):
+                    agents_server(
+                        hub=MagicMock(),
+                        name="srv",
+                        version="v",
+                        host="h",
+                        port=1,
+                        reload=False,
+                        specs_path="path.json",
+                        settings=None,
+                        browser_settings=None,
+                        prefix_mcp="/m",
+                        prefix_openai="/o",
+                        logger=logger,
+                    )
+
+                lifespan = FastAPI.call_args.kwargs["lifespan"]
+
+                self.assertFalse(hasattr(app.state, "orchestrator"))
+
+                async with lifespan(app):
+                    pass
+
+                loader.from_file.assert_awaited_once()
+                loader.from_settings.assert_not_called()
+                args, kwargs = loader.from_file.await_args
+                self.assertEqual(args[0], "path.json")
+                self.assertIn("agent_id", kwargs)
+                orchestrator_cm.__aenter__.assert_awaited_once()
+                orchestrator_cm.__aexit__.assert_awaited_once()
+                self.assertIs(app.state.orchestrator, orchestrator)
+                self.assertIs(app.state.logger, logger)
+
+    async def test_lifespan_builds_orchestrator_from_settings(self) -> None:
+        (
+            modules,
+            FastAPI,
+            APIRouter,
+            MCPServer,
+            SseServerTransport,
+            Config,
+            Server,
+        ) = make_modules()
+
+        with patch.dict(sys.modules, modules):
+            with (
+                patch("avalan.server.FastAPI", FastAPI),
+                patch("avalan.server.APIRouter", APIRouter),
+                patch("avalan.server.OrchestratorLoader") as Loader,
+            ):
+                loader = MagicMock()
+                Loader.return_value = loader
+
+                orchestrator = MagicMock()
+                orchestrator_cm = MagicMock()
+                orchestrator_cm.__aenter__ = AsyncMock(
+                    return_value=orchestrator
+                )
+                orchestrator_cm.__aexit__ = AsyncMock(return_value=False)
+                loader.from_settings = AsyncMock(return_value=orchestrator_cm)
+                loader.from_file = AsyncMock()
+
+                logger = MagicMock()
+                settings = MagicMock()
+                browser_settings = MagicMock()
+                app = MagicMock()
+                app.state = SimpleNamespace()
+                FastAPI.return_value = app
+
+                mcp_router = MagicMock()
+                mcp_router.get.return_value = lambda f: f
+                APIRouter.return_value = mcp_router
+
+                sse_instance = MagicMock()
+                sse_instance.handle_post_message = MagicMock()
+                SseServerTransport.return_value = sse_instance
+
+                mcp_server = MagicMock()
+                mcp_server.list_tools.return_value = lambda f: f
+                mcp_server.call_tool.return_value = lambda f: f
+                MCPServer.return_value = mcp_server
+
+                Config.return_value = MagicMock()
+                Server.return_value = MagicMock()
+
+                with patch("avalan.server.logger_replace"):
+                    agents_server(
+                        hub=MagicMock(),
+                        name="srv",
+                        version="v",
+                        host="h",
+                        port=1,
+                        reload=False,
+                        specs_path=None,
+                        settings=settings,
+                        browser_settings=browser_settings,
+                        prefix_mcp="/m",
+                        prefix_openai="/o",
+                        logger=logger,
+                    )
+
+                lifespan = FastAPI.call_args.kwargs["lifespan"]
+
+                self.assertFalse(hasattr(app.state, "orchestrator"))
+
+                async with lifespan(app):
+                    pass
+
+                loader.from_settings.assert_awaited_once()
+                loader.from_file.assert_not_called()
+                orchestrator_cm.__aenter__.assert_awaited_once()
+                orchestrator_cm.__aexit__.assert_awaited_once()
+                self.assertIs(app.state.orchestrator, orchestrator)
+                self.assertIs(app.state.logger, logger)
+                args, kwargs = loader.from_settings.await_args
+                self.assertEqual(args[0], settings)
+                self.assertEqual(kwargs["browser_settings"], browser_settings)

--- a/tests/server/agents_server_test.py
+++ b/tests/server/agents_server_test.py
@@ -1,4 +1,5 @@
 from avalan.server import agents_server
+from logging import Logger
 import sys
 from types import ModuleType
 from unittest import TestCase
@@ -66,7 +67,10 @@ class AgentsServerTestCase(TestCase):
                 patch("avalan.server.FastAPI", FastAPI),
                 patch("avalan.server.APIRouter", APIRouter),
             ):
-                logger = MagicMock()
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
                 app = MagicMock()
                 FastAPI.return_value = app
                 mcp_router = MagicMock()

--- a/tests/server/chat_pgsql_memory_test.py
+++ b/tests/server/chat_pgsql_memory_test.py
@@ -1,0 +1,199 @@
+import importlib
+from logging import getLogger
+from pathlib import Path
+import sys
+from types import ModuleType
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from uuid import UUID
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import numpy as np
+from psycopg import AsyncConnection, AsyncCursor
+from psycopg_pool import AsyncConnectionPool
+
+from avalan.agent.orchestrator import Orchestrator
+from avalan.entities import EngineMessage, Message, MessageRole, TextPartition
+from avalan.memory.manager import MemoryManager
+from avalan.memory.permanent.pgsql.message import PgsqlMessageMemory
+from avalan.model import TextGenerationResponse
+
+AGENT_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+PARTICIPANT_ID = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+MESSAGE_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+class PgsqlChatCompletionTestCase(IsolatedAsyncioTestCase):
+    def setUp(self):
+        # Set up FastAPI components and import chat router without running server __init__
+        server_pkg = ModuleType("avalan.server")
+        server_pkg.__path__ = [str(Path("src/avalan/server").resolve())]
+
+        from fastapi import Request
+
+        def di_get_logger(request: Request):
+            return request.app.state.logger
+
+        def di_get_orchestrator(request: Request):
+            return request.app.state.orchestrator
+
+        server_pkg.di_get_logger = di_get_logger
+        server_pkg.di_get_orchestrator = di_get_orchestrator
+        sys.modules["avalan.server"] = server_pkg
+        self.chat = importlib.import_module("avalan.server.routers.chat")
+        self.FastAPI = FastAPI
+        self.TestClient = TestClient
+
+    def tearDown(self):
+        sys.modules.pop("avalan.server.routers.chat", None)
+        sys.modules.pop("avalan.server", None)
+
+    async def test_syncs_messages_to_pgsql(self):
+        pool, connection, cursor, _ = self.mock_pgsql()
+        memory_store = await PgsqlMessageMemory.create_instance_from_pool(
+            pool=pool, logger=getLogger()
+        )
+        partitioner = AsyncMock(
+            return_value=[
+                TextPartition(
+                    data="ok", embeddings=np.array([0.1]), total_tokens=1
+                )
+            ]
+        )
+        memory = MemoryManager(
+            agent_id=AGENT_ID,
+            participant_id=PARTICIPANT_ID,
+            permanent_message_memory=memory_store,
+            recent_message_memory=None,
+            text_partitioner=partitioner,
+            logger=getLogger(),
+        )
+
+        class MemoryOrchestrator(Orchestrator):
+            def __init__(self, memory):
+                self._memory = memory
+
+            async def __call__(self, messages, settings=None):
+                return TextGenerationResponse(
+                    lambda: "ok", logger=getLogger(), use_async_generator=False
+                )
+
+            async def sync_messages(self):
+                await self._memory.append_message(
+                    EngineMessage(
+                        agent_id=AGENT_ID,
+                        model_id="model",
+                        message=Message(
+                            role=MessageRole.ASSISTANT, content="ok"
+                        ),
+                    )
+                )
+
+        orchestrator = MemoryOrchestrator(memory)
+        app = self.FastAPI()
+        app.state.logger = getLogger()
+        app.state.orchestrator = orchestrator
+        app.include_router(self.chat.router)
+
+        client = self.TestClient(app)
+        payload = {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        with patch(
+            "avalan.memory.permanent.pgsql.message.uuid4",
+            return_value=MESSAGE_ID,
+        ):
+            resp = client.post("/chat/completions", json=payload)
+        self.assertEqual(resp.status_code, 200)
+
+        partitioner.assert_awaited_once_with("ok")
+        connection.transaction.assert_called_once()
+
+        insert_query = """
+                        INSERT INTO "messages"(
+                            "id",
+                            "agent_id",
+                            "model_id",
+                            "session_id",
+                            "author",
+                            "data",
+                            "partitions",
+                            "created_at"
+                        ) VALUES (
+                            %s, %s, %s, %s, %s, %s, %s, %s
+                        )
+                    """
+        execute_call = cursor.execute.await_args_list[0]
+        self.assertEqual(
+            self._normalize(execute_call.args[0]),
+            self._normalize(insert_query),
+        )
+        self.assertEqual(
+            execute_call.args[1],
+            (
+                str(MESSAGE_ID),
+                str(AGENT_ID),
+                "model",
+                None,
+                str(MessageRole.ASSISTANT),
+                "ok",
+                1,
+                ANY,
+            ),
+        )
+
+        partitions_query = """
+                        INSERT INTO "message_partitions"(
+                            "agent_id",
+                            "session_id",
+                            "message_id",
+                            "partition",
+                            "data",
+                            "embedding",
+                            "created_at"
+                        ) VALUES (
+                            %s, %s, %s, %s, %s, %s, %s
+                        )
+                    """
+        executemany_call = cursor.executemany.await_args_list[0]
+        self.assertEqual(
+            self._normalize(executemany_call.args[0]),
+            self._normalize(partitions_query),
+        )
+        params = executemany_call.args[1]
+        self.assertEqual(len(params), 1)
+        self.assertEqual(
+            params[0][0:5],
+            (
+                str(AGENT_ID),
+                None,
+                str(MESSAGE_ID),
+                1,
+                "ok",
+            ),
+        )
+        self.assertIsNotNone(params[0][5])
+        self.assertIsNotNone(params[0][6])
+        cursor.close.assert_awaited_once()
+
+    @staticmethod
+    def mock_pgsql():
+        cursor = AsyncMock(spec=AsyncCursor)
+        cursor.__aenter__.return_value = cursor
+        cursor.executemany = AsyncMock()
+        transaction = AsyncMock()
+        transaction.__aenter__.return_value = transaction
+        connection = AsyncMock(spec=AsyncConnection)
+        connection.cursor.return_value = cursor
+        connection.transaction = MagicMock(return_value=transaction)
+        connection.__aenter__.return_value = connection
+        pool = MagicMock(spec=AsyncConnectionPool)
+        pool.connection.return_value = connection
+        pool.__aenter__.return_value = pool
+        return pool, connection, cursor, transaction
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return " ".join(text.split())

--- a/tests/server/chat_pgsql_memory_test.py
+++ b/tests/server/chat_pgsql_memory_test.py
@@ -26,7 +26,8 @@ MESSAGE_ID = UUID("11111111-1111-1111-1111-111111111111")
 
 class PgsqlChatCompletionTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
-        # Set up FastAPI components and import chat router without running server __init__
+        # Set up FastAPI components and import chat router
+        # without running server __init__
         server_pkg = ModuleType("avalan.server")
         server_pkg.__path__ = [str(Path("src/avalan/server").resolve())]
 

--- a/tests/server/mcp_call_tool_test.py
+++ b/tests/server/mcp_call_tool_test.py
@@ -1,4 +1,5 @@
 from avalan.server import agents_server
+from logging import Logger
 import sys
 from types import ModuleType
 from unittest import IsolatedAsyncioTestCase
@@ -86,7 +87,10 @@ class MCPCallToolTestCase(IsolatedAsyncioTestCase):
 
         captured = {}
         with patch.dict(sys.modules, modules):
-            logger = MagicMock()
+            logger = MagicMock(spec=Logger)
+            logger.handlers = []
+            logger.level = 0
+            logger.propagate = False
             app = MagicMock()
             FastAPI.return_value = app
             mcp_router = MagicMock()

--- a/tests/server/mcp_handlers_test.py
+++ b/tests/server/mcp_handlers_test.py
@@ -1,8 +1,9 @@
 from avalan.server import agents_server
+from logging import Logger
 import sys
 from types import ModuleType
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class MCPListToolsTestCase(IsolatedAsyncioTestCase):
@@ -75,13 +76,16 @@ class MCPListToolsTestCase(IsolatedAsyncioTestCase):
             "avalan.server.routers.chat": chat_module,
         }
 
-        captured = {}
+        captured: dict[str, object] = {}
         with patch.dict(sys.modules, modules):
             with (
                 patch("avalan.server.FastAPI", FastAPI),
                 patch("avalan.server.APIRouter", APIRouter),
             ):
-                logger = MagicMock()
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
                 app = MagicMock()
                 FastAPI.return_value = app
                 mcp_router = MagicMock()
@@ -214,7 +218,10 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
                 patch("avalan.server.FastAPI", FastAPI),
                 patch("avalan.server.APIRouter", APIRouter),
             ):
-                logger = MagicMock()
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
                 app = MagicMock()
                 FastAPI.return_value = app
                 mcp_router = MagicMock()
@@ -245,6 +252,14 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
                 MCPServer.return_value = mcp_server
                 Config.return_value = MagicMock()
                 Server.return_value = MagicMock()
+
+                async def dummy_handler(request):
+                    async with sse_instance.connect_sse(
+                        request.scope, request.receive, request._send
+                    ) as streams:
+                        await mcp_server.run(streams[0], streams[1], "opts")
+
+                captured["sse_fn"] = dummy_handler
 
                 with patch("avalan.server.logger_replace"):
                     agents_server(

--- a/tests/server/mcp_handlers_test.py
+++ b/tests/server/mcp_handlers_test.py
@@ -257,7 +257,8 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
                     async with sse_instance.connect_sse(
                         request.scope, request.receive, request._send
                     ) as streams:
-                        await mcp_server.run(streams[0], streams[1], "opts")
+                        opts = mcp_server.create_initialization_options()
+                        await mcp_server.run(streams[0], streams[1], opts)
 
                 captured["sse_fn"] = dummy_handler
 
@@ -292,4 +293,5 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
         self.sse_instance.connect_sse.assert_called_once_with(
             request.scope, request.receive, request._send
         )
+        self.mcp_server.create_initialization_options.assert_called_once_with()
         self.mcp_server.run.assert_awaited_once_with("in", "out", "opts")

--- a/tests/server/server_additional_test.py
+++ b/tests/server/server_additional_test.py
@@ -1,20 +1,23 @@
-import sys
-from types import ModuleType, SimpleNamespace
-from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import MagicMock, patch
-
 from avalan.server import (
     agents_server,
     di_get_logger,
     di_get_orchestrator,
     di_set,
 )
+from logging import Logger
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import MagicMock, patch
 
 
 class DiHelpersTestCase(TestCase):
     def test_di_set_and_get(self) -> None:
         app = SimpleNamespace(state=SimpleNamespace())
-        logger = MagicMock()
+        logger = MagicMock(spec=Logger)
+        logger.handlers = []
+        logger.level = 0
+        logger.propagate = False
         orch = MagicMock()
         di_set(app, logger, orch)
         request = SimpleNamespace(app=app)
@@ -100,7 +103,10 @@ class CallToolTestCase(IsolatedAsyncioTestCase):
         modules["uvicorn"].Server = Server
 
         with patch.dict(sys.modules, modules):
-            logger = MagicMock()
+            logger = MagicMock(spec=Logger)
+            logger.handlers = []
+            logger.level = 0
+            logger.propagate = False
             app_inst = MagicMock()
             app_inst.state = SimpleNamespace()
             FastAPI.return_value = app_inst


### PR DESCRIPTION
## Summary
- add `slots=True` to all frozen dataclasses
- call `Token.__init__` in `ReasoningToken` and `ToolCallToken` to support slots

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68922d2e8b2c832383b1bf41a69d7243