### PR TITLE
Wrap tool call token events with content part

### DIFF
--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -186,6 +186,8 @@ def _switch_state(
             events.append(_output_item_done())
         elif state is ResponseState.TOOL_CALLING:
             events.append(_custom_tool_call_input_done())
+            if tool_call is not None:
+                events.append(_content_part_done())
             events.append(_output_item_done(tool_call))
         elif state is ResponseState.ANSWERING:
             events.append(_output_text_done())
@@ -197,6 +199,8 @@ def _switch_state(
             events.append(_content_part_added("reasoning_text"))
         elif new_state is ResponseState.TOOL_CALLING:
             events.append(_output_item_added(new_state, tool_call))
+            if tool_call is not None:
+                events.append(_content_part_added("input_text"))
         elif new_state is ResponseState.ANSWERING:
             events.append(_output_item_added(new_state))
             events.append(_content_part_added("output_text"))


### PR DESCRIPTION
## Summary
- wrap ToolCallToken SSE output in a content part when a call object is present
- cover custom tool call content wrapping in responses utilities
- test SSE stream includes content part events for tool calls with call details

## Testing
- `make lint`
- `poetry run pytest --verbose -s`

------
https://chatgpt.com/codex/tasks/task_e_68c3432940a4832397411f465afdff28