### PR TITLE
Add hyperedge and entity dataclasses

### DIFF
--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -106,6 +106,44 @@ class PermanentMemoryPartition:
     created_at: datetime
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Hyperedge:
+    id: UUID
+    relation: str
+    surface_text: str
+    embedding: ndarray
+    symbols: dict | None = None
+    created_at: datetime
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class HyperedgeMemory:
+    hyperedge_id: UUID
+    memory_id: UUID
+    char_start: int | None = None
+    char_end: int | None = None
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Entity:
+    id: UUID
+    name: str
+    type: str | None = None
+    embedding: ndarray
+    symbols: dict | None = None
+    participant_id: UUID | None = None
+    namespace: str | None = None
+    created_at: datetime
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class HyperedgeEntity:
+    hyperedge_id: UUID
+    entity_id: UUID
+    role_idx: int
+    role_label: str | None = None
+
+
 class PermanentMessageMemory(MessageMemory):
     _session_id: UUID | None = None
     _sentence_model: SentenceTransformerModel

--- a/src/avalan/memory/permanent/migrations/pgsql/up/00002-reasoning-graphs-up.sql
+++ b/src/avalan/memory/permanent/migrations/pgsql/up/00002-reasoning-graphs-up.sql
@@ -4,12 +4,13 @@
 -- 1. FACTS: n-ary hyperedges
 -- =========================================
 CREATE TABLE IF NOT EXISTS "hyperedges" (
-    "id"           BIGSERIAL PRIMARY KEY,
+    "id"           UUID NOT NULL,
     "relation"     TEXT NOT NULL,
     "surface_text" TEXT NOT NULL,
     "embedding"    VECTOR(1024) NOT NULL,
     "symbols"      JSONB DEFAULT NULL,
-    "created_at"   TIMESTAMPTZ NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+    "created_at"   TIMESTAMPTZ NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    PRIMARY KEY("id")
 );
 
 -- Choose ONE ANN index:
@@ -26,7 +27,7 @@ CREATE INDEX IF NOT EXISTS "ix_hyperedges_relation_lc"
 -- 2. PROVENANCE: link hyperedges → memories
 -- =========================================
 CREATE TABLE IF NOT EXISTS "hyperedges_memories" (
-    "hyperedge_id" BIGINT NOT NULL REFERENCES "hyperedges"("id") ON DELETE CASCADE,
+    "hyperedge_id" UUID  NOT NULL REFERENCES "hyperedges"("id") ON DELETE CASCADE,
     "memory_id"    UUID   NOT NULL REFERENCES "memories"("id")  ON DELETE CASCADE,
     "char_start"   INT,
     "char_end"     INT,
@@ -57,7 +58,7 @@ WHERE m."is_deleted" = FALSE;
 -- 3. ENTITIES
 -- =========================================
 CREATE TABLE IF NOT EXISTS "entities" (
-    "id"             BIGSERIAL PRIMARY KEY,
+    "id"             UUID NOT NULL,
     "name"           TEXT NOT NULL,
     "name_lc"        TEXT GENERATED ALWAYS AS (LOWER("name")) STORED,
     "type"           TEXT,
@@ -66,7 +67,8 @@ CREATE TABLE IF NOT EXISTS "entities" (
     "participant_id" UUID,
     "namespace"      TEXT,
     "namespace_tree" LTREE GENERATED ALWAYS AS (text2ltree("namespace")) STORED,
-    "created_at"     TIMESTAMPTZ NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+    "created_at"     TIMESTAMPTZ NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    PRIMARY KEY("id")
 );
 
 ALTER TABLE "entities"
@@ -86,8 +88,8 @@ CREATE INDEX IF NOT EXISTS "ix_entities_scope"
 -- 4. ARGUMENTS: hyperedge ↔ entity mapping (ordered)
 -- =========================================
 CREATE TABLE IF NOT EXISTS "hyperedge_entities" (
-    "hyperedge_id" BIGINT NOT NULL REFERENCES "hyperedges"("id") ON DELETE CASCADE,
-    "entity_id"    BIGINT NOT NULL REFERENCES "entities"("id")   ON DELETE CASCADE,
+    "hyperedge_id" UUID  NOT NULL REFERENCES "hyperedges"("id") ON DELETE CASCADE,
+    "entity_id"    UUID  NOT NULL REFERENCES "entities"("id")   ON DELETE CASCADE,
     "role_idx"     INT    NOT NULL CHECK ("role_idx" >= 1),
     "role_label"   TEXT,
     PRIMARY KEY ("hyperedge_id", "role_idx")

--- a/tests/memory/permanent/reasoning_entities_test.py
+++ b/tests/memory/permanent/reasoning_entities_test.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from unittest import TestCase
+from uuid import uuid4
+from numpy import array
+
+from avalan.memory.permanent import (
+    Entity,
+    Hyperedge,
+    HyperedgeEntity,
+    HyperedgeMemory,
+)
+
+
+class ReasoningEntitiesTestCase(TestCase):
+    def test_hyperedge(self):
+        now = datetime.now()
+        hyperedge = Hyperedge(
+            id=uuid4(),
+            relation="rel",
+            surface_text="A rel B",
+            embedding=array([0.0, 1.0]),
+            symbols={"foo": "bar"},
+            created_at=now,
+        )
+        self.assertEqual(hyperedge.relation, "rel")
+        self.assertEqual(hyperedge.symbols["foo"], "bar")
+        self.assertEqual(hyperedge.embedding.shape, (2,))
+        self.assertEqual(hyperedge.created_at, now)
+
+    def test_hyperedge_memory(self):
+        memory_id = uuid4()
+        hyperedge_id = uuid4()
+        hyperedge_memory = HyperedgeMemory(
+            hyperedge_id=hyperedge_id,
+            memory_id=memory_id,
+            char_start=1,
+            char_end=5,
+        )
+        self.assertEqual(hyperedge_memory.memory_id, memory_id)
+        self.assertEqual(hyperedge_memory.char_start, 1)
+
+    def test_entity_and_hyperedge_entity(self):
+        now = datetime.now()
+        participant_id = uuid4()
+        entity = Entity(
+            id=uuid4(),
+            name="Alice",
+            type="person",
+            embedding=array([1.0, 0.0]),
+            participant_id=participant_id,
+            namespace="ns",
+            created_at=now,
+        )
+        self.assertEqual(entity.name, "Alice")
+        hyperedge_id = uuid4()
+        hyperedge_entity = HyperedgeEntity(
+            hyperedge_id=hyperedge_id,
+            entity_id=entity.id,
+            role_idx=1,
+            role_label="subject",
+        )
+        self.assertEqual(hyperedge_entity.role_idx, 1)
+        with self.assertRaises(TypeError):
+            HyperedgeEntity(hyperedge_id=uuid4(), entity_id=uuid4())


### PR DESCRIPTION
## Summary
- map hyperedges, hyperedges_memories, entities, and hyperedge_entities tables to new dataclasses
- switch hyperedge and entity identifiers to UUIDs
- test creation and validation of the new reasoning graph entities
- use UUIDs for hyperedge and entity IDs in migrations

## Testing
- `make lint`
- `poetry run pytest --verbose -s`
- `make test-coverage` *(fails: Could not open file coverage.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a11c30c3248323ade6711b07c4980f