### PR TITLE
Use tool_call_status for tool call termination detection

### DIFF
--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -65,11 +65,11 @@ class ToolCallResponseParser:
         else:
             result.append(ToolCallToken(token_str))
             status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if (
-                status is ToolCallParser.ToolCallBufferStatus.CLOSED
-                or "<|call|>" in self._tag_buffer
-                or "<|channel|>final<|message|>" in self._tag_buffer
-            ):
+            if status is not ToolCallParser.ToolCallBufferStatus.CLOSED:
+                status = self._tool_manager.tool_call_status(
+                    f"<tool_call>{self._tag_buffer}"
+                )
+            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
                 self._inside_call = False
 
         if not result:

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -83,6 +83,7 @@ class ToolCallParser:
                     "<|start|>assistant<|channel|>commentary",
                 ]
             )
+            end.append("<|channel|>final<|message|>")
         max_len = max(len(s) for s in start)
         tail = buffer[-max_len:]
         for s in start:


### PR DESCRIPTION
## Summary
- use ToolCallParser.tool_call_status to detect tool call termination instead of raw string checks
- treat `<|channel|>final<|message|>` as an end token for harmony tool calls

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bcb35e57548323a6b8463e4659a8ce