### PR TITLE
Add MCP router coverage tests

### DIFF
--- a/src/avalan/server/routers/mcp.py
+++ b/src/avalan/server/routers/mcp.py
@@ -427,9 +427,7 @@ async def _start_tool_streaming_response(
             "jsonrpc": "2.0",
             "id": request_id,
             "result": {
-                "content": (
-                    [{"type": "text", "text": text}] if text else []
-                ),
+                "content": [{"type": "text", "text": text}] if text else [],
                 "structuredContent": summary,
             },
         }

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -1605,7 +1605,9 @@ class LoaderFromSettingsTestCase(IsolatedAsyncioTestCase):
                 self.listeners: list[Callable[[Event], Any]] = []
 
             def add_listener(
-                self, listener: Callable[[Event], Any], event_types: Any | None = None
+                self,
+                listener: Callable[[Event], Any],
+                event_types: Any | None = None,
             ) -> None:
                 self.listeners.append(listener)
 
@@ -1678,7 +1680,9 @@ class LoaderFromSettingsTestCase(IsolatedAsyncioTestCase):
         logger.log.assert_called_once()
         level, message, payload = logger.log.call_args.args
         self.assertEqual(level, INFO)
-        self.assertEqual(message, "<Event tool_process @ OrchestratorLoader> %s")
+        self.assertEqual(
+            message, "<Event tool_process @ OrchestratorLoader> %s"
+        )
         self.assertEqual(payload, tool_event.payload)
 
         logger.log.reset_mock()

--- a/tests/server/agents_server_lifespan_test.py
+++ b/tests/server/agents_server_lifespan_test.py
@@ -50,10 +50,15 @@ async def test_agents_server_lifespan_initializes_state() -> None:
 
     with patch.dict(sys.modules, {"uvicorn": uvicorn_module}):
         with (
-            patch("avalan.server.FastAPI", side_effect=build_fastapi) as fastapi_mock,
-            patch("avalan.server.OrchestratorLoader", side_effect=build_loader) as loader_cls,
             patch(
-                "avalan.server.OrchestratorContext", return_value=context_instance
+                "avalan.server.FastAPI", side_effect=build_fastapi
+            ) as fastapi_mock,
+            patch(
+                "avalan.server.OrchestratorLoader", side_effect=build_loader
+            ) as loader_cls,
+            patch(
+                "avalan.server.OrchestratorContext",
+                return_value=context_instance,
             ) as context_cls,
             patch(
                 "avalan.server.mcp_router.MCPResourceStore",
@@ -61,7 +66,9 @@ async def test_agents_server_lifespan_initializes_state() -> None:
             ) as resource_store_cls,
             patch("avalan.server.logger_replace") as logger_replace,
             patch.dict(os.environ, {}, clear=True),
-            patch("avalan.server.uuid4", return_value=generated_participant_id) as uuid4_mock,
+            patch(
+                "avalan.server.uuid4", return_value=generated_participant_id
+            ) as uuid4_mock,
         ):
             server = agents_server(
                 hub=hub,

--- a/tests/server/mcp_router_test.py
+++ b/tests/server/mcp_router_test.py
@@ -1,16 +1,99 @@
-from avalan.entities import ReasoningToken, ToolCall, ToolCallResult, Token
+from avalan.entities import (
+    ReasoningToken,
+    ToolCall,
+    ToolCallError,
+    ToolCallResult,
+    ToolCallToken,
+    Token,
+    TokenDetail,
+)
 from avalan.event import Event, EventType
 from avalan.server.entities import ResponsesRequest
 from avalan.server.routers import mcp as mcp_router
-from asyncio import Event as AsyncEvent
-from asyncio import run
+from contextlib import suppress
+from asyncio import (
+    CancelledError,
+    Event as AsyncEvent,
+    run,
+)
 from logging import getLogger
 from json import dumps, loads
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, AsyncIterator
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+
+class DummyRequest:
+    def __init__(self, body: bytes | list[bytes]) -> None:
+        if isinstance(body, list):
+            self._body = body
+        else:
+            self._body = [body]
+        self.state = SimpleNamespace()
+        self.app = SimpleNamespace(state=SimpleNamespace())
+
+    async def stream(self):
+        for chunk in self._body:
+            yield chunk
+
+
+class DummyResponse:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+        self._index = 0
+        self.input_token_count = 3
+        self.output_token_count = 2
+        self._response_iterator = None
+        self._closed = False
+        self.text = ""
+
+    def __aiter__(self):
+        self._index = 0
+        self._response_iterator = self
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._index]
+        self._index += 1
+        return item() if callable(item) else item
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+    async def to_str(self) -> str:
+        return self.text
+
+
+class DummyOrchestrator(mcp_router.Orchestrator):
+    def __init__(self, tool: Any) -> None:
+        self._tool = tool
+
+    @property
+    def tool(self) -> Any:
+        return self._tool
+
+
+class StubTask:
+    def __init__(self, coro: Any) -> None:
+        self._coro = coro
+
+    def cancel(self) -> None:
+        with suppress(RuntimeError):
+            self._coro.close()
+
+    def __await__(self):  # type: ignore[override]
+        async def done() -> None:
+            return None
+
+        return done().__await__()
+
+
+def fake_create_task(coro: Any) -> StubTask:
+    return StubTask(coro)
 
 
 class MCPResourceStoreTestCase(TestCase):
