### PR TITLE
Use shared SSE formatter in A2A router

### DIFF
--- a/src/avalan/server/routers/mcp.py
+++ b/src/avalan/server/routers/mcp.py
@@ -1,4 +1,5 @@
 from . import orchestrate
+from ..sse import sse_bytes, sse_headers
 from ...agent.orchestrator import Orchestrator
 from ...entities import (
     ReasoningToken,
@@ -473,18 +474,14 @@ async def _start_tool_streaming_response(
                 base_path=base_path,
                 cancel_event=cancel_event,
             ):
-                yield b"data: " + chunk.rstrip(b"\n") + b"\n\n"
+                yield sse_bytes(chunk)
         finally:
             watcher.cancel()
             with suppress(Exception):
                 await watcher
 
-    headers = {
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-    }
     return StreamingResponse(
-        stream(), media_type="text/event-stream", headers=headers
+        stream(), media_type="text/event-stream", headers=sse_headers()
     )
 
 

--- a/src/avalan/server/sse.py
+++ b/src/avalan/server/sse.py
@@ -1,0 +1,35 @@
+from typing import Final
+
+SSE_HEADERS: Final[dict[str, str]] = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def sse_message(data: str | bytes, *, event: str | None = None) -> str:
+    """Format a server-sent event payload as a string."""
+    if isinstance(data, bytes):
+        text = data.decode("utf-8")
+    else:
+        text = data
+
+    lines = text.splitlines()
+    if not lines:
+        lines = [""]
+
+    parts: list[str] = []
+    if event is not None:
+        parts.append(f"event: {event}")
+    parts.extend(f"data: {line}" for line in lines)
+    return "\n".join(parts) + "\n\n"
+
+
+def sse_bytes(data: str | bytes, *, event: str | None = None) -> bytes:
+    """Format a server-sent event payload as bytes."""
+    return sse_message(data, event=event).encode("utf-8")
+
+
+def sse_headers() -> dict[str, str]:
+    """Return default headers for server-sent event responses."""
+    return dict(SSE_HEADERS)

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -15,11 +15,12 @@ from avalan.event import Event, EventType
 from avalan.server.routers.responses import (
     ResponseState,
     _new_state,
-    _sse,
     _switch_state,
     _token_to_sse,
     _tool_call_event_item,
 )
+from avalan.server.sse import sse_message
+from avalan.utils import to_json
 
 
 class ResponsesUtilsTestCase(TestCase):
@@ -207,5 +208,5 @@ class ResponsesUtilsTestCase(TestCase):
         self.assertEqual(result_payload["payload"], {"status": "ok"})
 
     def test_sse_formats_event_and_data(self) -> None:
-        result = _sse("test.event", {"a": 1})
+        result = sse_message(to_json({"a": 1}), event="test.event")
         self.assertEqual(result, 'event: test.event\ndata: {"a": 1}\n\n')


### PR DESCRIPTION
## Summary
- rebase the work branch on the latest origin/main state
- reuse the shared sse_message helper in the A2A router stream generator and remove the local SSE formatter

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68cff57b9d5483238704018a156527e1