### PR TITLE
Encode OpenAI tool errors as JSON

### DIFF
--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -188,12 +188,11 @@ class OpenAIClient(TextGenerationVendor):
             result_message = {
                 "type": "function_call_output",
                 "call_id": result.call.id,
-                "output": to_json(
-                    result.result
-                    if isinstance(result, ToolCallResult)
-                    else result.message
-                ),
             }
+            if isinstance(result, ToolCallResult):
+                result_message["output"] = to_json(result.result)
+            else:
+                result_message["output"] = to_json({"error": result.message})
             messages.append(result_message)
         return messages
 

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -188,11 +188,12 @@ class OpenAIClient(TextGenerationVendor):
             result_message = {
                 "type": "function_call_output",
                 "call_id": result.call.id,
+                "output": to_json(
+                    result.result
+                    if isinstance(result, ToolCallResult)
+                    else {"error": result.message}
+                ),
             }
-            if isinstance(result, ToolCallResult):
-                result_message["output"] = to_json(result.result)
-            else:
-                result_message["output"] = to_json({"error": result.message})
             messages.append(result_message)
         return messages
 


### PR DESCRIPTION
## Summary
- wrap OpenAI vendor tool errors in a JSON object under an `error` key
- add regression test for OpenAI tool error formatting

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c6c01a34908323acc402bc70ae1cb3