### PR TITLE
Ensure tool confirmation prompts render with tool displays

### DIFF
--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -32,7 +32,7 @@ def confirm_tool_call(
             "json",
         )
     )
-    kwargs = {"choices": ["y", "a", "n"], "default": "n"}
+    kwargs = {"choices": ["y", "a", "n"], "default": "n", "console": console}
     stdin_is_tty = stdin.isatty()
     with open(tty_path) if not stdin_is_tty else nullcontext() as tty:
         if not stdin_is_tty:

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -380,7 +380,9 @@ async def token_generation(
         not args.display_events and not args.display_tools
     ):
         with Live(
-            refresh_per_second=refresh_per_second, screen=args.record
+            refresh_per_second=refresh_per_second,
+            screen=args.record,
+            console=console,
         ) as live:
             await _token_stream(
                 args,
@@ -412,7 +414,10 @@ async def token_generation(
         tokens_group_index = 2
 
         with Live(
-            group, refresh_per_second=refresh_per_second, screen=args.record
+            group,
+            refresh_per_second=refresh_per_second,
+            screen=args.record,
+            console=console,
         ) as live:
             await gather(
                 _event_stream(

--- a/tests/cli/input_test.py
+++ b/tests/cli/input_test.py
@@ -124,6 +124,7 @@ class CliConfirmToolCallTestCase(TestCase):
             "Execute tool call? ([y]es/[a]ll/[n]o)",
             choices=["y", "a", "n"],
             default="n",
+            console=console,
         )
         self.assertEqual(result, "y")
 
@@ -147,6 +148,7 @@ class CliConfirmToolCallTestCase(TestCase):
             "Execute tool call? ([y]es/[a]ll/[n]o)",
             choices=["y", "a", "n"],
             default="n",
+            console=console,
             stream=fake_tty,
         )
         self.assertEqual(result, "y")
@@ -171,6 +173,7 @@ class CliConfirmToolCallTestCase(TestCase):
             "Execute tool call? ([y]es/[a]ll/[n]o)",
             choices=["y", "a", "n"],
             default="n",
+            console=console,
             stream=fake_tty,
         )
         self.assertEqual(result, "y")

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -4654,7 +4654,9 @@ class CliRecordOptionTestCase(IsolatedAsyncioTestCase):
                 with_stats=True,
             )
 
-        live_patch.assert_called_once_with(refresh_per_second=3, screen=True)
+        live_patch.assert_called_once_with(
+            refresh_per_second=3, screen=True, console=console
+        )
         ts_patch.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- fix CLI to attach console to tool confirmation prompts and Live displays so the prompt isn't hidden when using `--display-tools`
- update tests and expectations for console-aware prompts and Live

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c1b948c7d48323a14ec2b23e07a542