@@ -32,49 +115,211 @@ class MCPResourceStoreTestCase(TestCase):
         self.assertIn("call-1:stdout", streams)
         self.assertIn("call-1:logs", streams)
 
-
-class DummyRequest:
-    def __init__(self, body: bytes) -> None:
-        self._body = body
-        self.state = SimpleNamespace()
-        self.app = SimpleNamespace(state=SimpleNamespace())
-
-    async def stream(self):
-        yield self._body
+    def test_extract_append_streams_ignores_non_dict(self) -> None:
+        self.assertEqual(
+            mcp_router._extract_append_streams("call", [1, 2]), {}
+        )
 
 
-class DummyResponse:
-    def __init__(self, items: list[Any]) -> None:
-        self._items = items
-        self._index = 0
-        self.input_token_count = 3
-        self.output_token_count = 2
-        self._response_iterator = None
-        self._closed = False
+class MCPUtilityTestCase(TestCase):
+    def _request(self) -> DummyRequest:
+        request = DummyRequest(b"")
+        request.app.title = ""
+        request.app.version = None
+        return request
 
-    def __aiter__(self):
-        self._index = 0
-        self._response_iterator = self
-        return self
+    def test_extract_call_arguments_invalid_tool(self) -> None:
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            mcp_router._extract_call_arguments(
+                "tools/call", {"name": "invalid", "arguments": {}}
+            )
+        self.assertIn("Unsupported tool", str(exc.exception.detail))
 
-    async def __anext__(self):
-        if self._index >= len(self._items):
-            raise StopAsyncIteration
-        item = self._items[self._index]
-        self._index += 1
-        return item
+    def test_extract_call_arguments_missing_arguments(self) -> None:
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            mcp_router._extract_call_arguments(
+                "tools/call", {"name": "run", "arguments": "value"}
+            )
+        self.assertIn("Invalid tool arguments", str(exc.exception.detail))
 
-    async def aclose(self) -> None:
-        self._closed = True
+    def test_extract_call_arguments_tools_run_direct(self) -> None:
+        params = {
+            "model": "m",
+            "input": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        }
+        result = mcp_router._extract_call_arguments("tools/run", params)
+        self.assertIs(result, params)
 
+    def test_extract_call_arguments_tools_run_invalid(self) -> None:
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            mcp_router._extract_call_arguments(
+                "tools/run",
+                {"name": "run", "arguments": "bad"},
+            )
+        self.assertIn("Invalid tool arguments", str(exc.exception.detail))
 
-class DummyOrchestrator(mcp_router.Orchestrator):
-    def __init__(self, tool: Any) -> None:
-        self._tool = tool
+    def test_extract_call_arguments_unsupported_method(self) -> None:
+        with self.assertRaises(mcp_router.HTTPException):
+            mcp_router._extract_call_arguments("other", {})
 
