### PR TITLE
Simplify channel reasoning end tag

### DIFF
--- a/src/avalan/model/response/parsers/reasoning.py
+++ b/src/avalan/model/response/parsers/reasoning.py
@@ -12,7 +12,7 @@ class ReasoningParser:
         ReasoningTag.THINK: ("<think>", "</think>"),
         ReasoningTag.CHANNEL: (
             "<|channel|>analysis<|message|>",
-            "<|end|><|start|>assistant<|channel|>final<|message|>",
+            "<|end|>",
         ),
     }
 

--- a/tests/agent/reasoning_parser_split_tag_test.py
+++ b/tests/agent/reasoning_parser_split_tag_test.py
@@ -62,12 +62,7 @@ class ReasoningParserSplitTagTestCase(IsolatedAsyncioTestCase):
         )
         start_parts = ["<|channel|>", "analysis", "<|message|>"]
         message = ["Leo", "Messi", "dances", "past", "defenders"]
-        end_parts = [
-            "<|end|>",
-            "<|start|>assistant",
-            "<|channel|>final",
-            "<|message|>",
-        ]
+        end_parts = ["<|", "end", "|>"]
         outputs: list[object] = []
         for text in start_parts + message + end_parts:
             outputs.extend(await parser.push(text))

--- a/tests/agent/reasoning_parser_tag_test.py
+++ b/tests/agent/reasoning_parser_tag_test.py
@@ -24,7 +24,7 @@ class ReasoningParserTagTestCase(IsolatedAsyncioTestCase):
 
     async def test_channel_tag(self):
         start = "<|channel|>analysis<|message|>"
-        end = "<|end|><|start|>assistant<|channel|>final<|message|>"
+        end = "<|end|>"
         parser = ReasoningParser(
             reasoning_settings=ReasoningSettings(tag=ReasoningTag.CHANNEL),
             logger=getLogger(),
@@ -56,7 +56,7 @@ class ReasoningParserTagTestCase(IsolatedAsyncioTestCase):
 
     async def test_auto_tag_channel(self):
         start = "<|channel|>analysis<|message|>"
-        end = "<|end|><|start|>assistant<|channel|>final<|message|>"
+        end = "<|end|>"
         parser = ReasoningParser(
             reasoning_settings=ReasoningSettings(),
             logger=getLogger(),

--- a/tests/cli/agent_reasoning_tag_test.py
+++ b/tests/cli/agent_reasoning_tag_test.py
@@ -162,7 +162,4 @@ class CliAgentReasoningTagTestCase(IsolatedAsyncioTestCase):
     async def test_channel_tag(self):
         start, end = await self._run(ReasoningTag.CHANNEL)
         self.assertEqual(start, "<|channel|>analysis<|message|>")
-        self.assertEqual(
-            end,
-            "<|end|><|start|>assistant<|channel|>final<|message|>",
-        )
+        self.assertEqual(end, "<|end|>")

--- a/tests/cli/model_reasoning_tag_test.py
+++ b/tests/cli/model_reasoning_tag_test.py
@@ -126,7 +126,4 @@ class CliModelReasoningTagTestCase(IsolatedAsyncioTestCase):
     async def test_channel_tag(self):
         start, end = await self._run(ReasoningTag.CHANNEL)
         self.assertEqual(start, "<|channel|>analysis<|message|>")
-        self.assertEqual(
-            end,
-            "<|end|><|start|>assistant<|channel|>final<|message|>",
-        )
+        self.assertEqual(end, "<|end|>")


### PR DESCRIPTION
## Summary
- use `<|end|>` as the channel reasoning end tag in `ReasoningParser`
- update channel tag tests for the new end marker

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_689bf7ba5de48323929b71efb4a5a3eb