### PR TITLE
Allow configuring answer panel height

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -488,6 +488,21 @@ class CLI:
             help="How many tool events to show on tool call panel",
         )
 
+        display_answer_height_group = (
+            model_inference_display_parser.add_mutually_exclusive_group()
+        )
+        display_answer_height_group.add_argument(
+            "--display-answer-height-expand",
+            action="store_true",
+            help="Expand answer section to full height",
+        )
+        display_answer_height_group.add_argument(
+            "--display-answer-height",
+            type=int,
+            default=12,
+            help="Height of the answer section (defaults to 12)",
+        )
+
         # Agent command
         agent_parser = command_parsers.add_parser(
             name="agent",

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -647,6 +647,10 @@ async def _token_stream(
 
         if display_tokens and isinstance(token, Token):
             tokens.append(token)
+        limit_answer_height = not getattr(
+            args, "display_answer_height_expand", False
+        )
+        answer_height = getattr(args, "display_answer_height", 12)
 
         token_frames_promise = theme.tokens(
             lm.model_id,
@@ -697,8 +701,9 @@ async def _token_stream(
             console.width,
             logger,
             event_stats,
+            height=answer_height,
             tool_events_limit=tool_events_limit,
-            limit_answer_height=True,
+            limit_answer_height=limit_answer_height,
             maximum_frames=1,
             start_thinking=start_thinking,
         )

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -4640,6 +4640,137 @@ class CliRenderFrameTestCase(IsolatedAsyncioTestCase):
         self.assertTrue(orch_response.is_thinking)
         theme.tokens.assert_called_once()
 
+    async def test_token_stream_answer_height_expand_option(self):
+        async def token_gen():
+            yield model_cmds.Token(id=1, token="A")
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                return token_gen()
+
+        async def fake_frames(*_, **__):
+            yield (None, "frame")
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+            display_answer_height_expand=True,
+        )
+
+        console = MagicMock()
+        console.width = 80
+        live = MagicMock()
+        logger = MagicMock()
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_frames)
+
+        lm = SimpleNamespace(
+            model_id="m", tokenizer_config=None, input_token_count=lambda s: 1
+        )
+
+        await model_cmds._token_stream(
+            live=live,
+            group=None,
+            tokens_group_index=None,
+            args=args,
+            console=console,
+            theme=theme,
+            logger=logger,
+            orchestrator=None,
+            event_stats=None,
+            lm=lm,
+            input_string="hi",
+            response=Resp(),
+            display_tokens=0,
+            dtokens_pick=0,
+            refresh_per_second=2,
+            stop_signal=None,
+            tool_events_limit=None,
+            with_stats=True,
+        )
+
+        self.assertFalse(theme.tokens.call_args.kwargs["limit_answer_height"])
+
+    async def test_token_stream_answer_height_option(self):
+        async def token_gen():
+            yield model_cmds.Token(id=1, token="A")
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                return token_gen()
+
+        async def fake_frames(*_, **__):
+            yield (None, "frame")
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+            display_answer_height=20,
+        )
+
+        console = MagicMock()
+        console.width = 80
+        live = MagicMock()
+        logger = MagicMock()
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_frames)
+
+        lm = SimpleNamespace(
+            model_id="m", tokenizer_config=None, input_token_count=lambda s: 1
+        )
+
+        await model_cmds._token_stream(
+            live=live,
+            group=None,
+            tokens_group_index=None,
+            args=args,
+            console=console,
+            theme=theme,
+            logger=logger,
+            orchestrator=None,
+            event_stats=None,
+            lm=lm,
+            input_string="hi",
+            response=Resp(),
+            display_tokens=0,
+            dtokens_pick=0,
+            refresh_per_second=2,
+            stop_signal=None,
+            tool_events_limit=None,
+            with_stats=True,
+        )
+
+        self.assertTrue(theme.tokens.call_args.kwargs["limit_answer_height"])
+        self.assertEqual(theme.tokens.call_args.kwargs["height"], 20)
+
 
 class CliReasoningTokenTestCase(IsolatedAsyncioTestCase):
     async def test_reasoning_token_tracked(self):


### PR DESCRIPTION
## Summary
- add CLI flags to expand the answer panel or set its height
- respect new options when rendering token stream
- test answer height and expand options

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68974cfb81848323a5e8c3beba0d5d3d