### PR TITLE
Disallow legacy engine tools configuration

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -234,6 +234,12 @@ class OrchestratorLoader:
 
             uri = uri or config["engine"]["uri"]
             engine_config = config["engine"]
+            assert (
+                "tools" not in engine_config
+            ), (
+                "tools option in [engine] is no longer supported; "
+                "configure tools under [tools.enable]"
+            )
             tools_section = config.get("tools")
             if tools_section is None:
                 tools_section = {}
@@ -257,12 +263,6 @@ class OrchestratorLoader:
                             tool_name, str
                         ), "tools.enable entries must be strings"
                         enable_tools.append(tool_name)
-            legacy_tools = engine_config.pop("tools", None)
-            if enable_tools is None and legacy_tools is not None:
-                if isinstance(legacy_tools, str):
-                    enable_tools = [legacy_tools]
-                else:
-                    enable_tools = legacy_tools
             engine_config.pop("uri", None)
             orchestrator_type = (
                 config["agent"]["type"] if "type" in config["agent"] else None

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -561,6 +561,36 @@ enable = 3
 
             await stack.aclose()
 
+    async def test_engine_section_tools_option_not_supported(self):
+        config = """
+[agent]
+role = \"assistant\"
+
+[engine]
+uri = \"ai://local/model\"
+tools = [\"math.calculator\"]
+"""
+        with TemporaryDirectory() as tmp:
+            path = f"{tmp}/agent.toml"
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(config)
+
+            stack = AsyncExitStack()
+            hub = MagicMock(spec=HuggingfaceHub)
+            logger = MagicMock(spec=Logger)
+
+            loader = OrchestratorLoader(
+                hub=hub,
+                logger=logger,
+                participant_id=uuid4(),
+                stack=stack,
+            )
+
+            with self.assertRaises(AssertionError):
+                await loader.from_file(path, agent_id=uuid4())
+
+            await stack.aclose()
+
     async def test_tools_format_variants(self):
         for value, expected in (
             ("react", ToolFormat.REACT),


### PR DESCRIPTION
## Summary
- raise an assertion when agent specs still use the legacy `tools` option in the `[engine]` section
- remove the migration path in the loader and add coverage to ensure `[tools.enable]` is the only way to enable tools

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68d933e7e03083239ac3fbf5a19ed7dc