### PR TITLE
Add test coverage for harmony parser

### DIFF
--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -205,6 +205,19 @@ class ToolCallParserHarmonyTestCase(TestCase):
             ]
             self.assertEqual(parser(text), expected)
 
+    def test_empty_message(self):
+        parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        text = (
+            "<|channel|>commentary to=functions.database.ping "
+            "<|message|><|call|>"
+        )
+        call_id = _uuid4()
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(id=call_id, name="database.ping", arguments={})
+            ]
+            self.assertEqual(parser(text), expected)
+
     def test_invalid_json(self):
         parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
         text = (


### PR DESCRIPTION
## Summary
- test harmony tool parser with empty message to ensure proper default arguments

## Testing
- `poetry run pytest --verbose -s --cov=src/ --cov-report=json`
- `jq -r '.files["src/avalan/tool/parser.py"].summary' coverage.json`


------
https://chatgpt.com/codex/tasks/task_e_68c811a0eee48323b81bfa8df095e904