### PR TITLE
Improve tool call token detection

### DIFF
--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -1,13 +1,12 @@
 """Parser emitting events for detected tool calls."""
 
-from io import StringIO
-from time import perf_counter
-from typing import Any, Iterable
-
-from ....entities import ToolCallToken
+from ....entities import ToolCallToken, ToolFormat
 from ....event import Event, EventType
 from ....event.manager import EventManager
 from ....tool.manager import ToolManager
+from io import StringIO
+from time import perf_counter
+from typing import Any, Iterable
 
 
 class ToolCallParser:
@@ -21,6 +20,13 @@ class ToolCallParser:
         self._buffer = StringIO()
         self._tag_buffer = ""
         self._inside_call = False
+        self._pending_tokens: list[str] = []
+        self._pending_str = ""
+        tool_format = tool_manager.tool_format
+        self._start_sequences = ["<tool_call", "<tool ", "<tool>"]
+        self._end_sequences = ["</tool_call>", "</tool>", "/>", "<|call|>"]
+        if tool_format is ToolFormat.HARMONY:
+            self._start_sequences.append("<|channel|>commentary")
 
     async def push(self, token_str: str) -> Iterable[Any]:
         buffer_value = self._buffer.getvalue()
@@ -28,37 +34,47 @@ class ToolCallParser:
             buffer_value, token_str
         )
 
-        prev_inside = self._inside_call
-
         self._buffer.write(token_str)
         self._tag_buffer += token_str
         if len(self._tag_buffer) > 64:
             self._tag_buffer = self._tag_buffer[-64:]
 
-        if not self._inside_call and (
-            "<tool_call" in self._tag_buffer
-            or "<tool " in self._tag_buffer
-            or "<tool>" in self._tag_buffer
-        ):
-            self._inside_call = True
+        result: list[Any] = []
 
-        if self._inside_call and (
-            "</tool_call>" in self._tag_buffer
-            or "</tool>" in self._tag_buffer
-            or "/>" in self._tag_buffer
-        ):
-            self._inside_call = False
+        if not self._inside_call:
+            candidate = self._pending_str + token_str
+            start_triggered = False
+            for start in self._start_sequences:
+                if start.startswith(candidate):
+                    self._pending_tokens.append(token_str)
+                    self._pending_str = candidate
+                    return result
+                if candidate.startswith(start):
+                    self._inside_call = True
+                    start_triggered = True
+                    self._pending_tokens.append(token_str)
+                    result.extend(
+                        ToolCallToken(t) for t in self._pending_tokens
+                    )
+                    self._pending_tokens.clear()
+                    self._pending_str = ""
+                    break
+            if not start_triggered:
+                if self._pending_tokens:
+                    result.extend(self._pending_tokens)
+                    self._pending_tokens.clear()
+                    self._pending_str = ""
+                result.append(token_str)
+        else:
+            result.append(ToolCallToken(token_str))
+            if any(end in self._tag_buffer for end in self._end_sequences):
+                self._inside_call = False
 
-        start_triggered = not prev_inside and self._inside_call
-
-        item = (
-            ToolCallToken(token_str)
-            if prev_inside or start_triggered
-            else token_str
-        )
+        if not result:
+            return result
 
         if not should_check:
