### PR TITLE
Move tool enable settings to tools section

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -3,7 +3,7 @@
 This directory showcases configuration files and small programs that demonstrate Avalan's agent framework and model wrappers. Each entry links to the source and notes tunable parameters for experimentation.
 
 ## Agent configurations
-- [agent_tool.toml](agent_tool.toml) – Agent with a calculator tool. Modify `engine.uri` to use another model, extend the `tools` list, or change `run.max_new_tokens` to control response length.
+- [agent_tool.toml](agent_tool.toml) – Agent with a calculator tool. Modify `engine.uri` to use another model, extend the `tools.enable` list, or change `run.max_new_tokens` to control response length.
 - [agent_gettext_translator.toml](agent_gettext_translator.toml) – Template-driven gettext translator. Adjust `source_language`, `destination_language`, or switch `engine.uri` to a different model.
 - [agent_messi.toml](agent_messi.toml) – Persona of Leo Messi with recent and PostgreSQL-backed memory. Change `engine.uri`, memory connection strings, or `run.max_new_tokens` for longer answers.
 - [agent_nagini.toml](agent_nagini.toml) – Python-focused assistant emitting code between `<llm-code>` tags. Tweak `engine.uri`, `weight_type`, or `stop_strings` to fit your needs.

--- a/docs/examples/agent_memory.toml
+++ b/docs/examples/agent_memory.toml
@@ -11,9 +11,9 @@ about card games.
 [engine]
 uri = "ai://local/openai/gpt-oss-20b"
 backend = "mlx"
-tools = ["memory"]
 
-[tool]
+[tools]
+enable = ["memory"]
 format = "harmony"
 
 [memory]

--- a/docs/examples/agent_sql.toml
+++ b/docs/examples/agent_sql.toml
@@ -20,7 +20,8 @@ db_engine = "MySQL"
 uri = "ai://local/openai/gpt-oss-20b"
 backend = "mlx"
 
-[tool]
+[tools]
+enable = ["database"]
 format = "harmony"
 
 [tool.database]

--- a/docs/examples/agent_tool.toml
+++ b/docs/examples/agent_tool.toml
@@ -10,7 +10,9 @@
 
 [engine]
 uri = "NousResearch/Hermes-3-Llama-3.1-8B"
-tools = [
+
+[tools]
+enable = [
     "math.calculator"
 ]
 


### PR DESCRIPTION
## Summary
- update the orchestrator loader to read tool enablement and format options from the `[tools]` section while keeping legacy support
- expand loader tests to cover string, list, and invalid `tools.enable` values plus several `tools.format` enumerations
- refresh example agent configurations and README guidance to use the new `[tools]` layout

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68d9287d06f8832397419092c3e29879