### PR TITLE
Fix browser tool Playwright dependency handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8380,7 +8380,7 @@ type = ["pytest-mypy"]
 
 [extras]
 agent = ["jinja2"]
-all = ["RestrictedPython", "SQLAlchemy", "a2a-sdk", "accelerate", "aiomysql", "anthropic", "asyncpg", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "google-genai", "huggingface-hub", "imageio", "imageio-ffmpeg", "jinja2", "keyring", "litellm", "markdownify", "markitdown", "mcp", "openai", "opencv-python", "pgvector", "pillow", "playwright", "protobuf", "psycopg", "pydantic", "pytest", "pytest-cov", "sentence-transformers", "sentencepiece", "soundfile", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn", "youtube-transcript-api"]
+all = ["RestrictedPython", "SQLAlchemy", "a2a-sdk", "accelerate", "aiomysql", "anthropic", "asyncpg", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "google-genai", "huggingface-hub", "imageio", "imageio-ffmpeg", "jinja2", "keyring", "litellm", "markdownify", "markitdown", "openai", "opencv-python", "pgvector", "pillow", "protobuf", "psycopg", "pydantic", "pytest", "pytest-cov", "sentence-transformers", "sentencepiece", "soundfile", "sympy", "tiktoken", "torchaudio", "torchvision", "tree-sitter", "tree-sitter-python", "uvicorn", "youtube-transcript-api"]
 apple = ["mlx", "mlx-lm"]
 audio = ["soundfile", "torchaudio"]
 cpu = ["accelerate"]
@@ -8389,9 +8389,9 @@ mlx = ["mlx", "mlx-lm"]
 nvidia = ["bitsandbytes", "vllm"]
 quantization = ["bitsandbytes"]
 secrets = ["boto3", "keyring"]
-server = ["a2a-sdk", "fastapi", "mcp", "pydantic", "uvicorn"]
-test = ["RestrictedPython", "SQLAlchemy", "a2a-sdk", "aiomysql", "asyncpg", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "huggingface-hub", "imageio", "imageio-ffmpeg", "keyring", "litellm", "markdownify", "markitdown", "mcp", "mlx", "mlx-lm", "openai", "opencv-python", "pgvector", "pillow", "playwright", "psycopg", "pydantic", "pytest", "pytest-cov", "sympy", "tiktoken", "torchaudio", "tree-sitter", "tree-sitter-python"]
-tool = ["RestrictedPython", "SQLAlchemy", "aiomysql", "asyncpg", "playwright", "sympy", "youtube-transcript-api"]
+server = ["a2a-sdk", "fastapi", "pydantic", "uvicorn"]
+test = ["RestrictedPython", "SQLAlchemy", "a2a-sdk", "aiomysql", "asyncpg", "boto3", "diffusers", "elasticsearch", "faiss-cpu", "fastapi", "huggingface-hub", "imageio", "imageio-ffmpeg", "keyring", "litellm", "markdownify", "markitdown", "mlx", "mlx-lm", "openai", "opencv-python", "pgvector", "pillow", "psycopg", "pydantic", "pytest", "pytest-cov", "sympy", "tiktoken", "torchaudio", "tree-sitter", "tree-sitter-python"]
+tool = ["RestrictedPython", "SQLAlchemy", "aiomysql", "asyncpg", "sympy", "youtube-transcript-api"]
 translation = ["protobuf", "sentencepiece", "tiktoken"]
 vendors = ["anthropic", "google-genai", "litellm", "openai", "pillow", "tiktoken"]
 vision = ["diffusers", "imageio", "imageio-ffmpeg", "opencv-python", "pillow", "torchvision"]
@@ -8400,4 +8400,4 @@ vllm = ["vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "01c2b261fd26b481b6e5b39492c86572812674f96c3f597d6f49ab2a37b3640b"
+content-hash = "e2157224f47fcf1d20c65ad70e9b395e7e445e1b45b7fbaee08d9b1f40e5fed5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ quantization = [
 server = [
   "a2a-sdk==0.3.6",
   "fastapi==0.116.1",
-  "mcp==1.12.3",
   "pydantic==2.11.7",
   "uvicorn==0.35.0",
 ]
@@ -97,13 +96,11 @@ test = [
   "markdownify==1.1.0",
   "mlx==0.28.0",
   "mlx-lm==0.26.3",
-  "mcp==1.12.3",
   "pgvector==0.4.1",
   "pillow==11.3.0",
   # version limited because of vllm
   "openai==1.90.0",
   "opencv-python==4.12.0.88",
-  "playwright==1.54.0",
   "psycopg[binary,pool]==3.2.9",
   "pydantic==2.11.7",
   "pytest==8.4.1",
@@ -120,7 +117,6 @@ test = [
 tool = [
   "aiomysql==0.2.0",
   "asyncpg==0.30.0",
-  "playwright==1.54.0",
   "RestrictedPython==8.0",
   "SQLAlchemy==2.0.43",
   "sympy==1.14.0",
@@ -182,7 +178,6 @@ all = [
   "keyring==25.6.0",
   "markitdown[pdf]==0.1.2",
   "markdownify==1.1.0",
-  "mcp==1.12.3",
   # version limited because of vllm
   "openai==1.90.0",
   "litellm==1.75.0",
@@ -194,7 +189,6 @@ all = [
   "protobuf==6.31.1",
   "psycopg[binary,pool]==3.2.9",
   "pgvector==0.4.1",
-  "playwright==1.54.0",
   "pydantic==2.11.7",
   "pytest==8.4.1",
   "pytest-cov==6.2.1",

--- a/tests/tool/browser_tool_test.py
+++ b/tests/tool/browser_tool_test.py
@@ -83,6 +83,18 @@ class BrowserToolSetTestCase(IsolatedAsyncioTestCase):
         dummy_tool.with_client.assert_called_once_with("client2")
 
 
+class BrowserToolSetMissingDependencyTestCase(TestCase):
+    def test_init_raises_without_playwright(self):
+        with (
+            patch("avalan.tool.browser.async_playwright", None),
+            patch("avalan.tool.browser._PLAYWRIGHT_IMPORT_ERROR", ImportError()),
+        ):
+            with self.assertRaises(RuntimeError) as exc:
+                BrowserToolSet(settings=BrowserToolSettings())
+
+        self.assertIn("Playwright", str(exc.exception))
+
+
 class BrowserToolWithClientTestCase(TestCase):
     def test_with_client(self):
         client1 = MagicMock()


### PR DESCRIPTION
## Summary
- remove the `mcp` and `playwright` optional dependencies from the extras to keep Poetry installs on the modern installer
- add a guarded Playwright import helper and have the browser toolset request the client only when the dependency is present
- add a regression test that ensures the browser toolset raises a helpful error when Playwright is missing

## Testing
- poetry run pytest tests/tool/browser_tool_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d2822fa5ec8323a5ed80e38d8c8652