### PR TITLE
Allow updating database DSN via engine reload

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -70,6 +70,7 @@ class OrchestratorLoader:
         agent_id: UUID | None,
         disable_memory: bool = False,
         uri: str | None = None,
+        tool_settings: ToolSettingsContext | None = None,
     ) -> Orchestrator:
         _l = self._log_wrapper(self._logger)
 
@@ -248,8 +249,17 @@ class OrchestratorLoader:
             if database_config:
                 database_settings = DatabaseToolSettings(**database_config)
 
+            if tool_settings:
+                browser_settings = tool_settings.browser or browser_settings
+                database_settings = tool_settings.database or database_settings
+                extra = tool_settings.extra
+            else:
+                extra = None
+
             tool_settings = ToolSettingsContext(
-                browser=browser_settings, database=database_settings
+                browser=browser_settings,
+                database=database_settings,
+                extra=extra,
             )
 
             tool_format = None

--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -107,6 +107,7 @@ def agents_server(
                 orchestrator_cm = await loader.from_file(
                     ctx.specs_path,
                     agent_id=agent_id or uuid4(),
+                    tool_settings=ctx.tool_settings,
                 )
             else:
                 orchestrator_cm = await loader.from_settings(

--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -227,3 +227,4 @@ class ModelList(BaseModel):
 
 class EngineRequest(BaseModel):
     uri: str
+    database: str | None = None

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -2093,7 +2093,11 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
                 self.args.quiet = True
 
                 async def from_file(
-                    self_loader, path, agent_id, disable_memory
+                    self_loader,
+                    path,
+                    agent_id,
+                    disable_memory=None,
+                    **kwargs,
                 ):
                     import tomllib
 
@@ -2160,7 +2164,11 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
                 self.args.quiet = True
 
                 async def from_file(
-                    self_loader, path, agent_id, disable_memory
+                    self_loader,
+                    path,
+                    agent_id,
+                    disable_memory=None,
+                    **kwargs,
                 ):
                     import tomllib
 

--- a/tests/server/engine_reload_test.py
+++ b/tests/server/engine_reload_test.py
@@ -1,5 +1,7 @@
 from avalan.server.entities import EngineRequest, OrchestratorContext
 from avalan.tool.context import ToolSettingsContext
+from avalan.tool.database import DatabaseToolSettings
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -43,6 +45,7 @@ class EngineReloadTestCase(IsolatedAsyncioTestCase):
             "agent.toml",
             agent_id=original_agent_id,
             uri="new",
+            tool_settings=None,
         )
         stack.enter_async_context.assert_called_once_with(orchestrator_cm)
         di_set.assert_called_once_with(
@@ -53,7 +56,11 @@ class EngineReloadTestCase(IsolatedAsyncioTestCase):
     async def test_reload_from_settings(self) -> None:
         import avalan.server.routers.engine as eng
 
-        settings = MagicMock()
+        @dataclass
+        class DummySettings:
+            uri: str
+
+        settings = DummySettings(uri="old")
         pid = uuid4()
         orchestrator = MagicMock()
         orchestrator.id = uuid4()
@@ -89,9 +96,13 @@ class EngineReloadTestCase(IsolatedAsyncioTestCase):
             patch.object(eng, "di_set") as di_set,
         ):
             logger = MagicMock()
-            await eng.set_engine(request, EngineRequest(uri="new"), logger)
+            await eng.set_engine(
+                request,
+                EngineRequest(uri="new?max_new_tokens=1"),
+                logger,
+            )
         stack.aclose.assert_called_once()
-        repl.assert_called_once_with(settings, uri="new")
+        repl.assert_called_once_with(settings, uri="new?max_new_tokens=1")
         loader.from_settings.assert_called_once_with(
             new_settings, tool_settings=tool_settings
         )
@@ -101,3 +112,55 @@ class EngineReloadTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(request.app.state.agent_id, orchestrator.id)
         self.assertIs(request.app.state.ctx.settings, new_settings)
+
+    async def test_reload_updates_database_settings(self) -> None:
+        import avalan.server.routers.engine as eng
+
+        @dataclass
+        class DummySettings:
+            uri: str
+
+        settings = DummySettings(uri="old")
+        pid = uuid4()
+        orchestrator = MagicMock()
+        orchestrator.id = uuid4()
+        orchestrator_cm = MagicMock()
+        database_settings = DatabaseToolSettings(dsn="old")
+        tool_settings = ToolSettingsContext(database=database_settings)
+        loader = SimpleNamespace(
+            from_settings=AsyncMock(return_value=orchestrator_cm)
+        )
+        stack = SimpleNamespace(
+            aclose=AsyncMock(),
+            enter_async_context=AsyncMock(return_value=orchestrator),
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    ctx=OrchestratorContext(
+                        participant_id=pid,
+                        settings=settings,
+                        tool_settings=tool_settings,
+                    ),
+                    stack=stack,
+                    loader=loader,
+                )
+            )
+        )
+        with patch.object(eng, "di_set"):
+            logger = MagicMock()
+            await eng.set_engine(
+                request,
+                EngineRequest(uri="new", database="postgres://db"),
+                logger,
+            )
+        stack.aclose.assert_called_once()
+        loader.from_settings.assert_called_once()
+        passed_tool_settings = loader.from_settings.call_args.kwargs[
+            "tool_settings"
+        ]
+        self.assertEqual(passed_tool_settings.database.dsn, "postgres://db")
+        self.assertEqual(
+            request.app.state.ctx.tool_settings.database.dsn, "postgres://db"
+        )
+        self.assertEqual(request.app.state.ctx.settings.uri, "new")


### PR DESCRIPTION
## Summary
- allow POST /engine to accept optional database DSN and update tool settings
- support overriding tool settings in orchestrator loader and server startup
- test engine reload with generation params and database DSN overrides

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68bf882242dc83239e780348783e8996