### PR TITLE
Support user input templates in agent configuration

### DIFF
--- a/src/avalan/agent/blueprint.toml
+++ b/src/avalan/agent/blueprint.toml
@@ -22,6 +22,14 @@ instructions = """
 {{ orchestrator.agent_config['instructions'] | indent(4) }}
 """
 {% endif %}
+{% if orchestrator.agent_config.get('user') %}
+user = """
+{{ orchestrator.agent_config['user'] | indent(4) }}
+"""
+{% endif %}
+{% if orchestrator.agent_config.get('user_template') %}
+user_template = "{{ orchestrator.agent_config['user_template'] }}"
+{% endif %}
 
 [memory]
 recent = {{ orchestrator.memory_recent | lower }}

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -82,6 +82,9 @@ class OrchestratorLoader:
             ), "No uri defined in engine section of configuration"
 
             agent_config = config["agent"]
+            assert not (
+                "user" in agent_config and "user_template" in agent_config
+            ), "user and user_template are mutually exclusive"
 
             assert (
                 "engine" in config
@@ -402,6 +405,8 @@ class OrchestratorLoader:
                 ),
                 rules=settings.agent_config.get("rules"),
                 system=settings.agent_config.get("system"),
+                user=settings.agent_config.get("user"),
+                user_template=settings.agent_config.get("user_template"),
                 settings=engine_settings,
                 call_options=settings.call_options,
                 template_vars=settings.template_vars,
@@ -471,6 +476,8 @@ class OrchestratorLoader:
             ),
             rules=agent_config.get("rules"),
             system=agent_config.get("system"),
+            user=agent_config.get("user"),
+            user_template=agent_config.get("user_template"),
             settings=engine_settings,
             call_options=call_options,
             template_vars=template_vars,

--- a/src/avalan/agent/orchestrator/orchestrators/default.py
+++ b/src/avalan/agent/orchestrator/orchestrators/default.py
@@ -25,6 +25,8 @@ class DefaultOrchestrator(Orchestrator):
         instructions: str | None,
         rules: list[str] | None,
         system: str | None = None,
+        user: str | None = None,
+        user_template: str | None = None,
         template_id: str | None = None,
         settings: TransformerEngineSettings | None = None,
         call_options: dict | None = None,
@@ -68,4 +70,6 @@ class DefaultOrchestrator(Orchestrator):
             call_options=call_options,
             id=id,
             name=name,
+            user=user,
+            user_template=user_template,
         )

--- a/src/avalan/agent/orchestrator/orchestrators/json.py
+++ b/src/avalan/agent/orchestrator/orchestrators/json.py
@@ -98,6 +98,8 @@ class JsonOrchestrator(Orchestrator):
         name: str | None = None,
         rules: list[str] | None = [],
         system: str | None = None,
+        user: str | None = None,
+        user_template: str | None = None,
         template_id: str | None = None,
         settings: TransformerEngineSettings | None = None,
         call_options: dict | None = None,
@@ -136,6 +138,8 @@ class JsonOrchestrator(Orchestrator):
                 modality=Modality.TEXT_GENERATION,
             ),
             call_options=call_options,
+            user=user,
+            user_template=user_template,
         )
 
     async def __call__(self, input: Input, **kwargs) -> str:

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1662,6 +1662,10 @@ class CLI:
         group.add_argument(
             "--instructions", type=str, help="Agent instructions"
         )
+        group.add_argument("--user", type=str, help="User message template")
+        group.add_argument(
+            "--user-template", type=str, help="User message template file"
+        )
         group.add_argument(
             "--memory-recent",
             dest="memory_recent",

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -38,6 +38,8 @@ def get_orchestrator_settings(
     role: str | None = None,
     task: str | None = None,
     instructions: str | None = None,
+    user: str | None = None,
+    user_template: str | None = None,
     engine_uri: str | None = None,
     memory_recent: bool | None = None,
     memory_permanent_message: str | None = None,
@@ -51,6 +53,10 @@ def get_orchestrator_settings(
     cache_strategy: GenerationCacheStrategy | None = None,
 ) -> OrchestratorSettings:
     """Create ``OrchestratorSettings`` from CLI arguments."""
+    assert not (
+        (user or getattr(args, "user", None))
+        and (user_template or getattr(args, "user_template", None))
+    )
     memory_recent = (
         memory_recent
         if memory_recent is not None
@@ -98,6 +104,14 @@ def get_orchestrator_settings(
                     instructions
                     if instructions is not None
                     else args.instructions
+                ),
+                "user": (
+                    user if user is not None else getattr(args, "user", None)
+                ),
+                "user_template": (
+                    user_template
+                    if user_template is not None
+                    else getattr(args, "user_template", None)
                 ),
             }.items()
             if v is not None

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -588,6 +588,30 @@ uri = \"ai://local/model\"
         self.assertEqual(kwargs["rules"], ["r1", "r2"])
         self.assertIsNone(kwargs["system"])
 
+    async def test_agent_user_only(self):
+        config = """
+[agent]
+user = \"hello {{input}}\"
+
+[engine]
+uri = \"ai://local/model\"
+"""
+        kwargs = await self._run_loader(config)
+        self.assertEqual(kwargs["user"], "hello {{input}}")
+        self.assertIsNone(kwargs.get("user_template"))
+
+    async def test_agent_user_template_only(self):
+        config = """
+[agent]
+user_template = \"u.md\"
+
+[engine]
+uri = \"ai://local/model\"
+"""
+        kwargs = await self._run_loader(config)
+        self.assertEqual(kwargs["user_template"], "u.md")
+        self.assertIsNone(kwargs.get("user"))
+
 
 class LoadJsonOrchestratorVariantsTestCase(TestCase):
     def test_system_only(self):

--- a/tests/cli/get_orchestrator_settings_test.py
+++ b/tests/cli/get_orchestrator_settings_test.py
@@ -40,6 +40,37 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             OrchestratorLoader.DEFAULT_SENTENCE_MODEL_ID,
         )
 
+    def test_user_and_user_template(self):
+        args = Namespace(
+            name="a",
+            role=None,
+            task=None,
+            instructions=None,
+            engine_uri="ai://m",
+            backend="transformers",
+            run_max_new_tokens=10,
+            run_skip_special_tokens=False,
+            memory_recent=None,
+            no_session=False,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=200,
+            memory_engine_overlap=20,
+            memory_engine_window=40,
+            tool=None,
+            user="hi {{input}}",
+            user_template=None,
+        )
+        uid = UUID("00000000-0000-0000-0000-000000000004")
+        result = agent_cmds.get_orchestrator_settings(args, agent_id=uid)
+        self.assertEqual(result.agent_config["user"], "hi {{input}}")
+
+        args.user = None
+        args.user_template = "u.md"
+        result = agent_cmds.get_orchestrator_settings(args, agent_id=uid)
+        self.assertEqual(result.agent_config["user_template"], "u.md")
+
     def test_overrides(self):
         args = Namespace(
             name="n",


### PR DESCRIPTION
## Summary
- allow agent configs and CLI to specify `user` or `user_template` for rendering input messages
- add `--user` and `--user-template` options to agent CLI
- document user settings in blueprint and cover with tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b0faa5d6708323a2a370be20722412