### PR TITLE
Add shared agent CLI parser

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -580,16 +580,33 @@ class CLI:
             settings_cls=BrowserToolSettings,
         )
 
-        agent_run_parser = agent_command_parsers.add_parser(
-            name="run",
-            description="Run an AI agent",
-            parents=[global_parser, model_inference_display_parser],
-        )
-        agent_run_parser.add_argument(
+        agent_common_parser = ArgumentParser(add_help=False)
+        agent_common_parser.add_argument(
             "specifications_file",
             type=str,
             nargs="?",
             help="File that holds the agent specifications",
+        )
+        agent_common_parser.add_argument(
+            "--id", type=str, help="Use given ID as the agent ID"
+        )
+        agent_common_parser.add_argument(
+            "--participant",
+            default=uuid4(),
+            help=(
+                "If specified, this is the participant ID interacting with "
+                "the agent"
+            ),
+        )
+
+        agent_run_parser = agent_command_parsers.add_parser(
+            name="run",
+            description="Run an AI agent",
+            parents=[
+                global_parser,
+                model_inference_display_parser,
+                agent_common_parser,
+            ],
         )
         agent_run_parser.add_argument(
             "--conversation",
@@ -605,9 +622,6 @@ class CLI:
                 "Reload agent when the specification file changes "
                 "(only with --conversation)"
             ),
-        )
-        agent_run_parser.add_argument(
-            "--id", type=str, help="Use given ID as the agent ID"
         )
         agent_session_group = agent_run_parser.add_mutually_exclusive_group()
         agent_session_group.add_argument(
@@ -634,14 +648,6 @@ class CLI:
             "--load-recent-messages-limit",
             type=int,
             help="If specified, load up to these many recent messages",
-        )
-        agent_run_parser.add_argument(
-            "--participant",
-            default=uuid4(),
-            help=(
-                "If specified, this is the participant ID interacting with "
-                "the agent"
-            ),
         )
         agent_run_parser.add_argument(
             "--stats",
@@ -686,13 +692,7 @@ class CLI:
         agent_serve_parser = agent_command_parsers.add_parser(
             name="serve",
             description="Serve an AI agent as an API endpoint",
-            parents=[global_parser],
-        )
-        agent_serve_parser.add_argument(
-            "specifications_file",
-            type=str,
-            nargs="?",
-            help="File that holds the agent specifications",
+            parents=[global_parser, agent_common_parser],
         )
         CLI._add_agent_server_arguments(agent_serve_parser)
         CLI._add_agent_settings_arguments(agent_serve_parser)
@@ -705,7 +705,7 @@ class CLI:
         agent_proxy_parser = agent_command_parsers.add_parser(
             name="proxy",
             description="Serve a proxy agent as an API endpoint",
-            parents=[global_parser],
+            parents=[global_parser, agent_common_parser],
         )
         CLI._add_agent_server_arguments(agent_proxy_parser)
         CLI._add_agent_settings_arguments(agent_proxy_parser)

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -575,6 +575,8 @@ async def agent_serve(
 ) -> None:
     assert args.host and args.port
     specs_path = args.specifications_file
+    agent_id = getattr(args, "id", None)
+    participant_id = args.participant
     engine_uri = getattr(args, "engine_uri", None)
     assert not (
         specs_path and engine_uri
@@ -592,7 +594,7 @@ async def agent_serve(
         )
         settings = get_orchestrator_settings(
             args,
-            agent_id=uuid4(),
+            agent_id=agent_id or uuid4(),
             memory_recent=memory_recent,
             tools=(args.tool or []) + (getattr(args, "tools", None) or []),
         )
@@ -613,6 +615,8 @@ async def agent_serve(
         port=args.port,
         reload=args.reload,
         logger=logger,
+        agent_id=agent_id,
+        participant_id=participant_id,
     )
     await server.serve()
 

--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -8,7 +8,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from fastapi import APIRouter, FastAPI, Request
 from logging import Logger
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 if TYPE_CHECKING:
     from uvicorn import Server
@@ -27,6 +27,8 @@ def agents_server(
     prefix_mcp: str,
     prefix_openai: str,
     logger: Logger,
+    agent_id: UUID | None = None,
+    participant_id: UUID | None = None,
 ) -> "Server":
     """Build a configured Uvicorn server for Avalan agents.
 
@@ -46,6 +48,8 @@ def agents_server(
         prefix_mcp: URL prefix for MCP endpoints.
         prefix_openai: URL prefix for OpenAI-compatible endpoints.
         logger: Application logger.
+        agent_id: Optional agent identifier.
+        participant_id: Optional participant identifier.
 
     Returns:
         Configured Uvicorn server instance.
@@ -71,13 +75,13 @@ def agents_server(
             loader = OrchestratorLoader(
                 hub=hub,
                 logger=logger,
-                participant_id=uuid4(),
+                participant_id=participant_id or uuid4(),
                 stack=stack,
             )
             if specs_path:
                 orchestrator = await loader.from_file(
                     specs_path,
-                    agent_id=uuid4(),
+                    agent_id=agent_id or uuid4(),
                 )
             else:
                 orchestrator = await loader.from_settings(

--- a/tests/cli/agent_options_test.py
+++ b/tests/cli/agent_options_test.py
@@ -1,0 +1,90 @@
+from argparse import Namespace
+from logging import Logger
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from avalan.cli.__main__ import CLI
+from avalan.cli.commands import agent as agent_cmds
+
+
+class AgentParserOptionsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.parser = CLI._create_parser(
+            default_device="cpu",
+            cache_dir="/tmp",
+            default_locales_path="/tmp",
+            default_locale="en_US",
+        )
+
+    def test_run_parser_with_common_options(self) -> None:
+        args = self.parser.parse_args(
+            [
+                "agent",
+                "run",
+                "spec.toml",
+                "--participant",
+                "pid",
+                "--id",
+                "aid",
+            ]
+        )
+        self.assertEqual(args.specifications_file, "spec.toml")
+        self.assertEqual(args.participant, "pid")
+        self.assertEqual(args.id, "aid")
+
+    def test_serve_parser_with_common_options(self) -> None:
+        args = self.parser.parse_args(
+            [
+                "agent",
+                "serve",
+                "spec.toml",
+                "--participant",
+                "pid",
+                "--id",
+                "aid",
+            ]
+        )
+        self.assertEqual(args.specifications_file, "spec.toml")
+        self.assertEqual(args.participant, "pid")
+        self.assertEqual(args.id, "aid")
+
+    def test_run_parser_defaults(self) -> None:
+        args = self.parser.parse_args(["agent", "run", "spec.toml"])
+        self.assertTrue(args.participant)
+        self.assertIsNone(args.id)
+
+    def test_serve_parser_defaults(self) -> None:
+        args = self.parser.parse_args(["agent", "serve", "spec.toml"])
+        self.assertTrue(args.participant)
+        self.assertIsNone(args.id)
+
+
+class AgentServeForwardOptionsTestCase(IsolatedAsyncioTestCase):
+    async def test_agent_serve_passes_ids(self) -> None:
+        args = Namespace(
+            specifications_file="spec.toml",
+            engine_uri=None,
+            memory_recent=None,
+            tool=None,
+            tools=None,
+            host="localhost",
+            port=9001,
+            prefix_openai="/v1",
+            prefix_mcp="/mcp",
+            reload=False,
+            id="aid",
+            participant="pid",
+        )
+        hub = MagicMock()
+        logger = MagicMock(spec=Logger)
+        server = MagicMock()
+        server.serve = AsyncMock()
+        with patch(
+            "avalan.cli.commands.agent.agents_server", return_value=server
+        ) as srv_patch:
+            await agent_cmds.agent_serve(args, hub, logger, "name", "v")
+
+        srv_patch.assert_called_once()
+        self.assertEqual(srv_patch.call_args.kwargs["agent_id"], "aid")
+        self.assertEqual(srv_patch.call_args.kwargs["participant_id"], "pid")
+        server.serve.assert_awaited_once()

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -201,6 +201,8 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             prefix_mcp="mcp",
             reload=False,
             backend="transformers",
+            id=None,
+            participant="pid",
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -227,6 +229,8 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             port=80,
             reload=False,
             logger=logger,
+            agent_id=None,
+            participant_id="pid",
         )
         server.serve.assert_awaited_once()
 
@@ -262,6 +266,8 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             display_tools=False,
             display_tools_events=2,
             tools_confirm=False,
+            id=None,
+            participant="pid",
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -300,6 +306,8 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             port=80,
             reload=False,
             logger=logger,
+            agent_id=None,
+            participant_id="pid",
         )
         server.serve.assert_awaited_once()
 
@@ -335,6 +343,8 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             display_tools=False,
             display_tools_events=2,
             tools_confirm=False,
+            id=None,
+            participant="pid",
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -375,6 +385,8 @@ class CliAgentProxyTestCase(unittest.IsolatedAsyncioTestCase):
             display_tools=False,
             display_tools_events=2,
             tools_confirm=False,
+            id=None,
+            participant="pid",
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -402,6 +414,8 @@ class CliAgentProxyTestCase(unittest.IsolatedAsyncioTestCase):
             reload=False,
             backend="transformers",
             engine_uri=None,
+            id=None,
+            participant="pid",
         )
         hub = MagicMock()
         logger = MagicMock()

--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -142,6 +142,8 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                 args, kwargs = loader.from_file.await_args
                 self.assertEqual(args[0], "path.json")
                 self.assertIn("agent_id", kwargs)
+                _, loader_kwargs = Loader.call_args
+                self.assertIn("participant_id", loader_kwargs)
                 orchestrator_cm.__aenter__.assert_awaited_once()
                 orchestrator_cm.__aexit__.assert_awaited_once()
                 self.assertIs(app.state.orchestrator, orchestrator)
@@ -234,3 +236,5 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                 args, kwargs = loader.from_settings.await_args
                 self.assertEqual(args[0], settings)
                 self.assertEqual(kwargs["browser_settings"], browser_settings)
+                _, loader_kwargs = Loader.call_args
+                self.assertIn("participant_id", loader_kwargs)


### PR DESCRIPTION
## Summary
- Add common agent CLI parser so run, serve and proxy share specification, id and participant options
- Support `--participant` and `--id` for `agent serve` and proxy
- Test agent option parsing and server forwarding of identifiers

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68af85f402688323af0e6cb3011a7ade