### PR TITLE
Add MCP client tool set

### DIFF
--- a/src/avalan/tool/mcp.py
+++ b/src/avalan/tool/mcp.py
@@ -1,0 +1,47 @@
+from . import Tool, ToolSet
+from ..compat import override
+from ..entities import ToolCallContext
+from contextlib import AsyncExitStack
+
+
+class McpCallTool(Tool):
+    """Call an MCP server tool using the MCP client.
+
+    Args:
+        uri: Base URI of the MCP server.
+        name: Name of the tool to invoke.
+        arguments: Arguments to send to the tool.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__name__ = "call"
+
+    async def __call__(
+        self,
+        uri: str,
+        name: str,
+        arguments: dict[str, object] | None,
+        *,
+        context: ToolCallContext,
+    ) -> list[object]:
+        from mcp import Client
+
+        async with Client(uri) as client:
+            return await client.call_tool(name, arguments or {})
+
+
+class McpToolSet(ToolSet):
+    """Tool set providing MCP client functionality."""
+
+    @override
+    def __init__(
+        self,
+        *,
+        exit_stack: AsyncExitStack | None = None,
+        namespace: str | None = "mcp",
+    ) -> None:
+        tools = [McpCallTool()]
+        super().__init__(
+            exit_stack=exit_stack, namespace=namespace, tools=tools
+        )

--- a/tests/tool/mcp_tool_test.py
+++ b/tests/tool/mcp_tool_test.py
@@ -1,0 +1,43 @@
+from avalan.tool.mcp import McpCallTool, McpToolSet
+from avalan.entities import ToolCallContext
+from types import ModuleType
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+
+
+class McpCallToolTestCase(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.addCleanup(patch.stopall)
+        client = AsyncMock()
+        client.__aenter__.return_value = client
+        client.__aexit__.return_value = False
+        client.call_tool.return_value = ["result"]
+        self.client = client
+        self.Client = MagicMock(return_value=client)
+        mcp_mod = ModuleType("mcp")
+        mcp_mod.Client = self.Client
+        patch.dict(sys.modules, {"mcp": mcp_mod}).start()
+        self.tool = McpCallTool()
+
+    async def test_call_with_arguments(self):
+        context = ToolCallContext()
+        result = await self.tool(
+            "http://host", "calc", {"a": 1}, context=context
+        )
+        self.assertEqual(result, ["result"])
+        self.Client.assert_called_once_with("http://host")
+        self.client.call_tool.assert_awaited_once_with("calc", {"a": 1})
+
+    async def test_call_without_arguments(self):
+        context = ToolCallContext()
+        await self.tool("http://host", "calc", None, context=context)
+        self.client.call_tool.assert_awaited_once_with("calc", {})
+
+
+class McpToolSetTestCase(TestCase):
+    def test_default_namespace(self):
+        toolset = McpToolSet()
+        self.assertEqual(toolset.namespace, "mcp")
+        self.assertEqual(len(toolset.tools), 1)
+        self.assertEqual(toolset.tools[0].__name__, "call")


### PR DESCRIPTION
## Summary
- add `McpCallTool` for invoking remote MCP tools
- group MCP tools under new `McpToolSet` with default namespace `mcp`
- cover MCP tools with dedicated unit tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68a37f9c93c48323bb7a0d23de34d5a1