### PR TITLE
Add vendor tool call token tests

### DIFF
--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from avalan.entities import ToolCall, ToolCallToken
+from avalan.model.vendor import TextGenerationVendor
+
+
+class VendorBuildToolCallTokenTestCase(TestCase):
+    def test_build_tool_call_token_from_string_json(self) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="1",
+            tool_name="pkg__tool",
+            arguments='{"a": 1}',
+        )
+        expected = ToolCallToken(
+            token=(
+                '<tool_call>{"name": "pkg.tool", "arguments": {"a":'
+                " 1}}</tool_call>"
+            ),
+            call=ToolCall(id="1", name="pkg.tool", arguments={"a": 1}),
+        )
+        self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_handles_invalid_json_str(self) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id=None,
+            tool_name="tool",
+            arguments='{"a": }',
+        )
+        expected = ToolCallToken(
+            token='<tool_call>{"name": "tool", "arguments": {}}</tool_call>',
+            call=ToolCall(id=None, name="tool", arguments={}),
+        )
+        self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_from_dict(self) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="2",
+            tool_name=None,
+            arguments={"b": 2},
+        )
+        expected = ToolCallToken(
+            token='<tool_call>{"name": "", "arguments": {"b": 2}}</tool_call>',
+            call=ToolCall(id="2", name="", arguments={"b": 2}),
+        )
+        self.assertEqual(token, expected)


### PR DESCRIPTION
## Summary
- test JSON parsing, invalid input, and dict handling in TextGenerationVendor.build_tool_call_token
- ensure vendor.py now has full test coverage

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c0b3eb80cc83239d71d675218fecf4