-    @property
-    def tool(self) -> Any:
-        return self._tool
+    def test_collect_tool_descriptions(self) -> None:
+        descriptions = mcp_router._collect_tool_descriptions()
+        self.assertEqual(len(descriptions), 1)
+        self.assertEqual(descriptions[0]["name"], "run")
+        self.assertEqual(
+            descriptions[0]["inputSchema"],
+            ResponsesRequest.model_json_schema(),
+        )
+
+    def test_token_text_variants(self) -> None:
+        token = Token(token="a")
+        detail = TokenDetail(token="b")
+        self.assertEqual(mcp_router._token_text(token), "a")
+        self.assertEqual(mcp_router._token_text(detail), "b")
+        self.assertEqual(mcp_router._token_text("text"), "text")
+        self.assertEqual(mcp_router._token_text(123), "")
+
+    def test_tool_call_token_notification_variants(self) -> None:
+        empty = ToolCallToken(token="")
+        self.assertIsNone(mcp_router._tool_call_token_notification(empty))
+
+        delta = ToolCallToken(token="chunk")
+        message = mcp_router._tool_call_token_notification(delta)
+        self.assertEqual(
+            message["params"]["message"]["delta"],
+            "chunk",
+        )
+
+        call = ToolCall(id="t", name="run", arguments={})
+        token = ToolCallToken(token="ignored", call=call)
+        notification = mcp_router._tool_call_token_notification(token)
+        payload = notification["params"]["message"]
+        self.assertEqual(payload["toolCallId"], "t")
+        self.assertEqual(
+            loads(payload["delta"]),
+            {"id": "t", "name": "run", "arguments": {}},
+        )
+
+    def test_resource_notification_variants(self) -> None:
+        resource = mcp_router.MCPResource(
+            id="1",
+            uri="uri",
+            http_uri="/res/1",
+            mime_type="text/plain",
+            text="payload",
+            revision=1,
+        )
+        open_payload = mcp_router._resource_notification(resource)
+        self.assertEqual(
+            open_payload["params"]["resources"][0]["delta"]["set"]["text"],
+            "payload",
+        )
+
+        resource.closed = True
+        closed_payload = mcp_router._resource_notification(resource)
+        self.assertTrue(closed_payload["params"]["resources"][0]["closed"])
+
+    def test_tool_call_event_item_variants(self) -> None:
+        call = ToolCall(id="c1", name="run", arguments={})
+        error_event = Event(
+            type=EventType.TOOL_RESULT,
+            payload={
+                "result": ToolCallError(
+                    id="e1",
+                    call=call,
+                    name="run",
+                    arguments={},
+                    error=Exception("boom"),
+                    message="boom",
+                )
+            },
+        )
+        error_item = mcp_router._tool_call_event_item(error_event)
+        self.assertEqual(error_item["error"], "boom")
+
+        result_event = Event(
+            type=EventType.TOOL_RESULT,
+            payload={
+                "result": ToolCallResult(
+                    id="r1",
+                    call=call,
+                    name="run",
+                    arguments={},
+                    result={"answer": 1},
+                )
+            },
+        )
+        result_item = mcp_router._tool_call_event_item(result_event)
+        self.assertIn("result", result_item)
+
+        list_event = Event(
+            type=EventType.TOOL_PROCESS,
+            payload=[call],
+        )
+        list_item = mcp_router._tool_call_event_item(list_event)
+        self.assertEqual(list_item["id"], "c1")
+
+        none_event = Event(type=EventType.TOOL_PROCESS, payload=None)
+        self.assertIsNone(mcp_router._tool_call_event_item(none_event))
+
+    def test_get_resource_store_reuses_instance(self) -> None:
+        request = self._request()
+        first = mcp_router._get_resource_store(request)
+        second = mcp_router._get_resource_store(request)
+        self.assertIs(first, second)
+
+    def test_server_info_defaults_and_state_version(self) -> None:
+        request = self._request()
+        info = mcp_router._server_info(request)
+        self.assertEqual(info["name"], "avalan")
+        self.assertEqual(info["version"], "0.0.0")
+
+        request.app.state.version = "1.2.3"
+        info_state = mcp_router._server_info(request)
+        self.assertEqual(info_state["version"], "1.2.3")
+
+    def test_server_info_app_version(self) -> None:
+        request = self._request()
+        request.app.title = "Test"
+        request.app.version = "2.0"
+        info = mcp_router._server_info(request)
+        self.assertEqual(info, {"name": "Test", "version": "2.0"})
+
+    def test_server_capabilities_with_tools(self) -> None:
+        tool_manager = SimpleNamespace(is_empty=False)
+        orchestrator = SimpleNamespace(tool=tool_manager)
+        caps = mcp_router._server_capabilities(orchestrator)
+        self.assertTrue(caps["tools"]["call"])
+
+    def test_server_capabilities_without_tools(self) -> None:
+        orchestrator = SimpleNamespace(tool=None)
+        caps = mcp_router._server_capabilities(orchestrator)
+        self.assertFalse(caps["tools"]["call"])
+
+    def test_handle_list_tools_invalid_params(self) -> None:
+        request = self._request()
+        message = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "tools/list",
+            "params": "bad",
+        }
+        with self.assertRaises(mcp_router.HTTPException):
+            mcp_router._handle_list_tools_message(
+                request, MagicMock(), SimpleNamespace(tool=None), message
+            )
+
+    def test_handle_initialize_message_defaults(self) -> None:
+        request = self._request()
+        response = mcp_router._handle_initialize_message(
+            request,
+            MagicMock(),
+            SimpleNamespace(tool=None),
+            {"jsonrpc": "2.0"},
+        )
+        payload = loads(response.body.decode("utf-8"))
+        self.assertEqual(payload["result"]["protocolVersion"], "1.0.0")
 
 
 class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
