### PR TITLE
Add exec_driver_sql to dummy async connection

### DIFF
--- a/tests/tool/database_tool_test.py
+++ b/tests/tool/database_tool_test.py
@@ -23,6 +23,12 @@ def dummy_create_async_engine(dsn: str, **kwargs):
         def __init__(self, conn):
             self.conn = conn
 
+        async def exec_driver_sql(self, sql: str, *args, **kwargs):
+            result = self.conn.exec_driver_sql(sql, *args, **kwargs)
+            if not result.returns_rows:
+                self.conn.commit()
+            return result
+
         async def execute(self, stmt):
             result = self.conn.execute(stmt)
             if not result.returns_rows:


### PR DESCRIPTION
## Summary
- ensure test dummy async engine exposes `exec_driver_sql` to mimic SQLAlchemy's async connection

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c4366941f48323b9bc113a49b75e0e