### PR TITLE
Wrap tool call SSE events with identified output and content items

### DIFF
--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -191,12 +191,12 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
                 ),
             ),
             SimpleNamespace(
-                type="response.custom_tool_call_input.delta",
+                type="response.function_call_arguments.delta",
                 id="c1",
                 delta="{",
             ),
             SimpleNamespace(
-                type="response.custom_tool_call_input.delta",
+                type="response.function_call_arguments.delta",
                 id="c1",
                 delta="}",
             ),

--- a/tests/server/create_response_sse_test.py
+++ b/tests/server/create_response_sse_test.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from json import loads
 from logging import getLogger
 from pathlib import Path
 from types import ModuleType
@@ -8,9 +9,13 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 
 from avalan.agent.orchestrator import Orchestrator
-from avalan.entities import MessageRole, ReasoningToken, ToolCallToken
+from avalan.entities import (
+    MessageRole,
+    ReasoningToken,
+    ToolCall,
+    ToolCallToken,
+)
 from avalan.event import Event, EventType
-from avalan.model import TextGenerationResponse
 from avalan.server.entities import ChatMessage, ResponsesRequest
 
 
@@ -55,9 +60,20 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             for token in tokens:
                 yield token
 
-        response = TextGenerationResponse(
-            gen, logger=logger, use_async_generator=True
-        )
+        class DummyResponse:
+            def __init__(self, items) -> None:  # type: ignore[no-untyped-def]
+                self._items = items
+                self.input_token_count = 0
+                self.output_token_count = 0
+
+            def __aiter__(self):  # type: ignore[override]
+                async def gen():
+                    for item in self._items:
+                        yield item
+
+                return gen()
+
+        response = DummyResponse(tokens)
 
         async def orchestrate_stub(request, logger, orch):
             return response, uuid4(), 0
@@ -87,8 +103,10 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
+            "response.content_part.added",
             "response.custom_tool_call_input.delta",
             "response.custom_tool_call_input.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.content_part.added",
@@ -123,8 +141,12 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             data_lines[content_indices[0]],
         )
         self.assertIn(
-            '"part":{"type":"output_text"}',
+            '"part":{"type":"input_text"}',
             data_lines[content_indices[1]],
+        )
+        self.assertIn(
+            '"part":{"type":"output_text"}',
+            data_lines[content_indices[2]],
         )
         orchestrator.sync_messages.assert_awaited_once()
 
@@ -156,13 +178,20 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             "a4",
         ]
 
-        async def gen():
-            for token in tokens:
-                yield token
+        class DummyResponse:
+            def __init__(self, items) -> None:  # type: ignore[no-untyped-def]
+                self._items = items
+                self.input_token_count = 0
+                self.output_token_count = 0
 
-        response = TextGenerationResponse(
-            gen, logger=logger, use_async_generator=True
-        )
+            def __aiter__(self):  # type: ignore[override]
+                async def gen():
+                    for item in self._items:
+                        yield item
+
+                return gen()
+
+        response = DummyResponse(tokens)
 
         async def orchestrate_stub(request, logger, orch):
             return response, uuid4(), 0
@@ -193,9 +222,11 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
+            "response.content_part.added",
             "response.custom_tool_call_input.delta",
             "response.custom_tool_call_input.delta",
             "response.custom_tool_call_input.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.content_part.added",
@@ -212,9 +243,11 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
+            "response.content_part.added",
             "response.custom_tool_call_input.delta",
             "response.custom_tool_call_input.delta",
             "response.custom_tool_call_input.done",
+            "response.content_part.done",
             "response.output_item.done",
             "response.output_item.added",
             "response.content_part.added",
@@ -265,17 +298,142 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
             data_lines[content_indices[0]],
         )
         self.assertIn(
-            '"part":{"type":"output_text"}',
+            '"part":{"type":"input_text"}',
             data_lines[content_indices[1]],
         )
         self.assertIn(
-            '"part":{"type":"reasoning_text"}',
+            '"part":{"type":"output_text"}',
             data_lines[content_indices[2]],
         )
         self.assertIn(
-            '"part":{"type":"output_text"}',
+            '"part":{"type":"reasoning_text"}',
             data_lines[content_indices[3]],
         )
