### PR TITLE
Stub responses router in server tests

### DIFF
--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -38,6 +38,8 @@ def make_modules():
 
     chat_mod = ModuleType("avalan.server.routers.chat")
     chat_mod.router = MagicMock()
+    responses_mod = ModuleType("avalan.server.routers.responses")
+    responses_mod.router = MagicMock()
 
     modules = {
         "fastapi": fastapi_mod,
@@ -47,6 +49,7 @@ def make_modules():
         "uvicorn": uvicorn_mod,
         "starlette.requests": starlette_requests_mod,
         "avalan.server.routers.chat": chat_mod,
+        "avalan.server.routers.responses": responses_mod,
     }
 
     return (

--- a/tests/server/agents_server_test.py
+++ b/tests/server/agents_server_test.py
@@ -40,6 +40,8 @@ class AgentsServerTestCase(TestCase):
         chat_module = ModuleType("avalan.server.routers.chat")
         chat_router = MagicMock()
         chat_module.router = chat_router
+        responses_module = ModuleType("avalan.server.routers.responses")
+        responses_module.router = MagicMock()
 
         mcp_mod = ModuleType("mcp")
         server_pkg = ModuleType("mcp.server")
@@ -60,6 +62,7 @@ class AgentsServerTestCase(TestCase):
             "uvicorn": uvicorn_mod,
             "starlette.requests": starlette_requests_mod,
             "avalan.server.routers.chat": chat_module,
+            "avalan.server.routers.responses": responses_module,
         }
 
         with patch.dict(sys.modules, modules):

--- a/tests/server/mcp_call_tool_test.py
+++ b/tests/server/mcp_call_tool_test.py
@@ -63,6 +63,8 @@ class MCPCallToolTestCase(IsolatedAsyncioTestCase):
 
         chat_module = ModuleType("avalan.server.routers.chat")
         chat_module.router = MagicMock()
+        responses_module = ModuleType("avalan.server.routers.responses")
+        responses_module.router = MagicMock()
 
         mcp_mod = ModuleType("mcp")
         server_pkg = ModuleType("mcp.server")
@@ -83,6 +85,7 @@ class MCPCallToolTestCase(IsolatedAsyncioTestCase):
             "uvicorn": uvicorn_mod,
             "starlette.requests": starlette_requests_mod,
             "avalan.server.routers.chat": chat_module,
+            "avalan.server.routers.responses": responses_module,
         }
 
         captured = {}

--- a/tests/server/mcp_handlers_test.py
+++ b/tests/server/mcp_handlers_test.py
@@ -54,6 +54,8 @@ class MCPListToolsTestCase(IsolatedAsyncioTestCase):
 
         chat_module = ModuleType("avalan.server.routers.chat")
         chat_module.router = MagicMock()
+        responses_module = ModuleType("avalan.server.routers.responses")
+        responses_module.router = MagicMock()
 
         mcp_mod = ModuleType("mcp")
         server_pkg = ModuleType("mcp.server")
@@ -74,6 +76,7 @@ class MCPListToolsTestCase(IsolatedAsyncioTestCase):
             "uvicorn": uvicorn_mod,
             "starlette.requests": starlette_requests_mod,
             "avalan.server.routers.chat": chat_module,
+            "avalan.server.routers.responses": responses_module,
         }
 
         captured: dict[str, object] = {}
@@ -181,6 +184,8 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
 
         chat_module = ModuleType("avalan.server.routers.chat")
         chat_module.router = MagicMock()
+        responses_module = ModuleType("avalan.server.routers.responses")
+        responses_module.router = MagicMock()
 
         mcp_mod = ModuleType("mcp")
         server_pkg = ModuleType("mcp.server")
@@ -201,6 +206,7 @@ class MCPSseHandlerTestCase(IsolatedAsyncioTestCase):
             "uvicorn": uvicorn_mod,
             "starlette.requests": starlette_requests_mod,
             "avalan.server.routers.chat": chat_module,
+            "avalan.server.routers.responses": responses_module,
         }
 
         class DummyContext:


### PR DESCRIPTION
## Summary
- avoid FastAPI dependency by stubbing responses router in server tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b88ac3ed548323ba3a58502831ca2d