@@ -169,7 +414,9 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
 
         orchestrator.sync_messages.assert_awaited()
 
-        messages = [loads(part) for part in "".join(chunks).splitlines() if part]
+        messages = [
+            loads(part) for part in "".join(chunks).splitlines() if part
+        ]
         dict_messages = [msg for msg in messages if isinstance(msg, dict)]
         methods = [
             msg.get("method") for msg in dict_messages if "method" in msg
@@ -212,7 +459,9 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
         ):
             chunks.append(chunk.decode("utf-8"))
 
-        messages = [loads(part) for part in "".join(chunks).splitlines() if part]
+        messages = [
+            loads(part) for part in "".join(chunks).splitlines() if part
+        ]
         dict_messages = [msg for msg in messages if isinstance(msg, dict)]
         errors = [msg["error"] for msg in dict_messages if "error" in msg]
         self.assertTrue(errors)
@@ -350,3 +599,460 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(rid, "call-2")
         self.assertTrue(req_model.stream)
         self.assertTrue(token)
+
+
+class MCPRouterEdgeCaseAsyncTestCase(IsolatedAsyncioTestCase):
+    def _responses_request(self, stream: bool = False) -> ResponsesRequest:
+        return ResponsesRequest.model_validate(
+            {
+                "model": "test",
+                "input": [{"role": "user", "content": "hi"}],
+                "stream": stream,
+            }
+        )
+
+    async def test_expect_jsonrpc_message_invalid_payload(self) -> None:
+        body = b"[1]"
+        request = DummyRequest(body)
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            await mcp_router._expect_jsonrpc_message(request, {"tools/list"})
+        self.assertIn("Invalid MCP payload", str(exc.exception.detail))
+
+    async def test_expect_jsonrpc_message_unsupported_method(self) -> None:
+        message = {"jsonrpc": "2.0", "id": "x", "method": "bad"}
+        body = (dumps(message) + mcp_router.RS).encode("utf-8")
+        request = DummyRequest(body)
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            await mcp_router._expect_jsonrpc_message(request, {"tools/list"})
+        self.assertIn("Unsupported MCP method", str(exc.exception.detail))
+
+    async def test_consume_call_request_missing_params(self) -> None:
+        message = {
+            "jsonrpc": "2.0",
+            "method": "tools/run",
+            "params": "bad",
+        }
+        body = (dumps(message) + mcp_router.RS).encode("utf-8")
+        request = DummyRequest(body)
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            await mcp_router._consume_call_request(request)
+        self.assertIn("Missing MCP params", str(exc.exception.detail))
+
+    async def test_consume_call_request_invalid_arguments(self) -> None:
+        message = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "run", "arguments": []},
+        }
+        body = (dumps(message) + mcp_router.RS).encode("utf-8")
+        request = DummyRequest(body)
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            await mcp_router._consume_call_request(request)
+        self.assertIn("Invalid tool arguments", str(exc.exception.detail))
+
+    async def test_consume_call_request_generates_defaults(self) -> None:
+        message = {
+            "jsonrpc": "2.0",
+            "method": "tools/run",
+            "params": {
+                "model": "m",
+                "input": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+        }
+        follow_up = {"jsonrpc": "2.0", "method": "ping"}
+        body = (
+            dumps(message) + mcp_router.RS + dumps(follow_up) + mcp_router.RS
+        ).encode("utf-8")
+        request = DummyRequest(body)
+        request.app.state.mcp_resource_base_path = "/m"
+        with patch.object(mcp_router, "uuid4", return_value=UUID(int=1234)):
+            (
+                request_id,
+                model,
+                progress,
+            ) = await mcp_router._consume_call_request(request)
+        self.assertEqual(request_id, str(UUID(int=1234)))
+        self.assertEqual(progress, str(UUID(int=1234)))
+        self.assertFalse(model.stream)
+        remaining = []
+        async for item in mcp_router._iter_jsonrpc_messages(request):
+            remaining.append(item)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["method"], "ping")
+
+    async def test_iter_jsonrpc_messages_invalid_json(self) -> None:
+        request = DummyRequest(b"{invalid}")
+        with self.assertRaises(mcp_router.HTTPException) as exc:
+            async for _ in mcp_router._iter_jsonrpc_messages(request):
+                pass
+        self.assertIn("Invalid MCP payload", str(exc.exception.detail))
+
+    async def test_iter_jsonrpc_messages_uses_stored_iterator(self) -> None:
+        async def stored() -> AsyncIterator[dict[str, Any]]:
+            yield {"jsonrpc": "2.0", "method": "tools/list"}
+
+        request = DummyRequest(b"")
+        request.state._mcp_message_iter = stored()
+        messages = []
+        async for item in mcp_router._iter_jsonrpc_messages(request):
+            messages.append(item)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["method"], "tools/list")
+
+    async def test_watch_for_cancellation_sets_event(self) -> None:
+        async def generator() -> AsyncIterator[dict[str, Any]]:
+            yield {"method": "notifications/cancelled"}
+
+        cancel_event = AsyncEvent()
+        logger = MagicMock()
+        await mcp_router._watch_for_cancellation(
+            generator(), cancel_event, logger
+        )
+        self.assertTrue(cancel_event.is_set())
+
+    async def test_start_tool_streaming_response_non_stream(self) -> None:
+        request = DummyRequest(b"")
+        responses_request = self._responses_request(stream=False)
+        response_object = DummyResponse([])
+        response_object.text = "answer"
+        response_object.input_token_count = 1
+        response_object.output_token_count = 2
+        orchestrator = MagicMock()
+        orchestrator.sync_messages = AsyncMock()
+        logger = getLogger("test.stream.non")
+
+        async def no_messages():
+            if False:
+                yield {}
+
+        request.state._mcp_message_iter = no_messages()
+        with (
+            patch.object(
+                mcp_router,
+                "orchestrate",
+                AsyncMock(return_value=(response_object, UUID(int=1), 42)),
+            ),
+            patch.object(
+                mcp_router, "create_task", side_effect=fake_create_task
+            ),
+        ):
+            result = await mcp_router._start_tool_streaming_response(
+                request,
+                logger,
+                orchestrator,
+                "req-1",
+                responses_request,
+                "progress",
+            )
+        self.assertIsInstance(result, mcp_router.JSONResponse)
+        payload = loads(result.body.decode("utf-8"))
+        self.assertEqual(
+            payload["result"]["structuredContent"]["model"], "test"
+        )
+        self.assertEqual(
+            payload["result"]["structuredContent"]["usage"]["total_tokens"],
+            3,
+        )
+
+    async def test_start_tool_streaming_response_streaming(self) -> None:
+        async def stream(**_: Any) -> AsyncIterator[bytes]:
+            yield b'{"chunk":1}\n'
+
+        request = DummyRequest(b"")
+        responses_request = self._responses_request(stream=True)
+        response_object = DummyResponse([])
+        orchestrator = MagicMock()
+        orchestrator.sync_messages = AsyncMock()
+        logger = getLogger("test.stream.yes")
+
+        async def no_messages():
+            if False:
+                yield {}
+
+        request.state._mcp_message_iter = no_messages()
+        with (
+            patch.object(
+                mcp_router,
+                "orchestrate",
+                AsyncMock(return_value=(response_object, UUID(int=2), 99)),
+            ),
+            patch.object(
+                mcp_router, "_stream_mcp_response", side_effect=stream
+            ),
+            patch.object(
+                mcp_router, "create_task", side_effect=fake_create_task
+            ),
+        ):
+            result = await mcp_router._start_tool_streaming_response(
+                request,
+                logger,
+                orchestrator,
+                "req-2",
+                responses_request,
+                "progress",
+            )
+        self.assertIsInstance(result, mcp_router.StreamingResponse)
+        chunks = []
+        try:
+            async for chunk in result.body_iterator:  # type: ignore[attr-defined]
+                chunks.append(chunk)
+        except CancelledError:
+            pass
+        self.assertTrue(chunks)
+        self.assertTrue(any(b"answer.completed" in chunk for chunk in chunks))
+        self.assertTrue(any(b"structuredContent" in chunk for chunk in chunks))
+
+    async def test_stream_mcp_response_handles_tool_error(self) -> None:
+        call = ToolCall(id="c", name="run", arguments={})
+        tool_error = ToolCallError(
+            id="err",
+            call=call,
+            name="run",
+            arguments={},
+            error=Exception("x"),
+            message="bad",
+        )
+        response = DummyResponse(
+            [
+                Event(
+                    type=EventType.TOOL_RESULT,
+                    payload={"result": tool_error},
+                    started=1.0,
+                    finished=2.0,
+                    elapsed=1.0,
+                ),
+                ToolCallToken(token="input", call=None),
+            ]
+        )
+        response.input_token_count = 0
+        response.output_token_count = 0
+        orchestrator = MagicMock()
+        orchestrator.sync_messages = AsyncMock()
+        cancel_event = AsyncEvent()
+        store = mcp_router.MCPResourceStore()
+        request_model = self._responses_request(stream=True)
+        payloads = []
+        async for chunk in mcp_router._stream_mcp_response(
+            request_id="id",
+            request_model=request_model,
+            response=response,
+            response_id=uuid4(),
+            timestamp=1,
+            progress_token="tok",
+            orchestrator=orchestrator,
+            logger=MagicMock(),
+            resource_store=store,
+            base_path="/m",
+            cancel_event=cancel_event,
+        ):
+            payloads.append(loads(chunk.decode("utf-8")))
+        orchestrator.sync_messages.assert_awaited()
+        errors = [
+            item
+            for item in payloads
+            if isinstance(item, dict)
+            and item.get("method") == "notifications/message"
+        ]
+        self.assertTrue(any("error" in e["params"]["message"] for e in errors))
+
+    async def test_stream_mcp_response_cancellation_closes_resources(
+        self,
+    ) -> None:
+        cancel_event = AsyncEvent()
+        store = mcp_router.MCPResourceStore()
+        call = ToolCall(id="c", name="run", arguments={})
+        tool_result = ToolCallResult(
+            id="res",
+            call=call,
+            name="run",
+            arguments={},
+            result={"stdout": "log"},
+        )
+
+        def cancel() -> Token:
+            cancel_event.set()
+            return Token(token="ignored")
+
+        response = DummyResponse(
+            [
+                Event(
+                    type=EventType.TOOL_RESULT,
+                    payload={"result": tool_result},
+                ),
+                cancel,
+            ]
+        )
+        response.input_token_count = 1
+        response.output_token_count = 1
+        orchestrator = MagicMock()
+        orchestrator.sync_messages = AsyncMock()
+        request_model = self._responses_request(stream=True)
+        payloads = []
+        async for chunk in mcp_router._stream_mcp_response(
+            request_id="id",
+            request_model=request_model,
+            response=response,
+            response_id=uuid4(),
+            timestamp=1,
+            progress_token="tok",
+            orchestrator=orchestrator,
+            logger=MagicMock(),
+            resource_store=store,
+            base_path="/base",
+            cancel_event=cancel_event,
+        ):
+            payloads.append(loads(chunk.decode("utf-8")))
+        orchestrator.sync_messages.assert_awaited()
+        self.assertTrue(response._closed)
+        resource_updates = [
+            item
+            for item in payloads
+            if isinstance(item, dict)
+            and item.get("method") == "notifications/resources/updated"
+        ]
+        self.assertTrue(resource_updates)
+        self.assertTrue(
+            resource_updates[-1]["params"]["resources"][0]["closed"]
+        )
+        errors = [
+            item
+            for item in payloads
+            if isinstance(item, dict) and "error" in item
+        ]
+        self.assertEqual(errors[-1]["error"]["code"], -32000)
+
+    async def test_create_router_mcp_rpc_tools_run(self) -> None:
+        router = mcp_router.create_router()
+        endpoint = None
+        for route in router.routes:
+            if getattr(route, "path", None) == "/":
+                endpoint = route.endpoint
+                break
+        self.assertIsNotNone(endpoint)
+
+        request = DummyRequest(
+            (
+                dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "call",
+                        "method": "tools/run",
+                        "params": {
+                            "model": "m",
+                            "input": [{"role": "user", "content": "hello"}],
+                        },
+                    }
+                )
+                + mcp_router.RS
+            ).encode("utf-8")
+        )
+        request.app.state.mcp_resource_base_path = "/base"
+
+        async def fake_start(*args, **kwargs):
+            return mcp_router.PlainTextResponse("ok")
+
+        orchestrator = DummyOrchestrator(SimpleNamespace(is_empty=True))
+        with patch.object(
+            mcp_router,
+            "_start_tool_streaming_response",
+            side_effect=fake_start,
+        ) as starter:
+            response = await endpoint(
+                request,
+                logger=getLogger("test.mcp.rpc"),
+                orchestrator=orchestrator,
+            )
+        self.assertIsInstance(response, mcp_router.PlainTextResponse)
+        self.assertTrue(starter.called)
+
+    async def test_create_router_mcp_rpc_unsupported_method(self) -> None:
+        router = mcp_router.create_router()
+        endpoint = None
+        for route in router.routes:
+            if getattr(route, "path", None) == "/":
+                endpoint = route.endpoint
+                break
+        self.assertIsNotNone(endpoint)
+
+        request = DummyRequest(
+            (
+                dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "x",
+                        "method": "unknown",
+                    }
+                )
+                + mcp_router.RS
+            ).encode("utf-8")
+        )
+        orchestrator = DummyOrchestrator(SimpleNamespace(is_empty=True))
+        with self.assertRaises(mcp_router.HTTPException):
+            await endpoint(
+                request,
+                logger=getLogger("test.mcp.rpc"),
+                orchestrator=orchestrator,
+            )
+
+    async def test_mcp_run_tool_endpoint(self) -> None:
+        router = mcp_router.create_router()
+        endpoint = None
+        for route in router.routes:
+            if getattr(route, "path", None) == "/tools/run":
+                endpoint = route.endpoint
+                break
+        self.assertIsNotNone(endpoint)
+
+        body = (
+            dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "call",
+                    "method": "tools/run",
+                    "params": {
+                        "model": "m",
+                        "input": [{"role": "user", "content": "hi"}],
+                    },
+                }
+            )
+            + mcp_router.RS
+        ).encode("utf-8")
+        request = DummyRequest(body)
+        request.app.state.mcp_resource_base_path = "/base"
+
+        async def fake_start(*args, **kwargs):
+            return mcp_router.PlainTextResponse("stream")
+
+        orchestrator = DummyOrchestrator(SimpleNamespace(is_empty=False))
+        with patch.object(
+            mcp_router,
+            "_start_tool_streaming_response",
+            side_effect=fake_start,
+        ) as starter:
+            response = await endpoint(
+                request,
+                logger=getLogger("test.mcp.run"),
+                orchestrator=orchestrator,
+            )
+        self.assertIsInstance(response, mcp_router.PlainTextResponse)
+        self.assertTrue(starter.called)
+
+    async def test_mcp_get_resource_endpoint(self) -> None:
+        request = DummyRequest(b"")
+        store = mcp_router.MCPResourceStore()
+        request.app.state.mcp_resource_store = store
+        created = await store.create(base_path="/base", initial_text="hello")
+        router = mcp_router.create_router()
+        endpoint = None
+        for route in router.routes:
+            if getattr(route, "path", None) == "/resources/{resource_id}":
+                endpoint = route.endpoint
+                break
+        self.assertIsNotNone(endpoint)
+        response = await endpoint(  # type: ignore[operator]
+            request,
+            resource_id=created.id,
+        )
+        self.assertIsInstance(response, mcp_router.PlainTextResponse)
+        self.assertEqual(response.body.decode("utf-8"), "hello")


### PR DESCRIPTION
## Summary
- build comprehensive MCP router tests covering resource store helpers, JSON-RPC dispatch, streaming flows, cancellation, and error handling
- flatten the JSON payload construction in `_start_tool_streaming_response` for formatter compliance
- apply minor formatting updates to existing loader and server lifespan tests to satisfy linters

## Testing
- poetry run pytest --verbose -s
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68ccbb0f0cc48323b2a16b0a0acfa6bf