### PR TITLE
Return memory partitions from permanent memory search APIs

### DIFF
--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -17,7 +17,7 @@ from ...entities import (
 )
 from ...event import Event, EventStats
 from ...memory.partitioner.text import TextPartition
-from ...memory.permanent import Memory
+from ...memory.permanent import Memory, PermanentMemoryPartition
 from dataclasses import fields
 from datetime import datetime
 from enum import StrEnum
@@ -264,7 +264,10 @@ class Theme(ABC):
 
     @abstractmethod
     def memory_search_matches(
-        self, participant_id: UUID, namespace: str, memories: list[Memory]
+        self,
+        participant_id: UUID,
+        namespace: str,
+        memories: list[PermanentMemoryPartition],
     ) -> RenderableType:
         raise NotImplementedError()
 

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -18,7 +18,7 @@ from ...entities import (
 )
 from ...event import Event, EventStats, EventType, TOOL_TYPES
 from ...memory.partitioner.text import TextPartition
-from ...memory.permanent import Memory
+from ...memory.permanent import Memory, PermanentMemoryPartition
 from ...utils import _j, _lf, to_json
 from datetime import datetime
 from humanize import (
@@ -1406,7 +1406,10 @@ class FancyTheme(Theme):
         return group
 
     def memory_search_matches(
-        self, participant_id: UUID, namespace: str, memories: list[Memory]
+        self,
+        participant_id: UUID,
+        namespace: str,
+        memories: list[PermanentMemoryPartition],
     ) -> RenderableType:
         _, _f, _i = self._, self._f, self._icons
         group = Group(
@@ -1415,14 +1418,17 @@ class FancyTheme(Theme):
                     Panel(
                         memory.data,
                         title=(
-                            _i["memory"] + " " + _f("id", memory.identifier)
+                            _i["memory"]
+                            + " "
+                            + _f("id", str(memory.memory_id))
                         ),
                         title_align="left",
                         subtitle=_(
-                            "Participant: {participant} – Namespace: {ns}"
+                            "Participant: {participant} – Namespace: {ns} – Partition: {partition}"
                         ).format(
-                            participant=_f("participant_id", participant_id),
+                            participant=_f("participant_id", str(participant_id)),
                             ns=_f("id", namespace),
+                            partition=_f("number", memory.partition),
                         ),
                         subtitle_align="left",
                         expand=True,

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -4,8 +4,8 @@ from ..event.manager import EventManager
 from ..memory import RecentMessageMemory
 from ..memory.partitioner.text import TextPartitioner
 from ..memory.permanent import (
-    Memory,
     PermanentMemory,
+    PermanentMemoryPartition,
     PermanentMessageMemory,
     VectorFunction,
 )
@@ -326,7 +326,7 @@ class MemoryManager:
         )
         return messages
 
-    async def search(
+    async def search_partitions(
         self,
         search: str,
         *,
@@ -334,7 +334,7 @@ class MemoryManager:
         namespace: str,
         function: VectorFunction,
         limit: int | None = None,
-    ) -> list[Memory]:
+    ) -> list[PermanentMemoryPartition]:
         if namespace not in self._permanent_memories:
             raise ValueError(f"Memory namespace {namespace} not defined")
 

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -345,7 +345,7 @@ class PermanentMemory(MemoryStore[Memory]):
         namespace: str,
         function: VectorFunction,
         limit: int | None = None,
-    ) -> list[Memory]:
+    ) -> list[PermanentMemoryPartition]:
         raise NotImplementedError()
 
     @staticmethod

--- a/src/avalan/memory/permanent/elasticsearch/raw.py
+++ b/src/avalan/memory/permanent/elasticsearch/raw.py
@@ -7,12 +7,13 @@ from elasticsearch import AsyncElasticsearch
 
 from ....memory.partitioner.text import TextPartition
 from ....memory.permanent import (
-    Memory,
     MemoryType,
     PermanentMemory,
+    PermanentMemoryPartition,
     VectorFunction,
 )
 from . import ElasticsearchMemory, to_thread  # noqa: F401
+import numpy as np
 
 
 class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
@@ -98,6 +99,10 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
                     "memory_id": str(row.memory_id),
                     "participant_id": str(row.participant_id),
                     "namespace": namespace,
+                    "partition": row.partition,
+                    "data": row.data,
+                    "embedding": row.embedding.tolist(),
+                    "created_at": row.created_at.isoformat(),
                 },
             )
 
@@ -109,7 +114,7 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
         namespace: str,
         function: VectorFunction,
         limit: int | None = None,
