### PR TITLE
Improve server route error handling

### DIFF
--- a/src/avalan/server/routers/__init__.py
+++ b/src/avalan/server/routers/__init__.py
@@ -11,6 +11,7 @@ from ...server.entities import ChatCompletionRequest, ContentImage, ContentText
 from logging import Logger
 from time import time
 from uuid import uuid4
+from fastapi import HTTPException
 
 
 async def orchestrate(
@@ -24,7 +25,10 @@ async def orchestrate(
     ]
 
     if request.stream and (request.n or 1) > 1:
-        raise ValueError("Streaming multiple completions is not supported")
+        raise HTTPException(
+            status_code=400,
+            detail="Streaming multiple completions is not supported",
+        )
 
     response_id = uuid4()
     timestamp = int(time())

--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -12,6 +12,7 @@ def make_modules():
     fastapi_mod = ModuleType("fastapi")
     fastapi_mod.FastAPI = FastAPI
     fastapi_mod.APIRouter = APIRouter
+    fastapi_mod.HTTPException = Exception
 
     MCPServer = MagicMock()
     SseServerTransport = MagicMock()

--- a/tests/server/agents_server_test.py
+++ b/tests/server/agents_server_test.py
@@ -14,6 +14,7 @@ class AgentsServerTestCase(TestCase):
         fastapi_mod = ModuleType("fastapi")
         fastapi_mod.FastAPI = FastAPI
         fastapi_mod.APIRouter = APIRouter
+        fastapi_mod.HTTPException = Exception
 
         MCPServer = MagicMock()
         SseServerTransport = MagicMock()
@@ -141,6 +142,7 @@ class AgentsServerTestCase(TestCase):
         fastapi_mod = ModuleType("fastapi")
         fastapi_mod.FastAPI = FastAPI
         fastapi_mod.APIRouter = APIRouter
+        fastapi_mod.HTTPException = Exception
 
         CORSMiddleware = MagicMock()
 

--- a/tests/server/chat_router_unit_test.py
+++ b/tests/server/chat_router_unit_test.py
@@ -1,9 +1,3 @@
-from avalan.server.entities import (
-    ChatCompletionRequest,
-    ChatMessage,
-    ContentImage,
-    ContentText,
-)
 from avalan.agent.orchestrator import Orchestrator
 from avalan.entities import (
     MessageContentImage,
@@ -11,6 +5,13 @@ from avalan.entities import (
     MessageRole,
 )
 from avalan.model import TextGenerationResponse
+from avalan.server.entities import (
+    ChatCompletionRequest,
+    ChatMessage,
+    ContentImage,
+    ContentText,
+)
+from fastapi import HTTPException
 from logging import Logger, getLogger
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
@@ -112,7 +113,7 @@ class ChatRouterUnitTest(IsolatedAsyncioTestCase):
             stream=True,
             n=2,
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(HTTPException):
             await self.chat.create_chat_completion(req, logger, orch)
         orch.assert_not_awaited()
 


### PR DESCRIPTION
## Summary
- ensure streaming multiple completions returns HTTP 400 via FastAPI HTTPException
- adjust server tests to expect HTTPException and stub it in fake FastAPI modules

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bb753f03248323aa2a0418c0aacb5d