### PR TITLE
Allow configurable reasoning tags

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -40,6 +40,7 @@ from ..entities import (
     TimestepSpacing,
     TextGenerationLoaderClass,
     Backend,
+    ReasoningTag,
     User,
     WeightType,
 )
@@ -640,6 +641,13 @@ class CLI:
             "--tools-confirm",
             action="store_true",
             help="Confirm tool calls before execution",
+        )
+        agent_run_parser.add_argument(
+            "--reasoning-tag",
+            type=str,
+            choices=[t.value for t in ReasoningTag],
+            default=ReasoningTag.THINK.value,
+            help="Reasoning tag style",
         )
 
         CLI._add_agent_settings_arguments(agent_run_parser)
@@ -1344,6 +1352,13 @@ class CLI:
             action="store_true",
             default=False,
             help="Disable reasoning parser",
+        )
+        model_run_parser.add_argument(
+            "--reasoning-tag",
+            type=str,
+            choices=[t.value for t in ReasoningTag],
+            default=ReasoningTag.THINK.value,
+            help="Reasoning tag style",
         )
         model_run_parser.add_argument(
             "--reasoning-max-new-tokens",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -19,12 +19,7 @@ SimilarityFunction = Literal["cosine", "dot", "euclidean", "manhattan"]
 
 ImageTextGenerationLoaderClass = Literal["gemma3", "qwen2"]
 
-TextGenerationLoaderClass = Literal[
-    "auto",
-    "gemma3",
-    "gpt-oss",
-    "mistral3"
-]
+TextGenerationLoaderClass = Literal["auto", "gemma3", "gpt-oss", "mistral3"]
 
 
 class Backend(StrEnum):
@@ -180,6 +175,11 @@ class BetaSchedule(StrEnum):
     SQUAREDCOS_CAP_V2 = "squaredcos_cap_v2"
 
 
+class ReasoningTag(StrEnum):
+    THINK = "think"
+    CHANNEL = "channel"
+
+
 @dataclass(frozen=True, kw_only=True, slots=True)
 class QuantizationSettings:
     load_in_4bit: bool
@@ -233,6 +233,7 @@ class ReasoningSettings:
     max_new_tokens: int | None = None
     enabled: bool = True
     stop_on_max_new_tokens: bool = False
+    tag: ReasoningTag = ReasoningTag.THINK
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -4,6 +4,7 @@ from ..entities import (
     GenerationSettings,
     ChatSettings,
     ReasoningSettings,
+    ReasoningTag,
     Input,
     Modality,
     Operation,
@@ -489,6 +490,9 @@ class ModelManager(ContextDecorator):
                 args,
                 "reasoning_stop_on_max_new_tokens",
                 False,
+            ),
+            tag=ReasoningTag(
+                getattr(args, "reasoning_tag", ReasoningTag.THINK.value)
             ),
         )
         settings = GenerationSettings(

--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -1,4 +1,4 @@
-from ....entities import ReasoningSettings, ReasoningToken
+from ....entities import ReasoningSettings, ReasoningTag, ReasoningToken
 from logging import Logger
 from typing import Any, Iterable
 
@@ -8,6 +8,14 @@ class ReasoningTokenLimitExceeded(Exception):
 
 
 class ReasoningParser:
+    tags: dict[ReasoningTag, tuple[str, str]] = {
+        ReasoningTag.THINK: ("<think>", "</think>"),
+        ReasoningTag.CHANNEL: (
+            "<|channel|>analysis<|message|>",
+            "<|end|><|start|>assistant<|channel|>final<|message|>",
+        ),
+    }
+
     _settings: ReasoningSettings
     _start_tag: str
     _end_tag: str
@@ -26,15 +34,16 @@ class ReasoningParser:
         *,
         reasoning_settings: ReasoningSettings,
         logger: Logger,
-        start_tag: str = "<think>",
-        end_tag: str = "</think>",
+        start_tag: str | None = None,
+        end_tag: str | None = None,
         prefixes: list[str] | None = None,
         max_thinking_turns: int = 1,
     ) -> None:
         self._settings = reasoning_settings
         self._logger = logger
