### PR TITLE
Add tests for ModelManager async context and boolean params

### DIFF
--- a/tests/model/model_manager_extra_test.py
+++ b/tests/model/model_manager_extra_test.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from avalan.entities import (
     Backend,
     EngineUri,
@@ -146,3 +148,18 @@ class ModelManagerExtraTestCase(TestCase):
                         self.assertEqual(args["output_hidden_states"], value)
                     le.assert_called_once_with(uri, ges.return_value, modality)
                     self.assertEqual(result, "model")
+
+    def test_parse_uri_boolean_params(self):
+        manager = ModelManager(self.hub, self.logger)
+        uri = manager.parse_uri("ai://openai/gpt-4o?stream=true&debug=false")
+        self.assertTrue(uri.params["stream"])
+        self.assertFalse(uri.params["debug"])
+
+    def test_async_context_manager(self):
+        manager = ModelManager(self.hub, self.logger)
+
+        async def run():
+            async with manager as mm:
+                self.assertIs(mm, manager)
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
- test ModelManager async context manager
- test parse_uri boolean query parsing

## Testing
- `make lint`
- `poetry run pytest --verbose -s`
- `poetry run pytest --cov=src/ --cov-report=json`


------
https://chatgpt.com/codex/tasks/task_e_68c0b748ac2483238734b75c2fb58a4e