### PR TITLE
Add CORS configuration options for agent server

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1673,6 +1673,32 @@ class CLI:
             default=False,
             help="Hot reload on code changes",
         )
+        parser.add_argument(
+            "--cors-origin",
+            action="append",
+            help="Allowed CORS origin; may be specified multiple times",
+        )
+        parser.add_argument(
+            "--cors-origin-regex",
+            type=str,
+            help="Allowed CORS origin regex",
+        )
+        parser.add_argument(
+            "--cors-method",
+            action="append",
+            help="Allowed CORS method; may be specified multiple times",
+        )
+        parser.add_argument(
+            "--cors-header",
+            action="append",
+            help="Allowed CORS header; may be specified multiple times",
+        )
+        parser.add_argument(
+            "--cors-credentials",
+            action="store_true",
+            default=False,
+            help="Allow CORS credentials",
+        )
         return parser
 
     @staticmethod

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -654,6 +654,11 @@ async def agent_serve(
         logger=logger,
         agent_id=agent_id,
         participant_id=participant_id,
+        allow_origins=args.cors_origin,
+        allow_origin_regex=args.cors_origin_regex,
+        allow_methods=args.cors_method,
+        allow_headers=args.cors_header,
+        allow_credentials=args.cors_credentials,
     )
     await server.serve()
 

--- a/tests/cli/agent_options_test.py
+++ b/tests/cli/agent_options_test.py
@@ -74,6 +74,11 @@ class AgentServeForwardOptionsTestCase(IsolatedAsyncioTestCase):
             reload=False,
             id="aid",
             participant="pid",
+            cors_origin=None,
+            cors_origin_regex=None,
+            cors_method=None,
+            cors_header=None,
+            cors_credentials=False,
         )
         hub = MagicMock()
         logger = MagicMock(spec=Logger)

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -206,6 +206,11 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             backend="transformers",
             id=None,
             participant="pid",
+            cors_origin=None,
+            cors_origin_regex=None,
+            cors_method=None,
+            cors_header=None,
+            cors_credentials=False,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -235,6 +240,64 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
                 logger=logger,
                 agent_id=None,
                 participant_id="pid",
+                allow_origins=None,
+                allow_origin_regex=None,
+                allow_methods=None,
+                allow_headers=None,
+                allow_credentials=False,
+            )
+        server.serve.assert_awaited_once()
+
+    async def test_agent_serve_cors_args_forwarded(self):
+        args = Namespace(
+            host="0.0.0.0",
+            port=80,
+            specifications_file=None,
+            prefix_openai="oa",
+            prefix_mcp="mcp",
+            reload=False,
+            backend="transformers",
+            id=None,
+            participant="pid",
+            cors_origin=["https://a"],
+            cors_origin_regex="^https://.*$",
+            cors_method=["GET"],
+            cors_header=["X-Test"],
+            cors_credentials=True,
+        )
+        hub = MagicMock()
+        logger = MagicMock()
+        server = MagicMock()
+        server.serve = AsyncMock()
+
+        with NamedTemporaryFile("w") as spec:
+            args.specifications_file = spec.name
+            with patch.object(
+                agent_cmds, "agents_server", return_value=server
+            ) as asrv:
+                await agent_cmds.agent_serve(args, hub, logger, "name", "1.0")
+
+            asrv.assert_called_once_with(
+                hub=hub,
+                name="name",
+                version="1.0",
+                prefix_openai="oa",
+                prefix_mcp="mcp",
+                specs_path=spec.name,
+                settings=None,
+                browser_settings=None,
+                database_settings=None,
+                host="0.0.0.0",
+                port=80,
+                reload=False,
+                logger=logger,
+                agent_id=None,
+                participant_id="pid",
+                allow_origins=["https://a"],
+                allow_origin_regex="^https://.*$",
+                allow_methods=["GET"],
+                allow_headers=["X-Test"],
+                allow_credentials=True,
             )
         server.serve.assert_awaited_once()
 
@@ -272,6 +335,11 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             tools_confirm=False,
             id=None,
             participant="pid",
+            cors_origin=None,
+            cors_origin_regex=None,
+            cors_method=None,
+            cors_header=None,
+            cors_credentials=False,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -320,6 +388,11 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             logger=logger,
             agent_id=None,
             participant_id="pid",
+            allow_origins=None,
+            allow_origin_regex=None,
+            allow_methods=None,
+            allow_headers=None,
+            allow_credentials=False,
         )
         server.serve.assert_awaited_once()
 
