### PR TITLE
Allow engine reload without URI

### DIFF
--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -1,7 +1,7 @@
 from ..entities import MessageRole, OrchestratorSettings
 from ..tool.context import ToolSettingsContext
 from dataclasses import dataclass
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Annotated, Literal
 from uuid import UUID
 
@@ -226,5 +226,11 @@ class ModelList(BaseModel):
 
 
 class EngineRequest(BaseModel):
-    uri: str
+    uri: str | None = None
     database: str | None = None
+
+    @model_validator(mode="after")
+    def check_uri_or_database(self) -> "EngineRequest":
+        if self.uri is None and self.database is None:
+            raise ValueError("Provide uri or database")
+        return self

--- a/tests/server/engine_reload_test.py
+++ b/tests/server/engine_reload_test.py
@@ -2,6 +2,7 @@ from avalan.server.entities import EngineRequest, OrchestratorContext
 from avalan.tool.context import ToolSettingsContext
 from avalan.tool.database import DatabaseToolSettings
 from dataclasses import dataclass
+from pydantic import ValidationError
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -218,3 +219,57 @@ class EngineReloadTestCase(IsolatedAsyncioTestCase):
         di_set.assert_called_once_with(
             request.app, logger=logger, orchestrator=orchestrator
         )
+
+    async def test_reload_with_only_database(self) -> None:
+        import avalan.server.routers.engine as eng
+
+        @dataclass
+        class DummySettings:
+            uri: str
+
+        settings = DummySettings(uri="old")
+        pid = uuid4()
+        orchestrator = MagicMock()
+        orchestrator.id = uuid4()
+        orchestrator_cm = MagicMock()
+        database_settings = DatabaseToolSettings(dsn="old")
+        tool_settings = ToolSettingsContext(database=database_settings)
+        loader = SimpleNamespace(
+            from_settings=AsyncMock(return_value=orchestrator_cm)
+        )
+        stack = SimpleNamespace(
+            aclose=AsyncMock(),
+            enter_async_context=AsyncMock(return_value=orchestrator),
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    ctx=OrchestratorContext(
+                        participant_id=pid,
+                        settings=settings,
+                        tool_settings=tool_settings,
+                    ),
+                    stack=stack,
+                    loader=loader,
+                )
+            )
+        )
+        with patch.object(eng, "di_set"):
+            logger = MagicMock()
+            await eng.set_engine(
+                request, EngineRequest(database="postgres://db"), logger
+            )
+        stack.aclose.assert_called_once()
+        loader.from_settings.assert_called_once()
+        passed_tool_settings = loader.from_settings.call_args.kwargs[
+            "tool_settings"
+        ]
+        self.assertEqual(passed_tool_settings.database.dsn, "postgres://db")
+        self.assertEqual(
+            request.app.state.ctx.tool_settings.database.dsn, "postgres://db"
+        )
+        self.assertEqual(request.app.state.ctx.settings.uri, "old")
+
+    def test_engine_request_requires_uri_or_database(self) -> None:
+        with self.assertRaises(ValidationError):
+            EngineRequest()


### PR DESCRIPTION
## Summary
- permit `/engine` requests without a new URI as long as a database or URI is provided
- reload endpoint keeps existing engine settings when URI omitted and updates database separately
- test reload with only database and validation of request payload

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c0686a5c208323a168e91830bbea46