### PR TITLE
Mock ast-grep subprocess in tests

### DIFF
--- a/tests/tool/ast_grep_tool_test.py
+++ b/tests/tool/ast_grep_tool_test.py
@@ -12,7 +12,8 @@ class AstGrepToolTestCase(IsolatedAsyncioTestCase):
         process.communicate = AsyncMock(return_value=(b"out", b""))
         process.returncode = 0
         with patch(
-            "asyncio.create_subprocess_exec", AsyncMock(return_value=process)
+            "avalan.tool.code.create_subprocess_exec",
+            AsyncMock(return_value=process),
         ) as create:
             result = await tool("x", context=ToolCallContext(), lang="py")
         create.assert_awaited_once_with(
@@ -32,7 +33,8 @@ class AstGrepToolTestCase(IsolatedAsyncioTestCase):
         process.communicate = AsyncMock(return_value=(b"", b""))
         process.returncode = 0
         with patch(
-            "asyncio.create_subprocess_exec", AsyncMock(return_value=process)
+            "avalan.tool.code.create_subprocess_exec",
+            AsyncMock(return_value=process),
         ) as create:
             await tool(
                 "p",
@@ -61,7 +63,8 @@ class AstGrepToolTestCase(IsolatedAsyncioTestCase):
         process.communicate = AsyncMock(return_value=(b"", b"err"))
         process.returncode = 1
         with patch(
-            "asyncio.create_subprocess_exec", AsyncMock(return_value=process)
+            "avalan.tool.code.create_subprocess_exec",
+            AsyncMock(return_value=process),
         ):
             with self.assertRaises(RuntimeError):
                 await tool("p", context=ToolCallContext(), lang="py")


### PR DESCRIPTION
## Summary
- mock `create_subprocess_exec` in ast-grep tool tests to avoid invoking external `ast-grep` binary

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c368eadb948323a298c4f93d575e55