### PR TITLE
Handle unmatched double quotes when masking SQL spans

### DIFF
--- a/src/avalan/tool/database.py
+++ b/src/avalan/tool/database.py
@@ -519,10 +519,15 @@ def _masked_spans(sql: str) -> list[tuple[int, int]]:
             continue
 
         if char == '"':
-            in_double = True
-            start = idx
-            idx += 1
-            continue
+            if not in_double:
+                prev = sql[idx - 1] if idx > 0 else ""
+                if prev.isalnum() or prev == "_":
+                    idx += 1
+                    continue
+                in_double = True
+                start = idx
+                idx += 1
+                continue
 
         if char == "`":
             in_backtick = True


### PR DESCRIPTION
## Summary
- prevent `_masked_spans` from treating stray trailing double quotes as the start of a quoted region
- allow identifier case normalization to continue replacing table names even after malformed tokens

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68dbb05f890c8323b15301df63a802ac