### PR TITLE
Add memory manager invalid message test

### DIFF
--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -475,5 +475,26 @@ class MemoryManagerEventTestCase(IsolatedAsyncioTestCase):
         )
 
 
+class MemoryManagerEdgeCaseTestCase(IsolatedAsyncioTestCase):
+    async def test_append_message_skips_non_engine_message(self):
+        manager = MemoryManager(
+            agent_id=uuid4(),
+            participant_id=uuid4(),
+            permanent_message_memory=None,
+            recent_message_memory=RecentMessageMemory(),
+            text_partitioner=AsyncMock(),
+            logger=MagicMock(),
+            event_manager=None,
+        )
+
+        await manager.append_message("bad")
+
+        manager._logger.info.assert_called_once_with(
+            "Skipping non engine message %s", "bad"
+        )
+        manager._text_partitioner.assert_not_called()
+        self.assertTrue(manager.recent_message.is_empty)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- test that MemoryManager.append_message skips non EngineMessage inputs

## Testing
- `poetry run pytest tests/memory --cov=src/avalan/memory --cov-report=term-missing -q`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68bfbb02af8c83239278ba450874edc1