### PR TITLE
Update NVIDIA bitsandbytes wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,8 @@ apple = [
 ]
 nvidia = [
   "vllm==0.10.0",
-  "bitsandbytes==0.46.1",
+  # requires NVIDIA GPUs with CUDA 12.6 runtime to match the bitsandbytes wheel
+  "bitsandbytes-cuda126==0.46.1",
 ]
 all = [
   "accelerate==1.9.0",


### PR DESCRIPTION
## Summary
- use the CUDA 12.6-specific bitsandbytes wheel in the nvidia optional dependency set
- document the CUDA 12.6 runtime requirement alongside the dependency entry

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68cad5f320b08323b2f42c1300e53a43