### PR TITLE
Fix tool confirmation when stdin is piped

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,7 +85,7 @@ sequence_parallel,replicate}]
               [--locale LOCALE]
               [--loader-class {auto,gemma3,gpt-oss,mistral3}]
               [--backend {transformers,mlx,vllm}] [--locales LOCALES]
-              [--low-cpu-mem-usage] [--login] [--no-repl] [--quiet] [--record]
+              [--low-cpu-mem-usage] [--login] [--no-repl] [--quiet] [--tty TTY] [--record]
               [--revision REVISION] [--skip-hub-access-check] [--verbose]
               [--version]
               [--weight-type {auto,bool,bf16,f16,f32,f64,fp16,fp32,i8,i16,i32,i64,ui8}]
@@ -136,6 +136,7 @@ sequence_parallel,replicate}
                         is displayed in model run (sets --disable-loading-
                         progress-bar, --skip-hub-access-check, --skip-special-
                         tokens automatically)
+  --tty TTY             TTY stream to use for interactive prompts
   --record              If specified, the current console output will be
                         regularly saved to SVG files.
   --revision REVISION   Model revision to use
@@ -162,7 +163,7 @@ sequence_parallel,replicate}]
                     [--locale LOCALE]
                     [--loader-class {auto,gemma3,gpt-oss,mistral3}]
                     [--backend {transformers,mlx,vllm}] [--locales LOCALES]
-                    [--low-cpu-mem-usage] [--login] [--no-repl] [--quiet]
+                    [--low-cpu-mem-usage] [--login] [--no-repl] [--quiet] [--tty TTY]
                     [--record] [--revision REVISION] [--skip-hub-access-check]
                     [--verbose] [--version]
                     [--weight-type {auto,bool,bf16,f16,f32,f64,fp16,fp32,i8,i16,i32,i64,ui8}]
@@ -212,6 +213,7 @@ sequence_parallel,replicate}
                         is displayed in model run (sets --disable-loading-
                         progress-bar, --skip-hub-access-check, --skip-special-
                         tokens automatically)
+  --tty TTY             TTY stream to use for interactive prompts
   --record              If specified, the current console output will be
                         regularly saved to SVG files.
   --revision REVISION   Model revision to use
@@ -516,7 +518,7 @@ sequence_parallel,replicate}]
                         [--skip-load-recent-messages]
                         [--load-recent-messages-limit LOAD_RECENT_MESSAGES_LIMIT]
                         [--participant PARTICIPANT] [--stats] [--sync]
-                        [--tty TTY] [--tools-confirm]
+                        [--tools-confirm]
                         [--reasoning-tag {think,channel}]
                         [--engine-uri ENGINE_URI] [--name NAME] [--role ROLE]
                         [--task TASK] [--instructions INSTRUCTIONS]
@@ -652,8 +654,6 @@ sequence_parallel,replicate}
                         with the agent
   --stats               Show token generation statistics for agent output
   --sync                Don't use an async generator (token streaming)
-  --tty TTY             TTY stream (only applicable if combining
-                        --conversation with input piping)
   --tools-confirm       Confirm tool calls before execution
   --reasoning-tag {think,channel}
                         Reasoning tag style

--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -22,7 +22,9 @@ def confirm(console: Console, prompt: str) -> bool:
     return Confirm.ask(prompt)
 
 
-def confirm_tool_call(console: Console, call: ToolCall) -> str:
+def confirm_tool_call(
+    console: Console, call: ToolCall, *, tty_path: str = "/dev/tty"
+) -> str:
     """Return user's decision on executing ``call``."""
     console.print(
         Syntax(
@@ -30,11 +32,15 @@ def confirm_tool_call(console: Console, call: ToolCall) -> str:
             "json",
         )
     )
