### PR TITLE
Fix harmony tool call termination parsing

### DIFF
--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -65,7 +65,11 @@ class ToolCallResponseParser:
         else:
             result.append(ToolCallToken(token_str))
             status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+            if (
+                status is ToolCallParser.ToolCallBufferStatus.CLOSED
+                or "<|call|>" in self._tag_buffer
+                or "<|channel|>final<|message|>" in self._tag_buffer
+            ):
                 self._inside_call = False
 
         if not result:


### PR DESCRIPTION
## Summary
- ensure `ToolCallResponseParser` exits tool-call state after `<|call|>` or final channel markers
- add regression test for harmony tool call followed by final channel

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68bcae69d2b08323a50f87bf6b1a6319