### PR TITLE
Adjust MCP tool request to use input string

### DIFF
--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -174,6 +174,12 @@ class ResponsesRequest(BaseModel):
         return self.input
 
 
+class MCPToolRequest(BaseModel):
+    input_string: str = Field(
+        ..., description="Input to pass to the orchestrator via MCP"
+    )
+
+
 class ChatCompletionChunkChoiceDelta(BaseModel):
     content: str
 


### PR DESCRIPTION
## Summary
- add an MCPToolRequest model that accepts a single input_string for MCP tool calls
- build chat completion requests inside the MCP router from the new input_string and update tool schema handling
- refresh MCP router tests to cover the new request shape and streaming setup

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68cd8828392483239f928a07b859a444