### PR TITLE
Unify agent tool configuration section

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -3,7 +3,7 @@
 This directory showcases configuration files and small programs that demonstrate Avalan's agent framework and model wrappers. Each entry links to the source and notes tunable parameters for experimentation.
 
 ## Agent configurations
-- [agent_tool.toml](agent_tool.toml) – Agent with a calculator tool. Modify `engine.uri` to use another model, extend the `tools.enable` list, or change `run.max_new_tokens` to control response length.
+- [agent_tool.toml](agent_tool.toml) – Agent with a calculator tool. Modify `engine.uri` to use another model, extend the `tool.enable` list, or change `run.max_new_tokens` to control response length.
 - [agent_gettext_translator.toml](agent_gettext_translator.toml) – Template-driven gettext translator. Adjust `source_language`, `destination_language`, or switch `engine.uri` to a different model.
 - [agent_messi.toml](agent_messi.toml) – Persona of Leo Messi with recent and PostgreSQL-backed memory. Change `engine.uri`, memory connection strings, or `run.max_new_tokens` for longer answers.
 - [agent_nagini.toml](agent_nagini.toml) – Python-focused assistant emitting code between `<llm-code>` tags. Tweak `engine.uri`, `weight_type`, or `stop_strings` to fit your needs.

--- a/docs/examples/agent_memory.toml
+++ b/docs/examples/agent_memory.toml
@@ -12,7 +12,7 @@ about card games.
 uri = "ai://local/openai/gpt-oss-20b"
 backend = "mlx"
 
-[tools]
+[tool]
 enable = ["memory"]
 format = "harmony"
 

--- a/docs/examples/agent_sql.toml
+++ b/docs/examples/agent_sql.toml
@@ -20,7 +20,7 @@ db_engine = "MySQL"
 uri = "ai://local/openai/gpt-oss-20b"
 backend = "mlx"
 
-[tools]
+[tool]
 enable = ["database"]
 format = "harmony"
 

--- a/docs/examples/agent_tool.toml
+++ b/docs/examples/agent_tool.toml
@@ -11,7 +11,7 @@
 [engine]
 uri = "NousResearch/Hermes-3-Llama-3.1-8B"
 
-[tools]
+[tool]
 enable = [
     "math.calculator"
 ]

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -64,7 +64,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "\n## Creating Agents via CLI Arguments and Configuration Files\n\nAgents can be built inline with CLI flags or from TOML configuration files.\n\n### Inline Agent\n```bash\npoetry run avalan agent run     --engine-uri meta-llama/Meta-Llama-3-8B-Instruct     --tool math.calculator     --memory-recent     --name 'Helper'     --role 'You are a helpful assistant named Helper.'\n```\n\n### Configuration File\nCreate `my_agent.toml`:\n\n```toml\n[engine]\nuri = \"meta-llama/Meta-Llama-3-8B-Instruct\"\n\n[run]\nname = \"Helper\"\nrole = \"You are a helpful assistant named Helper.\"\nmemory_recent = true\n[[tools]]\nid = \"math.calculator\"\n```\n\nLaunch it with:\n\n```bash\npoetry run avalan agent run my_agent.toml\n```\n"
+   "source": "\n## Creating Agents via CLI Arguments and Configuration Files\n\nAgents can be built inline with CLI flags or from TOML configuration files.\n\n### Inline Agent\n```bash\npoetry run avalan agent run     --engine-uri meta-llama/Meta-Llama-3-8B-Instruct     --tool math.calculator     --memory-recent     --name 'Helper'     --role 'You are a helpful assistant named Helper.'\n```\n\n### Configuration File\nCreate `my_agent.toml`:\n\n```toml\n[engine]\nuri = \"meta-llama/Meta-Llama-3-8B-Instruct\"\n\n[run]\nname = \"Helper\"\nrole = \"You are a helpful assistant named Helper.\"\nmemory_recent = true\n[tool]\nenable = [\"math.calculator\"]\n```\n\nLaunch it with:\n\n```bash\npoetry run avalan agent run my_agent.toml\n```\n"
   },
   {
    "cell_type": "markdown",

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -384,7 +384,7 @@ role = \"assistant\"
 [engine]
 uri = \"ai://local/model\"
 
-[tools]
+[tool]
 format = \"react\"
 """
         with TemporaryDirectory() as tmp:
@@ -452,7 +452,7 @@ format = \"react\"
                 self.assertEqual(settings.tool_format, ToolFormat.REACT)
             await stack.aclose()
 
-    async def test_tools_enable_accepts_list(self):
+    async def test_tool_enable_accepts_list(self):
         config = """
 [agent]
 role = \"assistant\"
@@ -460,7 +460,7 @@ role = \"assistant\"
 [engine]
 uri = \"ai://local/model\"
 
-[tools]
+[tool]
 enable = [\"math.calculator\", \"browser.open\"]
 """
         with TemporaryDirectory() as tmp:
@@ -492,7 +492,7 @@ enable = [\"math.calculator\", \"browser.open\"]
                 )
             await stack.aclose()
 
-    async def test_tools_enable_accepts_string(self):
+    async def test_tool_enable_accepts_string(self):
         config = """
 [agent]
 role = \"assistant\"
@@ -500,7 +500,7 @@ role = \"assistant\"
 [engine]
 uri = \"ai://local/model\"
 
-[tools]
+[tool]
 enable = \"math.calculator\"
 """
         with TemporaryDirectory() as tmp:
@@ -529,7 +529,7 @@ enable = \"math.calculator\"
                 self.assertEqual(settings.tools, ["math.calculator"])
             await stack.aclose()
 
-    async def test_tools_enable_invalid_type(self):
+    async def test_tool_enable_invalid_type(self):
         config = """
 [agent]
 role = \"assistant\"
@@ -537,7 +537,7 @@ role = \"assistant\"
 [engine]
 uri = \"ai://local/model\"
 
-[tools]
+[tool]
 enable = 3
 """
         with TemporaryDirectory() as tmp:
@@ -591,7 +591,7 @@ tools = [\"math.calculator\"]
 
             await stack.aclose()
 
-    async def test_tools_format_variants(self):
+    async def test_tool_format_variants(self):
         for value, expected in (
             ("react", ToolFormat.REACT),
             ("json", ToolFormat.JSON),
@@ -605,7 +605,7 @@ role = \"assistant\"
 [engine]
 uri = \"ai://local/model\"
 
-[tools]
+[tool]
 format = \"{value}\"
 """
                 with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- consolidate tool configuration under the `[tool]` section and validate nested tool settings during load
- update loader tests to expect the new layout and keep coverage of enable/format parsing
- refresh examples and tutorial snippets to use the new `[tool]` syntax

## Testing
- poetry run pytest --verbose -s


------
https://chatgpt.com/codex/tasks/task_e_68d941831c4c832397cc8104d275cd9b