### PR TITLE
Document OpenAI responses API support for agent serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,6 +1271,9 @@ Serve your agents on an OpenAI API–compatible endpoint:
 avalan agent serve docs/examples/agent_tool.toml -vvv
 ```
 
+> [!NOTE]
+> Avalan's OpenAI-compatible endpoint supports both the legacy completions API and the newer [Responses API](https://platform.openai.com/docs/guides/responses).
+
 Agents listen on port 9001 by default.
 
 > [!TIP]


### PR DESCRIPTION
## Summary
- highlight Avalan's OpenAI-compatible server supports both legacy completions and the newer Responses API
- place callout before port instructions for clarity

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b89c4c84108323819d1591d9ed6a50