### PR TITLE
Add namespace-based tool selection

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1719,6 +1719,12 @@ class CLI:
         group.add_argument(
             "--tool", type=str, action="append", help="Enable tool"
         )
+        group.add_argument(
+            "--tools",
+            type=str,
+            action="append",
+            help="Enable tools matching namespace",
+        )
         return group
 
     @staticmethod

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -124,7 +124,11 @@ def get_orchestrator_settings(
         sentence_model_overlap_size=args.memory_engine_overlap,
         sentence_model_window_size=args.memory_engine_window,
         json_config=None,
-        tools=tools if tools is not None else args.tool or [],
+        tools=(
+            tools
+            if tools is not None
+            else (args.tool or []) + (getattr(args, "tools", None) or [])
+        ),
         log_events=True,
     )
 
@@ -252,7 +256,8 @@ async def agent_message_search(
                     args,
                     agent_id=agent_id,
                     memory_recent=memory_recent,
-                    tools=args.tool,
+                    tools=(args.tool or [])
+                    + (getattr(args, "tools", None) or []),
                 )
                 browser_settings = get_tool_settings(
                     args, prefix="browser", settings_cls=BrowserToolSettings
@@ -380,7 +385,7 @@ async def agent_run(
                 args,
                 agent_id=agent_id or uuid4(),
                 memory_recent=memory_recent,
-                tools=args.tool,
+                tools=(args.tool or []) + (getattr(args, "tools", None) or []),
                 max_new_tokens=getattr(args, "run_max_new_tokens", None),
                 temperature=getattr(args, "run_temperature", None),
                 top_k=getattr(args, "run_top_k", None),
@@ -575,7 +580,7 @@ async def agent_serve(
             args,
             agent_id=uuid4(),
             memory_recent=memory_recent,
-            tools=args.tool,
+            tools=(args.tool or []) + (getattr(args, "tools", None) or []),
         )
         browser_settings = get_tool_settings(
             args, prefix="browser", settings_cls=BrowserToolSettings
@@ -668,7 +673,7 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         memory_recent=memory_recent,
         memory_permanent_message=memory_permanent_message,
         max_new_tokens=args.run_max_new_tokens or 1024,
-        tools=args.tool or [],
+        tools=(args.tool or []) + (getattr(args, "tools", None) or []),
     )
 
     browser_tool = get_tool_settings(

--- a/src/avalan/tool/__init__.py
+++ b/src/avalan/tool/__init__.py
@@ -110,12 +110,17 @@ class ToolSet(ContextDecorator):
 
     def with_enabled_tools(self, enable_tools: list[str]) -> "ToolSet":
         prefix = f"{self.namespace}." if self.namespace else ""
-        tools = [
-            tool
-            for tool in self._tools
-            if f"{prefix}{getattr(tool, '__name__', tool.__class__.__name__)}"
-            in enable_tools
-        ]
+
+        tools = []
+        for tool in self._tools:
+            name = (
+                f"{prefix}{getattr(tool, '__name__', tool.__class__.__name__)}"
+            )
+            for enabled in enable_tools:
+                if name == enabled or name.startswith(f"{enabled}."):
+                    tools.append(tool)
+                    break
+
         self._tools = tools
         return self
 

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -51,6 +51,33 @@ class ToolManagerCreationTestCase(TestCase):
         self.assertTrue(manager.is_empty)
         self.assertIsNone(manager.tools)
 
+    def test_enable_tools_partial_namespace(self):
+        calculator = CalculatorTool()
+        manager = ToolManager.create_instance(
+            enable_tools=["math"],
+            available_toolsets=[ToolSet(namespace="math", tools=[calculator])],
+            settings=ToolManagerSettings(),
+        )
+        self.assertEqual(manager.tools, [calculator])
+
+    def test_enable_tools_full_namespace(self):
+        calculator = CalculatorTool()
+        manager = ToolManager.create_instance(
+            enable_tools=["math.calculator"],
+            available_toolsets=[ToolSet(namespace="math", tools=[calculator])],
+            settings=ToolManagerSettings(),
+        )
+        self.assertEqual(manager.tools, [calculator])
+
+    def test_enable_tools_no_namespace_match(self):
+        calculator = CalculatorTool()
+        manager = ToolManager.create_instance(
+            enable_tools=["science"],
+            available_toolsets=[ToolSet(namespace="math", tools=[calculator])],
+            settings=ToolManagerSettings(),
+        )
+        self.assertTrue(manager.is_empty)
+
 
 class DummyAdder:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- allow enabling multiple tools via new `--tools` CLI flag that matches namespaces
- include namespace-aware filtering in `ToolSet.with_enabled_tools`
- accept both `--tool` and `--tools` when building orchestrator settings
- add tests for partial, full, and missing namespace matches

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_689ccfce74a08323b1219d48bf49df73