### PR TITLE
Add template vars to generation settings

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -296,9 +296,7 @@ class Orchestrator:
             await self._last_engine_agent.sync_messages()
 
     def _input_messages(
-        self,
-        specification: Specification,
-        input: Input
+        self, specification: Specification, input: Input
     ) -> Message | list[Message]:
         input_type = specification.input_type
         assert (
@@ -313,12 +311,17 @@ class Orchestrator:
 
         if self._user_template or self._user:
             message = (
-                input if isinstance(input, Message)
-                else input[-1] if (
-                    isinstance(input, list) and input
-                    and isinstance(input[-1], Message)
+                input
+                if isinstance(input, Message)
+                else (
+                    input[-1]
+                    if (
+                        isinstance(input, list)
+                        and input
+                        and isinstance(input[-1], Message)
+                    )
+                    else None
                 )
-                else None
             )
 
             if message and (
@@ -326,13 +329,18 @@ class Orchestrator:
                 or isinstance(message.content, MessageContentText)
             ):
                 render_vars = (
-                    specification.template_vars
+                    specification.template_vars.copy()
                     if specification.template_vars
                     else {}
                 )
+                if (
+                    specification.settings
+                    and specification.settings.template_vars
+                ):
+                    render_vars.update(specification.settings.template_vars)
                 message_content = (
                     message.content.text
-                        if isinstance(message.content, MessageContentText)
+                    if isinstance(message.content, MessageContentText)
                     else message.content
                 )
                 render_vars.update({"input": message_content})

--- a/src/avalan/agent/renderer.py
+++ b/src/avalan/agent/renderer.py
@@ -97,7 +97,13 @@ class TemplateEngineAgent(EngineAgent):
             return kwargs
 
         template_id = specification.template_id or "agent.md"
-        template_vars = specification.template_vars or {}
+        template_vars = (
+            specification.template_vars.copy()
+            if specification.template_vars
+            else {}
+        )
+        if specification.settings and specification.settings.template_vars:
+            template_vars.update(specification.settings.template_vars)
         template_vars.setdefault("name", self._name)
         template_vars.setdefault(
             "roles",

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -381,6 +381,10 @@ class GenerationSettings:
     chat_settings: ChatSettings = field(default_factory=ChatSettings)
     reasoning: ReasoningSettings = field(default_factory=ReasoningSettings)
 
+    # Templating ------------------------------------------------------------
+    # Additional variables available during prompt and message rendering
+    template_vars: dict | None = None
+
     # Response settings ------------------------------------------------------
     # How to format the model response
     response_format: dict | None = None

--- a/tests/agent/template_engine_agent_test.py
+++ b/tests/agent/template_engine_agent_test.py
@@ -1,6 +1,11 @@
 from avalan.agent import Goal, Role, Specification
 from avalan.agent.renderer import Renderer, TemplateEngineAgent
-from avalan.entities import EngineMessage, EngineUri, MessageRole
+from avalan.entities import (
+    EngineMessage,
+    EngineUri,
+    MessageRole,
+    GenerationSettings,
+)
 from avalan.event import EventType
 from avalan.event.manager import EventManager
 from avalan.memory.manager import MemoryManager
@@ -94,6 +99,24 @@ class TemplateEngineAgentPrepareTestCase(TestCase):
             goal=Goal(task="do {{verb}}", instructions=["inst {{verb}}"]),
             rules=["rule {{verb}}"],
             template_vars={"verb": "run"},
+        )
+        result = self.agent._prepare_call(spec, "hi")
+        expected_prompt = self.renderer(
+            "agent.md",
+            name="Bob",
+            roles=[b"role run"],
+            task=b"do run",
+            instructions=[b"inst run"],
+            rules=[b"rule run"],
+        )
+        self.assertEqual(result["system_prompt"], expected_prompt)
+
+    def test_prepare_call_with_settings_template_vars(self):
+        spec = Specification(
+            role=Role(persona=["role {{verb}}"]),
+            goal=Goal(task="do {{verb}}", instructions=["inst {{verb}}"]),
+            rules=["rule {{verb}}"],
+            settings=GenerationSettings(template_vars={"verb": "run"}),
         )
         result = self.agent._prepare_call(spec, "hi")
         expected_prompt = self.renderer(


### PR DESCRIPTION
## Summary
- allow `GenerationSettings` to carry template variables
- merge `specification.settings.template_vars` into renderer message templates and orchestrator user rendering
- cover settings-provided template vars in agent layout and user/user_template flows

## Testing
- `make lint`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1b5350ac083238472411f48769cd5