### PR TITLE
Support local model download directories

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -357,6 +357,17 @@ class CLI:
             type=int,
             help="How many download workers to use",
         )
+        model_install_parser.add_argument(
+            "--local-dir",
+            type=str,
+            help="Local directory to download the model to",
+        )
+        model_install_parser.add_argument(
+            "--local-dir-symlinks",
+            action="store_true",
+            default=None,
+            help="Use symlinks when downloading to local dir",
+        )
 
         # Model options shared by commands: memory embeddings, model
         model_options_parser = ArgumentParser(add_help=False)

--- a/src/avalan/cli/commands/cache.py
+++ b/src/avalan/cli/commands/cache.py
@@ -50,6 +50,8 @@ def cache_download(
             model_id,
             tqdm_class=create_live_tqdm_class(progress_template),
             workers=workers,
+            local_dir=args.local_dir,
+            local_dir_use_symlinks=args.local_dir_symlinks,
         )
         console.print(theme.download_finished(model_id, path))
     except HubAccessDeniedException:

--- a/src/avalan/model/hubs/huggingface.py
+++ b/src/avalan/model/hubs/huggingface.py
@@ -142,6 +142,8 @@ class HuggingfaceHub:
         *,
         workers: int = 8,
         tqdm_class: type[tqdm] | Callable[..., tqdm] | None = None,
+        local_dir: str | None = None,
+        local_dir_use_symlinks: bool | None = None,
     ) -> str:
         try:
             path = self._hf.snapshot_download(
@@ -150,6 +152,12 @@ class HuggingfaceHub:
                 tqdm_class=tqdm_class,
                 force_download=False,
                 max_workers=workers,
+                local_dir=local_dir,
+                local_dir_use_symlinks=(
+                    local_dir_use_symlinks
+                    if local_dir_use_symlinks is not None
+                    else False
+                ),
             )
             return path
         except GatedRepoError as e:

--- a/tests/cli/cache_test.py
+++ b/tests/cli/cache_test.py
@@ -71,7 +71,11 @@ class CliCacheDeleteTestCase(unittest.TestCase):
 class CliCacheDownloadTestCase(unittest.TestCase):
     def setUp(self):
         self.args = Namespace(
-            model="m", skip_hub_access_check=False, workers=8
+            model="m",
+            skip_hub_access_check=False,
+            workers=8,
+            local_dir=None,
+            local_dir_symlinks=None,
         )
         self.console = MagicMock()
         self.theme = MagicMock()
@@ -84,6 +88,8 @@ class CliCacheDownloadTestCase(unittest.TestCase):
     def test_successful_download(self):
         self.hub.download.return_value = "/path"
         self.hub.can_access.return_value = True
+        self.args.local_dir = "/ld"
+        self.args.local_dir_symlinks = True
         with patch.object(
             cache_cmds, "create_live_tqdm_class", return_value="C"
         ) as cltc:
@@ -94,7 +100,11 @@ class CliCacheDownloadTestCase(unittest.TestCase):
         self.theme.download_start.assert_called_once_with("m")
         cltc.assert_called_once_with(("tpl",))
         self.hub.download.assert_called_once_with(
-            "m", tqdm_class="C", workers=8
+            "m",
+            tqdm_class="C",
+            workers=8,
+            local_dir="/ld",
+            local_dir_use_symlinks=True,
         )
         self.theme.download_finished.assert_called_once_with("m", "/path")
         self.theme.download_access_denied.assert_not_called()

--- a/tests/model/hubs/huggingface_test.py
+++ b/tests/model/hubs/huggingface_test.py
@@ -125,6 +125,8 @@ class HuggingfaceHubTestCase(TestCase):
             tqdm_class=None,
             force_download=False,
             max_workers=8,
+            local_dir=None,
+            local_dir_use_symlinks=False,
         )
         self.hf_instance.snapshot_download.side_effect = GatedRepoError(
             "denied"


### PR DESCRIPTION
## Summary
- allow `HuggingfaceHub.download` to place checkpoints in a custom directory and optionally use symlinks (disabled by default)
- expose `--local-dir` and `--local-dir-symlinks` for `cache download` and `model install`
- verify CLI options are forwarded to the hub download calls

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68aec3d184608323829d876df594473e