### PR TITLE
Fix streaming for split tool call prefixes

### DIFF
--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -489,6 +489,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                         "token_id": token_id,
                         "model_id": self._engine_agent.engine.model_id,
                         "token": token_str,
+                        "token_type": type(item).__qualname__,
                         "step": self._step,
                     },
                 )

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -504,6 +504,8 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
 
         if isinstance(item, str) and self._tool_parser:
             items = await self._tool_parser.push(item)
+            if not items:
+                return await self.__anext__()
         else:
             items = [item]
 

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -65,7 +65,11 @@ class ToolCallResponseParser:
         else:
             result.append(ToolCallToken(token_str))
             status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+            if (
+                status is ToolCallParser.ToolCallBufferStatus.CLOSED
+                or "<|call|>" in self._tag_buffer
+                or "<|channel|>final<|message|>" in self._tag_buffer
+            ):
                 self._inside_call = False
 
         if not result:

--- a/tests/agent/default_orchestrator_test.py
+++ b/tests/agent/default_orchestrator_test.py
@@ -229,11 +229,23 @@ class DefaultOrchestratorTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 1, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 1,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 2, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 2,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
 
         memory.__exit__.assert_called_once()

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -174,11 +174,23 @@ class OrchestratorResponseIterationTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(token_events), 2)
         self.assertEqual(
             token_events[0].payload,
-            {"token_id": 42, "model_id": "m", "token": "a", "step": 0},
+            {
+                "token_id": 42,
+                "token_type": "str",
+                "model_id": "m",
+                "token": "a",
+                "step": 0,
+            },
         )
         self.assertEqual(
             token_events[1].payload,
-            {"token_id": 5, "model_id": "m", "token": "b", "step": 1},
+            {
+                "token_id": 5,
+                "token_type": "Token",
+                "model_id": "m",
+                "token": "b",
+                "step": 1,
+            },
         )
 
     async def test_harmony_streaming_handles_split_prefix(self) -> None:


### PR DESCRIPTION
## Summary
- avoid blocking when tool call prefixes span multiple tokens
- add regression test for Harmony tool call prefix streaming

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bca540d3048323b92edcac2ad84775