### PR TITLE
Log tool events at info level

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -8,6 +8,7 @@ from ..entities import (
     ToolFormat,
     ToolManagerSettings,
 )
+from ..event import Event, EventType
 from ..event.manager import EventManager
 from ..memory.manager import MemoryManager
 from ..memory.partitioner.text import TextPartitioner
@@ -325,9 +326,20 @@ class OrchestratorLoader:
 
         event_manager = EventManager()
         if settings.log_events:
-            event_manager.add_listener(
-                lambda e: _l("%s", e.payload, inner_type=f"Event {e.type}")
-            )
+
+            def _log_event(event: Event) -> None:
+                is_info_event = event.type in (
+                    EventType.TOOL_PROCESS,
+                    EventType.TOOL_RESULT,
+                )
+                _l(
+                    "%s",
+                    event.payload,
+                    inner_type=f"Event {event.type}",
+                    is_debug=not is_info_event,
+                )
+
+            event_manager.add_listener(_log_event)
 
         _l("Loading memory manager for agent %s", settings.agent_id)
 


### PR DESCRIPTION
## Summary
- log tool process and tool result events at INFO while keeping other event logs at DEBUG within the orchestrator loader

## Testing
- poetry run pytest --verbose -s
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68cc7a5d8be48323a35ef449d83af110