### PR TITLE
Handle Harmony parser without params

### DIFF
--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -142,14 +142,20 @@ class ToolCallParser:
             r"(?:<\|start\|>assistant)?"
             r"<\|channel\|>(?:commentary|analysis)"
             r" to=(?:functions\.)?([\w\.]+)"
+            r"(?:<\|channel\|>(?:commentary|analysis))?"
             r"[^<]*"
-            r"(?:<\|constrain\|>json)?<\|message\|>(\{.*?\})<\|call\|>"
+            r"(?:<\|constrain\|>json)?"
+            r"<\|message\|>\s*(\{.*?\})?\s*<\|call\|>"
         )
         for match in finditer(pattern, text, DOTALL):
-            try:
-                args = loads(match.group(2))
-            except JSONDecodeError:
-                continue
+            args_text = match.group(2)
+            if args_text:
+                try:
+                    args = loads(args_text)
+                except JSONDecodeError:
+                    continue
+            else:
+                args = {}
             tool_calls.append(
                 ToolCall(id=uuid4(), name=match.group(1), arguments=args)
             )

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -187,6 +187,24 @@ class ToolCallParserHarmonyTestCase(TestCase):
             ]
             self.assertEqual(parser(text), expected)
 
+    def test_commentary_channel_after_to(self):
+        parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        text = (
+            "<|start|>assistant<|channel|>commentary"
+            " to=functions.database.tables<|channel|>commentary"
+            " <|constrain|>json<|message|>{}<|call|>"
+        )
+        call_id = _uuid4()
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="database.tables",
+                    arguments={},
+                )
+            ]
+            self.assertEqual(parser(text), expected)
+
     def test_invalid_json(self):
         parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
         text = (


### PR DESCRIPTION
## Summary
- allow Harmony tool call parsing when `to=` is followed by an extra channel marker
- support Harmony tool calls with no arguments
- add regression test for Harmony tool calls that omit arguments and repeat `channel`

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c57fe9e36083239940c9b4effc14ff