### PR TITLE
Respect skip_special_tokens in text generation

### DIFF
--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -239,13 +239,11 @@ class TextGenerationModel(BaseNLPModel):
         skip_special_tokens: bool,
         **kwargs,
     ) -> str:
-        _l = self._log
         input_length = inputs["input_ids"].shape[1]
         outputs = self._generate_output(inputs, settings, stopping_criterias)
-        response = self._tokenizer.decode(
-            outputs[0][input_length:], skip_special_tokens=False
+        return self._tokenizer.decode(
+            outputs[0][input_length:], skip_special_tokens=skip_special_tokens
         )
-        return response
 
     async def _token_generator(
         self,

--- a/tests/model/nlp/text_generation_methods_more_test.py
+++ b/tests/model/nlp/text_generation_methods_more_test.py
@@ -162,6 +162,32 @@ class StringOutputTestCase(TestCase):
         )
         self.assertEqual(result, "ok")
 
+    def test_string_output_skip_special_tokens_true(self):
+        model = TextGenerationModel(
+            "m",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+            logger=getLogger(),
+        )
+        model._tokenizer = MagicMock()
+        model._tokenizer.decode.return_value = "ok"
+        model._log = MagicMock()
+        inputs = {"input_ids": torch.tensor([[1, 2]])}
+        with patch.object(
+            TextGenerationModel,
+            "_generate_output",
+            return_value=[[1, 2, 3, 4]],
+        ) as gen:
+            result = model._string_output(
+                inputs, GenerationSettings(), None, True
+            )
+        gen.assert_called_once()
+        model._tokenizer.decode.assert_called_once_with(
+            [3, 4], skip_special_tokens=True
+        )
+        self.assertEqual(result, "ok")
+
 
 class TokenGeneratorTestCase(IsolatedAsyncioTestCase):
     async def _setup(self, entmax_available: bool):


### PR DESCRIPTION
## Summary
- Ensure TextGenerationModel's string output obeys the `skip_special_tokens` option when decoding
- Cover skip special tokens behavior with a dedicated unit test

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68a91d1ee99c8323a8069d188e1e3d97