-            return [item]
+            return result
 
         if self._event_manager:
             await self._event_manager.trigger(
@@ -67,7 +83,7 @@ class ToolCallParser:
 
         calls = self._tool_manager.get_calls(self._buffer.getvalue())
         if not calls:
-            return [item]
+            return result
 
         event = Event(
             type=EventType.TOOL_PROCESS, payload=calls, started=perf_counter()
@@ -76,7 +92,12 @@ class ToolCallParser:
         self._buffer = StringIO()
         self._tag_buffer = ""
         self._inside_call = False
-        return [item, event]
+        return result + [event]
 
     async def flush(self) -> Iterable[Any]:
-        return []
+        result = []
+        if self._pending_tokens:
+            result.extend(self._pending_tokens)
+            self._pending_tokens.clear()
+            self._pending_str = ""
+        return result

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -1,15 +1,17 @@
 """Parser emitting events for detected tool calls."""
 
-from ....entities import ToolCallToken, ToolFormat
-from ....event import Event, EventType
-from ....event.manager import EventManager
-from ....tool.manager import ToolManager
 from io import StringIO
 from time import perf_counter
 from typing import Any, Iterable
 
+from ....entities import ToolCallToken
+from ....event import Event, EventType
+from ....event.manager import EventManager
+from ....tool.manager import ToolManager
+from ....tool.parser import ToolCallParser
 
-class ToolCallParser:
+
+class ToolCallResponseParser:
     """Parse tool calls during streaming."""
 
     def __init__(
@@ -22,11 +24,6 @@ class ToolCallParser:
         self._inside_call = False
         self._pending_tokens: list[str] = []
         self._pending_str = ""
-        tool_format = tool_manager.tool_format
-        self._start_sequences = ["<tool_call", "<tool ", "<tool>"]
-        self._end_sequences = ["</tool_call>", "</tool>", "/>", "<|call|>"]
-        if tool_format is ToolFormat.HARMONY:
-            self._start_sequences.append("<|channel|>commentary")
 
     async def push(self, token_str: str) -> Iterable[Any]:
         buffer_value = self._buffer.getvalue()
@@ -43,23 +40,23 @@ class ToolCallParser:
 
         if not self._inside_call:
             candidate = self._pending_str + token_str
-            start_triggered = False
-            for start in self._start_sequences:
-                if start.startswith(candidate):
-                    self._pending_tokens.append(token_str)
-                    self._pending_str = candidate
-                    return result
-                if candidate.startswith(start):
-                    self._inside_call = True
-                    start_triggered = True
-                    self._pending_tokens.append(token_str)
-                    result.extend(
-                        ToolCallToken(t) for t in self._pending_tokens
-                    )
-                    self._pending_tokens.clear()
-                    self._pending_str = ""
-                    break
-            if not start_triggered:
+            status = self._tool_manager.tool_call_status(candidate)
+            if status is ToolCallParser.ToolCallBufferStatus.PREFIX:
+                self._pending_tokens.append(token_str)
+                self._pending_str = candidate
+                return result
+            if status in (
+                ToolCallParser.ToolCallBufferStatus.OPEN,
+                ToolCallParser.ToolCallBufferStatus.CLOSED,
+            ):
+                self._pending_tokens.append(token_str)
+                result.extend(ToolCallToken(t) for t in self._pending_tokens)
+                self._pending_tokens.clear()
+                self._pending_str = ""
+                self._inside_call = (
+                    status is ToolCallParser.ToolCallBufferStatus.OPEN
+                )
+            else:
                 if self._pending_tokens:
                     result.extend(self._pending_tokens)
                     self._pending_tokens.clear()
@@ -67,7 +64,12 @@ class ToolCallParser:
                 result.append(token_str)
         else:
             result.append(ToolCallToken(token_str))
-            if any(end in self._tag_buffer for end in self._end_sequences):
+            status = self._tool_manager.tool_call_status(self._tag_buffer)
+            if (
+                status is ToolCallParser.ToolCallBufferStatus.CLOSED
+                or "<|call|>" in self._tag_buffer
+                or "<|channel|>final<|message|>" in self._tag_buffer
+            ):
                 self._inside_call = False
 
         if not result:

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -65,11 +65,11 @@ class ToolCallResponseParser:
         else:
             result.append(ToolCallToken(token_str))
             status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if (
-                status is ToolCallParser.ToolCallBufferStatus.CLOSED
-                or "<|call|>" in self._tag_buffer
-                or "<|channel|>final<|message|>" in self._tag_buffer
-            ):
+            if status is not ToolCallParser.ToolCallBufferStatus.CLOSED:
+                status = self._tool_manager.tool_call_status(
+                    f"<tool_call>{self._tag_buffer}"
+                )
+            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
                 self._inside_call = False
 
         if not result:

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -101,6 +101,12 @@ class ToolManager(ContextDecorator):
         """Proxy :meth:`ToolCallParser.is_potential_tool_call`."""
         return self._parser.is_potential_tool_call(buffer, token_str)
 
+    def tool_call_status(
+        self, buffer: str
+    ) -> ToolCallParser.ToolCallBufferStatus:
+        """Proxy :meth:`ToolCallParser.tool_call_status`."""
+        return self._parser.tool_call_status(buffer)
+
     def get_calls(self, text: str) -> list[ToolCall] | None:
         return self._parser(text)
 

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -4,8 +4,9 @@ from ..entities import (
     ToolCall,
     ToolCallContext,
     ToolCallResult,
-    ToolManagerSettings,
     ToolFilter,
+    ToolFormat,
+    ToolManagerSettings,
     ToolTransformer,
 )
 from collections.abc import Callable, Sequence
@@ -51,6 +52,11 @@ class ToolManager(ContextDecorator):
     @property
     def tools(self) -> list[Callable] | None:
         return list(self._tools.values()) if self._tools else None
+
+    @property
+    def tool_format(self) -> ToolFormat | None:
+        """Return the tool format configured for this manager."""
+        return self._parser.tool_format
 
     def json_schemas(self) -> list[dict] | None:
         schemas = []

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -19,6 +19,11 @@ class ToolCallParser:
         self._tool_format = tool_format
         self._eos_token = eos_token
 
+    @property
+    def tool_format(self) -> ToolFormat | None:
+        """Return the tool format used by the parser."""
+        return self._tool_format
+
     def __call__(self, text: str) -> list[ToolCall] | None:
         calls = (
             self._parse_json(text)

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -83,6 +83,7 @@ class ToolCallParser:
                     "<|start|>assistant<|channel|>commentary",
                 ]
             )
+            end.append("<|channel|>final<|message|>")
         max_len = max(len(s) for s in start)
         tail = buffer[-max_len:]
         for s in start:

--- a/tests/agent/default_orchestrator_test.py
+++ b/tests/agent/default_orchestrator_test.py
@@ -229,11 +229,23 @@ class DefaultOrchestratorTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 1, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 1,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 2, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 2,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
 
         memory.__exit__.assert_called_once()

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -1,35 +1,37 @@
+from asyncio import wait_for
+from collections.abc import AsyncIterator
+from avalan.agent import AgentOperation, EngineEnvironment, Specification
+from avalan.agent.engine import EngineAgent
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
+    GenerationSettings,
     Message,
     MessageRole,
+    ReasoningSettings,
+    ReasoningToken,
+    ToolCall,
     ToolCallContext,
+    ToolCallResult,
+    ToolCallToken,
+    ToolFormat,
     Token,
     TokenDetail,
     TransformerEngineSettings,
 )
 from avalan.event import EventType
 from avalan.event.manager import EventManager
-from avalan.agent.engine import EngineAgent
 from avalan.model import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
-from logging import getLogger
-from avalan.model.response.parsers.tool import ToolCallParser
-from avalan.entities import (
-    ReasoningToken,
-    ToolCallToken,
-    GenerationSettings,
-    ReasoningSettings,
-)
-
-from unittest import IsolatedAsyncioTestCase
-from dataclasses import dataclass
+from avalan.model.response.parsers.tool import ToolCallResponseParser
 from avalan.tool.manager import ToolManager
-from avalan.entities import ToolCall, ToolCallResult
+from avalan.tool.parser import ToolCallParser
+from dataclasses import dataclass
 from io import StringIO
+from logging import getLogger
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -83,7 +85,9 @@ def _complex_response():
         tm = MagicMock()
         tm.is_potential_tool_call.return_value = True
         tm.get_calls.return_value = None
-        tp = ToolCallParser(tm, None)
+        base_parser = ToolCallParser()
+        tm.tool_call_status.side_effect = base_parser.tool_call_status
+        tp = ToolCallResponseParser(tm, None)
 
         sequence = [
             "X",
@@ -170,12 +174,73 @@ class OrchestratorResponseIterationTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 42, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 42,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 5, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 5,
+                "token_type": "Token",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
+
+    async def test_harmony_streaming_handles_split_prefix(self) -> None:
+        engine = _DummyEngine()
+        engine.tokenizer.encode.return_value = [1]
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        async def gen() -> AsyncIterator[str]:
+            yield "<|start|>assistant"
+            yield "<|channel|>commentary to=mytool <|message|>{}<|call|>"
+
+        settings = GenerationSettings()
+        response = TextGenerationResponse(
+            lambda **_: gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=settings,
+            settings=settings,
+        )
+
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        tool_manager = MagicMock(spec=ToolManager)
+        tool_manager.is_potential_tool_call.side_effect = (
+            base_parser.is_potential_tool_call
+        )
+        tool_manager.tool_call_status.side_effect = (
+            base_parser.tool_call_status
+        )
+        tool_manager.get_calls.side_effect = base_parser
+        tool_manager.is_empty = False
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            response,
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+            tool=tool_manager,
+        )
+
+        iterator = resp.__aiter__()
+        first = await wait_for(iterator.__anext__(), 1)
+        second = await wait_for(iterator.__anext__(), 1)
+        self.assertIsInstance(first, ToolCallToken)
+        self.assertIsInstance(second, ToolCallToken)
 
 
 @dataclass

--- a/tests/agent/tool_call_parser_extra_test.py
+++ b/tests/agent/tool_call_parser_extra_test.py
@@ -58,7 +58,7 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         parser = ToolCallParser(manager, None)
         items = await parser.push('<tool_call name="calc"/>')
 
-        self.assertEqual(items[0], '<tool_call name="calc"/>')
+        self.assertIsInstance(items[0], ToolCallToken)
         self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
         manager.get_calls.assert_called_once_with('<tool_call name="calc"/>')
         self.assertFalse(parser._inside_call)

--- a/tests/agent/tool_call_parser_extra_test.py
+++ b/tests/agent/tool_call_parser_extra_test.py
@@ -1,5 +1,6 @@
-from avalan.model.response.parsers.tool import ToolCallParser
-from avalan.entities import ToolCallToken
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.entities import ToolCallToken, ToolFormat
+from avalan.tool.parser import ToolCallParser
 from avalan.event import EventType
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
@@ -9,7 +10,10 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
     async def test_tag_buffer_trim_no_check(self):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = False
-        parser = ToolCallParser(manager, None)
+        manager.tool_call_status.return_value = (
+            ToolCallParser.ToolCallBufferStatus.NONE
+        )
+        parser = ToolCallResponseParser(manager, None)
 
         long_token = "a" * 65
         result = await parser.push(long_token)
@@ -21,10 +25,12 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.return_value = [MagicMock()]
+        base_parser = ToolCallParser()
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
         event_manager = MagicMock()
         event_manager.trigger = AsyncMock()
 
-        parser = ToolCallParser(manager, event_manager)
+        parser = ToolCallResponseParser(manager, event_manager)
         items = await parser.push("<tool_call>")
 
         self.assertIsInstance(items[0], ToolCallToken)
@@ -40,10 +46,13 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.return_value = None
+        manager.tool_call_status.return_value = (
+            ToolCallParser.ToolCallBufferStatus.NONE
+        )
         event_manager = MagicMock()
         event_manager.trigger = AsyncMock()
 
-        parser = ToolCallParser(manager, event_manager)
+        parser = ToolCallResponseParser(manager, event_manager)
         items = await parser.push("no_call")
 
         self.assertEqual(items, ["no_call"])
@@ -54,8 +63,10 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.return_value = [MagicMock()]
+        base_parser = ToolCallParser()
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
 
-        parser = ToolCallParser(manager, None)
+        parser = ToolCallResponseParser(manager, None)
         items = await parser.push('<tool_call name="calc"/>')
 
         self.assertIsInstance(items[0], ToolCallToken)
@@ -63,3 +74,35 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         manager.get_calls.assert_called_once_with('<tool_call name="calc"/>')
         self.assertFalse(parser._inside_call)
         self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_harmony_long_call_followed_by_final_channel(self):
+        manager = MagicMock()
+        manager.is_potential_tool_call.return_value = True
+
+        def _get_calls(text: str):
+            return [MagicMock()] if "<|call|>" in text else None
+
+        manager.get_calls.side_effect = _get_calls
+        manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
+
+        parser = ToolCallResponseParser(manager, None)
+        long_content = "x" * 100
+        parts = [
+            "<|channel|>commentary to=functions.db.run code<|message|>{"
+            + long_content,
+            "}<|call|>",
+            "<|channel|>final<|message|>",
+            "done",
+        ]
+        tokens: list = []
+        for part in parts:
+            tokens.extend(await parser.push(part))
+
+        self.assertIsInstance(tokens[0], ToolCallToken)
+        self.assertNotIsInstance(tokens[-2], ToolCallToken)
+        self.assertNotIsInstance(tokens[-1], ToolCallToken)
+        self.assertEqual(tokens[-2], "<|channel|>final<|message|>")
+        self.assertEqual(tokens[-1], "done")
+        self.assertFalse(parser._inside_call)

--- a/tests/agent/tool_call_parser_test.py
+++ b/tests/agent/tool_call_parser_test.py
@@ -1,5 +1,5 @@
 from avalan.model.response.parsers.tool import ToolCallParser
-from avalan.entities import ToolCallToken
+from avalan.entities import ToolCallToken, ToolFormat
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
@@ -23,3 +23,29 @@ class ToolCallParserTestCase(IsolatedAsyncioTestCase):
         self.assertIsInstance(tokens[1], ToolCallToken)
         self.assertIsInstance(tokens[2], ToolCallToken)
         self.assertEqual(tokens[-1], "y")
+
+    async def test_harmony_format_tokens(self):
+        manager = MagicMock()
+
+        def _get_calls(text: str):
+            return [MagicMock()] if "<|call|>" in text else None
+
+        manager.is_potential_tool_call.return_value = True
+        manager.get_calls.side_effect = _get_calls
+        manager.tool_format = ToolFormat.HARMONY
+
+        parser = ToolCallParser(manager, None)
+        tokens: list = []
+        parts = [
+            "<|channel|>",
+            "commentary to=functions.db.run code<|message|>{}",
+            "<|call|>",
+            "end",
+        ]
+        for part in parts:
+            tokens.extend(await parser.push(part))
+
+        self.assertIsInstance(tokens[0], ToolCallToken)
+        self.assertIsInstance(tokens[1], ToolCallToken)
+        self.assertIsInstance(tokens[2], ToolCallToken)
+        self.assertEqual(tokens[-1], "end")

--- a/tests/agent/tool_call_parser_test.py
+++ b/tests/agent/tool_call_parser_test.py
@@ -1,5 +1,6 @@
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
 from avalan.entities import ToolCallToken, ToolFormat
+from avalan.tool.parser import ToolCallParser
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
@@ -13,8 +14,10 @@ class ToolCallParserTestCase(IsolatedAsyncioTestCase):
 
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.side_effect = _get_calls
+        base_parser = ToolCallParser()
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
 
-        parser = ToolCallParser(manager, None)
+        parser = ToolCallResponseParser(manager, None)
         tokens = []
         for t in ["<tool_call>", "x", "</tool_call>", "y"]:
             tokens.extend(await parser.push(t))
@@ -33,12 +36,43 @@ class ToolCallParserTestCase(IsolatedAsyncioTestCase):
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.side_effect = _get_calls
         manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
 
-        parser = ToolCallParser(manager, None)
+        parser = ToolCallResponseParser(manager, None)
         tokens: list = []
         parts = [
             "<|channel|>",
             "commentary to=functions.db.run code<|message|>{}",
+            "<|call|>",
+            "end",
+        ]
+        for part in parts:
+            tokens.extend(await parser.push(part))
+
+        self.assertIsInstance(tokens[0], ToolCallToken)
+        self.assertIsInstance(tokens[1], ToolCallToken)
+        self.assertIsInstance(tokens[2], ToolCallToken)
+        self.assertEqual(tokens[-1], "end")
+
+    async def test_harmony_format_tokens_with_prefix(self):
+        manager = MagicMock()
+
+        def _get_calls(text: str):
+            return [MagicMock()] if "<|call|>" in text else None
+
+        manager.is_potential_tool_call.return_value = True
+        manager.get_calls.side_effect = _get_calls
+        manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
+
+        parser = ToolCallResponseParser(manager, None)
+        tokens: list = []
+        parts = [
+            "<|start|>",
+            "assistant<|channel|>commentary to=functions.db.run code",
+            "<|message|>{}",
             "<|call|>",
             "end",
         ]

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -38,7 +38,8 @@ from avalan.entities import (
     ReasoningSettings,
     ToolFormat,
 )
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 from avalan.entities import ReasoningToken, Token, TokenDetail, ToolCallToken
 from avalan.tool.browser import BrowserToolSettings
 from avalan.tool.database import DatabaseToolSettings
@@ -2324,7 +2325,9 @@ class CliAgentMixedTokensTestCase(unittest.IsolatedAsyncioTestCase):
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
-            tp = ToolCallParser(tm, None)
+            base_parser = ToolCallParser()
+            tm.tool_call_status.side_effect = base_parser.tool_call_status
+            tp = ToolCallResponseParser(tm, None)
             sequence = [
                 "X",
                 "<think>",

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -31,7 +31,8 @@ from avalan.entities import (
 )
 from avalan.entities import TransformerEngineSettings
 from avalan.model.nlp.text.generation import TextGenerationModel
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 import asyncio
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 
@@ -5123,7 +5124,9 @@ class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
-            tp = ToolCallParser(tm, None)
+            base_parser = ToolCallParser()
+            tm.tool_call_status.side_effect = base_parser.tool_call_status
+            tp = ToolCallResponseParser(tm, None)
             sequence = [
                 "X",
                 "<think>",

--- a/tests/model/text_generation_response_extra_test.py
+++ b/tests/model/text_generation_response_extra_test.py
@@ -1,7 +1,8 @@
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
 from logging import getLogger
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 from avalan.entities import (
     GenerationSettings,
     ReasoningSettings,
@@ -21,7 +22,9 @@ async def _complex_generator():
     tm = MagicMock()
     tm.is_potential_tool_call.return_value = True
     tm.get_calls.return_value = None
-    tp = ToolCallParser(tm, None)
+    base_parser = ToolCallParser()
+    tm.tool_call_status.side_effect = base_parser.tool_call_status
+    tp = ToolCallResponseParser(tm, None)
 
     sequence = [
         "X",

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -2,8 +2,9 @@ from avalan.entities import (
     ToolCall,
     ToolCallContext,
     ToolCallResult,
-    ToolManagerSettings,
     ToolFilter,
+    ToolFormat,
+    ToolManagerSettings,
     ToolTransformer,
 )
 from avalan.tool import Tool, ToolSet
@@ -41,6 +42,11 @@ class ToolManagerCreationTestCase(TestCase):
         )
         self.assertTrue(manager.is_empty)
         self.assertIsNone(manager.tools)
+
+    def test_tool_format_property(self):
+        settings = ToolManagerSettings(tool_format=ToolFormat.HARMONY)
+        manager = ToolManager.create_instance(settings=settings)
+        self.assertEqual(manager.tool_format, ToolFormat.HARMONY)
 
     def test_toolset_without_tools(self):
         manager = ToolManager.create_instance(

--- a/tests/tool/tool_parser_extra_test.py
+++ b/tests/tool/tool_parser_extra_test.py
@@ -52,6 +52,28 @@ class ToolCallParserExtraTestCase(TestCase):
         self.assertFalse(parser.is_potential_tool_call("", ""))
         self.assertTrue(parser.is_potential_tool_call("", "a"))
 
+    def test_tool_format_property(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        self.assertIs(parser.tool_format, ToolFormat.REACT)
+
+    def test_set_eos_token_method(self):
+        parser = ToolCallParser()
+        parser.set_eos_token("<END>")
+        call_id = _uuid4()
+        text = (
+            '<tool_call>{"name": "calculator", "arguments": {"expression": '
+            '"2"}}</tool_call><END>'
+        )
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={"expression": "2"},
+                )
+            ]
+            self.assertEqual(parser(text), expected)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- detect tool calls from their initial tokens across formats including Harmony
- handle pending tokens and flush them when a call completes
- test Harmony and self-closing tag scenarios
- expose tool format via ToolManager and parser to avoid private attribute access
- adjust tests to use the public tool_format property

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f09f9ec832399271f0d679ad466