### PR TITLE
Refactor ModelManager into modality registry

### DIFF
--- a/src/avalan/model/modalities/__init__.py
+++ b/src/avalan/model/modalities/__init__.py
@@ -1,0 +1,2 @@
+from .registry import ModalityRegistry as ModalityRegistry
+from . import audio, text, vision  # noqa: F401

--- a/src/avalan/model/modalities/audio.py
+++ b/src/avalan/model/modalities/audio.py
@@ -1,0 +1,98 @@
+from .registry import ModalityRegistry
+from ..audio.classification import AudioClassificationModel
+from ..audio.generation import AudioGenerationModel
+from ..audio.speech import TextToSpeechModel
+from ..audio.speech_recognition import SpeechRecognitionModel
+from ...entities import EngineUri, Modality, Operation
+from ...tool.manager import ToolManager
+
+from typing import Any
+
+
+@ModalityRegistry.register(Modality.AUDIO_CLASSIFICATION)
+class AudioClassificationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: AudioClassificationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["audio"]
+            and operation.parameters["audio"].path
+            and operation.parameters["audio"].sampling_rate
+        )
+
+        return await model(
+            path=operation.parameters["audio"].path,
+            sampling_rate=operation.parameters["audio"].sampling_rate,
+        )
+
+
+@ModalityRegistry.register(Modality.AUDIO_SPEECH_RECOGNITION)
+class AudioSpeechRecognitionModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: SpeechRecognitionModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["audio"]
+            and operation.parameters["audio"].path
+            and operation.parameters["audio"].sampling_rate
+        )
+
+        return await model(
+            path=operation.parameters["audio"].path,
+            sampling_rate=operation.parameters["audio"].sampling_rate,
+        )
+
+
+@ModalityRegistry.register(Modality.AUDIO_TEXT_TO_SPEECH)
+class AudioTextToSpeechModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TextToSpeechModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["audio"]
+            and operation.parameters["audio"].path
+            and operation.parameters["audio"].sampling_rate
+        )
+
+        return await model(
+            path=operation.parameters["audio"].path,
+            prompt=operation.input,
+            max_new_tokens=operation.generation_settings.max_new_tokens,
+            reference_path=operation.parameters["audio"].reference_path,
+            reference_text=operation.parameters["audio"].reference_text,
+            sampling_rate=operation.parameters["audio"].sampling_rate,
+        )
+
+
+@ModalityRegistry.register(Modality.AUDIO_GENERATION)
+class AudioGenerationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: AudioGenerationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["audio"]
+            and operation.parameters["audio"].path
+        )
+
+        return await model(
+            operation.input,
+            operation.parameters["audio"].path,
+            operation.generation_settings.max_new_tokens,
+        )

--- a/src/avalan/model/modalities/registry.py
+++ b/src/avalan/model/modalities/registry.py
@@ -1,0 +1,33 @@
+from collections.abc import Awaitable, Callable
+from inspect import isclass
+from typing import Any
+
+from ...entities import EngineUri, Modality, Operation
+from ...tool.manager import ToolManager
+
+ModalityCallable = Callable[
+    [EngineUri, Any, Operation, ToolManager | None],
+    Awaitable[Any],
+]
+
+
+class ModalityRegistry:
+    _handlers: dict[Modality, ModalityCallable] = {}
+
+    @classmethod
+    def register(
+        cls, modality: Modality
+    ) -> Callable[[ModalityCallable], ModalityCallable]:
+        def decorator(handler: ModalityCallable | type) -> ModalityCallable:
+            cls._handlers[modality] = (
+                handler() if isclass(handler) else handler
+            )
+            return handler
+
+        return decorator
+
+    @classmethod
+    def get(cls, modality: Modality) -> ModalityCallable:
+        if modality not in cls._handlers:
+            raise NotImplementedError(f"Modality {modality} not registered")
+        return cls._handlers[modality]

