### PR TITLE
Support harmony tool call prefixes

### DIFF
--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -489,6 +489,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                         "token_id": token_id,
                         "model_id": self._engine_agent.engine.model_id,
                         "token": token_str,
+                        "token_type": type(item).__qualname__,
                         "step": self._step,
                     },
                 )
@@ -504,6 +505,8 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
 
         if isinstance(item, str) and self._tool_parser:
             items = await self._tool_parser.push(item)
+            if not items:
+                return await self.__anext__()
         else:
             items = [item]
 

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -15,7 +15,7 @@ from ....event import Event, EventType
 from ....event.manager import EventManager
 from ....model.response.text import TextGenerationResponse
 from ....tool.manager import ToolManager
-from ....model.response.parsers.tool import ToolCallParser
+from ....model.response.parsers.tool import ToolCallResponseParser
 from ....cli import CommandAbortException
 from dataclasses import asdict, is_dataclass
 from inspect import iscoroutine
@@ -47,7 +47,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     _participant_id: UUID | None
     _session_id: UUID | None
     _parser_queue: Queue[Token | TokenDetail | Event] | None
-    _tool_parser: ToolCallParser | None
+    _tool_parser: ToolCallResponseParser | None
 
     def __init__(
         self,
@@ -84,7 +84,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         self._tool_confirm_all = False
         self._parser_queue = Queue()
         self._tool_parser = (
-            ToolCallParser(self._tool_manager, self._event_manager)
+            ToolCallResponseParser(self._tool_manager, self._event_manager)
             if enable_tool_parsing and self._tool_manager
             else None
         )

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -1,15 +1,17 @@
 """Parser emitting events for detected tool calls."""
 
-from ....entities import ToolCallToken, ToolFormat
-from ....event import Event, EventType
-from ....event.manager import EventManager
-from ....tool.manager import ToolManager
 from io import StringIO
 from time import perf_counter
 from typing import Any, Iterable
 
+from ....entities import ToolCallToken
+from ....event import Event, EventType
+from ....event.manager import EventManager
+from ....tool.manager import ToolManager
+from ....tool.parser import ToolCallParser
 
-class ToolCallParser:
+
+class ToolCallResponseParser:
     """Parse tool calls during streaming."""
 
     def __init__(
@@ -22,11 +24,6 @@ class ToolCallParser:
         self._inside_call = False
         self._pending_tokens: list[str] = []
         self._pending_str = ""
-        tool_format = tool_manager.tool_format
-        self._start_sequences = ["<tool_call", "<tool ", "<tool>"]
-        self._end_sequences = ["</tool_call>", "</tool>", "/>", "<|call|>"]
-        if tool_format is ToolFormat.HARMONY:
-            self._start_sequences.append("<|channel|>commentary")
 
     async def push(self, token_str: str) -> Iterable[Any]:
         buffer_value = self._buffer.getvalue()
@@ -43,23 +40,23 @@ class ToolCallParser:
 
         if not self._inside_call:
             candidate = self._pending_str + token_str
-            start_triggered = False
-            for start in self._start_sequences:
-                if start.startswith(candidate):
-                    self._pending_tokens.append(token_str)
-                    self._pending_str = candidate
-                    return result
-                if candidate.startswith(start):
-                    self._inside_call = True
-                    start_triggered = True
-                    self._pending_tokens.append(token_str)
-                    result.extend(
-                        ToolCallToken(t) for t in self._pending_tokens
-                    )
-                    self._pending_tokens.clear()
-                    self._pending_str = ""
-                    break
-            if not start_triggered:
+            status = self._tool_manager.tool_call_status(candidate)
+            if status is ToolCallParser.ToolCallBufferStatus.PREFIX:
+                self._pending_tokens.append(token_str)
+                self._pending_str = candidate
+                return result
+            if status in (
+                ToolCallParser.ToolCallBufferStatus.OPEN,
+                ToolCallParser.ToolCallBufferStatus.CLOSED,
+            ):
+                self._pending_tokens.append(token_str)
+                result.extend(ToolCallToken(t) for t in self._pending_tokens)
+                self._pending_tokens.clear()
+                self._pending_str = ""
+                self._inside_call = (
+                    status is ToolCallParser.ToolCallBufferStatus.OPEN
+                )
+            else:
                 if self._pending_tokens:
                     result.extend(self._pending_tokens)
                     self._pending_tokens.clear()
@@ -67,7 +64,8 @@ class ToolCallParser:
                 result.append(token_str)
         else:
             result.append(ToolCallToken(token_str))
-            if any(end in self._tag_buffer for end in self._end_sequences):
+            status = self._tool_manager.tool_call_status(self._tag_buffer)
+            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
                 self._inside_call = False
 
         if not result:

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -65,7 +65,11 @@ class ToolCallResponseParser:
         else:
             result.append(ToolCallToken(token_str))
             status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+            if (
+                status is ToolCallParser.ToolCallBufferStatus.CLOSED
+                or "<|call|>" in self._tag_buffer
+                or "<|channel|>final<|message|>" in self._tag_buffer
+            ):
                 self._inside_call = False
 
         if not result:

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -101,6 +101,12 @@ class ToolManager(ContextDecorator):
         """Proxy :meth:`ToolCallParser.is_potential_tool_call`."""
         return self._parser.is_potential_tool_call(buffer, token_str)
 
+    def tool_call_status(
+        self, buffer: str
+    ) -> ToolCallParser.ToolCallBufferStatus:
+        """Proxy :meth:`ToolCallParser.tool_call_status`."""
+        return self._parser.tool_call_status(buffer)
+
     def get_calls(self, text: str) -> list[ToolCall] | None:
         return self._parser(text)
 

--- a/tests/agent/default_orchestrator_test.py
+++ b/tests/agent/default_orchestrator_test.py
@@ -229,11 +229,23 @@ class DefaultOrchestratorTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 1, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 1,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 2, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 2,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
 
         memory.__exit__.assert_called_once()

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -1,36 +1,37 @@
+from asyncio import wait_for
+from collections.abc import AsyncIterator
+from avalan.agent import AgentOperation, EngineEnvironment, Specification
+from avalan.agent.engine import EngineAgent
 from avalan.agent.orchestrator.response.orchestrator_response import (
     OrchestratorResponse,
 )
-from avalan.agent import EngineEnvironment, AgentOperation, Specification
 from avalan.entities import (
     EngineUri,
+    GenerationSettings,
     Message,
     MessageRole,
+    ReasoningSettings,
+    ReasoningToken,
+    ToolCall,
     ToolCallContext,
+    ToolCallResult,
+    ToolCallToken,
+    ToolFormat,
     Token,
     TokenDetail,
     TransformerEngineSettings,
 )
 from avalan.event import EventType
 from avalan.event.manager import EventManager
-from avalan.agent.engine import EngineAgent
 from avalan.model import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
-from logging import getLogger
 from avalan.model.response.parsers.tool import ToolCallResponseParser
-from avalan.tool.parser import ToolCallParser
-from avalan.entities import (
-    ReasoningToken,
-    ToolCallToken,
-    GenerationSettings,
-    ReasoningSettings,
-)
-
-from unittest import IsolatedAsyncioTestCase
-from dataclasses import dataclass
 from avalan.tool.manager import ToolManager
-from avalan.entities import ToolCall, ToolCallResult
+from avalan.tool.parser import ToolCallParser
+from dataclasses import dataclass
 from io import StringIO
+from logging import getLogger
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -173,12 +174,73 @@ class OrchestratorResponseIterationTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 42, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 42,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 5, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 5,
+                "token_type": "Token",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
+
+    async def test_harmony_streaming_handles_split_prefix(self) -> None:
+        engine = _DummyEngine()
+        engine.tokenizer.encode.return_value = [1]
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        async def gen() -> AsyncIterator[str]:
+            yield "<|start|>assistant"
+            yield "<|channel|>commentary to=mytool <|message|>{}<|call|>"
+
+        settings = GenerationSettings()
+        response = TextGenerationResponse(
+            lambda **_: gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=settings,
+            settings=settings,
+        )
+
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        tool_manager = MagicMock(spec=ToolManager)
+        tool_manager.is_potential_tool_call.side_effect = (
+            base_parser.is_potential_tool_call
+        )
+        tool_manager.tool_call_status.side_effect = (
+            base_parser.tool_call_status
+        )
+        tool_manager.get_calls.side_effect = base_parser
+        tool_manager.is_empty = False
+
+        resp = OrchestratorResponse(
+            Message(role=MessageRole.USER, content="hi"),
+            response,
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+            tool=tool_manager,
+        )
+
+        iterator = resp.__aiter__()
+        first = await wait_for(iterator.__anext__(), 1)
+        second = await wait_for(iterator.__anext__(), 1)
+        self.assertIsInstance(first, ToolCallToken)
+        self.assertIsInstance(second, ToolCallToken)
 
 
 @dataclass

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -17,7 +17,8 @@ from avalan.agent.engine import EngineAgent
 from avalan.model import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
 from logging import getLogger
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 from avalan.entities import (
     ReasoningToken,
     ToolCallToken,
@@ -83,7 +84,9 @@ def _complex_response():
         tm = MagicMock()
         tm.is_potential_tool_call.return_value = True
         tm.get_calls.return_value = None
-        tp = ToolCallParser(tm, None)
+        base_parser = ToolCallParser()
+        tm.tool_call_status.side_effect = base_parser.tool_call_status
+        tp = ToolCallResponseParser(tm, None)
 
         sequence = [
             "X",

--- a/tests/agent/tool_call_parser_test.py
+++ b/tests/agent/tool_call_parser_test.py
@@ -1,5 +1,6 @@
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
 from avalan.entities import ToolCallToken, ToolFormat
+from avalan.tool.parser import ToolCallParser
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
@@ -13,8 +14,10 @@ class ToolCallParserTestCase(IsolatedAsyncioTestCase):
 
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.side_effect = _get_calls
+        base_parser = ToolCallParser()
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
 
-        parser = ToolCallParser(manager, None)
+        parser = ToolCallResponseParser(manager, None)
         tokens = []
         for t in ["<tool_call>", "x", "</tool_call>", "y"]:
             tokens.extend(await parser.push(t))
@@ -33,12 +36,43 @@ class ToolCallParserTestCase(IsolatedAsyncioTestCase):
         manager.is_potential_tool_call.return_value = True
         manager.get_calls.side_effect = _get_calls
         manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
 
-        parser = ToolCallParser(manager, None)
+        parser = ToolCallResponseParser(manager, None)
         tokens: list = []
         parts = [
             "<|channel|>",
             "commentary to=functions.db.run code<|message|>{}",
+            "<|call|>",
+            "end",
+        ]
+        for part in parts:
+            tokens.extend(await parser.push(part))
+
+        self.assertIsInstance(tokens[0], ToolCallToken)
+        self.assertIsInstance(tokens[1], ToolCallToken)
+        self.assertIsInstance(tokens[2], ToolCallToken)
+        self.assertEqual(tokens[-1], "end")
+
+    async def test_harmony_format_tokens_with_prefix(self):
+        manager = MagicMock()
+
+        def _get_calls(text: str):
+            return [MagicMock()] if "<|call|>" in text else None
+
+        manager.is_potential_tool_call.return_value = True
+        manager.get_calls.side_effect = _get_calls
+        manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
+
+        parser = ToolCallResponseParser(manager, None)
+        tokens: list = []
+        parts = [
+            "<|start|>",
+            "assistant<|channel|>commentary to=functions.db.run code",
+            "<|message|>{}",
             "<|call|>",
             "end",
         ]

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -38,7 +38,8 @@ from avalan.entities import (
     ReasoningSettings,
     ToolFormat,
 )
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 from avalan.entities import ReasoningToken, Token, TokenDetail, ToolCallToken
 from avalan.tool.browser import BrowserToolSettings
 from avalan.tool.database import DatabaseToolSettings
@@ -2324,7 +2325,9 @@ class CliAgentMixedTokensTestCase(unittest.IsolatedAsyncioTestCase):
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
-            tp = ToolCallParser(tm, None)
+            base_parser = ToolCallParser()
+            tm.tool_call_status.side_effect = base_parser.tool_call_status
+            tp = ToolCallResponseParser(tm, None)
             sequence = [
                 "X",
                 "<think>",

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -31,7 +31,8 @@ from avalan.entities import (
 )
 from avalan.entities import TransformerEngineSettings
 from avalan.model.nlp.text.generation import TextGenerationModel
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 import asyncio
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 
@@ -5123,7 +5124,9 @@ class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):
             tm = MagicMock()
             tm.is_potential_tool_call.return_value = True
             tm.get_calls.return_value = None
-            tp = ToolCallParser(tm, None)
+            base_parser = ToolCallParser()
+            tm.tool_call_status.side_effect = base_parser.tool_call_status
+            tp = ToolCallResponseParser(tm, None)
             sequence = [
                 "X",
                 "<think>",

--- a/tests/model/text_generation_response_extra_test.py
+++ b/tests/model/text_generation_response_extra_test.py
@@ -1,7 +1,8 @@
 from avalan.model.response.text import TextGenerationResponse
 from avalan.model.response.parsers.reasoning import ReasoningParser
 from logging import getLogger
-from avalan.model.response.parsers.tool import ToolCallParser
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.parser import ToolCallParser
 from avalan.entities import (
     GenerationSettings,
     ReasoningSettings,
@@ -21,7 +22,9 @@ async def _complex_generator():
     tm = MagicMock()
     tm.is_potential_tool_call.return_value = True
     tm.get_calls.return_value = None
-    tp = ToolCallParser(tm, None)
+    base_parser = ToolCallParser()
+    tm.tool_call_status.side_effect = base_parser.tool_call_status
+    tp = ToolCallResponseParser(tm, None)
 
     sequence = [
         "X",


### PR DESCRIPTION
## Summary
- extend harmony tool call parsing to accept optional `<|start|>assistant` prefix and expose buffer status utility
- rename streaming ToolCallParser to ToolCallResponseParser and drive token detection via `tool_call_status`
- update orchestrator to use the new response parser

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bca06787688323b9541b3b719c875d