### PR TITLE
Handle pipe edge labels in Flow

### DIFF
--- a/src/avalan/flow/flow.py
+++ b/src/avalan/flow/flow.py
@@ -1,10 +1,12 @@
 from ..flow.connection import Connection
 from ..flow.node import Node
-from typing import Any, Callable
 from re import match
+from typing import Any, Callable
 
 
 class Flow:
+    """Directed graph of nodes and connections."""
+
     def __init__(self) -> None:
         self.nodes: dict[str, Node] = {}
         self.connections: list[Connection] = []
@@ -31,6 +33,11 @@ class Flow:
         self.outgoing[src_name].append(conn)
 
     def parse_mermaid(self, mermaid: str) -> None:
+        """Populate the flow from a Mermaid diagram.
+
+        Edge labels are accepted in both ``A -- label --> B`` and
+        ``A -->|label| B`` forms. Lines without edges are ignored.
+        """
         lines = [line.strip() for line in mermaid.splitlines() if line.strip()]
         if lines and lines[0].lower().startswith("graph"):
             lines = lines[1:]
@@ -40,11 +47,14 @@ class Flow:
             left, right = line.split("-->", 1)
             left = left.strip()
             right = right.strip()
-            # strip edge label syntax: A -- text --> B
             label = None
             if "--" in left:
                 parts = left.split("--", 1)
                 left, label = parts[0].strip(), parts[1].strip()
+            elif right.startswith("|"):
+                label, right = right[1:].split("|", 1)
+                label = label.strip()
+                right = right.strip()
             src_id, src_lbl, src_shape = self._parse_node(left)
             dst_id, dst_lbl, dst_shape = self._parse_node(right)
             for nid, nlbl, nshape in [

--- a/tests/flow/flow_test.py
+++ b/tests/flow/flow_test.py
@@ -52,6 +52,19 @@ class FlowParseMermaidTestCase(TestCase):
         self.assertEqual(flow.connections[0].src.name, "A")
         self.assertEqual(flow.connections[0].dest.name, "B")
 
+    def test_parse_mermaid_pipe_label(self):
+        mermaid = """
+        graph LR
+        A -->|edge| B
+        """
+        flow = Flow()
+        flow.parse_mermaid(mermaid)
+
+        self.assertEqual(len(flow.connections), 1)
+        self.assertEqual(flow.connections[0].label, "edge")
+        self.assertIn("A", flow.nodes)
+        self.assertIn("B", flow.nodes)
+
 
 class FlowExecutionTestCase(TestCase):
     def test_manual_execution(self):


### PR DESCRIPTION
## Summary
- support parsing pipe-style edge labels in `Flow.parse_mermaid`
- document flow class and mermaid parsing
- test mermaid parsing with pipe labels

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68a7bddadddc8323a8b254f5d536bb59