### PR TITLE
Adapt tests to ModelTask manager interface

### DIFF
--- a/tests/agent/json_orchestrator_test.py
+++ b/tests/agent/json_orchestrator_test.py
@@ -6,6 +6,7 @@ from avalan.agent.orchestrator.orchestrators.json import (
 from avalan.agent.renderer import TemplateEngineAgent
 from avalan.entities import (
     EngineUri,
+    Message,
     MessageRole,
     TransformerEngineSettings,
 )
@@ -180,10 +181,11 @@ class JsonOrchestratorExecutionTestCase(IsolatedAsyncioTestCase):
             result = await orch("hi")
 
         agent_mock.assert_awaited_once()
-        spec_arg, msg_arg = agent_mock.await_args.args
-        self.assertEqual(msg_arg.content, "hi")
-        self.assertEqual(msg_arg.role, MessageRole.USER)
-        self.assertEqual(spec_arg.role, Role(persona=["assistant"]))
+        context = agent_mock.await_args.args[0]
+        self.assertIsInstance(context.input, Message)
+        self.assertEqual(context.input.content, "hi")
+        self.assertEqual(context.input.role, MessageRole.USER)
+        self.assertEqual(context.specification.role, Role(persona=["assistant"]))
 
         self.assertEqual(result, '{"value": "ok"}')
         self.assertTrue(

--- a/tests/agent/orchestrator_response_additional_test.py
+++ b/tests/agent/orchestrator_response_additional_test.py
@@ -320,6 +320,9 @@ class OrchestratorResponseAdditionalCoverageTestCase(IsolatedAsyncioTestCase):
         model_event = await resp.__anext__()
         self.assertEqual(model_event.type, EventType.TOOL_MODEL_RESPONSE)
 
-        args, kwargs = agent.await_args_list[0]
-        messages = args[1]
-        self.assertEqual(messages[2].tool_call_error.message, "boom")
+        context = agent.await_args_list[0].args[0]
+        assert isinstance(context.input, list)
+        self.assertEqual(
+            context.input[2].tool_call_error.message,
+            "boom",
+        )

--- a/tests/cli/model_reasoning_tag_test.py
+++ b/tests/cli/model_reasoning_tag_test.py
@@ -52,9 +52,8 @@ class CliModelReasoningTagTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def manager_call(
-            self, _engine_uri, _model, operation, tool=None
-        ):
+        async def manager_call(self, model_task):
+            operation = model_task.operation
             async def gen():
                 yield "t"
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -1707,6 +1707,15 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
                     modality=Modality.AUDIO_TEXT_TO_SPEECH,
                 )
                 manager.assert_awaited_once()
+                task = manager.await_args_list[0].args[0]
+                operation = task.operation
+                audio_params = operation.parameters["audio"]
+                self.assertIs(task.model, lm)
+                self.assertEqual(operation.input, "hi")
+                self.assertEqual(audio_params.path, "out.wav")
+                self.assertEqual(audio_params.reference_path, ref_path)
+                self.assertEqual(audio_params.reference_text, ref_text)
+                self.assertEqual(audio_params.sampling_rate, 16_000)
                 lm.assert_not_called()
                 tg_patch.assert_not_called()
                 self.assertEqual(
@@ -1803,6 +1812,13 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             modality=Modality.AUDIO_GENERATION,
         )
         manager.assert_awaited_once()
+        task = manager.await_args_list[0].args[0]
+        operation = task.operation
+        audio_params = operation.parameters["audio"]
+        self.assertIs(task.model, lm)
+        self.assertEqual(operation.input, "hi")
+        self.assertEqual(audio_params.path, "out.wav")
+        self.assertEqual(audio_params.sampling_rate, 44_100)
         lm.assert_not_called()
         tg_patch.assert_not_called()
         self.assertEqual(
@@ -1899,6 +1915,12 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             modality=Modality.AUDIO_SPEECH_RECOGNITION,
         )
         manager.assert_awaited_once()
+        task = manager.await_args_list[0].args[0]
+        operation = task.operation
+        audio_params = operation.parameters["audio"]
+        self.assertIs(task.model, lm)
+        self.assertEqual(audio_params.path, "in.wav")
+        self.assertEqual(audio_params.sampling_rate, 16_000)
         lm.assert_not_called()
         tg_patch.assert_not_called()
         self.assertEqual(console.print.call_args.args[0], "transcript")
@@ -1993,7 +2015,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
             modality=Modality.AUDIO_CLASSIFICATION,
         )
         manager.assert_awaited_once()
