### PR TITLE
Document default agent port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,6 +1271,11 @@ Serve your agents on an OpenAI API–compatible endpoint:
 avalan agent serve docs/examples/agent_tool.toml -vvv
 ```
 
+Agents listen on port 9001 by default.
+
+> [!TIP]
+> Use `--port` to serve the agent on a different port.
+
 Or build an agent from inline settings and expose its OpenAI API endpoints:
 
 ```bash
@@ -1308,6 +1313,8 @@ avalan agent proxy \
     --run-max-new-tokens 1024 \
     -v
 ```
+
+Like `agent serve`, the proxy listens on port 9001 by default.
 
 And you can connect to it from another terminal using `--base-url`:
 

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -83,6 +83,21 @@ class CliParallelOptionTestCase(TestCase):
         self.assertEqual(args.parallel_count, 5)
 
 
+class CliAgentPortTestCase(TestCase):
+    def setUp(self) -> None:
+        self.logger = MagicMock()
+        with patch.object(sys, "argv", ["prog"]):
+            self.cli = CLI(self.logger)
+
+    def test_agent_serve_default_port(self) -> None:
+        args = self.cli._parser.parse_args(["agent", "serve"])
+        self.assertEqual(args.port, 9001)
+
+    def test_agent_proxy_default_port(self) -> None:
+        args = self.cli._parser.parse_args(["agent", "proxy"])
+        self.assertEqual(args.port, 9001)
+
+
 class CliCallTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
         from logging import getLogger


### PR DESCRIPTION
## Summary
- document 9001 as the default agent port and mention the `--port` option
- test that `agent serve` and `agent proxy` default to port 9001

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68a31cfffa74832386fe38380a4c6c71