--- a/src/avalan/model/modalities/text.py
+++ b/src/avalan/model/modalities/text.py
@@ -1,0 +1,162 @@
+from .registry import ModalityRegistry
+from ..criteria import KeywordStoppingCriteria
+from ..nlp.question import QuestionAnsweringModel
+from ..nlp.sequence import (
+    SequenceClassificationModel,
+    SequenceToSequenceModel,
+    TranslationModel,
+)
+from ..nlp.text.generation import TextGenerationModel
+from ..nlp.text.mlxlm import MlxLmModel
+from ..nlp.token import TokenClassificationModel
+from ...entities import EngineUri, Modality, Operation
+from ...tool.manager import ToolManager
+
+from typing import Any
+
+
+def _stopping_criteria(
+    operation: Operation, model: Any
+) -> KeywordStoppingCriteria | None:
+    text_params = (
+        operation.parameters["text"] if operation.parameters else None
+    )
+    if text_params and text_params.stop_on_keywords:
+        return KeywordStoppingCriteria(
+            text_params.stop_on_keywords, model.tokenizer
+        )
+    return None
+
+
+@ModalityRegistry.register(Modality.TEXT_GENERATION)
+class TextGenerationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TextGenerationModel | MlxLmModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert operation.input and operation.parameters["text"]
+
+        criteria = _stopping_criteria(operation, model)
+        is_mlx = isinstance(model, MlxLmModel)
+        if engine_uri.is_local and not is_mlx:
+            return await model(
+                operation.input,
+                system_prompt=operation.parameters["text"].system_prompt,
+                settings=operation.generation_settings,
+                stopping_criterias=[criteria] if criteria else None,
+                manual_sampling=operation.parameters["text"].manual_sampling,
+                pick=operation.parameters["text"].pick_tokens,
+                skip_special_tokens=operation.parameters[
+                    "text"
+                ].skip_special_tokens,
+                tool=tool,
+            )
+        return await model(
+            operation.input,
+            system_prompt=operation.parameters["text"].system_prompt,
+            settings=operation.generation_settings,
+            tool=tool,
+        )
+
+
+@ModalityRegistry.register(Modality.TEXT_QUESTION_ANSWERING)
+class TextQuestionAnsweringModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: QuestionAnsweringModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["text"]
+            and operation.parameters["text"].context
+        )
+
+        return await model(
+            operation.input,
+            context=operation.parameters["text"].context,
+            system_prompt=operation.parameters["text"].system_prompt,
+        )
+
+
+@ModalityRegistry.register(Modality.TEXT_SEQUENCE_CLASSIFICATION)
+class TextSequenceClassificationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: SequenceClassificationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert operation.input
+        return await model(operation.input)
+
+
+@ModalityRegistry.register(Modality.TEXT_SEQUENCE_TO_SEQUENCE)
+class TextSequenceToSequenceModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: SequenceToSequenceModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert operation.input and operation.parameters["text"]
+        criteria = _stopping_criteria(operation, model)
+        return await model(
+            operation.input,
+            settings=operation.generation_settings,
+            stopping_criterias=[criteria] if criteria else None,
+        )
+
+
+@ModalityRegistry.register(Modality.TEXT_TOKEN_CLASSIFICATION)
+class TextTokenClassificationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TokenClassificationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert operation.input and operation.parameters["text"]
+        return await model(
+            operation.input,
+            labeled_only=operation.parameters["text"].labeled_only or False,
+            system_prompt=operation.parameters["text"].system_prompt,
+        )
+
+
+@ModalityRegistry.register(Modality.TEXT_TRANSLATION)
+class TextTranslationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TranslationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["text"]
+            and operation.parameters["text"].language_source
+            and operation.parameters["text"].language_destination
+        )
+        criteria = _stopping_criteria(operation, model)
+        return await model(
+            operation.input,
+            source_language=operation.parameters["text"].language_source,
+            destination_language=operation.parameters[
+                "text"
+            ].language_destination,
+            settings=operation.generation_settings,
+            stopping_criterias=[criteria] if criteria else None,
+            skip_special_tokens=operation.parameters[
+                "text"
+            ].skip_special_tokens,
+        )

