### PR TITLE
Fix database tool tests to use async engine

### DIFF
--- a/tests/tool/database_tool_test.py
+++ b/tests/tool/database_tool_test.py
@@ -94,35 +94,35 @@ class DatabaseToolSetTestCase(IsolatedAsyncioTestCase):
         self.tmp.cleanup()
 
     async def test_run_tool_returns_rows(self):
-        engine = create_engine(self.dsn)
+        engine = dummy_create_async_engine(self.dsn)
         tool = DatabaseRunTool(engine, self.settings)
         rows = await tool(
             "SELECT id, title FROM books", context=ToolCallContext()
         )
         self.assertEqual(rows, [{"id": 1, "title": "Book"}])
-        engine.dispose()
+        await engine.dispose()
 
     async def test_run_tool_no_rows(self):
-        engine = create_engine(self.dsn)
+        engine = dummy_create_async_engine(self.dsn)
         tool = DatabaseRunTool(engine, self.settings)
         rows = await tool(
             "INSERT INTO authors(name) VALUES ('Other')",
             context=ToolCallContext(),
         )
         self.assertEqual(rows, [])
-        engine.dispose()
+        await engine.dispose()
 
     async def test_tables_tool_lists_tables(self):
-        engine = create_engine(self.dsn)
+        engine = dummy_create_async_engine(self.dsn)
         tool = DatabaseTablesTool(engine, self.settings)
         tables = await tool(context=ToolCallContext())
         self.assertIn("main", tables)
         self.assertIn("authors", tables["main"])
         self.assertIn("books", tables["main"])
-        engine.dispose()
+        await engine.dispose()
 
     async def test_inspect_tool_returns_schema(self):
-        engine = create_engine(self.dsn)
+        engine = dummy_create_async_engine(self.dsn)
         tool = DatabaseInspectTool(engine, self.settings)
         table = await tool("books", context=ToolCallContext())
         self.assertEqual(table.name, "books")
@@ -133,7 +133,7 @@ class DatabaseToolSetTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(fk.field, "author_id")
         self.assertEqual(fk.ref_table, "main.authors")
         self.assertEqual(fk.ref_field, "id")
-        engine.dispose()
+        await engine.dispose()
 
     async def test_toolset_reuses_engine_and_disposes(self):
         async with DatabaseToolSet(self.settings) as toolset:


### PR DESCRIPTION
## Summary
- use dummy async engine when testing database tools

## Testing
- `poetry run pytest tests/tool/database_tool_test.py -q`
- `poetry run pytest --verbose -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46b78df448323b5523938027fae20