### PR TITLE
Support distributed inference configuration

### DIFF
--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -209,6 +209,7 @@ class EngineSettings:
     disable_loading_progress_bar: bool = True
     enable_eval: bool = True
     parallel: ParallelStrategy | dict[str, ParallelStrategy] | None = None
+    distributed_config: dict[str, object] | None = None
     trust_remote_code: bool = False
     tokenizer_name_or_path: str | None = None
     subfolder: str | None = None

--- a/src/avalan/model/audio/classification.py
+++ b/src/avalan/model/audio/classification.py
@@ -23,6 +23,9 @@ class AudioClassificationModel(BaseAudioModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
             subfolder=self._settings.subfolder or "",
         ).to(self._device)
 

--- a/src/avalan/model/audio/generation.py
+++ b/src/avalan/model/audio/generation.py
@@ -24,6 +24,9 @@ class AudioGenerationModel(BaseAudioModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
             subfolder=self._settings.subfolder or "",
         ).to(self._device)
         return model

--- a/src/avalan/model/audio/speech.py
+++ b/src/avalan/model/audio/speech.py
@@ -28,6 +28,9 @@ class TextToSpeechModel(BaseAudioModel):
             trust_remote_code=self._settings.trust_remote_code,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
             subfolder=self._settings.subfolder or "",
         )
         return model

--- a/src/avalan/model/audio/speech_recognition.py
+++ b/src/avalan/model/audio/speech_recognition.py
@@ -32,6 +32,9 @@ class SpeechRecognitionModel(BaseAudioModel):
             ctc_loss_reduction="mean",
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
             ignore_mismatched_sizes=True,
             subfolder=self._settings.subfolder or "",
         )

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -107,6 +107,16 @@ class Engine(ABC):
         return parallel.value
 
     @staticmethod
+    def _get_distributed_config(
+        distributed_config: dict[str, object] | None,
+    ) -> dict[str, object] | None:
+        if distributed_config is None:
+            return None
+        config = {"enable_expert_parallel": False}
+        config.update(distributed_config)
+        return config
+
+    @staticmethod
     def weight(weight_type: WeightType) -> Literal["auto"] | dtype:
         return Engine._WEIGHTS.get(weight_type, "auto")
 

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -34,6 +34,9 @@ class QuestionAnsweringModel(BaseNLPModel):
             token=self._settings.access_token,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/src/avalan/model/nlp/sentence.py
+++ b/src/avalan/model/nlp/sentence.py
@@ -49,6 +49,9 @@ class SentenceTransformerModel(BaseNLPModel):
                 ),
                 "device_map": self._device,
                 "tp_plan": Engine._get_tp_plan(self._settings.parallel),
+                "distributed_config": Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
             },
             backend="torch",
             similarity_fn_name=None,

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -40,6 +40,9 @@ class SequenceClassificationModel(BaseNLPModel):
             token=self._settings.access_token,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 
@@ -106,6 +109,9 @@ class SequenceToSequenceModel(BaseNLPModel):
             token=self._settings.access_token,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -103,6 +103,9 @@ class TextGenerationModel(BaseNLPModel):
             quantization_config=bnb_config,
             revision=self._settings.revision,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         if model_args["quantization_config"] is None:
             model_args.pop("quantization_config", None)

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -36,6 +36,9 @@ class TokenClassificationModel(BaseNLPModel):
             token=self._settings.access_token,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         labels = (
             getattr(model.config, "id2label", None)

--- a/src/avalan/model/vision/classification.py
+++ b/src/avalan/model/vision/classification.py
@@ -28,6 +28,9 @@ class ImageClassificationModel(BaseVisionModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/src/avalan/model/vision/decoder.py
+++ b/src/avalan/model/vision/decoder.py
@@ -26,6 +26,9 @@ class VisionEncoderDecoderModel(ImageToTextModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/src/avalan/model/vision/detection.py
+++ b/src/avalan/model/vision/detection.py
@@ -41,6 +41,9 @@ class ObjectDetectionModel(ImageClassificationModel):
             revision=self._revision,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/src/avalan/model/vision/segmentation.py
+++ b/src/avalan/model/vision/segmentation.py
@@ -26,6 +26,9 @@ class SemanticSegmentationModel(BaseVisionModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         model.eval()
         return model

--- a/src/avalan/model/vision/text.py
+++ b/src/avalan/model/vision/text.py
@@ -40,6 +40,9 @@ class ImageToTextModel(TransformerModel):
             self._model_id,
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 
@@ -99,6 +102,9 @@ class ImageTextToTextModel(ImageToTextModel):
             torch_dtype=Engine.weight(self._settings.weight_type),
             device_map=self._device,
             tp_plan=Engine._get_tp_plan(self._settings.parallel),
+            distributed_config=Engine._get_distributed_config(
+                self._settings.distributed_config
+            ),
         )
         return model
 

--- a/tests/cli/tokenizer_test.py
+++ b/tests/cli/tokenizer_test.py
@@ -41,6 +41,7 @@ class CliTokenizerTestCase(IsolatedAsyncioTestCase):
             ) -> None:
                 self.device = device
                 self.cache_dir = cache_dir
+                self.distributed_config = None
                 for key, value in kwargs.items():
                     setattr(self, key, value)
 

--- a/tests/model/audio/audio_classification_test.py
+++ b/tests/model/audio/audio_classification_test.py
@@ -60,6 +60,7 @@ class AudioClassificationModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
                 subfolder="",
             )
             model_instance.to.assert_called_once_with(model._device)

--- a/tests/model/audio/audio_generation_test.py
+++ b/tests/model/audio/audio_generation_test.py
@@ -56,6 +56,7 @@ class AudioGenerationModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
                 subfolder="",
             )
 

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -66,6 +66,7 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
                 ctc_loss_reduction="mean",
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
                 ignore_mismatched_sizes=True,
                 subfolder="",
             )

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -60,6 +60,7 @@ class TextToSpeechModelInstantiationTestCase(TestCase):
                 trust_remote_code=False,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
                 subfolder="",
             )
 

