### PR TITLE
Await native tools without arguments

### DIFF
--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -157,7 +157,7 @@ class ToolManager(ContextDecorator):
             await tool(*call.arguments.values(), context=context)
             if is_native_tool and call.arguments
             else (
-                tool(context=context)
+                await tool(context=context)
                 if is_native_tool
                 else (
                     await tool(*call.arguments.values())


### PR DESCRIPTION
## Summary
- await native tool execution even when no arguments are provided
- add tests covering native and non-native tools with and without arguments

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b482ce82708323b8106320c4d695f2