@@ -357,6 +430,11 @@ class CliAgentServeTestCase(unittest.IsolatedAsyncioTestCase):
             tools_confirm=False,
             id=None,
             participant="pid",
+            cors_origin=None,
+            cors_origin_regex=None,
+            cors_method=None,
+            cors_header=None,
+            cors_credentials=False,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -399,6 +477,11 @@ class CliAgentProxyTestCase(unittest.IsolatedAsyncioTestCase):
             tools_confirm=False,
             id=None,
             participant="pid",
+            cors_origin=["https://a"],
+            cors_origin_regex="^https://.*$",
+            cors_method=["GET"],
+            cors_header=["X-Test"],
+            cors_credentials=True,
         )
         hub = MagicMock()
         logger = MagicMock()
@@ -416,6 +499,11 @@ class CliAgentProxyTestCase(unittest.IsolatedAsyncioTestCase):
             "postgresql://avalan:password@localhost:5432/avalan",
         )
         self.assertIsNone(args.specifications_file)
+        self.assertEqual(args.cors_origin, ["https://a"])
+        self.assertEqual(args.cors_origin_regex, "^https://.*$")
+        self.assertEqual(args.cors_method, ["GET"])
+        self.assertEqual(args.cors_header, ["X-Test"])
+        self.assertTrue(args.cors_credentials)
 
     async def test_agent_proxy_requires_engine(self):
         args = Namespace(
@@ -428,6 +516,11 @@ class CliAgentProxyTestCase(unittest.IsolatedAsyncioTestCase):
             engine_uri=None,
             id=None,
             participant="pid",
+            cors_origin=None,
+            cors_origin_regex=None,
+            cors_method=None,
+            cors_header=None,
+            cors_credentials=False,
         )
         hub = MagicMock()
         logger = MagicMock()

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -98,6 +98,57 @@ class CliAgentPortTestCase(TestCase):
         self.assertEqual(args.port, 9001)
 
 
+class CliAgentCorsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.logger = MagicMock()
+        with patch.object(sys, "argv", ["prog"]):
+            self.cli = CLI(self.logger)
+
+    def test_agent_serve_cors_options(self) -> None:
+        args = self.cli._parser.parse_args(
+            [
+                "agent",
+                "serve",
+                "--cors-origin",
+                "https://a",
+                "--cors-origin",
+                "https://b",
+                "--cors-origin-regex",
+                "^https://example.com$",
+                "--cors-method",
+                "GET",
+                "--cors-method",
+                "POST",
+                "--cors-header",
+                "X-Test",
+                "--cors-header",
+                "X-Other",
+                "--cors-credentials",
+            ]
+        )
+        self.assertEqual(args.cors_origin, ["https://a", "https://b"])
+        self.assertEqual(args.cors_origin_regex, "^https://example.com$")
+        self.assertEqual(args.cors_method, ["GET", "POST"])
+        self.assertEqual(args.cors_header, ["X-Test", "X-Other"])
+        self.assertTrue(args.cors_credentials)
+
+    def test_agent_proxy_cors_options(self) -> None:
+        args = self.cli._parser.parse_args(
+            [
+                "agent",
+                "proxy",
+                "--engine-uri",
+                "uri",
+                "--cors-origin",
+                "https://a",
+                "--cors-method",
+                "GET",
+            ]
+        )
+        self.assertEqual(args.cors_origin, ["https://a"])
+        self.assertEqual(args.cors_method, ["GET"])
+
+
 class CliCallTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
         from logging import getLogger

--- a/tests/server/agents_server_test.py
+++ b/tests/server/agents_server_test.py
@@ -75,6 +75,7 @@ class AgentsServerTestCase(TestCase):
                 logger.level = 0
                 logger.propagate = False
                 app = MagicMock()
+                app.add_middleware = MagicMock()
                 FastAPI.return_value = app
                 mcp_router = MagicMock()
                 mcp_router.get.return_value = lambda f: f
@@ -131,4 +132,120 @@ class AgentsServerTestCase(TestCase):
                 "uvicorn.asgi",
                 "uvicorn.lifespan",
             ],
