### PR TITLE
Add response format to OpenAI vendor

### DIFF
--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -68,6 +68,8 @@ class OpenAIClient(TextGenerationVendor):
                 kwargs["top_p"] = settings.top_p
             if settings.stop_strings is not None:
                 kwargs["text"] = {"stop": settings.stop_strings}
+            if settings.response_format is not None:
+                kwargs["response_format"] = settings.response_format
         if tool:
             schemas = tool.json_schemas()
             if schemas:

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -146,6 +146,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             temperature=0.5,
             top_p=0.8,
             text={"stop": ["stop"]},
+            response_format={"type": "json_schema"},
             tools=[{"a": 1}],
         )
 


### PR DESCRIPTION
## Summary
- forward response_format option in OpenAI vendor calls
- test that response_format is passed through to OpenAI API

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68b989a07f988323bd332636a23ed2e4