### PR TITLE
Add server lifespan tests

### DIFF
--- a/tests/server/orchestrator_di_test.py
+++ b/tests/server/orchestrator_di_test.py
@@ -82,6 +82,15 @@ class OrchestratorDiTestCase(IsolatedAsyncioTestCase):
         self.assertIs(result, orchestrator)
         loader.from_settings.assert_called_once()
 
+    async def test_di_get_orchestrator_returns_existing(self) -> None:
+        orchestrator = DummyOrchestrator()
+        state = SimpleNamespace(orchestrator=orchestrator)
+        request = SimpleNamespace(app=SimpleNamespace(state=state))
+
+        result = await di_get_orchestrator(request)
+
+        self.assertIs(result, orchestrator)
+
     async def test_di_get_logger(self) -> None:
         logger = MagicMock(spec=Logger)
         app_state = SimpleNamespace(logger=logger)


### PR DESCRIPTION
## Summary
- add an anyio-based test covering agents_server lifespan initialization and dependency wiring
- extend orchestrator DI tests to verify returning an already prepared orchestrator

## Testing
- poetry run pytest --verbose -s


------
https://chatgpt.com/codex/tasks/task_e_68ccb680b79483238905d99275f6d9c9