### PR TITLE
Handle non-string tool results

### DIFF
--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -2247,7 +2247,7 @@ class FancyTheme(Theme):
                                             or []
                                         ),
                                         result="[spring_green3]"
-                                        + event.payload["result"].result
+                                        + str(event.payload["result"].result)
                                         + "[/spring_green3]",
                                     )
                                     if event.type == EventType.TOOL_RESULT


### PR DESCRIPTION
## Summary
- avoid string concatenation errors in FancyTheme event log by stringifying tool results
- add regression test ensuring coroutine tool outputs are logged safely
- await tool calls without arguments to prevent coroutine leaks
- add tests covering no-argument tools and async functions

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b472643644832392e7ca75ebd718a7