### PR TITLE
Defer orchestrator initialization

### DIFF
--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -1,4 +1,4 @@
-from avalan.server import agents_server
+from avalan.server import agents_server, di_get_orchestrator
 from logging import Logger
 import sys
 from types import ModuleType, SimpleNamespace
@@ -140,11 +140,11 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                     )
 
                 lifespan = FastAPI.call_args.kwargs["lifespan"]
-
                 self.assertFalse(hasattr(app.state, "orchestrator"))
 
                 async with lifespan(app):
-                    pass
+                    self.assertFalse(hasattr(app.state, "orchestrator"))
+                    await di_get_orchestrator(SimpleNamespace(app=app))
 
                 loader.from_file.assert_awaited_once()
                 loader.from_settings.assert_not_called()
@@ -232,11 +232,11 @@ class AgentsServerLifespanTestCase(IsolatedAsyncioTestCase):
                     )
 
                 lifespan = FastAPI.call_args.kwargs["lifespan"]
-
                 self.assertFalse(hasattr(app.state, "orchestrator"))
 
                 async with lifespan(app):
-                    pass
+                    self.assertFalse(hasattr(app.state, "orchestrator"))
+                    await di_get_orchestrator(SimpleNamespace(app=app))
 
                 loader.from_settings.assert_awaited_once()
                 loader.from_file.assert_not_called()

--- a/tests/server/chat_router_unit_test.py
+++ b/tests/server/chat_router_unit_test.py
@@ -81,7 +81,7 @@ class ChatRouterUnitTest(IsolatedAsyncioTestCase):
                 )()
             },
         )()
-        self.assertEqual(self.chat.di_get_orchestrator(req), 1)
+        self.assertEqual(await self.chat.di_get_orchestrator(req), 1)
 
     async def test_create_chat_completion_stream(self) -> None:
         async def output_gen():

--- a/tests/server/server_additional_test.py
+++ b/tests/server/server_additional_test.py
@@ -5,6 +5,7 @@ from avalan.server import (
     di_set,
 )
 from logging import Logger
+import asyncio
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
@@ -22,7 +23,7 @@ class DiHelpersTestCase(TestCase):
         di_set(app, logger, orch)
         request = SimpleNamespace(app=app)
         self.assertIs(di_get_logger(request), logger)
-        self.assertIs(di_get_orchestrator(request), orch)
+        self.assertIs(asyncio.run(di_get_orchestrator(request)), orch)
 
 
 class AgentsServerValidationTestCase(TestCase):


### PR DESCRIPTION
## Summary
- load orchestrator on first request instead of server startup
- adjust dependency helper and tests for lazy loading

## Testing
- `poetry run ruff check src/avalan/server/__init__.py tests/server/agents_server_lifespan_test.py tests/server/chat_router_unit_test.py tests/server/server_additional_test.py`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c33651af2483238afa26613229d0aa