### PR TITLE
Rename A2A CLI flag names

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1691,6 +1691,17 @@ class CLI:
             help="URL prefix for A2A endpoints (defaults to /a2a)",
         )
         parser.add_argument(
+            "--a2a-name",
+            default="run",
+            type=str,
+            help="A2A tool name for task execution (defaults to run)",
+        )
+        parser.add_argument(
+            "--a2a-description",
+            type=str,
+            help="A2A tool description for the agent card",
+        )
+        parser.add_argument(
             "--reload",
             action="store_true",
             default=False,

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -658,6 +658,8 @@ async def agent_serve(
         a2a_prefix=getattr(args, "a2a_prefix", "/a2a") or "/a2a",
         mcp_name=getattr(args, "mcp_name", "run") or "run",
         mcp_description=getattr(args, "mcp_description", None),
+        a2a_tool_name=getattr(args, "a2a_name", "run") or "run",
+        a2a_tool_description=getattr(args, "a2a_description", None),
         specs_path=specs_path,
         settings=settings,
         tool_settings=tool_settings,

--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -35,6 +35,8 @@ def agents_server(
     logger: Logger,
     mcp_description: str | None = None,
     a2a_prefix: str = "/a2a",
+    a2a_tool_name: str = "run",
+    a2a_tool_description: str | None = None,
     agent_id: UUID | None = None,
     participant_id: UUID | None = None,
     allow_origins: list[str] | None = None,
@@ -82,6 +84,9 @@ def agents_server(
             app.state.mcp_tool_name = mcp_name or "run"
             if mcp_description:
                 app.state.mcp_tool_description = mcp_description
+            app.state.a2a_tool_name = a2a_tool_name or "run"
+            if a2a_tool_description:
+                app.state.a2a_tool_description = a2a_tool_description
             yield
 
     logger.debug("Creating %s server", name)


### PR DESCRIPTION
## Summary
- rename the agent serve CLI flags to --a2a-name and --a2a-description while preserving their defaults
- adjust the agent server setup to read the renamed arguments when configuring the A2A tool metadata

## Testing
- make lint
- poetry run pytest --verbose -s tests/server/test_a2a.py

------
https://chatgpt.com/codex/tasks/task_e_68d17f6f7dc883238ceaf0a669d3363d