### PR TITLE
Add TextGenerationModality vendor tests

### DIFF
--- a/tests/model/text_generation_modality_vendors_test.py
+++ b/tests/model/text_generation_modality_vendors_test.py
@@ -1,0 +1,58 @@
+from contextlib import AsyncExitStack
+from logging import Logger
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from avalan.entities import EngineUri, TransformerEngineSettings
+from avalan.model.modalities.text import TextGenerationModality
+
+
+@pytest.mark.parametrize(
+    "vendor,class_name",
+    [
+        ("anthropic", "AnthropicModel"),
+        ("openai", "OpenAIModel"),
+        ("openrouter", "OpenRouterModel"),
+        ("anyscale", "AnyScaleModel"),
+        ("together", "TogetherModel"),
+        ("deepseek", "DeepSeekModel"),
+        ("deepinfra", "DeepInfraModel"),
+        ("groq", "GroqModel"),
+        ("ollama", "OllamaModel"),
+        ("huggingface", "HuggingfaceModel"),
+        ("hyperbolic", "HyperbolicModel"),
+        ("litellm", "LiteLLMModel"),
+    ],
+)
+def test_load_engine_per_vendor(vendor: str, class_name: str) -> None:
+    loader = MagicMock()
+    stub = types.ModuleType(f"avalan.model.nlp.text.vendor.{vendor}")
+    setattr(stub, class_name, loader)
+    engine_uri = EngineUri(
+        host=None,
+        port=None,
+        user=None,
+        password=None,
+        vendor=vendor,
+        model_id="model",
+        params={},
+    )
+    settings = TransformerEngineSettings()
+    logger = MagicMock(spec=Logger)
+    exit_stack = AsyncExitStack()
+    with patch.dict(
+        sys.modules, {f"avalan.model.nlp.text.vendor.{vendor}": stub}
+    ):
+        result = TextGenerationModality().load_engine(
+            engine_uri, settings, logger, exit_stack
+        )
+    loader.assert_called_once_with(
+        model_id="model",
+        settings=settings,
+        logger=logger,
+        exit_stack=exit_stack,
+    )
+    assert result is loader.return_value


### PR DESCRIPTION
## Summary
- test TextGenerationModality.load_engine across all supported vendors

## Testing
- `poetry run ruff format tests/model/text_generation_modality_vendors_test.py && poetry run black tests/model/text_generation_modality_vendors_test.py && poetry run ruff check --fix tests/model/text_generation_modality_vendors_test.py`
- `poetry run pytest --verbose -s`
- `PYTHONPATH=temp_stub poetry run pytest --cov=avalan.model.modalities.text --cov-report=json tests/model/text_generation_modality_vendors_test.py -q` *(fails: ModuleNotFoundError: No module named 'torch.distributed'; 'torch' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c030301db883238067b36dd63b1762