### PR TITLE
Propagate identifiers in ModelCallContext

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -183,6 +183,13 @@ class Orchestrator:
 
         messages = self._input_messages(operation.specification, input)
 
+        participant_id = getattr(self._memory, "participant_id", None)
+        session_id = (
+            self._memory.permanent_message.session_id
+            if self._memory.permanent_message
+            else None
+        )
+
         # Execute operation
         engine_args = {**(self._call_options or {}), **kwargs}
         start = perf_counter()
@@ -204,6 +211,9 @@ class Orchestrator:
             specification=operation.specification,
             input=messages,
             engine_args=dict(engine_args),
+            agent_id=self._id,
+            participant_id=participant_id,
+            session_id=session_id,
         )
         result = await engine_agent(context)
         self._logger.info(
@@ -239,12 +249,8 @@ class Orchestrator:
             tool=self._tool,
             tool_confirm=tool_confirm,
             agent_id=self._id,
-            participant_id=self._memory.participant_id,
-            session_id=(
-                self._memory.permanent_message.session_id
-                if self._memory.permanent_message
-                else None
-            ),
+            participant_id=participant_id,
+            session_id=session_id,
         )
 
     async def __aenter__(self):

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -575,6 +575,21 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
             engine_args=dict(self._engine_args),
             parent=parent_context,
             root_parent=root_parent,
+            agent_id=(
+                parent_context.agent_id
+                if parent_context
+                else self._agent_id
+            ),
+            participant_id=(
+                parent_context.participant_id
+                if parent_context
+                else self._participant_id
+            ),
+            session_id=(
+                parent_context.session_id
+                if parent_context
+                else self._session_id
+            ),
         )
         self._context = context
         return context

--- a/src/avalan/model/call.py
+++ b/src/avalan/model/call.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from ..agent import Specification
 from ..entities import EngineUri, Input, Operation
@@ -16,6 +17,9 @@ class ModelCallContext:
     engine_args: dict[str, Any] = field(default_factory=dict)
     parent: "ModelCallContext | None" = None
     root_parent: "ModelCallContext | None" = None
+    agent_id: UUID | None = None
+    participant_id: UUID | None = None
+    session_id: UUID | None = None
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)


### PR DESCRIPTION
## Summary
- attach known agent, participant, and session identifiers to `ModelCallContext`
- propagate identifiers through orchestrator contexts and cover with tests

## Testing
- poetry run pytest tests/agent/orchestrator_response_test.py

------
https://chatgpt.com/codex/tasks/task_e_68e1042a13b08323a96fbd000a2d7a96