-        self._start_tag = start_tag
-        self._end_tag = end_tag
+        default_start, default_end = self.tags[reasoning_settings.tag]
+        self._start_tag = start_tag or default_start
+        self._end_tag = end_tag or default_end
         self._prefixes = tuple(prefixes or ["Think:"])
         self._thinking = False
         self._thinking_turns = 0

--- a/tests/agent/reasoning_parser_tag_test.py
+++ b/tests/agent/reasoning_parser_tag_test.py
@@ -1,0 +1,42 @@
+from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.entities import ReasoningSettings, ReasoningTag, ReasoningToken
+from logging import getLogger
+from unittest import IsolatedAsyncioTestCase
+
+
+class ReasoningParserTagTestCase(IsolatedAsyncioTestCase):
+    async def test_think_tag(self):
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(tag=ReasoningTag.THINK),
+            logger=getLogger(),
+        )
+        tokens: list[object] = []
+        for t in ["a", "<think>", "b", "</think>", "c"]:
+            tokens.extend(await parser.push(t))
+        self.assertEqual(tokens[0], "a")
+        self.assertIsInstance(tokens[1], ReasoningToken)
+        self.assertEqual(tokens[1].token, "<think>")
+        self.assertIsInstance(tokens[2], ReasoningToken)
+        self.assertEqual(tokens[2].token, "b")
+        self.assertIsInstance(tokens[3], ReasoningToken)
+        self.assertEqual(tokens[3].token, "</think>")
+        self.assertEqual(tokens[4], "c")
+
+    async def test_channel_tag(self):
+        start = "<|channel|>analysis<|message|>"
+        end = "<|end|><|start|>assistant<|channel|>final<|message|>"
+        parser = ReasoningParser(
+            reasoning_settings=ReasoningSettings(tag=ReasoningTag.CHANNEL),
+            logger=getLogger(),
+        )
+        tokens: list[object] = []
+        for t in ["x", start, "y", end, "z"]:
+            tokens.extend(await parser.push(t))
+        self.assertEqual(tokens[0], "x")
+        self.assertIsInstance(tokens[1], ReasoningToken)
+        self.assertEqual(tokens[1].token, start)
+        self.assertIsInstance(tokens[2], ReasoningToken)
+        self.assertEqual(tokens[2].token, "y")
+        self.assertIsInstance(tokens[3], ReasoningToken)
+        self.assertEqual(tokens[3].token, end)
+        self.assertEqual(tokens[4], "z")

