### PR TITLE
Adjust MCP router tests for explicit streaming requests

### DIFF
--- a/tests/server/mcp_router_test.py
+++ b/tests/server/mcp_router_test.py
@@ -95,6 +95,7 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
                 "arguments": {
                     "model": "gpt",
                     "input": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
                 },
             },
         }
@@ -331,6 +332,7 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
                 "arguments": {
                     "model": "gpt",
                     "input": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
                 },
             },
         }


### PR DESCRIPTION
## Summary
- request streaming explicitly in MCP router tests to reflect the updated default behavior

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68cc96c526ac832381dfb4bed4e703e4