### PR TITLE
Align agent init TOML options with agent run

### DIFF
--- a/src/avalan/agent/templates/blueprint.toml
+++ b/src/avalan/agent/templates/blueprint.toml
@@ -54,6 +54,42 @@ uri = "{{ orchestrator.uri }}"
 [run]
 max_new_tokens = {{ orchestrator.call_options['max_new_tokens'] }}
 skip_special_tokens = {{ orchestrator.call_options['skip_special_tokens'] | lower }}
+{% if orchestrator.call_options.get('temperature') is not none %}
+temperature = {{ orchestrator.call_options['temperature'] }}
+{% endif %}
+{% if orchestrator.call_options.get('top_k') is not none %}
+top_k = {{ orchestrator.call_options['top_k'] }}
+{% endif %}
+{% if orchestrator.call_options.get('top_p') is not none %}
+top_p = {{ orchestrator.call_options['top_p'] }}
+{% endif %}
+{% if orchestrator.call_options.get('use_cache') is not none %}
+use_cache = {{ orchestrator.call_options['use_cache'] | lower }}
+{% endif %}
+{% if orchestrator.call_options.get('cache_strategy') %}
+cache_strategy = "{{ orchestrator.call_options['cache_strategy'] }}"
+{% endif %}
+{% if orchestrator.call_options.get('chat_settings') %}
+
+[run.chat]
+{% for key, value in orchestrator.call_options['chat_settings'].items() %}
+{% if value is boolean %}{{ key }} = {{ value | lower }}
+{% elif value is number %}{{ key }} = {{ value }}
+{% else %}{{ key }} = "{{ value }}"
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if orchestrator.tools or tool_format %}
+[tool]
+{% if tool_format %}format = "{{ tool_format }}"
+{% endif %}
+{% if orchestrator.tools %}enable = [
+{% for tool in orchestrator.tools %}    "{{ tool }}"{% if not loop.last %},{% endif %}
+{% endfor %}
+]
+{% endif %}
+{% endif %}
 
 {% if browser_tool %}
 [tool.browser.open]

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -780,8 +780,17 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         engine_uri=engine_uri,
         memory_recent=memory_recent,
         memory_permanent_message=memory_permanent_message,
-        max_new_tokens=args.run_max_new_tokens or 1024,
+        max_new_tokens=(
+            args.run_max_new_tokens
+            if args.run_max_new_tokens is not None
+            else 1024
+        ),
         tools=(args.tool or []) + (getattr(args, "tools", None) or []),
+        temperature=getattr(args, "run_temperature", None),
+        top_k=getattr(args, "run_top_k", None),
+        top_p=getattr(args, "run_top_p", None),
+        use_cache=getattr(args, "run_use_cache", None),
+        cache_strategy=getattr(args, "run_cache_strategy", None),
     )
 
     browser_tool = get_tool_settings(
@@ -805,9 +814,11 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
         lstrip_blocks=True,
     )
     template = env.get_template("blueprint.toml")
+    tool_format = getattr(args, "tool_format", None)
     rendered = template.render(
         orchestrator=settings,
         browser_tool=browser_tool,
         database_tool=database_tool,
+        tool_format=tool_format,
     )
     console.print(Syntax(rendered, "toml"))


### PR DESCRIPTION
## Summary
- propagate run-specific generation options, cache controls, and tool format from `agent init` into orchestrator settings
- expand the blueprint template to emit temperature, sampling, cache, chat, and tool enable/format configuration blocks
- extend CLI agent init tests to cover the new options and rendered TOML output

## Testing
- poetry run pytest --verbose -s

------
https://chatgpt.com/codex/tasks/task_e_68e414bd69cc8323b3d0c2e22d282a56