--- a/tests/model/engine_tp_plan_test.py
+++ b/tests/model/engine_tp_plan_test.py
@@ -17,3 +17,20 @@ class GetTPPlanTestCase(unittest.TestCase):
     def test_dict(self) -> None:
         plan = Engine._get_tp_plan({"a": ParallelStrategy.ROWWISE})
         self.assertEqual(plan, {"a": "rowwise"})
+
+
+class GetDistributedConfigTestCase(unittest.TestCase):
+    def test_none(self) -> None:
+        self.assertIsNone(Engine._get_distributed_config(None))
+
+    def test_empty(self) -> None:
+        self.assertEqual(
+            Engine._get_distributed_config({}),
+            {"enable_expert_parallel": False},
+        )
+
+    def test_override(self) -> None:
+        self.assertEqual(
+            Engine._get_distributed_config({"enable_expert_parallel": True}),
+            {"enable_expert_parallel": True},
+        )

--- a/tests/model/nlp/question_test.py
+++ b/tests/model/nlp/question_test.py
@@ -88,6 +88,7 @@ class QuestionAnsweringModelInstantiationTestCase(TestCase):
                 token=None,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             tokenizer_mock.assert_called_once_with(
                 self.model_id,

--- a/tests/model/nlp/sentence_test.py
+++ b/tests/model/nlp/sentence_test.py
@@ -92,6 +92,7 @@ class SentenceTransformerModelTestCase(IsolatedAsyncioTestCase):
                             "low_cpu_mem_usage": True,
                             "device_map": Engine.get_default_device(),
                             "tp_plan": None,
+                            "distributed_config": None,
                         },
                         "backend": "torch",
                         "similarity_fn_name": None,

--- a/tests/model/nlp/sequence_test.py
+++ b/tests/model/nlp/sequence_test.py
@@ -87,6 +87,7 @@ class SequenceClassificationModelInstantiationTestCase(TestCase):
                 token=None,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id,

--- a/tests/model/nlp/sequence_to_sequence_model_test.py
+++ b/tests/model/nlp/sequence_to_sequence_model_test.py
@@ -82,6 +82,7 @@ class SequenceToSequenceModelInstantiationTestCase(TestCase):
                 token=None,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id, use_fast=True, subfolder=""

--- a/tests/model/nlp/text_test.py
+++ b/tests/model/nlp/text_test.py
@@ -125,6 +125,7 @@ class TextGenerationModelTestCase(TestCase):
                     token=None,
                     revision=None,
                     tp_plan=None,
+                    distributed_config=None,
                 )
                 auto_tokenizer_mock.assert_called_once_with(
                     model_id, use_fast=True, subfolder=""

--- a/tests/model/nlp/token_test.py
+++ b/tests/model/nlp/token_test.py
@@ -112,6 +112,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
                 token=None,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             auto_tokenizer_mock.assert_called_once_with(
                 self.model_id, use_fast=True, subfolder=""
@@ -161,6 +162,7 @@ class TokenClassificationModelInstantiationTestCase(TestCase):
                 token=None,
                 device_map=Engine.get_default_device(),
                 tp_plan="colwise",
+                distributed_config=None,
             )
             self.assertIs(model.model, model_instance)
 

--- a/tests/model/vision/detection_test.py
+++ b/tests/model/vision/detection_test.py
@@ -81,6 +81,7 @@ class ObjectDetectionModelInstantiationTestCase(TestCase):
                 revision="no_timm",
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
 
 

--- a/tests/model/vision/image_classification_test.py
+++ b/tests/model/vision/image_classification_test.py
@@ -80,6 +80,7 @@ class ImageClassificationModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
 
 

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -75,6 +75,7 @@ class ImageToTextModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(

--- a/tests/model/vision/image_text_to_text_model_test.py
+++ b/tests/model/vision/image_text_to_text_model_test.py
@@ -85,6 +85,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 torch_dtype="dtype",
                 device_map=model._device,
                 tp_plan=None,
+                distributed_config=None,
             )
 
     def test_instantiation_default_loader(self):
@@ -130,6 +131,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 torch_dtype="dtype",
                 device_map=model._device,
                 tp_plan=None,
+                distributed_config=None,
             )
 
     def test_instantiation_gemma3_loader(self):
@@ -174,6 +176,7 @@ class ImageTextToTextModelInstantiationTestCase(TestCase):
                 torch_dtype="dtype",
                 device_map=model._device,
                 tp_plan=None,
+                distributed_config=None,
             )
 
     def test_instantiation_invalid_loader(self):

--- a/tests/model/vision/segmentation_test.py
+++ b/tests/model/vision/segmentation_test.py
@@ -57,6 +57,7 @@ class SemanticSegmentationModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             # model_instance.eval.assert_called_once_with()
 

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -76,6 +76,7 @@ class VisionEncoderDecoderModelInstantiationTestCase(TestCase):
                 self.model_id,
                 device_map=Engine.get_default_device(),
                 tp_plan=None,
+                distributed_config=None,
             )
             model_instance.eval.assert_called_once()
             tokenizer_mock.assert_called_once_with(


### PR DESCRIPTION
## Summary
- allow passing optional distributed_config with enable_expert_parallel defaulting to False
- plumb distributed_config through Engine and model loaders
- test new distributed_config helper and update existing loader tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68b79fbc55d8832397d16e42fcf9ce56