### PR TITLE
Clarify README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">avalan</h1>
-<h3 align="center">The multi-backend, multi-modal framework for AI agent development, orchestration, and deployment</h3>
+<h3 align="center">The multi-backend, multi-modal micro-framework for AI agent development, orchestration, and deployment</h3>
 
 <p align="center">
   <a href="https://github.com/avalan-ai/avalan/actions/workflows/test.yml"><img src="https://github.com/avalan-ai/avalan/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>


### PR DESCRIPTION
## Summary
- update the README tagline to call Avalan a micro-framework

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68d2f212f5dc8323bc30c9c2d079e01d