### PR TITLE
Wrap reasoning text with content part SSE events

### DIFF
--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -166,6 +166,7 @@ def _switch_state(
     if state is not new_state:
         if state is ResponseState.REASONING:
             events.append(_reasoning_text_done())
+            events.append(_content_part_done())
             events.append(_output_item_done())
         elif state is ResponseState.TOOL_CALLING:
             events.append(_custom_tool_call_input_done())
@@ -177,11 +178,12 @@ def _switch_state(
 
         if new_state is ResponseState.REASONING:
             events.append(_output_item_added(new_state))
+            events.append(_content_part_added("reasoning_text"))
         elif new_state is ResponseState.TOOL_CALLING:
             events.append(_output_item_added(new_state))
         elif new_state is ResponseState.ANSWERING:
             events.append(_output_item_added(new_state))
-            events.append(_content_part_added())
+            events.append(_content_part_added("output_text"))
 
     return new_state, events
 
@@ -242,14 +244,14 @@ def _output_text_done() -> str:
     )
 
 
-def _content_part_added() -> str:
+def _content_part_added(part_type: str) -> str:
     return _sse(
         "response.content_part.added",
         {
             "type": "response.content_part.added",
             "output_index": 0,
             "content_index": 0,
-            "part": {"type": "output_text"},
+            "part": {"type": part_type},
         },
     )
 

--- a/tests/server/create_response_sse_test.py
+++ b/tests/server/create_response_sse_test.py
@@ -81,8 +81,10 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
         expected = [
             "response.created",
             "response.output_item.added",
+            "response.content_part.added",
             "response.reasoning_text.delta",
             "response.reasoning_text.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.custom_tool_call_input.delta",
@@ -110,6 +112,19 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
         self.assertIn(
             '"delta":"a"',
             data_lines[events.index("response.output_text.delta")],
+        )
+        content_indices = [
+            i
+            for i, e in enumerate(events)
+            if e == "response.content_part.added"
+        ]
+        self.assertIn(
+            '"part":{"type":"reasoning_text"}',
+            data_lines[content_indices[0]],
+        )
+        self.assertIn(
+            '"part":{"type":"output_text"}',
+            data_lines[content_indices[1]],
         )
         orchestrator.sync_messages.assert_awaited_once()
 
@@ -171,9 +186,11 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
         expected = [
             "response.created",
             "response.output_item.added",
+            "response.content_part.added",
             "response.reasoning_text.delta",
             "response.reasoning_text.delta",
             "response.reasoning_text.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.custom_tool_call_input.delta",
@@ -188,9 +205,11 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
+            "response.content_part.added",
             "response.reasoning_text.delta",
             "response.reasoning_text.delta",
             "response.reasoning_text.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.custom_tool_call_input.delta",
@@ -236,6 +255,27 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
         self.assertIn('"delta":"t4"', data_lines[tool_indices[3]])
         self.assertIn('"delta":"a3"', data_lines[answer_indices[2]])
         self.assertIn('"delta":"a4"', data_lines[answer_indices[3]])
+        content_indices = [
+            i
+            for i, e in enumerate(events)
+            if e == "response.content_part.added"
+        ]
+        self.assertIn(
+            '"part":{"type":"reasoning_text"}',
+            data_lines[content_indices[0]],
+        )
+        self.assertIn(
+            '"part":{"type":"output_text"}',
+            data_lines[content_indices[1]],
+        )
+        self.assertIn(
+            '"part":{"type":"reasoning_text"}',
+            data_lines[content_indices[2]],
+        )
+        self.assertIn(
+            '"part":{"type":"output_text"}',
+            data_lines[content_indices[3]],
+        )
         orchestrator.sync_messages.assert_awaited_once()
 
     async def test_streaming_ignores_events(self) -> None:


### PR DESCRIPTION
## Summary
- Emit `response.content_part.added` / `response.content_part.done` around reasoning text deltas in SSE responses
- Parameterize content-part helper to support reasoning and answer text
- Extend SSE tests to cover reasoning content-part events and types

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bcbc0f618883238059eb1ea54aafa6