### PR TITLE
Add configurability to MCP client tool

### DIFF
--- a/src/avalan/tool/mcp.py
+++ b/src/avalan/tool/mcp.py
@@ -13,9 +13,19 @@ class McpCallTool(Tool):
         arguments: Arguments to send to the tool.
     """
 
-    def __init__(self) -> None:
+    _client_params: dict[str, object]
+    _call_params: dict[str, object]
+
+    def __init__(
+        self,
+        *,
+        client_params: dict[str, object] | None = None,
+        call_params: dict[str, object] | None = None,
+    ) -> None:
         super().__init__()
         self.__name__ = "call"
+        self._client_params = client_params or {}
+        self._call_params = call_params or {}
 
     async def __call__(
         self,
@@ -27,8 +37,13 @@ class McpCallTool(Tool):
     ) -> list[object]:
         from mcp import Client
 
-        async with Client(uri) as client:
-            return await client.call_tool(name, arguments or {})
+        assert uri
+        assert name
+
+        async with Client(uri, **self._client_params) as client:
+            return await client.call_tool(
+                name, arguments or {}, **self._call_params
+            )
 
 
 class McpToolSet(ToolSet):

--- a/tests/tool/mcp_tool_test.py
+++ b/tests/tool/mcp_tool_test.py
@@ -34,6 +34,15 @@ class McpCallToolTestCase(IsolatedAsyncioTestCase):
         await self.tool("http://host", "calc", None, context=context)
         self.client.call_tool.assert_awaited_once_with("calc", {})
 
+    async def test_passes_client_and_call_params(self):
+        tool = McpCallTool(
+            client_params={"token": "x"}, call_params={"timeout": 1}
+        )
+        context = ToolCallContext()
+        await tool("http://host", "calc", None, context=context)
+        self.Client.assert_called_once_with("http://host", token="x")
+        self.client.call_tool.assert_awaited_once_with("calc", {}, timeout=1)
+
 
 class McpToolSetTestCase(TestCase):
     def test_default_namespace(self):


### PR DESCRIPTION
## Summary
- allow `McpCallTool` to accept configuration for creating the MCP client and calling tools
- test that optional client and call parameters are forwarded correctly

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68a671182f948323aa602dbcfbb5b65d