### PR TITLE
Handle z key to expand answers

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -4935,6 +4935,74 @@ class CliRenderFrameTestCase(IsolatedAsyncioTestCase):
         self.assertTrue(theme.tokens.call_args.kwargs["limit_answer_height"])
         self.assertEqual(theme.tokens.call_args.kwargs["height"], 20)
 
+    async def test_token_stream_answer_height_expand_signal(self):
+        async def token_gen():
+            yield model_cmds.Token(id=1, token="A")
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                return token_gen()
+
+        async def fake_frames(*_, **__):
+            yield (None, "frame")
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+            display_answer_height=20,
+        )
+
+        console = MagicMock()
+        console.width = 80
+        live = MagicMock()
+        logger = MagicMock()
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_frames)
+
+        lm = SimpleNamespace(
+            model_id="m", tokenizer_config=None, input_token_count=lambda s: 1
+        )
+        expand_signal = asyncio.Event()
+        expand_signal.set()
+
+        await model_cmds._token_stream(
+            live=live,
+            group=None,
+            tokens_group_index=None,
+            args=args,
+            console=console,
+            theme=theme,
+            logger=logger,
+            orchestrator=None,
+            event_stats=None,
+            lm=lm,
+            input_string="hi",
+            response=Resp(),
+            display_tokens=0,
+            dtokens_pick=0,
+            refresh_per_second=2,
+            stop_signal=None,
+            expand_signal=expand_signal,
+            tool_events_limit=None,
+            with_stats=True,
+        )
+
+        self.assertFalse(theme.tokens.call_args.kwargs["limit_answer_height"])
+
 
 class CliReasoningTokenTestCase(IsolatedAsyncioTestCase):
     async def test_reasoning_token_tracked(self):


### PR DESCRIPTION
## Summary
- listen for `z` keystrokes during token generation and expose an expand signal
- avoid keystroke listener during tests and implement non-blocking `z` detection

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_689f7a565e0c8323a66843ff0d2bba38