### PR TITLE
Handle Harmony tool calls without trailing commentary

### DIFF
--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -97,7 +97,7 @@ class ToolCallParser:
         tool_calls: list[ToolCall] = []
         pattern = (
             r"<\|channel\|>commentary to=(?:functions\.)?([\w\.]+)\s*"
-            r"<\|constrain\|>json<\|message\|>(\{.*?\})<\|call\|>commentary"
+            r"<\|constrain\|>json<\|message\|>(\{.*?\})<\|call\|>"
         )
         for match in finditer(pattern, text, DOTALL):
             try:


### PR DESCRIPTION
## Summary
- Allow Harmony tool-call parser to match `<|call|>` without requiring trailing `commentary`
- Cover Harmony parser with tests for calls with and without trailing `commentary`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68b732582ed48323900669a63991a65a