### PR TITLE
Add Amazon Bedrock vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Avalan empowers developers and enterprises to build, orchestrate, and deploy int
 
 - 🎞️ **Multi-modal** integration (NLP/text, vision, audio.)
 - 🔌 **Multi-backend** support ([transformers](https://github.com/huggingface/transformers), [vLLM](https://github.com/vllm-project/vllm), [mlx-lm](https://github.com/ml-explore/mlx-lm).)
-- 🔗 **Native adapters** for Anyscale, Anthropic, DeepInfra, DeepSeek, Google (Gemini), Groq, HuggingFace, Hyperbolic, LiteLLM, Ollama, OpenAI, OpenRouter, Together, among others.
+- 🔗 **Native adapters** for Amazon Bedrock, Anyscale, Anthropic, DeepInfra, DeepSeek, Google (Gemini), Groq, HuggingFace, Hyperbolic, LiteLLM, Ollama, OpenAI, OpenRouter, Together, among others.
 - 🤖 Sophisticated **memory management** with native implementations for PostgreSQL (pgvector), Elasticsearch, AWS Opensearch, AWS S3 Vectors, and reasoning graph storage.
 - 🧠 Multiple **reasoning strategies** including ReACT, Chain-of-Thought, Tree-of-Thought, Plan-and-Reflect, Self-Consistency, Scratchpad-Toolformer, Cascaded Prompting, Critic-Guided Direction-Following Experts, and Product-of-Experts.
 - 🔀 Intuitive pipelines with branching, filtering, and recursive **AI workflows**.
@@ -491,6 +491,18 @@ with TextGenerationModel(f"ai://{api_key}@openai/gpt-4o") as model:
         print(token, end="", flush=True)
 ```
 For a runnable script, see [docs/examples/text_generation.py](docs/examples/text_generation.py).
+
+Amazon Bedrock models use the same workflow. With your AWS credentials
+configured (for example with `AWS_PROFILE` or environment variables),
+you can target any Bedrock region via `--base-url`:
+
+```bash
+echo "Summarize the latest AWS re:Invent keynote in three bullet points." \
+    | avalan model run "ai://bedrock/anthropic.claude-3-5-sonnet-20241022-v1:0" \
+        --base-url "us-east-1" \
+        --max-new-tokens 256 \
+        --temperature .7
+```
 
 #### Token classification
 

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -43,6 +43,7 @@ ToolValue = bool | float | int | str | None
 Vendor = Literal[
     "anthropic",
     "anyscale",
+    "bedrock",
     "deepinfra",
     "deepseek",
     "google",

--- a/src/avalan/model/modalities/text.py
+++ b/src/avalan/model/modalities/text.py
@@ -91,6 +91,10 @@ class TextGenerationModality:
                 from ..nlp.text.vendor.openai import OpenAIModel as Loader
 
                 return Loader(**model_load_args, exit_stack=exit_stack)
+            case "bedrock":
+                from ..nlp.text.vendor.bedrock import BedrockModel as Loader
+
+                return Loader(**model_load_args, exit_stack=exit_stack)
             case "openrouter":
                 from ..nlp.text.vendor.openrouter import (
                     OpenRouterModel as Loader,

--- a/src/avalan/model/nlp/text/vendor/bedrock.py
+++ b/src/avalan/model/nlp/text/vendor/bedrock.py
@@ -1,0 +1,415 @@
+from . import TextGenerationVendorModel
+from ....message import TemplateMessageRole
+from ....vendor import TextGenerationVendor, TextGenerationVendorStream
+from .....compat import override
+from .....entities import (
+    GenerationSettings,
+    Message,
+    MessageContent,
+    MessageContentImage,
+    MessageContentText,
+    MessageRole,
+    ReasoningToken,
+    Token,
+    TokenDetail,
+    ToolCallError,
+    ToolCallResult,
+    ToolCallToken,
+)
+from .....model.stream import TextGenerationSingleStream
+from .....tool.manager import ToolManager
+from .....utils import to_json
+from aioboto3 import Session as Boto3Session
+from contextlib import AsyncExitStack
+from diffusers import DiffusionPipeline
+from json import dumps
+from typing import Any, AsyncIterator
+from transformers import PreTrainedModel
+
+
+def _get(event: Any, key: str) -> Any:
+    if isinstance(event, dict):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
+def _string(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        if "text" in value:
+            return _string(value["text"])
+        if "reasoningText" in value:
+            return _string(value["reasoningText"])
+        if "string" in value:
+            return _string(value["string"])
+    return None
+
+
+class BedrockStream(TextGenerationVendorStream):
+    def __init__(self, events: AsyncIterator):
+        async def generator() -> AsyncIterator[Token | TokenDetail | str]:
+            tool_blocks: dict[int, dict[str, Any]] = {}
+
+            async for event in events:
+                content_start = _get(event, "contentBlockStart")
+                if content_start:
+                    block_index = content_start.get("contentBlockIndex")
+                    block = content_start.get("contentBlock") or {}
+                    tool = (
+                        block.get("toolUse")
+                        if isinstance(block, dict)
+                        else None
+                    )
+                    if tool:
+                        tool_blocks[block_index] = {
+                            "id": tool.get("toolUseId"),
+                            "name": tool.get("name"),
+                            "fragments": [],
+                        }
+                        initial = tool.get("input")
+                        if initial not in (None, ""):
+                            fragment = (
+                                initial
+                                if isinstance(initial, str)
+                                else dumps(initial)
+                            )
+                            tool_blocks[block_index]["fragments"].append(
+                                fragment
+                            )
+                            yield ToolCallToken(token=fragment)
+                    continue
+
+                content_delta = _get(event, "contentBlockDelta")
+                if content_delta:
+                    block_index = content_delta.get("contentBlockIndex")
+                    delta = content_delta.get("delta") or {}
+                    text_block = delta.get("text")
+                    text_value = _string(text_block)
+                    if text_value:
+                        yield Token(token=text_value)
+                        continue
+                    reasoning_block = delta.get("reasoning")
+                    reasoning_value = _string(reasoning_block)
+                    if reasoning_value:
+                        yield ReasoningToken(token=reasoning_value)
+                        continue
+                    tool_delta = delta.get("toolUse")
+                    if tool_delta:
+                        fragment_value = tool_delta.get("input")
+                        if fragment_value not in (None, ""):
+                            fragment = (
+                                fragment_value
+                                if isinstance(fragment_value, str)
+                                else dumps(fragment_value)
+                            )
+                            tool_block = tool_blocks.setdefault(
+                                block_index,
+                                {
+                                    "id": tool_delta.get("toolUseId"),
+                                    "name": tool_delta.get("name"),
+                                    "fragments": [],
+                                },
+                            )
+                            tool_block["fragments"].append(fragment)
+                            yield ToolCallToken(token=fragment)
+                    continue
+
+                content_stop = _get(event, "contentBlockStop")
+                if content_stop:
+                    block_index = content_stop.get("contentBlockIndex")
+                    block = content_stop.get("contentBlock") or {}
+                    tool = (
+                        block.get("toolUse")
+                        if isinstance(block, dict)
+                        else None
+                    )
+                    cached = tool_blocks.pop(block_index, None)
+                    if tool:
+                        cached = cached or {
+                            "id": tool.get("toolUseId"),
+                            "name": tool.get("name"),
+                            "fragments": [],
+                        }
+                        final_input = tool.get("input")
+                        if final_input not in (None, ""):
+                            fragment = (
+                                final_input
+                                if isinstance(final_input, str)
+                                else dumps(final_input)
+                            )
+                            cached["fragments"].append(fragment)
+                    if cached:
+                        token = TextGenerationVendor.build_tool_call_token(
+                            cached.get("id"),
+                            cached.get("name"),
+                            "".join(cached.get("fragments", [])) or None,
+                        )
+                        yield token
+                    continue
+
+                if _get(event, "messageStop"):
+                    break
+
+        super().__init__(generator())
+
+    async def __anext__(self) -> Token | TokenDetail | str:
+        return await self._generator.__anext__()
+
+
+class BedrockClient(TextGenerationVendor):
+    _client: Any | None
+    _endpoint_url: str | None
+    _exit_stack: AsyncExitStack
+    _region_name: str | None
+    _session: Boto3Session
+
+    def __init__(
+        self,
+        *,
+        exit_stack: AsyncExitStack,
+        region_name: str | None = None,
+        endpoint_url: str | None = None,
+    ) -> None:
+        self._session = Boto3Session()
+        self._region_name = region_name
+        self._endpoint_url = endpoint_url
+        self._exit_stack = exit_stack
+        self._client = None
+
+    async def _client_instance(self) -> Any:
+        if self._client is None:
+            kwargs: dict[str, Any] = {}
+            if self._region_name:
+                kwargs["region_name"] = self._region_name
+            if self._endpoint_url:
+                kwargs["endpoint_url"] = self._endpoint_url
+            self._client = await self._exit_stack.enter_async_context(
+                self._session.client("bedrock-runtime", **kwargs)
+            )
+        return self._client
+
+    @override
+    async def __call__(
+        self,
+        model_id: str,
+        messages: list[Message],
+        settings: GenerationSettings | None = None,
+        *,
+        tool: ToolManager | None = None,
+        use_async_generator: bool = True,
+    ) -> AsyncIterator[Token | TokenDetail | str] | TextGenerationSingleStream:
+        client = await self._client_instance()
+        system_prompt = self._system_prompt(messages)
+        template_messages = self._template_messages(messages, ["system"])
+        payload: dict[str, Any] = {
+            "modelId": model_id,
+            "messages": template_messages,
+        }
+        if system_prompt:
+            payload["system"] = [{"text": system_prompt}]
+        inference = self._inference_config(settings)
+        if inference:
+            payload["inferenceConfig"] = inference
+        tool_config = self._tool_config(tool)
+        if tool_config:
+            payload["toolConfig"] = tool_config
+
+        if use_async_generator:
+            response = await client.converse_stream(**payload)
+            stream = (
+                response.get("stream") if isinstance(response, dict) else None
+            )
+            assert stream is not None, "Missing stream in Converse response"
+            events = (
+                await self._exit_stack.enter_async_context(stream)
+                if hasattr(stream, "__aenter__")
+                else stream
+            )
+            return BedrockStream(events=events)
+
+        response = await client.converse(**payload)
+        return TextGenerationSingleStream(self._response_text(response))
+
+    def _inference_config(
+        self, settings: GenerationSettings | None
+    ) -> dict[str, Any] | None:
+        if settings is None:
+            return None
+        config: dict[str, Any] = {}
+        if settings.max_new_tokens is not None:
+            config["maxTokens"] = settings.max_new_tokens
+        if settings.temperature is not None:
+            config["temperature"] = settings.temperature
+        if settings.top_p is not None:
+            config["topP"] = settings.top_p
+        if settings.top_k is not None:
+            config["topK"] = settings.top_k
+        if settings.stop_strings is not None:
+            stop = (
+                [settings.stop_strings]
+                if isinstance(settings.stop_strings, str)
+                else settings.stop_strings
+            )
+            config["stopSequences"] = stop
+        return config or None
+
+    def _tool_config(self, tool: ToolManager | None) -> dict[str, Any] | None:
+        schemas = self._tool_schemas(tool) if tool else None
+        if not schemas:
+            return None
+        return {"tools": schemas, "toolChoice": {"auto": {}}}
+
+    def _response_text(self, response: dict[str, Any]) -> str:
+        output = response.get("output") if isinstance(response, dict) else None
+        message = output.get("message") if isinstance(output, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            return ""
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            text_block = block.get("text")
+            text_value = _string(text_block)
+            if text_value:
+                parts.append(text_value)
+        return "".join(parts)
+
+    def _template_messages(
+        self,
+        messages: list[Message],
+        exclude_roles: list[TemplateMessageRole] | None = None,
+    ) -> list[dict[str, Any]]:
+        templated: list[dict[str, Any]] = []
+        for message in messages:
+            if exclude_roles and str(message.role) in exclude_roles:
+                continue
+            if message.role == MessageRole.TOOL:
+                result = message.tool_call_result or message.tool_call_error
+                if result:
+                    templated.append(self._tool_result_message(result))
+                continue
+            templated.append(self._format_message(message))
+        return templated
+
+    def _format_message(self, message: Message) -> dict[str, Any]:
+        role = str(message.role)
+        if role == str(MessageRole.DEVELOPER):
+            role = str(MessageRole.USER)
+        content_blocks = self._format_content(message.content)
+        if message.tool_calls:
+            for tool_call in message.tool_calls:
+                encoded_name = TextGenerationVendor.encode_tool_name(
+                    tool_call.name
+                )
+                content_blocks.append({
+                    "toolUse": {
+                        "toolUseId": tool_call.id,
+                        "name": encoded_name,
+                        "input": tool_call.arguments or [],
+                    }
+                })
+        return {"role": role, "content": content_blocks}
+
+    def _format_content(
+        self, content: str | MessageContent | list[MessageContent] | None
+    ) -> list[dict[str, Any]]:
+        if content is None:
+            return []
+        if isinstance(content, str):
+            return [{"text": {"text": content}}]
+        if isinstance(content, MessageContentText):
+            return [{"text": {"text": content.text}}]
+        if isinstance(content, MessageContentImage):
+            return [
+                {"image": {"source": self._image_source(content.image_url)}}
+            ]
+        if isinstance(content, list):
+            blocks: list[dict[str, Any]] = []
+            for block in content:
+                if isinstance(block, MessageContentText):
+                    blocks.append({"text": {"text": block.text}})
+                elif isinstance(block, MessageContentImage):
+                    blocks.append({
+                        "image": {
+                            "source": self._image_source(block.image_url)
+                        }
+                    })
+            return blocks
+        return [{"text": {"text": str(content)}}]
+
+    def _image_source(self, image_url: dict[str, Any]) -> dict[str, Any]:
+        if "url" in image_url:
+            return {"type": "url", "url": image_url["url"]}
+        if "data" in image_url:
+            media_type = image_url.get("mime_type", "image/png")
+            return {
+                "type": "base64",
+                "mediaType": media_type,
+                "data": image_url["data"],
+            }
+        return {"type": "url", "url": image_url.get("uri", "")}
+
+    def _tool_result_message(
+        self, result: ToolCallResult | ToolCallError
+    ) -> dict[str, Any]:
+        content: dict[str, Any] = {
+            "toolUseId": result.call.id,
+            "content": [
+                {
+                    "text": {
+                        "text": to_json(
+                            result.result
+                            if isinstance(result, ToolCallResult)
+                            else result.message
+                        )
+                    }
+                }
+            ],
+            "status": (
+                "success" if isinstance(result, ToolCallResult) else "error"
+            ),
+        }
+        if isinstance(result, ToolCallError):
+            content["error"] = {
+                "name": result.error.__class__.__name__,
+                "message": result.message,
+            }
+        return {
+            "role": str(MessageRole.USER),
+            "content": [{"toolResult": content}],
+        }
+
+    @staticmethod
+    def _tool_schemas(tool: ToolManager) -> list[dict[str, Any]] | None:
+        schemas = tool.json_schemas()
+        if not schemas:
+            return None
+        tools: list[dict[str, Any]] = []
+        for schema in schemas:
+            if schema.get("type") != "function":
+                continue
+            function = schema.get("function") or {}
+            encoded_name = TextGenerationVendor.encode_tool_name(
+                function.get("name", "")
+            )
+            tools.append({
+                "toolSpec": {
+                    "name": encoded_name,
+                    "description": function.get("description", ""),
+                    "inputSchema": {"json": function.get("parameters", {})},
+                }
+            })
+        return tools or None
+
+
+class BedrockModel(TextGenerationVendorModel):
+    def _load_model(
+        self,
+    ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
+        return BedrockClient(
+            exit_stack=self._exit_stack,
+            region_name=self._settings.base_url,
+            endpoint_url=self._settings.access_token,
+        )

--- a/tests/model/nlp/vendor_bedrock_test.py
+++ b/tests/model/nlp/vendor_bedrock_test.py
@@ -1,0 +1,348 @@
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+from importlib import import_module, reload
+from importlib.machinery import ModuleSpec
+from sys import modules
+from types import ModuleType, SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from avalan.entities import (
+    GenerationSettings,
+    Message,
+    MessageContentImage,
+    MessageContentText,
+    MessageRole,
+    ReasoningToken,
+    Token,
+    ToolCall,
+    ToolCallError,
+    ToolCallResult,
+    ToolCallToken,
+    TransformerEngineSettings,
+)
+
+
+class AsyncIter:
+    def __init__(self, items):
+        self._iter = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def patch_bedrock_imports():
+    aioboto3_stub = ModuleType("aioboto3")
+    aioboto3_stub.__spec__ = ModuleSpec("aioboto3", loader=None)
+    session_mock = MagicMock()
+    aioboto3_stub.Session = MagicMock(return_value=session_mock)
+
+    transformers_stub = ModuleType("transformers")
+    transformers_stub.__spec__ = ModuleSpec("transformers", loader=None)
+    transformers_stub.PreTrainedModel = type("PreTrainedModel", (), {})
+    transformers_stub.PreTrainedTokenizer = type("PreTrainedTokenizer", (), {})
+    transformers_stub.PreTrainedTokenizerFast = type(
+        "PreTrainedTokenizerFast", (), {}
+    )
+    transformers_stub.__getattr__ = lambda name: MagicMock()
+
+    transformers_utils_stub = ModuleType("transformers.utils")
+    transformers_utils_stub.__spec__ = ModuleSpec(
+        "transformers.utils", loader=None
+    )
+    transformers_utils_stub.get_json_schema = MagicMock()
+    transformers_logging_stub = ModuleType("transformers.utils.logging")
+    transformers_logging_stub.__spec__ = ModuleSpec(
+        "transformers.utils.logging", loader=None
+    )
+    transformers_logging_stub.disable_progress_bar = MagicMock()
+    transformers_logging_stub.enable_progress_bar = MagicMock()
+    transformers_utils_stub.logging = transformers_logging_stub
+
+    tokenization_stub = ModuleType("transformers.tokenization_utils_base")
+    tokenization_stub.__spec__ = ModuleSpec(
+        "transformers.tokenization_utils_base", loader=None
+    )
+    tokenization_stub.BatchEncoding = MagicMock()
+
+    generation_stub = ModuleType("transformers.generation")
+    generation_stub.__spec__ = ModuleSpec(
+        "transformers.generation", loader=None
+    )
+    generation_stub.StoppingCriteria = MagicMock()
+    generation_stub.StoppingCriteriaList = MagicMock()
+
+    diffusers_stub = ModuleType("diffusers")
+    diffusers_stub.__spec__ = ModuleSpec("diffusers", loader=None)
+    diffusers_stub.DiffusionPipeline = MagicMock()
+
+    patcher = patch.dict(
+        modules,
+        {
+            "aioboto3": aioboto3_stub,
+            "transformers": transformers_stub,
+            "transformers.utils": transformers_utils_stub,
+            "transformers.utils.logging": transformers_logging_stub,
+            "transformers.tokenization_utils_base": tokenization_stub,
+            "transformers.generation": generation_stub,
+            "diffusers": diffusers_stub,
+        },
+    )
+    patcher.start()
+    return aioboto3_stub, session_mock, patcher
+
+
+class ClientContext:
+    def __init__(self, client):
+        self._client = client
+
+    async def __aenter__(self):
+        return self._client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class BedrockTestCase(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.aioboto3_stub, self.session_mock, self.patch = (
+            patch_bedrock_imports()
+        )
+        reload(import_module("avalan.model.nlp.text.vendor.bedrock"))
+        self.mod = import_module("avalan.model.nlp.text.vendor.bedrock")
+        self.client = SimpleNamespace(
+            converse_stream=AsyncMock(), converse=AsyncMock()
+        )
+        self.session_mock.client.return_value = ClientContext(self.client)
+
+    def tearDown(self):
+        self.patch.stop()
+
+    async def test_stream_processing(self):
+        events = [
+            {
+                "contentBlockDelta": {
+                    "contentBlockIndex": 0,
+                    "delta": {"reasoning": {"text": "think"}},
+                }
+            },
+            {
+                "contentBlockStart": {
+                    "contentBlockIndex": 1,
+                    "contentBlock": {
+                        "toolUse": {
+                            "toolUseId": "id1",
+                            "name": "pkg__tool",
+                        }
+                    },
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "contentBlockIndex": 1,
+                    "delta": {"toolUse": {"input": "{"}},
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "contentBlockIndex": 1,
+                    "delta": {"toolUse": {"input": '"a":1}'}},
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "contentBlockIndex": 0,
+                    "delta": {"text": {"text": "hi"}},
+                }
+            },
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {}},
+        ]
+        with patch.object(
+            self.mod.TextGenerationVendor,
+            "build_tool_call_token",
+            return_value="tool",
+        ) as build:
+            stream = self.mod.BedrockStream(AsyncIter(events))
+            out = []
+            while True:
+                try:
+                    out.append(await stream.__anext__())
+                except StopAsyncIteration:
+                    break
+
+        self.assertEqual(len(out), 5)
+        self.assertIsInstance(out[0], ReasoningToken)
+        self.assertEqual(out[0].token, "think")
+        self.assertIsInstance(out[1], ToolCallToken)
+        self.assertEqual(out[1].token, "{")
+        self.assertIsInstance(out[2], ToolCallToken)
+        self.assertEqual(out[2].token, '"a":1}')
+        self.assertIsInstance(out[3], Token)
+        self.assertEqual(out[3].token, "hi")
+        self.assertEqual(out[4], "tool")
+        build.assert_called_once_with("id1", "pkg__tool", '{"a":1}')
+
+    async def test_client_stream_invocation(self):
+        self.client.converse_stream.return_value = {"stream": AsyncIter([])}
+        exit_stack = AsyncExitStack()
+        client = self.mod.BedrockClient(
+            exit_stack=exit_stack,
+            region_name="us-east-1",
+            endpoint_url="https://example.com",
+        )
+        client._system_prompt = MagicMock(return_value=None)
+        client._template_messages = MagicMock(
+            return_value=[{"role": "user", "content": []}]
+        )
+        client._inference_config = MagicMock(return_value=None)
+        client._tool_config = MagicMock(return_value=None)
+
+        with patch.object(self.mod, "BedrockStream") as StreamMock:
+            result = await client("model", [], GenerationSettings())
+
+        self.session_mock.client.assert_called_once_with(
+            "bedrock-runtime",
+            region_name="us-east-1",
+            endpoint_url="https://example.com",
+        )
+        self.client.converse_stream.assert_awaited_once_with(
+            modelId="model", messages=[{"role": "user", "content": []}]
+        )
+        StreamMock.assert_called_once_with(
+            events=self.client.converse_stream.return_value["stream"]
+        )
+        self.assertIs(result, StreamMock.return_value)
+        await exit_stack.aclose()
+
+    async def test_client_without_stream(self):
+        self.client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": {"text": "hello"}},
+                        {"text": {"text": " world"}},
+                    ]
+                }
+            }
+        }
+        exit_stack = AsyncExitStack()
+        client = self.mod.BedrockClient(exit_stack=exit_stack)
+        client._system_prompt = MagicMock(return_value=None)
+        client._template_messages = MagicMock(
+            return_value=[{"role": "user", "content": []}]
+        )
+        client._inference_config = MagicMock(return_value=None)
+        client._tool_config = MagicMock(return_value=None)
+
+        result = await client(
+            "model",
+            [],
+            GenerationSettings(),
+            use_async_generator=False,
+        )
+
+        text = await result.__anext__()
+        self.assertEqual(text, "hello world")
+        self.client.converse.assert_awaited_once()
+        await exit_stack.aclose()
+
+    def test_template_messages_and_tool_config(self):
+        client = self.mod.BedrockClient(exit_stack=AsyncExitStack())
+
+        @dataclass
+        class Payload:
+            value: int
+
+        tool_call = ToolCall(id="id1", name="pkg.tool", arguments={"a": 1})
+        tool_result = ToolCallResult(
+            id="id1", name="pkg.tool", call=tool_call, result=Payload(2)
+        )
+        tool_error = ToolCallError(
+            id="id2",
+            name="pkg.tool",
+            call=tool_call,
+            error=ValueError("bad"),
+            message="bad",
+        )
+
+        messages = [
+            Message(role=MessageRole.USER, content="hello"),
+            Message(
+                role=MessageRole.DEVELOPER,
+                content=MessageContentText(type="text", text="dev"),
+            ),
+            Message(
+                role=MessageRole.ASSISTANT,
+                content=[
+                    MessageContentText(type="text", text="chunk"),
+                    MessageContentImage(
+                        type="image_url",
+                        image_url={"url": "https://example.com"},
+                    ),
+                ],
+            ),
+            Message(role=MessageRole.TOOL, tool_call_result=tool_result),
+            Message(role=MessageRole.TOOL, tool_call_error=tool_error),
+        ]
+
+        templated = client._template_messages(messages)
+        self.assertEqual(templated[0]["role"], "user")
+        self.assertEqual(templated[0]["content"][0]["text"]["text"], "hello")
+        self.assertEqual(templated[1]["role"], "user")
+        self.assertEqual(templated[1]["content"][0]["text"]["text"], "dev")
+        self.assertEqual(
+            templated[2]["content"][1]["image"]["source"]["url"],
+            "https://example.com",
+        )
+        self.assertEqual(
+            templated[3]["content"][0]["toolResult"]["toolUseId"],
+            "id1",
+        )
+        self.assertEqual(
+            templated[4]["content"][0]["toolResult"]["status"],
+            "error",
+        )
+
+        tool_manager = MagicMock()
+        tool_manager.json_schemas.return_value = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "pkg.tool",
+                    "description": "desc",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+        config = client._tool_config(tool_manager)
+        self.assertEqual(
+            config["tools"][0]["toolSpec"]["name"],
+            "pkg__tool",
+        )
+
+    def test_model_loads_client(self):
+        settings = TransformerEngineSettings(
+            access_token="https://endpoint",
+            base_url="us-east-1",
+        )
+        model = self.mod.BedrockModel("model", settings)
+        client = model._load_model()
+        self.assertIsInstance(client, self.mod.BedrockClient)
+        self.assertEqual(client._region_name, "us-east-1")
+        self.assertEqual(client._endpoint_url, "https://endpoint")
+
+
+class BedrockStreamHelpersTest(TestCase):
+    def test_string_helper(self):
+        _, _, patcher = patch_bedrock_imports()
+        self.addCleanup(patcher.stop)
+        module = import_module("avalan.model.nlp.text.vendor.bedrock")
+        self.assertEqual(module._string({"text": {"text": "value"}}), "value")
+        self.assertIsNone(module._string(123))

--- a/tests/model/text_generation_modality_vendors_test.py
+++ b/tests/model/text_generation_modality_vendors_test.py
@@ -15,6 +15,7 @@ from avalan.model.modalities.text import TextGenerationModality
     [
         ("anthropic", "AnthropicModel"),
         ("openai", "OpenAIModel"),
+        ("bedrock", "BedrockModel"),
         ("openrouter", "OpenRouterModel"),
         ("anyscale", "AnyScaleModel"),
         ("together", "TogetherModel"),


### PR DESCRIPTION
## Summary
* add an Amazon Bedrock text-generation vendor that uses the async ConverseStream API, streams text/reasoning/tool tokens, and converts tool schemas and results for Bedrock
* register the new vendor so the text modality loader can instantiate it and extend the vendor smoke test matrix
* exercise the Bedrock client with dedicated tests covering streaming events, client payload construction, tool result handling, and helper utilities

## Testing
* poetry run pytest tests/model/nlp/vendor_bedrock_test.py
* poetry run pytest
* make lint

------
https://chatgpt.com/codex/tasks/task_e_68d0150393608323af669863dc8056c4