### PR TITLE
Add tests for OrchestratorResponse coverage

### DIFF
--- a/tests/agent/orchestrator_response_more_test.py
+++ b/tests/agent/orchestrator_response_more_test.py
@@ -109,3 +109,21 @@ class OrchestratorResponseMoreCoverageTestCase(IsolatedAsyncioTestCase):
         resp._tool_parser = MagicMock()
         resp._tool_parser.push = AsyncMock(return_value=[event])
         self.assertIs(await resp._emit("text"), event)
+
+    async def test_tool_parser_disabled(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = False
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+            tool=tool,
+            enable_tool_parsing=False,
+        )
+        self.assertIsNone(resp._tool_parser)

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -220,10 +220,18 @@ class OrchestratorResponseMethodsTestCase(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(resp.input_token_count, 3)
+        self.assertEqual(resp.output_token_count, 0)
+        self.assertTrue(resp.can_think)
+        self.assertFalse(resp.is_thinking)
+        resp.set_thinking(True)
+        self.assertTrue(resp.is_thinking)
         self.assertEqual(await resp.to_str(), '{"value": "ok"}')
+        self.assertEqual(resp.output_token_count, len('{"value": "ok"}'))
         self.assertEqual(await resp.to_json(), '{"value": "ok"}')
         result = await resp.to(Example)
         self.assertEqual(result, Example(value="ok"))
+        resp.set_thinking(False)
+        self.assertFalse(resp.is_thinking)
 
 
 class OrchestratorResponseEventTestCase(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- add comprehensive OrchestratorResponse method test covering token counts and thinking toggles
- ensure tool parsing can be disabled

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b963217af4832387381469267e476e