### PR TITLE
Improve memory coverage

### DIFF
--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -192,6 +192,18 @@ class MemoryManagerOperationTestCase(IsolatedAsyncioTestCase):
         )
         self.tp.assert_not_called()
 
+    async def test_list_memories_missing_namespace(self):
+        with self.assertRaises(KeyError) as caught:
+            await self.manager.list_memories(
+                participant_id=uuid4(),
+                namespace="missing",
+            )
+
+        self.assertIn(
+            "Memory namespace missing not defined", str(caught.exception)
+        )
+        self.permanent.list_memories.assert_not_called()
+
     def test_add_and_delete_permanent_memory(self):
         self.manager.add_permanent_memory("code", self.permanent)
         self.assertIn("code", self.manager._permanent_memories)

--- a/tests/memory/permanent/base_memory_test.py
+++ b/tests/memory/permanent/base_memory_test.py
@@ -165,6 +165,14 @@ class PermanentMemoryTestCase(IsolatedAsyncioTestCase):
                 function=VectorFunction.COSINE_DISTANCE,
             )
 
+    async def test_list_memories_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            await PermanentMemory.list_memories(
+                self.memory,
+                participant_id=uuid4(),
+                namespace="ns",
+            )
+
 
 class BuildPartitionsTestCase(TestCase):
     def setUp(self):

--- a/tests/memory/permanent/elasticsearch_raw_memory_test.py
+++ b/tests/memory/permanent/elasticsearch_raw_memory_test.py
@@ -173,6 +173,8 @@ class ElasticsearchRawMemoryTestCase(IsolatedAsyncioTestCase):
         client.search.return_value = {
             "hits": {
                 "hits": [
+                    {},
+                    {"_source": None},
                     {
                         "_source": {
                             "id": str(uuid4()),
@@ -187,7 +189,7 @@ class ElasticsearchRawMemoryTestCase(IsolatedAsyncioTestCase):
                             "created_at": created_at.isoformat(),
                             "description": "desc",
                         }
-                    }
+                    },
                 ]
             }
         }


### PR DESCRIPTION
## Summary
- add tests for memory manager list memoires error path and abstract permanent memory list
- extend raw Elasticsearch and S3Vectors memory tests to cover missing branches

## Testing
- poetry run pytest --cov=src/avalan/memory tests/memory
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68d6cbb93e4c83239dcdd600277c4b78