### PR TITLE
Test MCP SSE handler

### DIFF
--- a/tests/server/mcp_handlers_test.py
+++ b/tests/server/mcp_handlers_test.py
@@ -257,7 +257,8 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
                     async with sse_instance.connect_sse(
                         request.scope, request.receive, request._send
                     ) as streams:
-                        await mcp_server.run(streams[0], streams[1], "opts")
+                        opts = mcp_server.create_initialization_options()
+                        await mcp_server.run(streams[0], streams[1], opts)
 
                 captured["sse_fn"] = dummy_handler
 
@@ -292,4 +293,5 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
         self.sse_instance.connect_sse.assert_called_once_with(
             request.scope, request.receive, request._send
         )
+        self.mcp_server.create_initialization_options.assert_called_once_with()
         self.mcp_server.run.assert_awaited_once_with("in", "out", "opts")


### PR DESCRIPTION
## Summary
- add regression test for agents_server MCP `/sse/` handler

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6892b8cf1cb08323948f78c3c9857e5d