-    ) -> list[Memory]:
+    ) -> list[PermanentMemoryPartition]:
         assert participant_id and namespace and search_partitions
         query = search_partitions[0].embeddings.tolist()
         response = await self._query_vector(
@@ -123,30 +128,35 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
                 "namespace": namespace,
             },
         )
-        results: list[Memory] = []
+        results: list[PermanentMemoryPartition] = []
         for item in response.get("Items", []):
-            mem_id = item.get("Metadata", {}).get("memory_id")
-            if not mem_id:
-                continue
-            obj = await self._get_document(index=self._index, id=mem_id)
-            meta = obj.get("_source") if obj else None
-            if not meta:
+            metadata = item.get("Metadata") or {}
+            mem_id = metadata.get("memory_id")
+            partition_index = metadata.get("partition")
+            data = metadata.get("data")
+            participant = metadata.get("participant_id")
+            created_at = metadata.get("created_at")
+            embedding = metadata.get("embedding") or item.get("Vector")
+            if (
+                not mem_id
+                or partition_index is None
+                or data is None
+                or participant is None
+                or embedding is None
+                or created_at is None
+            ):
                 continue
             results.append(
-                Memory(
-                    id=UUID(meta["id"]),
-                    model_id=meta["model_id"],
-                    type=MemoryType(meta["type"]),
-                    participant_id=UUID(meta["participant_id"]),
-                    namespace=meta["namespace"],
-                    identifier=meta["identifier"],
-                    data=meta["data"],
-                    partitions=meta["partitions"],
-                    symbols=meta["symbols"],
-                    created_at=datetime.fromisoformat(meta["created_at"]),
+                PermanentMemoryPartition(
+                    participant_id=UUID(participant),
+                    memory_id=UUID(mem_id),
+                    partition=int(partition_index),
+                    data=data,
+                    embedding=np.array(embedding, dtype=float),
+                    created_at=datetime.fromisoformat(created_at),
                 )
             )
         return results
 
-    async def search(self, query: str) -> list[Memory] | None:
+    async def search(self, query: str) -> list[PermanentMemoryPartition] | None:
         raise NotImplementedError()

--- a/src/avalan/tool/memory.py
+++ b/src/avalan/tool/memory.py
@@ -2,7 +2,7 @@ from . import Tool, ToolSet
 from ..compat import override
 from ..entities import ToolCallContext
 from ..memory.manager import MemoryManager
-from ..memory.permanent import Memory, VectorFunction
+from ..memory.permanent import PermanentMemoryPartition, VectorFunction
 
 from contextlib import AsyncExitStack
 
@@ -84,8 +84,8 @@ class MemoryReadTool(Tool):
         *,
         context: ToolCallContext,
         limit: int | None = None,
-    ) -> list[Memory]:
-        """Return permanent memories that match the search query."""
+    ) -> list[PermanentMemoryPartition]:
+        """Return memory partitions that match the search query."""
         if (
             not namespace
             or not namespace.strip()
@@ -98,7 +98,7 @@ class MemoryReadTool(Tool):
             return []
 
         try:
-            memories = await self._memory_manager.search(
+            memories = await self._memory_manager.search_partitions(
                 search,
                 participant_id=context.participant_id,
                 namespace=namespace,

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -28,7 +28,7 @@ from avalan.entities import (
     ImageEntity,
     User,
 )
-from avalan.memory.permanent import Memory, MemoryType
+from avalan.memory.permanent import PermanentMemoryPartition
 from avalan.memory.partitioner.text import TextPartition
 
 from avalan.cli.theme.fancy import FancyTheme
@@ -442,19 +442,15 @@ class FancyThemeTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(group.renderables), 1)
 
     def test_memory_search_matches(self):
-        mem = Memory(
-            id=UUID(int=0),
-            model_id="m",
-            type=MemoryType.RAW,
-            participant_id=str(UUID(int=1)),
-            namespace="ns",
-            identifier="id",
+        partition = PermanentMemoryPartition(
+            participant_id=UUID(int=1),
+            memory_id=UUID(int=0),
+            partition=1,
             data="d",
-            partitions=1,
-            symbols={},
+            embedding=np.array([0.1]),
             created_at=datetime.now(),
         )
-        group = self.theme.memory_search_matches(str(UUID(int=1)), "ns", [mem])
+        group = self.theme.memory_search_matches(UUID(int=1), "ns", [partition])
         self.assertEqual(len(group.renderables), 1)
 
     def test_tokenizer_config(self):

--- a/tests/cli/theme_test.py
+++ b/tests/cli/theme_test.py
@@ -3,6 +3,7 @@ from avalan.entities import Model
 from avalan.event import Event
 import unittest
 from datetime import datetime
+from uuid import UUID
 from types import SimpleNamespace
 import numpy as np
 
@@ -357,7 +358,9 @@ class ThemeBaseMethodsCoverageTestCase(unittest.TestCase):
             lambda: Theme.search_message_matches(
                 self.theme, "id", SimpleNamespace(), []
             ),
-            lambda: Theme.memory_search_matches(self.theme, "id", "ns", []),
+            lambda: Theme.memory_search_matches(
+                self.theme, UUID(int=0), "ns", []
+            ),
             lambda: Theme.tokenizer_config(self.theme, None),
             lambda: Theme.tokenizer_tokens(self.theme, [], None, None),
             lambda: Theme.display_image_entities(self.theme, [], False),

--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -160,7 +160,7 @@ class MemoryManagerOperationTestCase(IsolatedAsyncioTestCase):
         self.permanent.search_memories.return_value = ["memory"]
         self.manager.add_permanent_memory(namespace, self.permanent)
 
-        memories = await self.manager.search(
+        memories = await self.manager.search_partitions(
             "query",
             participant_id=participant_id,
             namespace=namespace,

--- a/tests/memory/permanent/pgsql_test.py
+++ b/tests/memory/permanent/pgsql_test.py
@@ -164,24 +164,40 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 uuid4(),
                 "people",
                 2,
-                "microsoft/Phi-4-mini-instruct",
-                MemoryType.RAW,
                 VectorFunction.L2_DISTANCE,
                 [
-                    ("leo", "about leo", {"role": "footballer"}),
-                    ("dibu", "about dibu", {"role": "goalkeeper"}),
+                    (
+                        uuid4(),
+                        1,
+                        "about leo",
+                        datetime.now(timezone.utc),
+                    ),
+                    (
+                        uuid4(),
+                        1,
+                        "about dibu",
+                        datetime.now(timezone.utc),
+                    ),
                 ],
             ),
             (
                 uuid4(),
                 "pets",
                 None,
-                "openai/gpt",
-                MemoryType.RAW,
                 VectorFunction.COSINE_DISTANCE,
                 [
-                    ("fido", "about fido", {"role": "dog"}),
-                    ("garfield", "about garfield", {"role": "cat"}),
+                    (
+                        uuid4(),
+                        1,
+                        "about fido",
+                        datetime.now(timezone.utc),
+                    ),
+                    (
+                        uuid4(),
+                        1,
+                        "about garfield",
+                        datetime.now(timezone.utc),
+                    ),
                 ],
             ),
         ]
@@ -777,10 +793,8 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 participant_id,
                 namespace,
                 limit,
-                model_id,
-                mem_type,
                 function,
-                memories,
+                partitions,
             ) = fixture
 
             self.assertIsInstance(participant_id, UUID)
@@ -789,18 +803,14 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 pool_mock, connection_mock, cursor_mock = self.mock_query(
                     [
                         {
-                            "id": uuid4(),
-                            "model_id": model_id,
-                            "type": str(mem_type),
                             "participant_id": participant_id,
-                            "namespace": namespace,
-                            "identifier": m[0],
-                            "data": m[1],
-                            "partitions": 1,
-                            "symbols": m[2],
-                            "created_at": datetime.now(timezone.utc),
+                            "memory_id": partition[0],
+                            "partition": partition[1],
+                            "data": partition[2],
+                            "embedding": rand(384),
+                            "created_at": partition[3],
                         }
-                        for m in memories
+                        for partition in partitions
                     ],
                     fetch_all=True,
                 )
@@ -832,18 +842,14 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                     cursor_mock,
                     f"""
                     SELECT
-                        "memories"."id",
-                        "memories"."model_id",
-                        "memories"."memory_type" AS "type",
-                        "memories"."participant_id",
-                        "memories"."namespace",
-                        "memories"."identifier",
-                        "memories"."data",
-                        "memories"."partitions",
-                        "memories"."symbols",
-                        "memories"."created_at"
-                    FROM "memories"
-                    INNER JOIN "memory_partitions" ON (
+                        "memory_partitions"."participant_id",
+                        "memory_partitions"."memory_id",
+                        "memory_partitions"."partition",
+                        "memory_partitions"."data",
+                        "memory_partitions"."embedding",
+                        "memory_partitions"."created_at"
+                    FROM "memory_partitions"
+                    INNER JOIN "memories" ON (
                         "memory_partitions"."memory_id" = "memories"."id"
                     )
                     WHERE "memories"."participant_id" = %s
@@ -865,22 +871,19 @@ class PgsqlMessageMemoryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 expected_count = (
-                    limit if limit and len(memories) > limit else len(memories)
+                    limit
+                    if limit and len(partitions) > limit
+                    else len(partitions)
                 )
                 self.assertEqual(len(result), expected_count)
 
-                for i, mem in enumerate(memories):
-                    identifier, data, symbols = mem
+                for i, partition in enumerate(partitions):
                     result_item = result[i]
-                    self.assertEqual(result_item.model_id, model_id)
-                    self.assertEqual(result_item.type, mem_type)
-                    self.assertEqual(
-                        result_item.participant_id, participant_id
-                    )
-                    self.assertEqual(result_item.namespace, namespace)
-                    self.assertEqual(result_item.identifier, identifier)
-                    self.assertEqual(result_item.data, data)
-                    self.assertEqual(result_item.symbols, symbols)
+                    self.assertEqual(result_item.participant_id, participant_id)
+                    self.assertEqual(result_item.memory_id, partition[0])
+                    self.assertEqual(result_item.partition, partition[1])
+                    self.assertEqual(result_item.data, partition[2])
+                    self.assertEqual(result_item.created_at, partition[3])
                     if i == expected_count - 1:
                         break
 

--- a/tests/tool/memory_tool_test.py
+++ b/tests/tool/memory_tool_test.py
@@ -119,7 +119,7 @@ class MemoryReadToolTestCase(IsolatedAsyncioTestCase):
         result = await self.tool("docs", "query", context=ctx)
 
         self.assertEqual(result, [])
-        self.manager.search.assert_not_awaited()
+        self.manager.search_partitions.assert_not_awaited()
 
     async def test_returns_empty_when_input_invalid(self):
         ctx = ToolCallContext(participant_id=self.participant_id)
@@ -128,12 +128,12 @@ class MemoryReadToolTestCase(IsolatedAsyncioTestCase):
             with self.subTest(namespace=namespace, query=query):
                 result = await self.tool(namespace, query, context=ctx)
                 self.assertEqual(result, [])
-        self.manager.search.assert_not_awaited()
+        self.manager.search_partitions.assert_not_awaited()
 
     async def test_returns_memories(self):
         ctx = ToolCallContext(participant_id=self.participant_id)
         memory = MagicMock()
-        self.manager.search.return_value = [memory]
+        self.manager.search_partitions.return_value = [memory]
 
         result = await self.tool(
             "docs",
@@ -142,7 +142,7 @@ class MemoryReadToolTestCase(IsolatedAsyncioTestCase):
             limit=3,
         )
 
-        self.manager.search.assert_awaited_once_with(
+        self.manager.search_partitions.assert_awaited_once_with(
             "agent architecture",
             participant_id=self.participant_id,
             namespace="docs",
@@ -153,7 +153,7 @@ class MemoryReadToolTestCase(IsolatedAsyncioTestCase):
 
     async def test_returns_empty_on_missing_namespace(self):
         ctx = ToolCallContext(participant_id=self.participant_id)
-        self.manager.search.side_effect = KeyError("docs")
+        self.manager.search_partitions.side_effect = KeyError("docs")
 
         result = await self.tool("docs", "query", context=ctx)
 


### PR DESCRIPTION
## Summary
* rename `MemoryManager.search` to `search_partitions` and expose `PermanentMemoryPartition` results through the manager API.【F:src/avalan/memory/manager.py†L303-L350】【F:tests/memory/memory_manager_test.py†L155-L179】
* update the permanent memory interface and tool integrations to work with partition objects instead of full memory payloads.【F:src/avalan/memory/permanent/__init__.py†L324-L349】【F:src/avalan/tool/memory.py†L80-L111】【F:tests/tool/memory_tool_test.py†L110-L160】
* change the S3 and Elasticsearch permanent memories to store partition metadata alongside vectors and return partitions directly from vector queries, refreshing unit tests accordingly.【F:src/avalan/memory/permanent/s3vectors/raw.py†L63-L180】【F:src/avalan/memory/permanent/elasticsearch/raw.py†L60-L159】【F:tests/memory/permanent/s3vectors_raw_memory_test.py†L100-L154】【F:tests/memory/permanent/elasticsearch_raw_memory_test.py†L100-L219】

## Testing
* `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68d56d312258832383b715eba0426606