--- a/src/avalan/model/modalities/vision.py
+++ b/src/avalan/model/modalities/vision.py
@@ -1,0 +1,231 @@
+from .registry import ModalityRegistry
+from ..vision.classification import ImageClassificationModel
+from ..vision.decoder import VisionEncoderDecoderModel
+from ..vision.detection import ObjectDetectionModel
+from ..vision.diffusion import (
+    TextToAnimationModel,
+    TextToImageModel,
+    TextToVideoModel,
+)
+from ..vision.segmentation import SemanticSegmentationModel
+from ..vision.text import ImageTextToTextModel, ImageToTextModel
+from ...entities import EngineUri, Modality, Operation
+from ...tool.manager import ToolManager
+
+from typing import Any
+
+
+@ModalityRegistry.register(Modality.VISION_ENCODER_DECODER)
+class VisionEncoderDecoderModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: VisionEncoderDecoderModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+
+        return await model(
+            operation.parameters["vision"].path,
+            prompt=operation.input,
+            skip_special_tokens=operation.parameters[
+                "vision"
+            ].skip_special_tokens,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_IMAGE_CLASSIFICATION)
+class VisionImageClassificationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: ImageClassificationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+
+        return await model(operation.parameters["vision"].path)
+
+
+@ModalityRegistry.register(Modality.VISION_IMAGE_TO_TEXT)
+class VisionImageToTextModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: ImageToTextModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+
+        return await model(
+            operation.parameters["vision"].path,
+            skip_special_tokens=operation.parameters[
+                "vision"
+            ].skip_special_tokens,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_IMAGE_TEXT_TO_TEXT)
+class VisionImageTextToTextModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: ImageTextToTextModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+
+        return await model(
+            operation.parameters["vision"].path,
+            operation.input,
+            system_prompt=operation.parameters["vision"].system_prompt,
+            settings=operation.generation_settings,
+            width=operation.parameters["vision"].width,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_OBJECT_DETECTION)
+class VisionObjectDetectionModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: ObjectDetectionModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+            and operation.parameters["vision"].threshold is not None
+        )
+
+        return await model(
+            operation.parameters["vision"].path,
+            threshold=operation.parameters["vision"].threshold,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_TEXT_TO_IMAGE)
+class VisionTextToImageModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TextToImageModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["vision"]
+            and operation.parameters["vision"].path
+            and operation.parameters["vision"].color_model
+            and operation.parameters["vision"].high_noise_frac is not None
+            and operation.parameters["vision"].image_format
+            and operation.parameters["vision"].n_steps is not None
+        )
+
+        return await model(
+            operation.input,
+            operation.parameters["vision"].path,
+            color_model=operation.parameters["vision"].color_model,
+            high_noise_frac=operation.parameters["vision"].high_noise_frac,
+            image_format=operation.parameters["vision"].image_format,
+            n_steps=operation.parameters["vision"].n_steps,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_TEXT_TO_ANIMATION)
+class VisionTextToAnimationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TextToAnimationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["vision"]
+            and operation.parameters["vision"].path
+            and operation.parameters["vision"].n_steps is not None
+            and operation.parameters["vision"].timestep_spacing
+            and operation.parameters["vision"].beta_schedule
+            and operation.parameters["vision"].guidance_scale is not None
+        )
+
+        return await model(
+            operation.input,
+            operation.parameters["vision"].path,
+            beta_schedule=operation.parameters["vision"].beta_schedule,
+            guidance_scale=operation.parameters["vision"].guidance_scale,
+            steps=operation.parameters["vision"].n_steps,
+            timestep_spacing=operation.parameters["vision"].timestep_spacing,
+        )
+
+
+@ModalityRegistry.register(Modality.VISION_TEXT_TO_VIDEO)
+class VisionTextToVideoModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: TextToVideoModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.input
+            and operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+        vision = operation.parameters["vision"]
+        kwargs = {
+            "reference_path": vision.reference_path,
+            "negative_prompt": vision.negative_prompt,
+            "height": vision.height,
+            "downscale": vision.downscale,
+            "frames": vision.frames,
+            "denoise_strength": vision.denoise_strength,
+            "inference_steps": vision.inference_steps,
+            "decode_timestep": vision.decode_timestep,
+            "noise_scale": vision.noise_scale,
+            "frames_per_second": vision.frames_per_second,
+        }
+        if vision.width is not None:
+            kwargs["width"] = vision.width
+        if vision.n_steps is not None:
+            kwargs["steps"] = vision.n_steps
+
+        return await model(operation.input, vision.path, **kwargs)
+
+
+@ModalityRegistry.register(Modality.VISION_SEMANTIC_SEGMENTATION)
+class VisionSemanticSegmentationModality:
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: SemanticSegmentationModel,
+        operation: Operation,
+        tool: ToolManager | None = None,
+    ) -> Any:
+        assert (
+            operation.parameters["vision"]
+            and operation.parameters["vision"].path
+        )
+
+        return await model(operation.parameters["vision"].path)

--- a/tests/model/modality_registry_test.py
+++ b/tests/model/modality_registry_test.py
@@ -1,0 +1,14 @@
+import pytest
+
+from avalan.entities import Modality
+from avalan.model.modalities import ModalityRegistry
+
+
+def test_registry_contains_all_handlers():
+    for modality in Modality:
+        if modality is Modality.EMBEDDING:
+            with pytest.raises(NotImplementedError):
+                ModalityRegistry.get(modality)
+        else:
+            handler = ModalityRegistry.get(modality)
+            assert callable(handler)


### PR DESCRIPTION
## Summary
- decouple modality logic with a ModalityRegistry and dedicated handlers
- rewrite ModelManager to delegate calls through the registry
- add tests covering the registry and modality handlers

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_689e61ecdce48323a5261de5ef9df0e4