--- a/tests/cli/agent_reasoning_tag_test.py
+++ b/tests/cli/agent_reasoning_tag_test.py
@@ -1,0 +1,166 @@
+from avalan.cli.commands import agent as agent_cmds
+from avalan.entities import GenerationSettings, ReasoningSettings, ReasoningTag
+from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.model.response.text import TextGenerationResponse
+from argparse import Namespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+from logging import getLogger
+
+
+class CliAgentReasoningTagTestCase(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:  # type: ignore[override]
+        self.args = Namespace(
+            specifications_file="spec.toml",
+            id="aid",
+            participant="pid",
+            session="sid",
+            no_session=False,
+            no_repl=False,
+            quiet=False,
+            skip_hub_access_check=False,
+            tool_events=0,
+            tool=None,
+            run_max_new_tokens=100,
+            backend="transformers",
+            memory_recent=None,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            tty="/dev/tty",
+            display_tokens=0,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=0,
+            tools_confirm=False,
+            use_sync_generator=False,
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+            stats=False,
+            conversation=False,
+            watch=False,
+            skip_load_recent_messages=True,
+            load_recent_messages_limit=None,
+            start_thinking=False,
+            chat_disable_thinking=False,
+            reasoning_tag=ReasoningTag.THINK.value,
+        )
+        self.console = MagicMock()
+        status_cm = MagicMock()
+        status_cm.__enter__.return_value = None
+        status_cm.__exit__.return_value = False
+        self.console.status.return_value = status_cm
+        self.theme = MagicMock()
+        self.theme._ = lambda s: s
+        self.theme.icons = {"user_input": ">", "agent_output": "<"}
+        self.theme.agent.return_value = "agent_panel"
+        self.hub = MagicMock()
+        self.hub.can_access.return_value = True
+        self.hub.model.side_effect = lambda m: f"mdl-{m}"
+        self.logger = MagicMock()
+        self.orch = AsyncMock()
+        self.orch.engine_agent = True
+        self.orch.engine = MagicMock(model_id="m")
+        self.orch.model_ids = ["m"]
+        self.orch.event_manager.add_listener = MagicMock()
+        memory = MagicMock()
+        memory.continue_session = AsyncMock()
+        self.orch.memory = memory
+        self.dummy_stack = AsyncMock()
+        self.dummy_stack.__aenter__.return_value = self.dummy_stack
+        self.dummy_stack.__aexit__.return_value = False
+        self.dummy_stack.enter_async_context = AsyncMock(
+            return_value=self.orch
+        )
+
+    async def _run(self, tag: ReasoningTag) -> tuple[str, str]:
+        self.args.reasoning_tag = tag.value
+
+        async def gen():
+            yield "t"
+
+        class DummyOrchestratorResponse:
+            input_token_count = 1
+
+            def __init__(self) -> None:
+                settings = GenerationSettings(
+                    reasoning=ReasoningSettings(tag=tag)
+                )
+                self._resp = TextGenerationResponse(
+                    lambda **_: gen(),
+                    logger=getLogger(),
+                    use_async_generator=True,
+                    generation_settings=settings,
+                    settings=settings,
+                )
+
+            def __aiter__(self):
+                return self._resp.__aiter__()
+
+        recorded: dict[str, str] = {}
+        orig_init = ReasoningParser.__init__
+
+        def rec_init(
+            self,
+            *,
+            reasoning_settings,
+            logger,
+            start_tag=None,
+            end_tag=None,
+            prefixes=None,
+            max_thinking_turns=1,
+        ) -> None:
+            orig_init(
+                self,
+                reasoning_settings=reasoning_settings,
+                logger=logger,
+                start_tag=start_tag,
+                end_tag=end_tag,
+                prefixes=prefixes,
+                max_thinking_turns=max_thinking_turns,
+            )
+            recorded["start_tag"] = self._start_tag
+            recorded["end_tag"] = self._end_tag
+
+        with (
+            patch.object(agent_cmds, "get_input", return_value="hi"),
+            patch.object(
+                agent_cmds, "AsyncExitStack", return_value=self.dummy_stack
+            ),
+            patch.object(
+                agent_cmds.OrchestratorLoader,
+                "from_file",
+                new=AsyncMock(return_value=self.orch),
+            ),
+            patch.object(
+                agent_cmds, "token_generation", new_callable=AsyncMock
+            ),
+            patch.object(
+                agent_cmds, "OrchestratorResponse", DummyOrchestratorResponse
+            ),
+            patch.object(ReasoningParser, "__init__", rec_init),
+        ):
+            self.orch.side_effect = (
+                lambda *a, **kw: DummyOrchestratorResponse()
+            )
+            await agent_cmds.agent_run(
+                self.args, self.console, self.theme, self.hub, self.logger, 1
+            )
+        return recorded["start_tag"], recorded["end_tag"]
+
+    async def test_think_tag(self):
+        start, end = await self._run(ReasoningTag.THINK)
+        self.assertEqual(start, "<think>")
+        self.assertEqual(end, "</think>")
+
+    async def test_channel_tag(self):
+        start, end = await self._run(ReasoningTag.CHANNEL)
+        self.assertEqual(start, "<|channel|>analysis<|message|>")
+        self.assertEqual(
+            end,
+            "<|end|><|start|>assistant<|channel|>final<|message|>",
+        )

--- a/tests/cli/model_reasoning_tag_test.py
+++ b/tests/cli/model_reasoning_tag_test.py
@@ -1,0 +1,130 @@
+from avalan.cli.commands import model as model_cmds
+from avalan.entities import Modality, ReasoningTag
+from avalan.model.manager import ModelManager as RealModelManager
+from avalan.model.response.parsers.reasoning import ReasoningParser
+from avalan.model.response.text import TextGenerationResponse
+from types import SimpleNamespace
+from argparse import Namespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+from logging import getLogger
+
+
+class CliModelReasoningTagTestCase(IsolatedAsyncioTestCase):
+    async def _run(self, tag: ReasoningTag) -> tuple[str, str]:
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            model="id",
+            device="cpu",
+            max_new_tokens=2,
+            quiet=True,
+            skip_hub_access_check=False,
+            no_repl=False,
+            do_sample=True,
+            enable_gradient_calculation=True,
+            min_p=0.1,
+            repetition_penalty=1.0,
+            temperature=0.5,
+            top_k=5,
+            top_p=0.9,
+            use_cache=False,
+            stop_on_keyword=None,
+            system=None,
+            skip_special_tokens=False,
+            display_tokens=0,
+            tool_events=0,
+            display_events=False,
+            display_tools=False,
+            display_tools_events=0,
+            start_thinking=False,
+            chat_disable_thinking=False,
+            reasoning_tag=tag.value,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        hub = MagicMock()
+        logger = MagicMock()
+        engine_uri = SimpleNamespace(model_id="id", is_local=True)
+        load_cm = MagicMock()
+        load_cm.__enter__.return_value = MagicMock()
+        load_cm.__exit__.return_value = False
+        manager = RealModelManager(hub, logger)
+        manager.parse_uri = MagicMock(return_value=engine_uri)
+        manager.load = MagicMock(return_value=load_cm)
+
+        async def manager_call(
+            self, _engine_uri, _model, operation, tool=None
+        ):
+            async def gen():
+                yield "t"
+
+            return TextGenerationResponse(
+                lambda **_: gen(),
+                logger=getLogger(),
+                use_async_generator=True,
+                generation_settings=operation.generation_settings,
+                settings=operation.generation_settings,
+            )
+
+        recorded: dict[str, str] = {}
+        orig_init = ReasoningParser.__init__
+
+        def rec_init(
+            self,
+            *,
+            reasoning_settings,
+            logger,
+            start_tag=None,
+            end_tag=None,
+            prefixes=None,
+            max_thinking_turns=1,
+        ) -> None:
+            orig_init(
+                self,
+                reasoning_settings=reasoning_settings,
+                logger=logger,
+                start_tag=start_tag,
+                end_tag=end_tag,
+                prefixes=prefixes,
+                max_thinking_turns=max_thinking_turns,
+            )
+            recorded["start_tag"] = self._start_tag
+            recorded["end_tag"] = self._end_tag
+
+        with (
+            patch.object(model_cmds, "ModelManager", return_value=manager),
+            patch.object(
+                model_cmds.ModelManager,
+                "get_operation_from_arguments",
+                side_effect=RealModelManager.get_operation_from_arguments,
+            ),
+            patch.object(RealModelManager, "__call__", manager_call),
+            patch.object(
+                model_cmds,
+                "get_model_settings",
+                return_value={
+                    "engine_uri": engine_uri,
+                    "modality": Modality.TEXT_GENERATION,
+                },
+            ),
+            patch.object(model_cmds, "get_input", return_value="hi"),
+            patch.object(
+                model_cmds, "token_generation", new_callable=AsyncMock
+            ),
+            patch.object(ReasoningParser, "__init__", rec_init),
+        ):
+            await model_cmds.model_run(args, console, theme, hub, 5, logger)
+        return recorded["start_tag"], recorded["end_tag"]
+
+    async def test_think_tag(self):
+        start, end = await self._run(ReasoningTag.THINK)
+        self.assertEqual(start, "<think>")
+        self.assertEqual(end, "</think>")
+
+    async def test_channel_tag(self):
+        start, end = await self._run(ReasoningTag.CHANNEL)
+        self.assertEqual(start, "<|channel|>analysis<|message|>")
+        self.assertEqual(
+            end,
+            "<|end|><|start|>assistant<|channel|>final<|message|>",
+        )


### PR DESCRIPTION
## Summary
- add `ReasoningTag` enum and expose as `ReasoningSettings.tag`
- let `ReasoningParser` derive default tags from settings
- introduce `--reasoning-tag` option for `model run` and `agent run`
- test reasoning tag behavior for parser, model run, and agent run

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_6895448b62a48323b9b965069e17f0e6