### PR TITLE
Add tests for image and list content in TextGenerationModel

### DIFF
--- a/tests/model/nlp/text_generation_extra_test.py
+++ b/tests/model/nlp/text_generation_extra_test.py
@@ -7,6 +7,7 @@ import torch
 from avalan.entities import (
     GenerationSettings,
     Message,
+    MessageContentImage,
     MessageContentText,
     MessageRole,
     TransformerEngineSettings,
@@ -121,6 +122,164 @@ class TokenizeInputContentTextTestCase(TestCase):
         self.assertEqual(
             kwargs, {"add_special_tokens": True, "return_tensors": "pt"}
         )
+        token_out.to.assert_called_once_with("cpu")
+        self.assertIs(result, token_out)
+
+
+class TokenizeInputContentImageTestCase(TestCase):
+    def _setup(
+        self, has_template: bool
+    ) -> tuple[TextGenerationModel, MagicMock, MagicMock]:
+        model = TextGenerationModel(
+            "m",
+            TransformerEngineSettings(
+                auto_load_model=False,
+                auto_load_tokenizer=False,
+            ),
+        )
+        model._model = MagicMock(device="cpu")
+        tokenizer = MagicMock()
+        token_out = MagicMock()
+        token_out.to.return_value = token_out
+        if has_template:
+            tokenizer.chat_template = "tpl"
+            tokenizer.apply_chat_template.return_value = token_out
+        else:
+            tokenizer.chat_template = None
+            tokenizer.return_value = token_out
+        model._tokenizer = tokenizer
+        model._log = MagicMock()
+        return model, tokenizer, token_out
+
+    def test_image_content_with_template(self) -> None:
+        model, tokenizer, token_out = self._setup(True)
+        message = Message(
+            role=MessageRole.USER,
+            content=MessageContentImage(
+                type="image_url", image_url={"url": "u"}
+            ),
+        )
+        result = model._tokenize_input(message, None, context=None)
+        tokenizer.apply_chat_template.assert_called_once()
+        args, kwargs = tokenizer.apply_chat_template.call_args
+        self.assertEqual(
+            args[0],
+            [
+                {
+                    "role": MessageRole.USER,
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "u"}},
+                    ],
+                }
+            ],
+        )
+        token_out.to.assert_called_once_with("cpu")
+        self.assertIs(result, token_out)
+
+    def test_image_content_plain(self) -> None:
+        model, tokenizer, token_out = self._setup(False)
+        message = Message(
+            role=MessageRole.USER,
+            content=MessageContentImage(
+                type="image_url", image_url={"url": "u"}
+            ),
+        )
+        result = model._tokenize_input(message, None, context=None)
+        tokenizer.assert_called_once()
+        self.assertEqual(tokenizer.call_args[0][0], "None\n\n\n")
+        token_out.to.assert_called_once_with("cpu")
+        self.assertIs(result, token_out)
+
+
+class TokenizeInputContentListTestCase(TestCase):
+    def _setup(
+        self, has_template: bool
+    ) -> tuple[TextGenerationModel, MagicMock, MagicMock]:
+        model = TextGenerationModel(
+            "m",
+            TransformerEngineSettings(
+                auto_load_model=False,
+                auto_load_tokenizer=False,
+            ),
+        )
+        model._model = MagicMock(device="cpu")
+        tokenizer = MagicMock()
+        token_out = MagicMock()
+        token_out.to.return_value = token_out
+        if has_template:
+            tokenizer.chat_template = "tpl"
+            tokenizer.apply_chat_template.return_value = token_out
+        else:
+            tokenizer.chat_template = None
+            tokenizer.return_value = token_out
+        model._tokenizer = tokenizer
+        model._log = MagicMock()
+        return model, tokenizer, token_out
+
+    def test_list_content_with_template(self) -> None:
+        model, tokenizer, token_out = self._setup(True)
+        message = Message(
+            role=MessageRole.USER,
+            content=[
+                MessageContentImage(type="image_url", image_url={"url": "u"}),
+                MessageContentText(type="text", text="hi"),
+            ],
+        )
+        result = model._tokenize_input(message, None, context=None)
+        tokenizer.apply_chat_template.assert_called_once()
+        args, kwargs = tokenizer.apply_chat_template.call_args
+        self.assertEqual(
+            args[0],
+            [
+                {
+                    "role": MessageRole.USER,
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "u"}},
+                        {"type": "text", "text": "hi"},
+                    ],
+                }
+            ],
+        )
+        token_out.to.assert_called_once_with("cpu")
+        self.assertIs(result, token_out)
+
+    def test_list_content_plain(self) -> None:
+        model, tokenizer, token_out = self._setup(False)
+        message = Message(
+            role=MessageRole.USER,
+            content=[
+                MessageContentText(type="text", text="a"),
+                MessageContentImage(type="image_url", image_url={"url": "u"}),
+                MessageContentText(type="text", text="b"),
+            ],
+        )
+        result = model._tokenize_input(message, None, context=None)
+        tokenizer.assert_called_once()
+        self.assertEqual(tokenizer.call_args[0][0], "None\n\na\nb\n")
+        token_out.to.assert_called_once_with("cpu")
+        self.assertIs(result, token_out)
+
+
+class TokenizeInputUnknownContentTestCase(TestCase):
+    def test_unknown_content_converted_to_string(self) -> None:
+        model = TextGenerationModel(
+            "m",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+        )
+        model._model = MagicMock(device="cpu")
+        tokenizer = MagicMock(chat_template=None)
+        token_out = MagicMock()
+        token_out.to.return_value = token_out
+        tokenizer.return_value = token_out
+        model._tokenizer = tokenizer
+        model._log = MagicMock()
+
+        message = Message(role=MessageRole.USER, content=123)
+        result = model._tokenize_input(message, None, context=None)
+        tokenizer.assert_called_once()
+        self.assertEqual(tokenizer.call_args[0][0], "None\n\n123\n")
         token_out.to.assert_called_once_with("cpu")
         self.assertIs(result, token_out)
 


### PR DESCRIPTION
## Summary
- test `_tokenize_input` handles image-only messages with and without chat templates
- test `_tokenize_input` processes mixed content lists and unknown content values

## Testing
- `make lint`
- `poetry run pytest --verbose -s`
- `poetry run coverage run --include=src/avalan/model/nlp/text/generation.py -m pytest tests/model/nlp/text_generation_extra_test.py tests/model/nlp/text_generation_methods_more_test.py tests/model/nlp/text_generation_call_test.py tests/model/nlp/text_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3889bdb88323965de4b799e47f77