### PR TITLE
Handle Harmony tool calls without constrain clause

### DIFF
--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -96,8 +96,9 @@ class ToolCallParser:
     def _parse_harmony(self, text: str) -> list[ToolCall] | None:
         tool_calls: list[ToolCall] = []
         pattern = (
-            r"<\|channel\|>commentary to=(?:functions\.)?([\w\.]+)\s*"
-            r"<\|constrain\|>json<\|message\|>(\{.*?\})<\|call\|>"
+            r"<\|channel\|>commentary to=(?:functions\.)?([\w\.]+)"
+            r"[^<]*"
+            r"(?:<\|constrain\|>json)?<\|message\|>(\{.*?\})<\|call\|>"
         )
         for match in finditer(pattern, text, DOTALL):
             try:

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -131,6 +131,45 @@ class ToolCallParserHarmonyTestCase(TestCase):
             ]
             self.assertEqual(parser(text), expected)
 
+    def test_without_constrain_trailing_text(self):
+        parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        text = (
+            "<|start|>assistant<|channel|>commentary to=functions.database.run"
+            ' code<|message|>{"sql":"SELECT count(*) AS total_products FROM'
+            ' product;"}<|call|>'
+        )
+        call_id = _uuid4()
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="database.run",
+                    arguments={
+                        "sql": (
+                            "SELECT count(*) AS total_products FROM product;"
+                        )
+                    },
+                )
+            ]
+            self.assertEqual(parser(text), expected)
+
+    def test_without_constrain_without_trailing_text(self):
+        parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        text = (
+            "<|channel|>commentary to=functions.database.run"
+            '<|message|>{"sql":"SELECT 1"}<|call|>'
+        )
+        call_id = _uuid4()
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="database.run",
+                    arguments={"sql": "SELECT 1"},
+                )
+            ]
+            self.assertEqual(parser(text), expected)
+
     def test_invalid_json(self):
         parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
         text = (


### PR DESCRIPTION
## Summary
- allow trailing text and optional `<|constrain|>json` in Harmony tool-call parser
- test Harmony parsing without `constrain` block and with trailing text

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68bc76f8cd88832395967beb3bcd6bb9