-    return Prompt.ask(
-        "Execute tool call? ([y]es/[a]ll/[n]o)",
-        choices=["y", "a", "n"],
-        default="n",
-    )
+    kwargs = {"choices": ["y", "a", "n"], "default": "n"}
+    stdin_is_tty = stdin.isatty()
+    with open(tty_path) if not stdin_is_tty else nullcontext() as tty:
+        if not stdin_is_tty:
+            kwargs["stream"] = tty
+        return Prompt.ask(
+            "Execute tool call? ([y]es/[a]ll/[n]o)",
+            **kwargs,
+        )
 
 
 def has_input(console: Console) -> bool:

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -260,6 +260,11 @@ class CLI:
             + " automatically)",
         )
         global_parser.add_argument(
+            "--tty",
+            default="/dev/tty",
+            help="TTY stream to use for interactive prompts",
+        )
+        global_parser.add_argument(
             "--record",
             action="store_true",
             default=False,
@@ -668,14 +673,6 @@ class CLI:
             action="store_true",
             default=False,
             help="Don't use an async generator (token streaming)",
-        )
-        agent_run_parser.add_argument(
-            "--tty",
-            default="/dev/tty",
-            help=(
-                "TTY stream (only applicable if combining --conversation "
-                "with input piping)"
-            ),
         )
         agent_run_parser.add_argument(
             "--tools-confirm",
@@ -1902,7 +1899,7 @@ class CLI:
                 prompt_kwargs = {}
                 if has_input(console):
                     try:
-                        prompt_kwargs["stream"] = open("/dev/tty")
+                        prompt_kwargs["stream"] = open(args.tty)
                     except OSError:
                         pass
                 access_token = Prompt.ask(

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -236,11 +236,14 @@ async def agent_message_search(
 
     assert agent_id and participant_id and session_id
 
+    tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
+
     input_string = get_input(
         console,
         _i["user_input"] + " ",
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
+        tty_path=tty_path,
     )
     if not input_string:
         return
@@ -372,9 +375,10 @@ async def agent_run(
     load_recent_messages_limit = args.load_recent_messages_limit
 
     event_stats = EventStats()
+    tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
     def _confirm_call(call: ToolCall) -> str:
-        return confirm_tool_call(console, call)
+        return confirm_tool_call(console, call, tty_path=tty_path)
 
     async def _event_listener(event):
         nonlocal event_stats
@@ -547,7 +551,7 @@ async def agent_run(
                 echo_stdin=not args.no_repl,
                 force_prompt=in_conversation,
                 is_quiet=args.quiet,
-                tty_path=args.tty,
+                tty_path=tty_path,
             )
             if not input_string:
                 logger.debug("Finishing session with orchestrator")
@@ -676,6 +680,7 @@ async def agent_proxy(
 
 async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
     _ = theme._
+    tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
     name = args.name or Prompt.ask(_("Agent name"))
     role = args.role or get_input(
@@ -683,6 +688,7 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         _("Agent role") + " ",
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
+        tty_path=tty_path,
     )
 
     task = args.task or get_input(
@@ -690,12 +696,14 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         _("Agent task") + " ",
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
+        tty_path=tty_path,
     )
     instructions = args.instructions or get_input(
         console,
         _("Agent instructions") + " ",
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
+        tty_path=tty_path,
     )
 
     memory_recent = (

--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -156,6 +156,7 @@ async def memory_embeddings(
     searches = args.search or None
     search_k = args.search_k or 1
     sort_by: DistanceType = args.sort or DistanceType.L2
+    tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
     sort_key = {
         DistanceType.COSINE: lambda s: s.cosine_distance,
@@ -182,6 +183,7 @@ async def memory_embeddings(
                 _i["user_input"] + " ",
                 echo_stdin=not args.no_repl,
                 is_quiet=args.quiet,
+                tty_path=tty_path,
             )
             if not input_string:
                 return
@@ -380,12 +382,14 @@ async def memory_search(
     namespace = args.namespace
     dsn = args.dsn
     limit = args.limit
+    tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
     input_string = get_input(
         console,
         _i["user_input"] + " ",
         echo_stdin=not args.no_repl,
         is_quiet=args.quiet,
+        tty_path=tty_path,
     )
     if not input_string:
         return

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -176,12 +176,15 @@ async def model_run(
         with manager.load(**model_settings) as model:
             logger.debug("Loaded model %s", model.config.__repr__())
 
+            tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
+
             if operation.requires_input or has_input(console):
                 input_string = get_input(
                     console,
                     _i["user_input"] + " ",
                     echo_stdin=not args.no_repl,
                     is_quiet=args.quiet,
+                    tty_path=tty_path,
                 )
                 if not input_string:
                     return

--- a/src/avalan/cli/commands/tokenizer.py
+++ b/src/avalan/cli/commands/tokenizer.py
@@ -57,11 +57,14 @@ async def tokenize(
             console.print(theme.saved_tokenizer_files(args.save, total_files))
             return
 
+        tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
+
         input_string = get_input(
             console,
             _i["user_input"] + " ",
             echo_stdin=not args.no_repl,
             is_quiet=args.quiet,
+            tty_path=tty_path,
         )
         if input_string:
             logger.debug("Loaded model %s", lm.config.__repr__())

--- a/tests/cli/memory_test.py
+++ b/tests/cli/memory_test.py
@@ -382,6 +382,7 @@ class CliMemoryEmbeddingsTestCase(IsolatedAsyncioTestCase):
             self.theme.icons["user_input"] + " ",
             echo_stdin=not self.args.no_repl,
             is_quiet=self.args.quiet,
+            tty_path="/dev/tty",
         )
         gms_patch.assert_called_once_with(
             self.args,
@@ -655,6 +656,7 @@ class CliMemorySearchTestCase(IsolatedAsyncioTestCase):
             self.theme.icons["user_input"] + " ",
             echo_stdin=not self.args.no_repl,
             is_quiet=self.args.quiet,
+            tty_path="/dev/tty",
         )
         tp_patch.assert_called_once_with(
             model,

--- a/tests/cli/tokenizer_test.py
+++ b/tests/cli/tokenizer_test.py
@@ -201,6 +201,7 @@ class CliTokenizerTestCase(IsolatedAsyncioTestCase):
             self.theme.icons["user_input"] + " ",
             echo_stdin=not args.no_repl,
             is_quiet=args.quiet,
+            tty_path="/dev/tty",
         )
         self.theme.tokenizer_tokens.assert_called_once_with(
             ["tok"],


### PR DESCRIPTION
## Summary
- allow specifying TTY path globally with `--tty`
- ensure `confirm_tool_call` and other prompts read from configured TTY
- document global `--tty` option

## Testing
- `make lint`
- `poetry run pytest --verbose -s`
- `poetry run pytest --cov=src/ --cov-report=json`


------
https://chatgpt.com/codex/tasks/task_e_68b773a49b508323a57c4ea970f2df33