### PR TITLE
Cover non-OpenAI protocol normalization

### DIFF
--- a/tests/server/server_protocols_test.py
+++ b/tests/server/server_protocols_test.py
@@ -27,6 +27,11 @@ class TestNormalizeProtocols:
         with pytest.raises(AssertionError):
             _normalize_protocols({"mcp": {"anything"}})
 
+    def test_non_openai_protocol_defaults_to_empty_selection(self) -> None:
+        result = _normalize_protocols({"MCP": set(), "a2a": set()})
+
+        assert result == {"mcp": set(), "a2a": set()}
+
     def test_unknown_protocol_rejected(self) -> None:
         with pytest.raises(AssertionError):
             _normalize_protocols({"grpc": set()})


### PR DESCRIPTION
## Summary
- add a regression test ensuring non-OpenAI protocols default to empty endpoint selections when normalized

## Testing
- poetry run pytest --verbose -s
- poetry run pytest --cov=src/avalan/server --cov-report=json

------
https://chatgpt.com/codex/tasks/task_e_68d6a9da5c1c83239d9fe0cbbb7cec65