### PR TITLE
Add coverage tests for TextGenerationVendor

### DIFF
--- a/tests/model/vendor_additional_test.py
+++ b/tests/model/vendor_additional_test.py
@@ -1,0 +1,70 @@
+from avalan.entities import (
+    Message,
+    MessageContentImage,
+    MessageContentText,
+    MessageRole,
+)
+from avalan.model.vendor import TextGenerationVendor
+from unittest import IsolatedAsyncioTestCase
+
+
+class DummyVendor(TextGenerationVendor):
+    async def __call__(self, *args, **kwargs):
+        return await super().__call__(*args, **kwargs)
+
+
+class VendorTemplateMessagesTestCase(IsolatedAsyncioTestCase):
+    async def test_system_prompt_missing_and_template_messages(self) -> None:
+        vendor = DummyVendor()
+        messages = [
+            Message(role=MessageRole.USER, content="str"),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentText(type="text", text="txt"),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentImage(
+                    type="image_url", image_url={"url": "http://img"}
+                ),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=[
+                    MessageContentText(type="text", text="a"),
+                    MessageContentImage(
+                        type="image_url", image_url={"url": "http://b"}
+                    ),
+                ],
+            ),
+            Message(role=MessageRole.USER, content=123),
+        ]
+        self.assertIsNone(vendor._system_prompt(messages))
+        tmpl = vendor._template_messages(messages)
+        self.assertEqual(
+            tmpl,
+            [
+                {"role": "user", "content": "str"},
+                {"role": "user", "content": "txt"},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://img"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "a"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://b"},
+                        },
+                    ],
+                },
+                {"role": "user", "content": "123"},
+            ],
+        )


### PR DESCRIPTION
## Summary
- add comprehensive tests for TextGenerationVendor helper methods

## Testing
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6892c0212ffc83239214bdbc1feb088d