### PR TITLE
Reuse orchestrator loader in engine reload

### DIFF
--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -97,8 +97,6 @@ def agents_server(
                 stack=stack,
             )
             ctx = OrchestratorContext(
-                loader=loader,
-                hub=hub,
                 participant_id=pid,
                 specs_path=specs_path,
                 settings=settings,
@@ -107,6 +105,7 @@ def agents_server(
             )
             app.state.ctx = ctx
             app.state.stack = stack
+            app.state.loader = loader
             if ctx.specs_path:
                 orchestrator_cm = await loader.from_file(
                     ctx.specs_path,

--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -1,6 +1,4 @@
-from ..agent.loader import OrchestratorLoader
 from ..entities import MessageRole, OrchestratorSettings
-from ..model.hubs.huggingface import HuggingfaceHub
 from ..tool.browser import BrowserToolSettings
 from ..tool.database import DatabaseToolSettings
 from dataclasses import dataclass
@@ -13,8 +11,6 @@ JSONType = Literal["bool", "float", "int", "object", "string"]
 
 @dataclass(kw_only=True, frozen=True)
 class OrchestratorContext:
-    loader: OrchestratorLoader
-    hub: HuggingfaceHub
     participant_id: UUID
     specs_path: str | None = None
     settings: OrchestratorSettings | None = None

--- a/tests/server/engine_reload_test.py
+++ b/tests/server/engine_reload_test.py
@@ -1,105 +1,102 @@
+from avalan.server.entities import EngineRequest, OrchestratorContext
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
-
-from avalan.server.entities import EngineRequest, OrchestratorContext
 
 
 class EngineReloadTestCase(IsolatedAsyncioTestCase):
     async def test_reload_from_file(self) -> None:
         import avalan.server.routers.engine as eng
 
-        hub = MagicMock()
         pid = uuid4()
+        orchestrator = MagicMock()
+        orchestrator.id = uuid4()
+        orchestrator_cm = MagicMock()
+        loader = SimpleNamespace(
+            from_file=AsyncMock(return_value=orchestrator_cm)
+        )
+        stack = SimpleNamespace(
+            aclose=AsyncMock(),
+            enter_async_context=AsyncMock(return_value=orchestrator),
+        )
         request = SimpleNamespace(
             app=SimpleNamespace(
                 state=SimpleNamespace(
                     ctx=OrchestratorContext(
-                        loader=SimpleNamespace(hub=hub, participant_id=pid),
-                        hub=hub,
                         participant_id=pid,
                         specs_path="agent.toml",
                     ),
-                    stack=SimpleNamespace(aclose=AsyncMock()),
+                    stack=stack,
+                    loader=loader,
                     agent_id=uuid4(),
                 )
             )
         )
-        old_stack = request.app.state.stack
-        loader = MagicMock()
-        orchestrator_cm = MagicMock()
-        orchestrator = MagicMock()
-        orchestrator.id = uuid4()
-        orchestrator_cm.__aenter__ = AsyncMock(return_value=orchestrator)
-        loader.from_file = AsyncMock(return_value=orchestrator_cm)
-        new_stack = SimpleNamespace(
-            enter_async_context=AsyncMock(return_value=orchestrator)
-        )
-        with (
-            patch.object(
-                eng, "OrchestratorLoader", return_value=loader
-            ) as Loader,
-            patch.object(eng, "AsyncExitStack", return_value=new_stack),
-            patch.object(eng, "di_set") as di_set,
-        ):
+        with patch.object(eng, "di_set") as di_set:
             logger = MagicMock()
+            original_agent_id = request.app.state.agent_id
             await eng.set_engine(request, EngineRequest(uri="new"), logger)
-        old_stack.aclose.assert_called_once()
-        Loader.assert_called_once()
+        stack.aclose.assert_called_once()
+        loader.from_file.assert_called_once_with(
+            "agent.toml",
+            agent_id=original_agent_id,
+            uri="new",
+        )
+        stack.enter_async_context.assert_called_once_with(orchestrator_cm)
         di_set.assert_called_once_with(
             request.app, logger=logger, orchestrator=orchestrator
         )
-        self.assertIs(request.app.state.stack, new_stack)
         self.assertEqual(request.app.state.agent_id, orchestrator.id)
-        self.assertIs(request.app.state.ctx.loader, loader)
 
     async def test_reload_from_settings(self) -> None:
         import avalan.server.routers.engine as eng
 
         settings = MagicMock()
-        hub = MagicMock()
         pid = uuid4()
+        orchestrator = MagicMock()
+        orchestrator.id = uuid4()
+        orchestrator_cm = MagicMock()
+        browser_settings = MagicMock()
+        database_settings = MagicMock()
+        loader = SimpleNamespace(
+            from_settings=AsyncMock(return_value=orchestrator_cm)
+        )
+        stack = SimpleNamespace(
+            aclose=AsyncMock(),
+            enter_async_context=AsyncMock(return_value=orchestrator),
+        )
         request = SimpleNamespace(
             app=SimpleNamespace(
                 state=SimpleNamespace(
                     ctx=OrchestratorContext(
-                        loader=SimpleNamespace(hub=hub, participant_id=pid),
-                        hub=hub,
                         participant_id=pid,
                         settings=settings,
-                        browser_settings=MagicMock(),
-                        database_settings=MagicMock(),
+                        browser_settings=browser_settings,
+                        database_settings=database_settings,
                     ),
-                    stack=SimpleNamespace(aclose=AsyncMock()),
+                    stack=stack,
+                    loader=loader,
                 )
             )
         )
-        old_stack = request.app.state.stack
-        loader = MagicMock()
-        orchestrator_cm = MagicMock()
-        orchestrator = MagicMock()
-        orchestrator.id = uuid4()
-        orchestrator_cm.__aenter__ = AsyncMock(return_value=orchestrator)
-        loader.from_settings = AsyncMock(return_value=orchestrator_cm)
-        new_stack = SimpleNamespace(
-            enter_async_context=AsyncMock(return_value=orchestrator)
-        )
         new_settings = MagicMock()
         with (
-            patch.object(eng, "OrchestratorLoader", return_value=loader),
-            patch.object(eng, "AsyncExitStack", return_value=new_stack),
             patch.object(eng, "replace", return_value=new_settings) as repl,
             patch.object(eng, "di_set") as di_set,
         ):
             logger = MagicMock()
             await eng.set_engine(request, EngineRequest(uri="new"), logger)
-        old_stack.aclose.assert_called_once()
+        stack.aclose.assert_called_once()
         repl.assert_called_once_with(settings, uri="new")
+        loader.from_settings.assert_called_once_with(
+            new_settings,
+            browser_settings=browser_settings,
+            database_settings=database_settings,
+        )
+        stack.enter_async_context.assert_called_once_with(orchestrator_cm)
         di_set.assert_called_once_with(
             request.app, logger=logger, orchestrator=orchestrator
         )
-        self.assertIs(request.app.state.stack, new_stack)
         self.assertEqual(request.app.state.agent_id, orchestrator.id)
         self.assertIs(request.app.state.ctx.settings, new_settings)
-        self.assertIs(request.app.state.ctx.loader, loader)


### PR DESCRIPTION
## Summary
- streamline `OrchestratorContext` to only store participant and settings
- reuse loader & async stack when resetting engine
- adjust server lifespan and reload tests

## Testing
- `poetry run ruff check src/avalan/server/__init__.py src/avalan/server/entities.py src/avalan/server/routers/engine.py tests/server/engine_reload_test.py`
- `poetry run black --check src/avalan/server/__init__.py src/avalan/server/entities.py src/avalan/server/routers/engine.py tests/server/engine_reload_test.py`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bf15f3adec83239456ee91ab68c02f