-        operation = manager.await_args_list[0].args[2]
+        task = manager.await_args_list[0].args[0]
+        operation = task.operation
+        self.assertIs(task.model, lm)
         self.assertEqual(operation.parameters["audio"].path, "audio.wav")
         self.assertEqual(operation.parameters["audio"].sampling_rate, 16_000)
         theme.display_audio_labels.assert_called_once_with(
@@ -2148,9 +2172,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2252,9 +2276,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2354,9 +2378,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2451,9 +2475,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2558,9 +2582,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2672,9 +2696,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2777,9 +2801,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2880,9 +2904,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -2982,9 +3006,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3080,9 +3104,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3183,9 +3207,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3291,9 +3315,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3399,9 +3423,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3507,9 +3531,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3621,9 +3645,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3741,9 +3765,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3862,9 +3886,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect
@@ -3984,9 +4008,9 @@ class CliModelRunTestCase(IsolatedAsyncioTestCase):
         manager.parse_uri = MagicMock(return_value=engine_uri)
         manager.load = MagicMock(return_value=load_cm)
 
-        async def call_side_effect(engine_uri, model, operation):
+        async def call_side_effect(model_task):
             return await RealModelManager.__call__(
-                manager, engine_uri, model, operation
+                manager, model_task
             )
 
         manager.side_effect = call_side_effect

--- a/tests/model/model_manager_call_test.py
+++ b/tests/model/model_manager_call_test.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
+from avalan.agent import Specification
 from avalan.entities import (
     EngineUri,
     GenerationSettings,
@@ -13,6 +14,7 @@ from avalan.entities import (
 )
 from avalan.model.hubs.huggingface import HuggingfaceHub
 from avalan.model.manager import ModelManager
+from avalan.model.task import ModelTask, ModelTaskContext
 
 
 class DummyModel:
@@ -471,11 +473,18 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
         for modality, operation, expected in cases:
             with self.subTest(modality=modality):
                 model.called_with = None
-                result = await self.manager(
-                    self.engine_uri,
-                    model,
-                    operation,
+                task = ModelTask(
+                    engine_uri=self.engine_uri,
+                    model=model,
+                    operation=operation,
+                    tool=None,
+                    context=ModelTaskContext(
+                        specification=Specification(role=None, goal=None),
+                        input=operation.input,
+                        engine_args={},
+                    ),
                 )
+                result = await self.manager(task)
                 self.assertEqual(result, "ok")
                 self.assertEqual(model.called_with, expected)
 
@@ -489,7 +498,15 @@ class ModelManagerCallModalitiesTestCase(unittest.IsolatedAsyncioTestCase):
         )
         with self.assertRaises(NotImplementedError):
             await self.manager(
-                self.engine_uri,
-                model,
-                operation,
+                ModelTask(
+                    engine_uri=self.engine_uri,
+                    model=model,
+                    operation=operation,
+                    tool=None,
+                    context=ModelTaskContext(
+                        specification=Specification(role=None, goal=None),
+                        input=None,
+                        engine_args={},
+                    ),
+                )
             )


### PR DESCRIPTION
## Summary
- update orchestrator tests to validate ModelTaskContext inputs after the manager API change
- adjust CLI model tests to assert ModelTask-based manager calls and updated expectations
- create ModelTask-backed invocations in model manager call tests to align with new signature

## Testing
- poetry run pytest tests/cli/model_test.py
- poetry run pytest tests/cli/model_reasoning_tag_test.py
- poetry run pytest tests/model/model_manager_call_test.py
- poetry run pytest tests/agent/default_orchestrator_test.py -k DefaultOrchestratorTestCase
- poetry run pytest tests/agent/json_orchestrator_test.py -k JsonOrchestratorExecutionTestCase
- poetry run pytest tests/agent/orchestrator_response_additional_test.py -k OrchestratorResponseAdditionalCoverageTestCase

------
https://chatgpt.com/codex/tasks/task_e_68dec8f9b1488323b30ef988ed5ac61a