### PR TITLE
Allow Coveralls failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
         run: poetry run pytest --cov=src/ --cov-report=xml
 
       - name: Upload coverage to Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- allow Coveralls upload step to fail without failing workflow

## Testing
- `make lint`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68c6d11fbd88832398c737d925c496ae