### PR TITLE
Centralize tool call token handling across vendors

### DIFF
--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -175,7 +175,11 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertIsInstance(t5, ToolCallToken)
         self.assertEqual(t5.call.id, "c1")
         self.assertEqual(t5.call.name, "pkg.func")
-        self.assertEqual(t5.call.arguments, "{}")
+        self.assertEqual(t5.call.arguments, {})
+        self.assertEqual(
+            t5.token,
+            '<tool_call>{"name": "pkg.func", "arguments": {}}</tool_call>',
+        )
         t6 = await stream.__anext__()
         self.assertIsInstance(t6, Token)
         self.assertEqual(t6.token, "hi")


### PR DESCRIPTION
## Summary
- centralize ToolCall and ToolCallToken creation via `TextGenerationVendor.build_tool_call_token`
- update AnthropicStream and OpenAIStream to emit `<tool_call>` JSON tags using the shared method
- adjust OpenAI vendor test to expect structured tool call tokens

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68c033f0ec2883238a50e8b4d57f0993