+        )
+        app.add_middleware.assert_not_called()
+
+    def test_agents_server_cors_options(self):
+        FastAPI = MagicMock()
+        APIRouter = MagicMock()
+        fastapi_mod = ModuleType("fastapi")
+        fastapi_mod.FastAPI = FastAPI
+        fastapi_mod.APIRouter = APIRouter
+
+        CORSMiddleware = MagicMock()
+
+        MCPServer = MagicMock()
+        SseServerTransport = MagicMock()
+        Config = MagicMock()
+        Server = MagicMock()
+
+        mcp_server_mod = ModuleType("mcp.server.lowlevel.server")
+        mcp_server_mod.Server = MCPServer
+        sse_mod = ModuleType("mcp.server.sse")
+        sse_mod.SseServerTransport = SseServerTransport
+        types_mod = ModuleType("mcp.types")
+        types_mod.EmbeddedResource = object
+        types_mod.ImageContent = object
+        types_mod.TextContent = object
+        types_mod.Tool = object
+
+        uvicorn_mod = ModuleType("uvicorn")
+        uvicorn_mod.Config = Config
+        uvicorn_mod.Server = Server
+
+        starlette_requests_mod = ModuleType("starlette.requests")
+        starlette_requests_mod.Request = object
+
+        chat_module = ModuleType("avalan.server.routers.chat")
+        chat_module.router = MagicMock()
+        responses_module = ModuleType("avalan.server.routers.responses")
+        responses_module.router = MagicMock()
+
+        mcp_mod = ModuleType("mcp")
+        server_pkg = ModuleType("mcp.server")
+        lowlevel_pkg = ModuleType("mcp.server.lowlevel")
+        mcp_mod.server = server_pkg
+        server_pkg.lowlevel = lowlevel_pkg
+        lowlevel_pkg.server = mcp_server_mod
+        server_pkg.sse = sse_mod
+
+        modules = {
+            "fastapi": fastapi_mod,
+            "mcp": mcp_mod,
+            "mcp.server": server_pkg,
+            "mcp.server.lowlevel": lowlevel_pkg,
+            "mcp.server.lowlevel.server": mcp_server_mod,
+            "mcp.server.sse": sse_mod,
+            "mcp.types": types_mod,
+            "uvicorn": uvicorn_mod,
+            "starlette.requests": starlette_requests_mod,
+            "avalan.server.routers.chat": chat_module,
+            "avalan.server.routers.responses": responses_module,
+        }
+
+        with patch.dict(sys.modules, modules):
+            with (
+                patch("avalan.server.FastAPI", FastAPI),
+                patch("avalan.server.APIRouter", APIRouter),
+                patch("avalan.server.CORSMiddleware", CORSMiddleware),
+            ):
+                logger = MagicMock(spec=Logger)
+                logger.handlers = []
+                logger.level = 0
+                logger.propagate = False
+                app = MagicMock()
+                app.add_middleware = MagicMock()
+                FastAPI.return_value = app
+                mcp_router = MagicMock()
+                mcp_router.get.return_value = lambda f: f
+                APIRouter.return_value = mcp_router
+                sse_instance = MagicMock()
+                sse_instance.handle_post_message = MagicMock()
+                SseServerTransport.return_value = sse_instance
+                mcp_server = MagicMock()
+                mcp_server.list_tools.return_value = lambda f: f
+                mcp_server.call_tool.return_value = lambda f: f
+                MCPServer.return_value = mcp_server
+                Config.return_value = MagicMock()
+                Server.return_value = MagicMock()
+
+                with patch("avalan.server.logger_replace"):
+                    agents_server(
+                        hub=MagicMock(),
+                        name="srv",
+                        version="v",
+                        host="h",
+                        port=1,
+                        reload=False,
+                        specs_path=None,
+                        settings=MagicMock(),
+                        browser_settings=None,
+                        database_settings=None,
+                        prefix_mcp="/m",
+                        prefix_openai="/o",
+                        logger=logger,
+                        allow_origins=["https://a"],
+                        allow_origin_regex="^https://.*$",
+                        allow_methods=["GET"],
+                        allow_headers=["X-Test"],
+                        allow_credentials=True,
+                    )
+
+        app.add_middleware.assert_called_once_with(
+            CORSMiddleware,
+            allow_origins=["https://a"],
+            allow_origin_regex="^https://.*$",
+            allow_credentials=True,
+            allow_methods=["GET"],
+            allow_headers=["X-Test"],
         )


### PR DESCRIPTION
## Summary
- add CORS-related CLI flags to `agent serve` and `agent proxy`
- wire CORS options through to server creation and FastAPI CORSMiddleware
- test parsing and server behaviour for new CORS configuration

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68b99a32513c8323b79b31b9e10a1f63