### PR TITLE
Align CLI memory tests with MemorySource behavior

### DIFF
--- a/tests/event/event_manager_test.py
+++ b/tests/event/event_manager_test.py
@@ -99,7 +99,7 @@ class EventManagerTestCase(IsolatedAsyncioTestCase):
                 events.append(event)
 
         task = asyncio.create_task(iterate())
-        await asyncio.sleep(0.02)
+        await asyncio.wait_for(task, timeout=0.1)
         self.assertTrue(task.done())
         self.assertEqual(events, [])
 


### PR DESCRIPTION
## Summary
- update the CLI memory indexing tests to mock MemorySource when indexing URLs and assert against the new document API
- make the event manager listen test wait for the iterator task with a timeout so it no longer depends on short sleeps

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd41ddcf2c83238c4fd5715a87f911