+        self.assertIn(
+            '"part":{"type":"input_text"}',
+            data_lines[content_indices[4]],
+        )
+        self.assertIn(
+            '"part":{"type":"output_text"}',
+            data_lines[content_indices[5]],
+        )
+        orchestrator.sync_messages.assert_awaited_once()
+
+    async def test_custom_tool_call_call_wraps_items_with_id(self) -> None:
+        logger = getLogger()
+        orchestrator = Orchestrator.__new__(Orchestrator)
+        orchestrator.sync_messages = AsyncMock()
+
+        request = ResponsesRequest(
+            model="m",
+            input=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+
+        call = ToolCall(id="c1", name="t", arguments={})
+        tokens = [
+            "a",
+            Event(type=EventType.TOOL_PROCESS, payload=[call]),
+            ToolCallToken(token="t"),
+            "b",
+        ]
+
+        class DummyResponse:
+            def __init__(self, items) -> None:  # type: ignore[no-untyped-def]
+                self._items = items
+                self.input_token_count = 0
+                self.output_token_count = 0
+
+            def __aiter__(self):  # type: ignore[override]
+                async def gen():
+                    for item in self._items:
+                        yield item
+
+                return gen()
+
+        response = DummyResponse(tokens)
+
+        async def orchestrate_stub(request, logger, orch):
+            return response, uuid4(), 0
+
+        self.responses.orchestrate = orchestrate_stub  # type: ignore[attr-defined]
+
+        streaming_resp = await self.responses.create_response(
+            request, logger, orchestrator
+        )
+        chunks: list[str] = []
+        async for chunk in streaming_resp.body_iterator:
+            chunks.append(
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+            )
+
+        text = "".join(chunks)
+        blocks = [b for b in text.strip().split("\n\n") if b]
+        events = [block.split("\n")[0].split(": ")[1] for block in blocks]
+        data_lines = [block.split("\n")[1] for block in blocks]
+
+        expected = [
+            "response.created",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.done",
+            "response.output_item.done",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.custom_tool_call_input.call",
+            "response.function_call_arguments.delta",
+            "response.custom_tool_call_input.delta",
+            "response.custom_tool_call_input.done",
+            "response.content_part.done",
+            "response.output_item.done",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.done",
+            "response.output_item.done",
+            "response.completed",
+            "done",
+        ]
+
+        self.assertEqual(events, expected)
+
+        func_delta_index = events.index(
+            "response.function_call_arguments.delta"
+        )
+        data = loads(data_lines[func_delta_index][6:])
+        self.assertEqual(data["id"], "c1")
+        delta_obj = loads(data["delta"])
+        self.assertEqual(delta_obj["name"], "t")
+
+        output_indices = [
+            i
+            for i, e in enumerate(events)
+            if e == "response.output_item.added"
+        ]
+        self.assertIn('"id":"c1"', data_lines[output_indices[1]])
+
+        content_indices = [
+            i
+            for i, e in enumerate(events)
+            if e == "response.content_part.added"
+        ]
+        self.assertIn('"id":"c1"', data_lines[content_indices[1]])
+
+        content_done_indices = [
+            i
+            for i, e in enumerate(events)
+            if e == "response.content_part.done"
+        ]
+        self.assertIn('"id":"c1"', data_lines[content_done_indices[1]])
+
+        output_done_indices = [
+            i for i, e in enumerate(events) if e == "response.output_item.done"
+        ]
+        self.assertIn('"id":"c1"', data_lines[output_done_indices[1]])
+
         orchestrator.sync_messages.assert_awaited_once()
 
     async def test_streaming_ignores_events(self) -> None:

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -1,4 +1,5 @@
 from avalan.entities import ReasoningToken, ToolCallToken, Token, TokenDetail
+from json import loads
 from avalan.server.routers.responses import (
     ResponseState,
     _sse,
@@ -18,36 +19,52 @@ class ResponsesUtilsTestCase(TestCase):
 
         self.assertIn(
             "response.reasoning_text.delta",
-            _token_to_sse(rt, 0),
+            _token_to_sse(rt, 0)[0],
         )
         self.assertIn(
             '"delta":"r"',
-            _token_to_sse(rt, 0),
+            _token_to_sse(rt, 0)[0],
         )
         self.assertIn(
             "response.custom_tool_call_input.delta",
-            _token_to_sse(tc, 1),
+            _token_to_sse(tc, 1)[0],
         )
         self.assertIn(
             '"delta":"t"',
-            _token_to_sse(tc, 1),
+            _token_to_sse(tc, 1)[0],
         )
         self.assertIn(
             "response.output_text.delta",
-            _token_to_sse(tok, 2),
+            _token_to_sse(tok, 2)[0],
         )
         self.assertIn(
             '"delta":"a"',
-            _token_to_sse(tok, 2),
+            _token_to_sse(tok, 2)[0],
         )
         self.assertIn(
             '"delta":"b"',
-            _token_to_sse(detail, 3),
+            _token_to_sse(detail, 3)[0],
         )
+
+    def test_token_to_sse_handles_tool_result(self) -> None:
+        from avalan.entities import ToolCall, ToolCallResult
+        from avalan.event import Event, EventType
+
+        call = ToolCall(id="c1", name="t", arguments={"p": 1})
+        result = ToolCallResult(
+            id="c1", call=call, name="t", arguments={"p": 1}, result={"v": 2}
+        )
+        event = Event(type=EventType.TOOL_RESULT, payload={"result": result})
+
+        events = _token_to_sse(event, 0)
+        self.assertIn("response.custom_tool_call_input.call", events[0])
+        self.assertIn("response.function_call_arguments.delta", events[1])
+        data = loads(events[1].split("data: ")[1])
+        self.assertEqual(data["delta"], '{"v": 2}')
 
     def test_switch_state_generates_events(self) -> None:
         state = _new_state(ReasoningToken(token="r"))
-        events = _switch_state(None, state)
+        events = _switch_state(None, state, None, None)
         self.assertEqual(state, ResponseState.REASONING)
         names = [e.split("\n")[0].split(": ")[1] for e in events]
         self.assertEqual(
@@ -56,7 +73,7 @@ class ResponsesUtilsTestCase(TestCase):
         )
 
         new_state = _new_state(ToolCallToken(token="t"))
-        events = _switch_state(state, new_state)
+        events = _switch_state(state, new_state, None, None)
         self.assertEqual(new_state, ResponseState.TOOL_CALLING)
         names = [e.split("\n")[0].split(": ")[1] for e in events]
         self.assertEqual(
@@ -66,18 +83,20 @@ class ResponsesUtilsTestCase(TestCase):
                 "response.content_part.done",
                 "response.output_item.done",
                 "response.output_item.added",
+                "response.content_part.added",
             ],
         )
 
         state = new_state
         new_state = _new_state("answer")
-        events = _switch_state(state, new_state)
+        events = _switch_state(state, new_state, None, None)
         self.assertEqual(new_state, ResponseState.ANSWERING)
         names = [e.split("\n")[0].split(": ")[1] for e in events]
         self.assertEqual(
             names,
             [
                 "response.custom_tool_call_input.done",
+                "response.content_part.done",
                 "response.output_item.done",
                 "response.output_item.added",
                 "response.content_part.added",
@@ -86,7 +105,7 @@ class ResponsesUtilsTestCase(TestCase):
 
         state = new_state
         new_state = _new_state(None)
-        events = _switch_state(state, new_state)
+        events = _switch_state(state, new_state, None, None)
         self.assertIsNone(new_state)
         names = [e.split("\n")[0].split(": ")[1] for e in events]
         self.assertEqual(


### PR DESCRIPTION
## Summary
- emit `response.function_call_arguments.delta` with a JSON payload when a tool call or its result is fully identified
- handle ToolCallToken objects carrying call info by streaming JSON arguments
- adjust tests to expect and parse `function_call_arguments.delta` events

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c46ec1f52483238f47056eb0e552b9