### PR TITLE
Add to_json tests

### DIFF
--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from io import UnsupportedOperation
 from json import dumps
-from rich.console import Console, Group
+from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
 from rich.prompt import Confirm, Prompt
@@ -51,14 +51,12 @@ def confirm_tool_call(
         "default": "n",
         "console": console,
         "show_choices": True,
-        "show_default": True
+        "show_default": True,
     }
 
     with _pause_live(live) if live else nullcontext():
         call_element = Syntax(
-            dumps(
-                {"name": call.name, "arguments": call.arguments}, indent=2
-            ),
+            dumps({"name": call.name, "arguments": call.arguments}, indent=2),
             "json",
         )
         console.print(call_element)
@@ -69,7 +67,7 @@ def confirm_tool_call(
             prompt_element.append(" ")
             prompt_element.append(f"[{choices}]", "prompt.choices")
 
-            if (options["show_default"]):
+            if options["show_default"]:
                 default = Text(f"({options['default']})", "prompt.default")
                 prompt_element.append(" ")
                 prompt_element.append(default)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,9 +1,12 @@
 import logging
-from avalan.utils import _lf, _j, logger_replace
-from avalan.compat import override
-from avalan.cli.download import create_live_tqdm_class, tqdm_rich_progress
+from dataclasses import dataclass
+from decimal import Decimal
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+from avalan.cli.download import create_live_tqdm_class, tqdm_rich_progress
+from avalan.compat import override
+from avalan.utils import _j, _lf, logger_replace, to_json
 
 
 class UtilsListJoinTestCase(TestCase):
@@ -33,6 +36,23 @@ class UtilsLoggerReplaceTestCase(TestCase):
         self.assertIn(handler, target_logger.handlers)
         self.assertEqual(target_logger.level, logging.WARNING)
         self.assertFalse(target_logger.propagate)
+
+
+@dataclass
+class Dummy:
+    value: Decimal
+
+
+class UtilsToJsonTestCase(TestCase):
+    def test_to_json_dataclass_and_decimal(self) -> None:
+        self.assertEqual(
+            to_json(Dummy(Decimal("1.23"))),
+            '{"value": "1.23"}',
+        )
+
+    def test_to_json_unsupported_type(self) -> None:
+        with self.assertRaises(TypeError):
+            to_json(object())
 
 
 class CompatOverrideTestCase(TestCase):


### PR DESCRIPTION
## Summary
- add dataclass and Decimal tests for `to_json`
- remove unused import from CLI module

## Testing
- `make lint`
- `poetry run pytest --cov=avalan.utils`

------
https://chatgpt.com/codex/tasks/task_e_68c2f226e83c8323bc7d531f2d3f9486