### PR TITLE
Track output token counts and report usage metrics

### DIFF
--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -94,6 +94,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         return self._response.input_token_count
 
     @property
+    def output_token_count(self) -> int:
+        return self._response.output_token_count
+
+    @property
     def can_think(self) -> bool:
         return self._response.can_think
 

--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -88,9 +88,11 @@ async def create_response(
         "type": "response",
         "output": [{"content": [{"type": "output_text", "text": text}]}],
         "usage": {
-            "input_text_tokens": 0,
-            "output_text_tokens": 0,
-            "total_tokens": 0,
+            "input_text_tokens": response.input_token_count,
+            "output_text_tokens": response.output_token_count,
+            "total_tokens": (
+                response.input_token_count + response.output_token_count
+            ),
         },
     }
     await orchestrator.sync_messages()

--- a/tests/agent/orchestrator_response_more_test.py
+++ b/tests/agent/orchestrator_response_more_test.py
@@ -109,3 +109,21 @@ class OrchestratorResponseMoreCoverageTestCase(IsolatedAsyncioTestCase):
         resp._tool_parser = MagicMock()
         resp._tool_parser.push = AsyncMock(return_value=[event])
         self.assertIs(await resp._emit("text"), event)
+
+    async def test_tool_parser_disabled(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = False
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+            tool=tool,
+            enable_tool_parsing=False,
+        )
+        self.assertIsNone(resp._tool_parser)

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -220,10 +220,18 @@ class OrchestratorResponseMethodsTestCase(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(resp.input_token_count, 3)
+        self.assertEqual(resp.output_token_count, 0)
+        self.assertTrue(resp.can_think)
+        self.assertFalse(resp.is_thinking)
+        resp.set_thinking(True)
+        self.assertTrue(resp.is_thinking)
         self.assertEqual(await resp.to_str(), '{"value": "ok"}')
+        self.assertEqual(resp.output_token_count, len('{"value": "ok"}'))
         self.assertEqual(await resp.to_json(), '{"value": "ok"}')
         result = await resp.to(Example)
         self.assertEqual(result, Example(value="ok"))
+        resp.set_thinking(False)
+        self.assertFalse(resp.is_thinking)
 
 
 class OrchestratorResponseEventTestCase(IsolatedAsyncioTestCase):

--- a/tests/model/model_init_test.py
+++ b/tests/model/model_init_test.py
@@ -1,13 +1,12 @@
 from avalan.model.response.text import TextGenerationResponse
-from logging import getLogger
-from avalan.entities import GenerationSettings
+from avalan.entities import GenerationSettings, Message, MessageRole
+from avalan.model.response import InvalidJsonResponseException
 from avalan.model.stream import TextGenerationStream
 from avalan.model.vendor import (
     TextGenerationVendor,
     TextGenerationVendorStream,
 )
-from avalan.model.response import InvalidJsonResponseException
-from avalan.entities import Message, MessageRole
+from logging import getLogger
 from unittest import IsolatedAsyncioTestCase
 
 
@@ -39,6 +38,7 @@ class TextGenerationResponseTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(tokens, ["h", "i"])
         self.assertTrue(consumed)
         self.assertEqual(resp.input_token_count, 3)
+        self.assertEqual(resp.output_token_count, 2)
 
     async def test_to_json_valid_and_invalid(self):
         resp = TextGenerationResponse(
@@ -59,6 +59,38 @@ class TextGenerationResponseTestCase(IsolatedAsyncioTestCase):
         )
         with self.assertRaises(InvalidJsonResponseException):
             await invalid.to_json()
+
+    async def test_output_token_count_to_str(self):
+        async def gen():
+            for ch in "hi":
+                yield ch
+
+        resp = TextGenerationResponse(
+            lambda **_: gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
+        )
+
+        self.assertEqual(await resp.to_str(), "hi")
+        self.assertEqual(resp.output_token_count, 2)
+
+    async def test_output_token_count_to_json(self):
+        async def gen():
+            for ch in '{"a":1}':
+                yield ch
+
+        resp = TextGenerationResponse(
+            lambda **_: gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
+        )
+
+        self.assertEqual(await resp.to_json(), '{"a":1}')
+        self.assertEqual(resp.output_token_count, len('{"a":1}'))
 
 
 class StreamVendorTestCase(IsolatedAsyncioTestCase):

--- a/tests/server/responses_test.py
+++ b/tests/server/responses_test.py
@@ -28,11 +28,14 @@ class SimpleOrchestrator(Orchestrator):
         self.synced = False
 
     async def __call__(self, messages, settings=None):
-        def output_fn():
+        def output_fn(**_):
             return "c"
 
         return TextGenerationResponse(
-            output_fn, logger=getLogger(), use_async_generator=False
+            output_fn,
+            logger=getLogger(),
+            use_async_generator=False,
+            inputs={"input_ids": [[1, 2, 3]]},
         )
 
     async def sync_messages(self):  # type: ignore[override]
@@ -120,3 +123,11 @@ class ResponsesEndpointTestCase(IsolatedAsyncioTestCase):
         body = resp.json()
         self.assertEqual(body["output"][0]["content"][0]["text"], "c")
         self.assertTrue(orchestrator.synced)
+        self.assertEqual(
+            body["usage"],
+            {
+                "input_text_tokens": 3,
+                "output_text_tokens": 1,
+                "total_tokens": 4,
+            },
+        )


### PR DESCRIPTION
## Summary
- add `output_token_count` to `TextGenerationResponse` and increment it during streaming and string conversion
- surface `output_token_count` through `OrchestratorResponse`
- include input/output/total token usage in responses endpoint and cover with tests

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68b8ec89c328832393e6ee3999a5c8c4