### PR TITLE
Refactor responses SSE helper usage

### DIFF
--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -47,18 +47,20 @@ async def create_response(
         async def generate():
             seq = 0
 
-            yield _sse(
-                "response.created",
-                {
-                    "type": "response.created",
-                    "response": {
-                        "id": str(response_id),
-                        "created_at": timestamp,
-                        "model": request.model,
-                        "type": "response",
-                        "status": "in_progress",
-                    },
-                },
+            yield sse_message(
+                to_json(
+                    {
+                        "type": "response.created",
+                        "response": {
+                            "id": str(response_id),
+                            "created_at": timestamp,
+                            "model": request.model,
+                            "type": "response",
+                            "status": "in_progress",
+                        },
+                    }
+                ),
+                event="response.created",
             )
 
             state: ResponseState | None = None
@@ -103,7 +105,10 @@ async def create_response(
             for event in events:
                 yield event
 
-            yield _sse("response.completed", {"type": "response.completed"})
+            yield sse_message(
+                to_json({"type": "response.completed"}),
+                event="response.completed",
+            )
 
             yield sse_message("{}", event="done")
             await orchestrator.sync_messages()
@@ -141,15 +146,17 @@ def _token_to_sse(
 
     if isinstance(token, ReasoningToken):
         events.append(
-            _sse(
-                "response.reasoning_text.delta",
-                {
-                    "type": "response.reasoning_text.delta",
-                    "delta": token.token,
-                    "output_index": 0,
-                    "content_index": 0,
-                    "sequence_number": seq,
-                },
+            sse_message(
+                to_json(
+                    {
+                        "type": "response.reasoning_text.delta",
+                        "delta": token.token,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "sequence_number": seq,
+                    }
+                ),
+                event="response.reasoning_text.delta",
             )
         )
     elif isinstance(token, Event) and token.type in (
@@ -170,17 +177,19 @@ def _token_to_sse(
                 delta_obj["result"] = to_json(result) if result else None
 
         events.append(
-            _sse(
-                "response.function_call_arguments.delta",
-                {
-                    **delta_obj,
-                    "type": "response.function_call_arguments.delta",
-                    "delta": to_json(delta_obj),
-                    "id": item["id"],
-                    "output_index": 0,
-                    "content_index": 0,
-                    "sequence_number": seq,
-                },
+            sse_message(
+                to_json(
+                    {
+                        **delta_obj,
+                        "type": "response.function_call_arguments.delta",
+                        "delta": to_json(delta_obj),
+                        "id": item["id"],
+                        "output_index": 0,
+                        "content_index": 0,
+                        "sequence_number": seq,
+                    }
+                ),
+                event="response.function_call_arguments.delta",
             )
         )
     elif isinstance(token, ToolCallToken):
@@ -191,44 +200,52 @@ def _token_to_sse(
                 "arguments": token.call.arguments,
             }
             events.append(
-                _sse(
-                    "response.function_call_arguments.delta",
-                    {
-                        "type": "response.function_call_arguments.delta",
-                        "delta": to_json(delta_obj),
-                        "id": str(token.call.id),
-                        "output_index": 0,
-                        "content_index": 0,
-                        "sequence_number": seq,
-                    },
+                sse_message(
+                    to_json(
+                        {
+                            "type": "response.function_call_arguments.delta",
+                            "delta": to_json(delta_obj),
+                            "id": str(token.call.id),
+                            "output_index": 0,
+                            "content_index": 0,
+                            "sequence_number": seq,
+                        }
+                    ),
+                    event="response.function_call_arguments.delta",
                 )
             )
         else:
             events.append(
-                _sse(
-                    "response.custom_tool_call_input.delta",
-                    {
-                        "type": "response.custom_tool_call_input.delta",
-                        "delta": token.token,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "sequence_number": seq,
-                    },
+                sse_message(
+                    to_json(
+                        {
+                            "type": "response.custom_tool_call_input.delta",
+                            "delta": token.token,
+                            "output_index": 0,
+                            "content_index": 0,
+                            "sequence_number": seq,
+                        }
+                    ),
+                    event="response.custom_tool_call_input.delta",
                 )
             )
     else:
         events.append(
-            _sse(
-                "response.output_text.delta",
-                {
-                    "type": "response.output_text.delta",
-                    "delta": (
-                        token.token if isinstance(token, Token) else str(token)
-                    ),
-                    "output_index": 0,
-                    "content_index": 0,
-                    "sequence_number": seq,
-                },
+            sse_message(
+                to_json(
+                    {
+                        "type": "response.output_text.delta",
+                        "delta": (
+                            token.token
+                            if isinstance(token, Token)
+                            else str(token)
+                        ),
+                        "output_index": 0,
+                        "content_index": 0,
+                        "sequence_number": seq,
+                    }
+                ),
+                event="response.output_text.delta",
             )
         )
     return events
@@ -301,13 +318,15 @@ def _output_item_added(state: ResponseState, id: str | None = None) -> str:
     item = {"type": item_types[state]}
     if id is not None:
         item["id"] = id
-    return _sse(
-        "response.output_item.added",
-        {
-            "type": "response.output_item.added",
-            "output_index": 0,
-            "item": item,
-        },
+    return sse_message(
+        to_json(
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": item,
+            }
+        ),
+        event="response.output_item.added",
     )
 
 
@@ -315,17 +334,19 @@ def _output_item_done(id: str | None = None) -> str:
     data = {"type": "response.output_item.done", "output_index": 0}
     if id is not None:
         data["item"] = {"id": id}
-    return _sse("response.output_item.done", data)
+    return sse_message(to_json(data), event="response.output_item.done")
 
 
 def _reasoning_text_done() -> str:
-    return _sse(
-        "response.reasoning_text.done",
-        {
-            "type": "response.reasoning_text.done",
-            "output_index": 0,
-            "content_index": 0,
-        },
+    return sse_message(
+        to_json(
+            {
+                "type": "response.reasoning_text.done",
+                "output_index": 0,
+                "content_index": 0,
+            }
+        ),
+        event="response.reasoning_text.done",
     )
 
 
@@ -337,17 +358,22 @@ def _custom_tool_call_input_done(id: str | None = None) -> str:
     }
     if id is not None:
         data["id"] = id
-    return _sse("response.custom_tool_call_input.done", data)
+    return sse_message(
+        to_json(data),
+        event="response.custom_tool_call_input.done",
+    )
 
 
 def _output_text_done() -> str:
-    return _sse(
-        "response.output_text.done",
-        {
-            "type": "response.output_text.done",
-            "output_index": 0,
-            "content_index": 0,
-        },
+    return sse_message(
+        to_json(
+            {
+                "type": "response.output_text.done",
+                "output_index": 0,
+                "content_index": 0,
+            }
+        ),
+        event="response.output_text.done",
     )
 
 
@@ -355,14 +381,16 @@ def _content_part_added(part_type: str, id: str | None = None) -> str:
     part = {"type": part_type}
     if id is not None:
         part["id"] = id
-    return _sse(
-        "response.content_part.added",
-        {
-            "type": "response.content_part.added",
-            "output_index": 0,
-            "content_index": 0,
-            "part": part,
-        },
+    return sse_message(
+        to_json(
+            {
+                "type": "response.content_part.added",
+                "output_index": 0,
+                "content_index": 0,
+                "part": part,
+            }
+        ),
+        event="response.content_part.added",
     )
 
 
@@ -374,7 +402,7 @@ def _content_part_done(id: str | None = None) -> str:
     }
     if id is not None:
         data["part"] = {"id": id}
-    return _sse("response.content_part.done", data)
+    return sse_message(to_json(data), event="response.content_part.done")
 
 
 def _tool_call_event_item(event: Event) -> dict:
@@ -400,7 +428,3 @@ def _tool_call_event_item(event: Event) -> dict:
         else:
             item["result"] = tool_result
     return item
-
-
-def _sse(event: str, data: dict) -> str:
-    return sse_message(to_json(data), event=event)

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -15,11 +15,12 @@ from avalan.event import Event, EventType
 from avalan.server.routers.responses import (
     ResponseState,
     _new_state,
-    _sse,
     _switch_state,
     _token_to_sse,
     _tool_call_event_item,
 )
+from avalan.server.sse import sse_message
+from avalan.utils import to_json
 
 
 class ResponsesUtilsTestCase(TestCase):
@@ -207,5 +208,5 @@ class ResponsesUtilsTestCase(TestCase):
         self.assertEqual(result_payload["payload"], {"status": "ok"})
 
     def test_sse_formats_event_and_data(self) -> None:
-        result = _sse("test.event", {"a": 1})
+        result = sse_message(to_json({"a": 1}), event="test.event")
         self.assertEqual(result, 'event: test.event\ndata: {"a": 1}\n\n')


### PR DESCRIPTION
## Summary
- replace the private `_sse` helper with direct `sse_message` calls when streaming response events
- update response helper functions to serialize payloads before sending them through `sse_message`
- adjust response utility tests to assert against the new `sse_message` usage

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68cfeb5555308323b39b3ee7299ba073