### PR TITLE
Switch OpenAI vendor to responses API

### DIFF
--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -21,9 +21,9 @@ class OpenAIStream(TextGenerationVendorStream):
 
     async def __anext__(self) -> Token | TokenDetail | str:
         while True:
-            chunk = await self._generator.__anext__()
-            if getattr(chunk, "type", "") == "response.text.delta":
-                return chunk.delta
+            event = await self._generator.__anext__()
+            if getattr(event, "type", "") == "response.output_text.delta":
+                return event.delta
 
 
 class OpenAIClient(TextGenerationVendor):

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -48,7 +48,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.patch.stop()
 
     async def test_stream_client_and_model(self):
-        chunk = SimpleNamespace(type="response.text.delta", delta="x")
+        chunk = SimpleNamespace(type="response.output_text.delta", delta="x")
         stream = self.mod.OpenAIStream(AsyncIter([chunk]))
         self.assertEqual(await stream.__anext__(), "x")
         with self.assertRaises(StopAsyncIteration):


### PR DESCRIPTION
## Summary
- stream OpenAI responses using event-based `response.text.delta`
- swap chat completions for `responses.create` with updated settings

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b8353063788323878bfa945f930cef