### PR TITLE
Refactor ModalityRegistry engine loading

### DIFF
--- a/src/avalan/model/modalities/audio.py
+++ b/src/avalan/model/modalities/audio.py
@@ -3,14 +3,59 @@ from ..audio.classification import AudioClassificationModel
 from ..audio.generation import AudioGenerationModel
 from ..audio.speech import TextToSpeechModel
 from ..audio.speech_recognition import SpeechRecognitionModel
-from ...entities import EngineUri, Modality, Operation
+from ...entities import (
+    EngineUri,
+    GenerationSettings,
+    Input,
+    Modality,
+    Operation,
+    OperationAudioParameters,
+    OperationParameters,
+    TransformerEngineSettings,
+)
 from ...tool.manager import ToolManager
 
+from argparse import Namespace
+from logging import Logger
 from typing import Any
 
 
 @ModalityRegistry.register(Modality.AUDIO_CLASSIFICATION)
 class AudioClassificationModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> AudioClassificationModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return AudioClassificationModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            audio=OperationAudioParameters(
+                path=args.path,
+                sampling_rate=args.audio_sampling_rate,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.AUDIO_CLASSIFICATION,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -32,6 +77,40 @@ class AudioClassificationModality:
 
 @ModalityRegistry.register(Modality.AUDIO_SPEECH_RECOGNITION)
 class AudioSpeechRecognitionModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> SpeechRecognitionModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return SpeechRecognitionModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            audio=OperationAudioParameters(
+                path=args.path,
+                sampling_rate=args.audio_sampling_rate,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.AUDIO_SPEECH_RECOGNITION,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -53,6 +132,42 @@ class AudioSpeechRecognitionModality:
 
 @ModalityRegistry.register(Modality.AUDIO_TEXT_TO_SPEECH)
 class AudioTextToSpeechModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> TextToSpeechModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return TextToSpeechModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            audio=OperationAudioParameters(
+                path=args.path,
+                reference_path=args.audio_reference_path,
+                reference_text=args.audio_reference_text,
+                sampling_rate=args.audio_sampling_rate,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.AUDIO_TEXT_TO_SPEECH,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -78,6 +193,40 @@ class AudioTextToSpeechModality:
 
 @ModalityRegistry.register(Modality.AUDIO_GENERATION)
 class AudioGenerationModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> AudioGenerationModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return AudioGenerationModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            audio=OperationAudioParameters(
+                path=args.path,
+                sampling_rate=args.audio_sampling_rate,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.AUDIO_GENERATION,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,

--- a/src/avalan/model/modalities/registry.py
+++ b/src/avalan/model/modalities/registry.py
@@ -1,24 +1,55 @@
-from collections.abc import Awaitable, Callable
-from inspect import isclass
-from typing import Any
-
-from ...entities import EngineUri, Modality, Operation
+from ...entities import (
+    ChatSettings,
+    EngineUri,
+    GenerationSettings,
+    Input,
+    Modality,
+    Operation,
+    ReasoningSettings,
+    ReasoningTag,
+    TransformerEngineSettings,
+)
 from ...tool.manager import ToolManager
 
-ModalityCallable = Callable[
-    [EngineUri, Any, Operation, ToolManager | None],
-    Awaitable[Any],
-]
+from argparse import Namespace
+from collections.abc import Callable
+from inspect import isclass
+from logging import Logger
+from typing import Any, Protocol
+
+
+class ModalityHandler(Protocol):
+    async def __call__(
+        self,
+        engine_uri: EngineUri,
+        model: Any,
+        operation: Operation,
+        tool: ToolManager | None,
+    ) -> Any: ...
+
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> Any: ...
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation: ...
 
 
 class ModalityRegistry:
-    _handlers: dict[Modality, ModalityCallable] = {}
+    _handlers: dict[Modality, ModalityHandler] = {}
 
     @classmethod
     def register(
         cls, modality: Modality
-    ) -> Callable[[ModalityCallable], ModalityCallable]:
-        def decorator(handler: ModalityCallable | type) -> ModalityCallable:
+    ) -> Callable[[ModalityHandler | type], ModalityHandler]:
+        def decorator(handler: ModalityHandler | type) -> ModalityHandler:
             cls._handlers[modality] = (
                 handler() if isclass(handler) else handler
             )
@@ -27,7 +58,74 @@ class ModalityRegistry:
         return decorator
 
     @classmethod
-    def get(cls, modality: Modality) -> ModalityCallable:
+    def get(cls, modality: Modality) -> ModalityHandler:
         if modality not in cls._handlers:
             raise NotImplementedError(f"Modality {modality} not registered")
         return cls._handlers[modality]
+
+    @classmethod
+    def load_engine(
+        cls,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        modality: Modality,
+        logger: Logger,
+    ) -> Any:
+        handler = cls.get(modality)
+        return handler.load_engine(engine_uri, engine_settings, logger)
+
+    @classmethod
+    def get_operation_from_arguments(
+        cls,
+        modality: Modality,
+        args: Namespace,
+        input_string: Input | None,
+    ) -> Operation:
+        reasoning_settings = ReasoningSettings(
+            max_new_tokens=getattr(args, "reasoning_max_new_tokens", None),
+            enabled=not getattr(args, "no_reasoning", False),
+            stop_on_max_new_tokens=getattr(
+                args,
+                "reasoning_stop_on_max_new_tokens",
+                False,
+            ),
+            tag=(
+                ReasoningTag(getattr(args, "reasoning_tag"))
+                if getattr(args, "reasoning_tag", None)
+                else None
+            ),
+        )
+        settings = GenerationSettings(
+            do_sample=args.do_sample,
+            enable_gradient_calculation=args.enable_gradient_calculation,
+            max_new_tokens=args.max_new_tokens,
+            max_length=getattr(args, "text_max_length", None),
+            min_p=args.min_p,
+            num_beams=getattr(args, "text_num_beams", None),
+            repetition_penalty=args.repetition_penalty,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+            use_cache=args.use_cache,
+            chat_settings=ChatSettings(
+                enable_thinking=not getattr(
+                    args,
+                    "chat_disable_thinking",
+                    not reasoning_settings.enabled,
+                )
+            ),
+            reasoning=reasoning_settings,
+        )
+        try:
+            handler = cls.get(modality)
+        except NotImplementedError:
+            return Operation(
+                generation_settings=settings,
+                input=input_string,
+                modality=modality,
+                parameters=None,
+                requires_input=False,
+            )
+        return handler.get_operation_from_arguments(
+            args, input_string, settings
+        )

--- a/src/avalan/model/modalities/vision.py
+++ b/src/avalan/model/modalities/vision.py
@@ -9,14 +9,59 @@ from ..vision.diffusion import (
 )
 from ..vision.segmentation import SemanticSegmentationModel
 from ..vision.text import ImageTextToTextModel, ImageToTextModel
-from ...entities import EngineUri, Modality, Operation
+from ...entities import (
+    EngineUri,
+    GenerationSettings,
+    Input,
+    Modality,
+    Operation,
+    OperationParameters,
+    OperationVisionParameters,
+    TransformerEngineSettings,
+)
 from ...tool.manager import ToolManager
 
+from argparse import Namespace
+from logging import Logger
 from typing import Any
 
 
 @ModalityRegistry.register(Modality.VISION_ENCODER_DECODER)
 class VisionEncoderDecoderModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> VisionEncoderDecoderModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return VisionEncoderDecoderModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                skip_special_tokens=args.skip_special_tokens,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_ENCODER_DECODER,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -40,6 +85,39 @@ class VisionEncoderDecoderModality:
 
 @ModalityRegistry.register(Modality.VISION_IMAGE_CLASSIFICATION)
 class VisionImageClassificationModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> ImageClassificationModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return ImageClassificationModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_IMAGE_CLASSIFICATION,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -57,6 +135,40 @@ class VisionImageClassificationModality:
 
 @ModalityRegistry.register(Modality.VISION_IMAGE_TO_TEXT)
 class VisionImageToTextModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> ImageToTextModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return ImageToTextModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                skip_special_tokens=args.skip_special_tokens,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_IMAGE_TO_TEXT,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -79,6 +191,45 @@ class VisionImageToTextModality:
 
 @ModalityRegistry.register(Modality.VISION_IMAGE_TEXT_TO_TEXT)
 class VisionImageTextToTextModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> ImageTextToTextModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return ImageTextToTextModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                system_prompt=args.system or None,
+                width=getattr(
+                    args,
+                    "vision_width",
+                    getattr(args, "image_width", None),
+                ),
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_IMAGE_TEXT_TO_TEXT,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -102,6 +253,44 @@ class VisionImageTextToTextModality:
 
 @ModalityRegistry.register(Modality.VISION_OBJECT_DETECTION)
 class VisionObjectDetectionModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> ObjectDetectionModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return ObjectDetectionModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                threshold=getattr(
+                    args,
+                    "vision_threshold",
+                    getattr(args, "image_threshold", None),
+                ),
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_OBJECT_DETECTION,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -123,6 +312,43 @@ class VisionObjectDetectionModality:
 
 @ModalityRegistry.register(Modality.VISION_TEXT_TO_IMAGE)
 class VisionTextToImageModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> TextToImageModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return TextToImageModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                color_model=args.vision_color_model,
+                high_noise_frac=args.vision_high_noise_frac,
+                image_format=args.vision_image_format,
+                n_steps=args.vision_steps,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_TEXT_TO_IMAGE,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -152,6 +378,43 @@ class VisionTextToImageModality:
 
 @ModalityRegistry.register(Modality.VISION_TEXT_TO_ANIMATION)
 class VisionTextToAnimationModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> TextToAnimationModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return TextToAnimationModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                n_steps=args.vision_steps,
+                timestep_spacing=args.vision_timestep_spacing,
+                beta_schedule=args.vision_beta_schedule,
+                guidance_scale=args.vision_guidance_scale,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_TEXT_TO_ANIMATION,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -181,6 +444,53 @@ class VisionTextToAnimationModality:
 
 @ModalityRegistry.register(Modality.VISION_TEXT_TO_VIDEO)
 class VisionTextToVideoModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> TextToVideoModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return TextToVideoModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+                reference_path=getattr(args, "vision_reference_path", None),
+                negative_prompt=getattr(args, "vision_negative_prompt", None),
+                width=getattr(args, "vision_width", None),
+                height=getattr(args, "vision_height", None),
+                downscale=getattr(args, "vision_downscale", None),
+                frames=getattr(args, "vision_frames", None),
+                denoise_strength=getattr(
+                    args, "vision_denoise_strength", None
+                ),
+                n_steps=getattr(args, "vision_steps", None),
+                inference_steps=getattr(args, "vision_inference_steps", None),
+                decode_timestep=getattr(args, "vision_decode_timestep", None),
+                noise_scale=getattr(args, "vision_noise_scale", None),
+                frames_per_second=getattr(args, "vision_fps", None),
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_TEXT_TO_VIDEO,
+            parameters=parameters,
+            requires_input=True,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,
@@ -216,6 +526,39 @@ class VisionTextToVideoModality:
 
 @ModalityRegistry.register(Modality.VISION_SEMANTIC_SEGMENTATION)
 class VisionSemanticSegmentationModality:
+    def load_engine(
+        self,
+        engine_uri: EngineUri,
+        engine_settings: TransformerEngineSettings,
+        logger: Logger,
+    ) -> SemanticSegmentationModel:
+        if not engine_uri.is_local:
+            raise NotImplementedError()
+        return SemanticSegmentationModel(
+            model_id=engine_uri.model_id,
+            settings=engine_settings,
+            logger=logger,
+        )
+
+    def get_operation_from_arguments(
+        self,
+        args: Namespace,
+        input_string: Input | None,
+        settings: GenerationSettings,
+    ) -> Operation:
+        parameters = OperationParameters(
+            vision=OperationVisionParameters(
+                path=args.path,
+            )
+        )
+        return Operation(
+            generation_settings=settings,
+            input=input_string,
+            modality=Modality.VISION_SEMANTIC_SEGMENTATION,
+            parameters=parameters,
+            requires_input=False,
+        )
+
     async def __call__(
         self,
         engine_uri: EngineUri,

--- a/tests/model/modality_load_engine_nonlocal_test.py
+++ b/tests/model/modality_load_engine_nonlocal_test.py
@@ -1,0 +1,62 @@
+from logging import Logger
+from unittest.mock import MagicMock
+
+import pytest
+
+from avalan.entities import EngineUri, TransformerEngineSettings
+from avalan.model.modalities.audio import (
+    AudioSpeechRecognitionModality,
+    AudioTextToSpeechModality,
+)
+from avalan.model.modalities.text import (
+    TextGenerationModality,
+    TextSequenceClassificationModality,
+    TextTokenClassificationModality,
+)
+from avalan.model.modalities.vision import (
+    VisionEncoderDecoderModality,
+    VisionImageClassificationModality,
+    VisionImageTextToTextModality,
+    VisionImageToTextModality,
+    VisionObjectDetectionModality,
+    VisionSemanticSegmentationModality,
+    VisionTextToAnimationModality,
+    VisionTextToImageModality,
+    VisionTextToVideoModality,
+)
+
+
+@pytest.mark.parametrize(
+    "modality",
+    [
+        AudioSpeechRecognitionModality(),
+        AudioTextToSpeechModality(),
+        TextGenerationModality(),
+        TextSequenceClassificationModality(),
+        TextTokenClassificationModality(),
+        VisionEncoderDecoderModality(),
+        VisionImageClassificationModality(),
+        VisionImageToTextModality(),
+        VisionImageTextToTextModality(),
+        VisionObjectDetectionModality(),
+        VisionTextToImageModality(),
+        VisionTextToAnimationModality(),
+        VisionTextToVideoModality(),
+        VisionSemanticSegmentationModality(),
+    ],
+)
+def test_load_engine_non_local_raises(modality):
+    engine_uri = EngineUri(
+        host=None,
+        port=None,
+        user=None,
+        password=None,
+        vendor="google",
+        model_id="model",
+        params={},
+    )
+    settings = TransformerEngineSettings()
+    logger = MagicMock(spec=Logger)
+
+    with pytest.raises(NotImplementedError):
+        modality.load_engine(engine_uri, settings, logger)

--- a/tests/model/model_manager_modalities_test.py
+++ b/tests/model/model_manager_modalities_test.py
@@ -2,7 +2,7 @@ from avalan.entities import (
     Backend,
     EngineUri,
     Modality,
-    TransformerEngineSettings
+    TransformerEngineSettings,
 )
 from avalan.model.hubs.huggingface import HuggingfaceHub
 from avalan.model.manager import ModelManager
@@ -18,30 +18,68 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
 
     def test_load_engine_local_modalities(self):
         modalities = {
-            Modality.AUDIO_CLASSIFICATION: "AudioClassificationModel",
-            Modality.AUDIO_GENERATION: "AudioGenerationModel",
-            Modality.AUDIO_SPEECH_RECOGNITION: "SpeechRecognitionModel",
-            Modality.AUDIO_TEXT_TO_SPEECH: "TextToSpeechModel",
-            Modality.EMBEDDING: "SentenceTransformerModel",
-            Modality.TEXT_GENERATION: "TextGenerationModel",
-            Modality.TEXT_QUESTION_ANSWERING: "QuestionAnsweringModel",
-            Modality.TEXT_SEQUENCE_CLASSIFICATION: (
-                "SequenceClassificationModel"
+            Modality.AUDIO_CLASSIFICATION: (
+                "avalan.model.modalities.audio.AudioClassificationModel"
             ),
-            Modality.TEXT_SEQUENCE_TO_SEQUENCE: "SequenceToSequenceModel",
-            Modality.TEXT_TOKEN_CLASSIFICATION: "TokenClassificationModel",
-            Modality.TEXT_TRANSLATION: "TranslationModel",
-            Modality.VISION_OBJECT_DETECTION: "ObjectDetectionModel",
-            Modality.VISION_IMAGE_CLASSIFICATION: "ImageClassificationModel",
-            Modality.VISION_IMAGE_TO_TEXT: "ImageToTextModel",
-            Modality.VISION_IMAGE_TEXT_TO_TEXT: "ImageTextToTextModel",
-            Modality.VISION_ENCODER_DECODER: "VisionEncoderDecoderModel",
-            Modality.VISION_SEMANTIC_SEGMENTATION: "SemanticSegmentationModel",
-            Modality.VISION_TEXT_TO_IMAGE: "TextToImageModel",
-            Modality.VISION_TEXT_TO_ANIMATION: "TextToAnimationModel",
-            Modality.VISION_TEXT_TO_VIDEO: "TextToVideoModel",
+            Modality.AUDIO_GENERATION: (
+                "avalan.model.modalities.audio.AudioGenerationModel"
+            ),
+            Modality.AUDIO_SPEECH_RECOGNITION: (
+                "avalan.model.modalities.audio.SpeechRecognitionModel"
+            ),
+            Modality.AUDIO_TEXT_TO_SPEECH: (
+                "avalan.model.modalities.audio.TextToSpeechModel"
+            ),
+            Modality.EMBEDDING: (
+                "avalan.model.nlp.sentence.SentenceTransformerModel"
+            ),
+            Modality.TEXT_GENERATION: (
+                "avalan.model.modalities.text.TextGenerationModel"
+            ),
+            Modality.TEXT_QUESTION_ANSWERING: (
+                "avalan.model.modalities.text.QuestionAnsweringModel"
+            ),
+            Modality.TEXT_SEQUENCE_CLASSIFICATION: (
+                "avalan.model.modalities.text.SequenceClassificationModel"
+            ),
+            Modality.TEXT_SEQUENCE_TO_SEQUENCE: (
+                "avalan.model.modalities.text.SequenceToSequenceModel"
+            ),
+            Modality.TEXT_TOKEN_CLASSIFICATION: (
+                "avalan.model.modalities.text.TokenClassificationModel"
+            ),
+            Modality.TEXT_TRANSLATION: (
+                "avalan.model.modalities.text.TranslationModel"
+            ),
+            Modality.VISION_OBJECT_DETECTION: (
+                "avalan.model.modalities.vision.ObjectDetectionModel"
+            ),
+            Modality.VISION_IMAGE_CLASSIFICATION: (
+                "avalan.model.modalities.vision.ImageClassificationModel"
+            ),
+            Modality.VISION_IMAGE_TO_TEXT: (
+                "avalan.model.modalities.vision.ImageToTextModel"
+            ),
+            Modality.VISION_IMAGE_TEXT_TO_TEXT: (
+                "avalan.model.modalities.vision.ImageTextToTextModel"
+            ),
+            Modality.VISION_ENCODER_DECODER: (
+                "avalan.model.modalities.vision.VisionEncoderDecoderModel"
+            ),
+            Modality.VISION_SEMANTIC_SEGMENTATION: (
+                "avalan.model.modalities.vision.SemanticSegmentationModel"
+            ),
+            Modality.VISION_TEXT_TO_IMAGE: (
+                "avalan.model.modalities.vision.TextToImageModel"
+            ),
+            Modality.VISION_TEXT_TO_ANIMATION: (
+                "avalan.model.modalities.vision.TextToAnimationModel"
+            ),
+            Modality.VISION_TEXT_TO_VIDEO: (
+                "avalan.model.modalities.vision.TextToVideoModel"
+            ),
         }
-        for modality, class_name in modalities.items():
+        for modality, path in modalities.items():
             with self.subTest(modality=modality):
                 with ModelManager(self.hub, self.logger) as manager:
                     uri = manager.parse_uri(
@@ -49,7 +87,6 @@ class ModelManagerLoadEngineModalitiesTestCase(TestCase):
                     )
                     settings = TransformerEngineSettings()
                     manager._stack.enter_context = MagicMock()
-                    path = f"avalan.model.manager.{class_name}"
                     with patch(path) as Model:
                         result = manager.load_engine(uri, settings, modality)
                     Model.assert_called_once_with(

--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -5,8 +5,6 @@ from avalan.secrets import KeyringSecrets
 from logging import Logger
 from unittest import main, TestCase
 from unittest.mock import MagicMock, patch
-import sys
-import types
 
 
 class ManagerTestCase(TestCase):
@@ -297,13 +295,13 @@ class ManagerLoadEngineTestCase(TestCase):
         vendor_data = {
             "local": (
                 "ai://local/tiiuae/Falcon-E-3B-Instruct",
-                "avalan.model.manager.TextGenerationModel",
+                "avalan.model.modalities.text.TextGenerationModel",
                 "tiiuae/Falcon-E-3B-Instruct",
                 False,
             ),
             "sentence": (
                 "ai://local/tiiuae/Falcon-E-3B-Instruct",
-                "avalan.model.manager.SentenceTransformerModel",
+                "avalan.model.nlp.sentence.SentenceTransformerModel",
                 "tiiuae/Falcon-E-3B-Instruct",
                 True,
             ),
@@ -381,44 +379,16 @@ class ManagerLoadEngineTestCase(TestCase):
                     engine_uri = manager.parse_uri(uri)
                     settings = TransformerEngineSettings()
                     manager._stack.enter_context = MagicMock()
-                    if path.startswith("avalan.model.manager"):
-                        with patch(path) as Model:
-                            result = manager.load_engine(
-                                engine_uri,
-                                settings,
-                                (
-                                    Modality.EMBEDDING
-                                    if is_sentence
-                                    else Modality.TEXT_GENERATION
-                                ),
-                            )
-                            Model.assert_called_once_with(
-                                model_id=model_id,
-                                settings=settings,
-                                logger=self.logger_mock,
-                            )
-                            manager._stack.enter_context.assert_called_once_with(
-                                Model.return_value
-                            )
-                            self.assertIs(result, Model.return_value)
-                    else:
-                        module_path, class_name = path.rsplit(".", 1)
-                        dummy_module = types.SimpleNamespace()
-                        Model = MagicMock()
-                        setattr(dummy_module, class_name, Model)
-                        with patch.dict(
-                            sys.modules, {module_path: dummy_module}
-                        ):
-                            result = manager.load_engine(
-                                engine_uri,
-                                settings,
-                                (
-                                    Modality.EMBEDDING
-                                    if is_sentence
-                                    else Modality.TEXT_GENERATION
-                                ),
-                            )
-
+                    with patch(path) as Model:
+                        result = manager.load_engine(
+                            engine_uri,
+                            settings,
+                            (
+                                Modality.EMBEDDING
+                                if is_sentence
+                                else Modality.TEXT_GENERATION
+                            ),
+                        )
                         Model.assert_called_once_with(
                             model_id=model_id,
                             settings=settings,


### PR DESCRIPTION
## Summary
- delegate engine instantiation and argument parsing to modality handlers
- add load_engine and get_operation_from_arguments to each modality
- update manager and tests for new modality-based workflow
- restore explicit ModelType union enumerating supported models

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_689e9a6e86448323a8123bc063b47e23