### PR TITLE
Add coverage for memory namespace errors

### DIFF
--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -178,6 +178,18 @@ class MemoryManagerOperationTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(memories, ["memory"])
 
+    async def test_search_permanent_memory_missing_namespace(self):
+        with self.assertRaises(KeyError) as caught:
+            await self.manager.search_partitions(
+                "query",
+                participant_id=uuid4(),
+                namespace="missing",
+                function=VectorFunction.L2_DISTANCE,
+            )
+
+        self.assertIn("Memory namespace missing not defined", str(caught.exception))
+        self.tp.assert_not_called()
+
     def test_add_and_delete_permanent_memory(self):
         self.manager.add_permanent_memory("code", self.permanent)
         self.assertIn("code", self.manager._permanent_memories)


### PR DESCRIPTION
## Summary
- add a regression test for `MemoryManager.search_partitions` raising a `KeyError` when the namespace is missing
- ensure the test also verifies no partitions are generated when the namespace lookup fails

## Testing
- `poetry run pytest --cov=src/avalan/memory --cov-report=term-missing tests/memory -q`
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68d588b8579c83238b4b0d6c9ffc3eea