### PR TITLE
Refactor keyring secrets

### DIFF
--- a/src/avalan/secrets/__init__.py
+++ b/src/avalan/secrets/__init__.py
@@ -15,33 +15,4 @@ class Secrets(ABC):
         raise NotImplementedError()
 
 
-try:
-    from keyring import get_keyring
-    from keyring.backend import KeyringBackend
-except Exception:  # pragma Module may not be installed
-    get_keyring = None  # type: ignore
-    KeyringBackend = object  # type: ignore
-
-
-class KeyringSecrets:
-    _SERVICE = "avalan"
-
-    def __init__(self, ring: KeyringBackend | None = None):
-        if ring is None and get_keyring:
-            ring = get_keyring()
-        self._ring = ring
-
-    def read(self, key: str) -> str | None:
-        assert self._ring, "keyring package not installed"
-        return self._ring.get_password(self._SERVICE, key)
-
-    def write(self, key: str, secret: str) -> None:
-        assert self._ring, "keyring package not installed"
-        self._ring.set_password(self._SERVICE, key, secret)
-
-    def delete(self, key: str) -> None:
-        assert self._ring, "keyring package not installed"
-        try:
-            self._ring.delete_password(self._SERVICE, key)
-        except Exception:
-            pass
+from .keyring import KeyringSecrets as KeyringSecrets  # noqa: E402

--- a/src/avalan/secrets/keyring.py
+++ b/src/avalan/secrets/keyring.py
@@ -1,19 +1,37 @@
 from . import Secrets
-from keyring import get_keyring
-from keyring.backend import KeyringBackend
+
+try:
+    from keyring import get_keyring
+    from keyring.backend import KeyringBackend
+except Exception:  # pragma: no cover - optional dependency
+    get_keyring = None  # type: ignore[assignment]
+    KeyringBackend = object  # type: ignore[assignment]
 
 
 class KeyringSecrets(Secrets):
+    """Secrets backend backed by the system keyring."""
+
     _SERVICE = "avalan"
 
-    def __init__(self, ring: KeyringBackend | None = None):
-        self._ring = get_keyring()
+    def __init__(self, ring: KeyringBackend | None = None) -> None:
+        if ring is None and get_keyring:
+            ring = get_keyring()
+        self._ring = ring
 
     def read(self, key: str) -> str | None:
+        """Return secret stored under *key*."""
+        assert self._ring, "keyring package not installed"
         return self._ring.get_password(self._SERVICE, key)
 
     def write(self, key: str, secret: str) -> None:
+        """Store *secret* under *key*."""
+        assert self._ring, "keyring package not installed"
         self._ring.set_password(self._SERVICE, key, secret)
 
     def delete(self, key: str) -> None:
-        self._ring.delete_password(self._SERVICE, key)
+        """Remove secret associated with *key*."""
+        assert self._ring, "keyring package not installed"
+        try:
+            self._ring.delete_password(self._SERVICE, key)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- centralize `KeyringSecrets` in dedicated module and re-export from `avalan.secrets`
- harden keyring backend against missing keyring dependency
- adjust secrets module tests for new import behavior

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68a7c7b8ceb483239afd6d1e7ba18213