### PR TITLE
Remove A2A compatibility shim

### DIFF
--- a/src/avalan/server/a2a/schema.py
+++ b/src/avalan/server/a2a/schema.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
-from a2a_sdk.models.agent import AgentCard
-from a2a_sdk.models.event import Event
-from a2a_sdk.models.task import Task, TaskStatus
+from a2a.types.agent import AgentCard
+from a2a.types.event import Event
+from a2a.types.task import Task, TaskStatus
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/avalan/server/a2a/store.py
+++ b/src/avalan/server/a2a/store.py
@@ -5,10 +5,10 @@ from time import time
 from typing import Any, AsyncIterator
 from uuid import uuid4
 
-from a2a_sdk.models.event import Event
-from a2a_sdk.models.task import TaskStatus
-
 from .schema import TASK_STATUSES, ensure_task_status
+
+from a2a.types.event import Event
+from a2a.types.task import TaskStatus
 
 
 @dataclass(slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Test configuration for Avalan's pytest suite."""
+
+import sys
+import types
+from typing import Any
+
+
+def _install_a2a_stub() -> None:
+    if "a2a" in sys.modules:
+        return
+
+    class _DynamicEnum(str):
+        def __new__(cls, value: str) -> "_DynamicEnum":
+            return str.__new__(cls, value)
+
+        @property
+        def value(self) -> str:
+            return str(self)
+
+    class TaskStatus(_DynamicEnum):
+        pass
+
+    TaskStatus.CREATED = TaskStatus("created")  # type: ignore[attr-defined]
+    TaskStatus.RUNNING = TaskStatus("running")  # type: ignore[attr-defined]
+    TaskStatus.COMPLETED = TaskStatus("completed")  # type: ignore[attr-defined]
+    TaskStatus.FAILED = TaskStatus("failed")  # type: ignore[attr-defined]
+
+    class _SDKModel:
+        def __init__(self, **data: Any) -> None:
+            self._data = dict(data)
+
+        @classmethod
+        def model_validate(cls, payload: dict[str, Any]) -> "_SDKModel":
+            return cls(**payload)
+
+        def model_dump(
+            self, *, by_alias: bool = True, exclude_none: bool = True
+        ) -> dict[str, Any]:
+            if exclude_none:
+                return {
+                    key: value for key, value in self._data.items() if value is not None
+                }
+            return dict(self._data)
+
+        def dict(self, *, exclude_none: bool = True) -> dict[str, Any]:
+            return self.model_dump(exclude_none=exclude_none)
+
+    class AgentCard(_SDKModel):
+        pass
+
+    class Event(_SDKModel):
+        pass
+
+    class Task(_SDKModel):
+        pass
+
+    a2a_module = types.ModuleType("a2a")
+    types_module = types.ModuleType("a2a.types")
+    agent_module = types.ModuleType("a2a.types.agent")
+    event_module = types.ModuleType("a2a.types.event")
+    task_module = types.ModuleType("a2a.types.task")
+
+    agent_module.AgentCard = AgentCard
+    event_module.Event = Event
+    task_module.Task = Task
+    task_module.TaskStatus = TaskStatus
+
+    types_module.AgentCard = AgentCard
+    types_module.Event = Event
+    types_module.Task = Task
+    types_module.TaskStatus = TaskStatus
+    types_module.agent = agent_module
+    types_module.event = event_module
+    types_module.task = task_module
+
+    a2a_module.types = types_module
+
+    sys.modules["a2a"] = a2a_module
+    sys.modules["a2a.types"] = types_module
+    sys.modules["a2a.types.agent"] = agent_module
+    sys.modules["a2a.types.event"] = event_module
+    sys.modules["a2a.types.task"] = task_module
+
+
+_install_a2a_stub()

--- a/tests/server/a2a_translator_test.py
+++ b/tests/server/a2a_translator_test.py
@@ -15,11 +15,11 @@ ORIGINAL_SYS_PATH = list(sys.path)
 sys.path.insert(0, str(base_path))
 
 PREVIOUS_MODULES = {
-    "a2a_sdk": sys.modules.get("a2a_sdk"),
-    "a2a_sdk.models": sys.modules.get("a2a_sdk.models"),
-    "a2a_sdk.models.agent": sys.modules.get("a2a_sdk.models.agent"),
-    "a2a_sdk.models.event": sys.modules.get("a2a_sdk.models.event"),
-    "a2a_sdk.models.task": sys.modules.get("a2a_sdk.models.task"),
+    "a2a": sys.modules.get("a2a"),
+    "a2a.types": sys.modules.get("a2a.types"),
+    "a2a.types.agent": sys.modules.get("a2a.types.agent"),
+    "a2a.types.event": sys.modules.get("a2a.types.event"),
+    "a2a.types.task": sys.modules.get("a2a.types.task"),
     "avalan": sys.modules.get("avalan"),
     "avalan.server": sys.modules.get("avalan.server"),
     "avalan.agent": sys.modules.get("avalan.agent"),
@@ -141,27 +141,34 @@ class _TaskStatus(StrEnum):
     FAILED = "failed"
 
 
-a2a_sdk_module = types.ModuleType("a2a_sdk")
-a2a_sdk_models = types.ModuleType("a2a_sdk.models")
-a2a_sdk_agent = types.ModuleType("a2a_sdk.models.agent")
-a2a_sdk_event = types.ModuleType("a2a_sdk.models.event")
-a2a_sdk_task = types.ModuleType("a2a_sdk.models.task")
+a2a_module = types.ModuleType("a2a")
+a2a_types_module = types.ModuleType("a2a.types")
+a2a_types_agent = types.ModuleType("a2a.types.agent")
+a2a_types_event = types.ModuleType("a2a.types.event")
+a2a_types_task = types.ModuleType("a2a.types.task")
 
-a2a_sdk_agent.AgentCard = _AgentCard
-a2a_sdk_event.Event = _Event
-a2a_sdk_task.Task = _Task
-a2a_sdk_task.TaskStatus = _TaskStatus
+a2a_module.__path__ = []  # type: ignore[attr-defined]
+a2a_types_module.__path__ = []  # type: ignore[attr-defined]
 
-a2a_sdk_module.models = a2a_sdk_models
-a2a_sdk_models.agent = a2a_sdk_agent
-a2a_sdk_models.event = a2a_sdk_event
-a2a_sdk_models.task = a2a_sdk_task
+a2a_types_agent.AgentCard = _AgentCard
+a2a_types_event.Event = _Event
+a2a_types_task.Task = _Task
+a2a_types_task.TaskStatus = _TaskStatus
 
-sys.modules["a2a_sdk"] = a2a_sdk_module
-sys.modules["a2a_sdk.models"] = a2a_sdk_models
-sys.modules["a2a_sdk.models.agent"] = a2a_sdk_agent
-sys.modules["a2a_sdk.models.event"] = a2a_sdk_event
-sys.modules["a2a_sdk.models.task"] = a2a_sdk_task
+a2a_module.types = a2a_types_module
+a2a_types_module.AgentCard = _AgentCard
+a2a_types_module.Event = _Event
+a2a_types_module.Task = _Task
+a2a_types_module.TaskStatus = _TaskStatus
+a2a_types_module.agent = a2a_types_agent
+a2a_types_module.event = a2a_types_event
+a2a_types_module.task = a2a_types_task
+
+sys.modules["a2a"] = a2a_module
+sys.modules["a2a.types"] = a2a_types_module
+sys.modules["a2a.types.agent"] = a2a_types_agent
+sys.modules["a2a.types.event"] = a2a_types_event
+sys.modules["a2a.types.task"] = a2a_types_task
 
 from avalan.entities import ReasoningToken, Token
 from avalan.server.a2a.agent import build_agent_card


### PR DESCRIPTION
## Summary
- remove the local A2A compatibility module and import the SDK types directly from the installed `a2a` package
- adjust the server store to rely on the official event and task status classes without fallback logic
- add a pytest configuration stub that provides minimal `a2a` module definitions during tests to simulate the external dependency

## Testing
- poetry run pytest tests/server/a2a_translator_test.py -k translator
- poetry run pytest *(fails: baseline collection errors for unrelated modules such as `avalan.server` and `avalan.entities`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7f4e52a0832395d38fb9fca5e825