### PR TITLE
Add helper for embedding Avalan agent routes into existing FastAPI apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,6 +1485,38 @@ echo "What is (4 + 6) and then that result times 5, divided by 2?" | \
 > [!TIP]
 > Use `--protocol openai:responses,completion` to enable both OpenAI Responses and Completions endpoints, or narrow the surface by specifying just `responses` or `completion` after the colon.
 
+##### Embedding in existing FastAPI apps
+
+If you already run a FastAPI service, reuse the same OpenAI, MCP, or A2A endpoints without spawning a standalone server. Call `avalan.server.register_agent_endpoints` during startup to attach the routers and lifecycle management to your application:
+
+```python
+from fastapi import FastAPI
+from logging import getLogger
+
+from avalan.model.hubs.huggingface import HuggingfaceHub
+from avalan.server import register_agent_endpoints
+
+
+app = FastAPI()
+logger = getLogger("my-app")
+hub = HuggingfaceHub()
+
+register_agent_endpoints(
+    app,
+    hub=hub,
+    logger=logger,
+    specs_path="docs/examples/agent_tool.toml",
+    settings=None,
+    tool_settings=None,
+    mcp_prefix="/mcp",
+    openai_prefix="/v1",
+    mcp_name="run",
+    protocols={"openai": {"responses"}},
+)
+```
+
+The helper composes with any existing FastAPI lifespan logic, setting up the orchestrator loader only once and wiring the same streaming endpoints that `avalan agent serve` exposes.
+
 #### MCP server
 
 Avalan also embeds an HTTP MCP server alongside the OpenAI-compatible

--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -7,10 +7,11 @@ from ..utils import logger_replace
 from .a2a.store import TaskStore
 from .entities import OrchestratorContext
 from .routers import mcp as mcp_router
+from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
-from importlib import import_module
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from importlib import import_module
 from logging import Logger
 from typing import Mapping, TYPE_CHECKING
 from uuid import UUID, uuid4
@@ -59,46 +60,27 @@ def _normalize_protocols(
     return normalized
 
 
-def agents_server(
+def _create_lifespan(
+    *,
     hub: HuggingfaceHub,
-    name: str,
-    version: str,
-    host: str,
-    port: int,
-    reload: bool,
+    logger: Logger,
     specs_path: str | None,
     settings: OrchestratorSettings | None,
     tool_settings: ToolSettingsContext | None,
     mcp_prefix: str,
-    openai_prefix: str,
     mcp_name: str,
-    logger: Logger,
-    mcp_description: str | None = None,
-    a2a_prefix: str = "/a2a",
-    a2a_tool_name: str = "run",
-    a2a_tool_description: str | None = None,
-    agent_id: UUID | None = None,
-    participant_id: UUID | None = None,
-    allow_origins: list[str] | None = None,
-    allow_origin_regex: str | None = None,
-    allow_methods: list[str] | None = None,
-    allow_headers: list[str] | None = None,
-    allow_credentials: bool = False,
-    protocols: Mapping[str, set[str]] | None = None,
-) -> "Server":
-    """Build a configured Uvicorn server for Avalan agents."""
-    assert (specs_path is None) ^ (
-        settings is None
-    ), "Provide either specs_path or settings, but not both"
-
-    selected_protocols = _normalize_protocols(protocols)
-
-    from os import environ
-    from uvicorn import Config, Server
-
+    mcp_description: str | None,
+    a2a_tool_name: str,
+    a2a_tool_description: str | None,
+    selected_protocols: Mapping[str, set[str]],
+    agent_id: UUID | None,
+    participant_id: UUID | None,
+) -> Callable[[FastAPI], AsyncIterator[None]]:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         logger.info("Initializing app lifespan")
+        from os import environ
+
         environ["TOKENIZERS_PARALLELISM"] = "false"
         async with AsyncExitStack() as stack:
             logger.info("Loading OrchestratorLoader in app lifespan")
@@ -134,9 +116,18 @@ def agents_server(
                     app.state.mcp_tool_description = mcp_description
             yield
 
-    logger.debug("Creating %s server", name)
-    app = FastAPI(title=name, version=version, lifespan=lifespan)
+    return lifespan
 
+
+def _configure_cors(
+    app: FastAPI,
+    *,
+    allow_origins: list[str] | None,
+    allow_origin_regex: str | None,
+    allow_methods: list[str] | None,
+    allow_headers: list[str] | None,
+    allow_credentials: bool,
+) -> None:
     if any(
         [
             allow_origins,
@@ -155,7 +146,15 @@ def agents_server(
             allow_headers=allow_headers or ["*"],
         )
 
-    logger.debug("Adding routes to %s server", name)
+
+def _include_protocol_routers(
+    app: FastAPI,
+    *,
+    selected_protocols: Mapping[str, set[str]],
+    openai_prefix: str,
+    mcp_prefix: str,
+    a2a_prefix: str,
+) -> None:
     openai_endpoints = selected_protocols.get("openai")
     if openai_endpoints:
         if "completions" in openai_endpoints:
@@ -177,9 +176,160 @@ def agents_server(
         app.include_router(a2a_module.well_known_router)
 
     if "mcp" in selected_protocols:
-        logger.debug("Creating MCP HTTP stream router")
         mcp_http_router = mcp_router.create_router()
         app.include_router(mcp_http_router, prefix=mcp_prefix)
+
+
+def _attach_lifespan(app: FastAPI, lifespan: Callable[[FastAPI], AsyncIterator[None]]) -> None:
+    existing = app.router.lifespan_context
+
+    if existing is None:
+        app.router.lifespan_context = lifespan
+        return
+
+    @asynccontextmanager
+    async def combined(app_: FastAPI):
+        async with existing(app_):
+            async with lifespan(app_):
+                yield
+
+    app.router.lifespan_context = combined
+
+
+def register_agent_endpoints(
+    app: FastAPI,
+    *,
+    hub: HuggingfaceHub,
+    logger: Logger,
+    specs_path: str | None,
+    settings: OrchestratorSettings | None,
+    tool_settings: ToolSettingsContext | None,
+    mcp_prefix: str,
+    openai_prefix: str,
+    mcp_name: str,
+    mcp_description: str | None = None,
+    a2a_prefix: str = "/a2a",
+    a2a_tool_name: str = "run",
+    a2a_tool_description: str | None = None,
+    agent_id: UUID | None = None,
+    participant_id: UUID | None = None,
+    allow_origins: list[str] | None = None,
+    allow_origin_regex: str | None = None,
+    allow_methods: list[str] | None = None,
+    allow_headers: list[str] | None = None,
+    allow_credentials: bool = False,
+    protocols: Mapping[str, set[str]] | None = None,
+) -> None:
+    assert (specs_path is None) ^ (
+        settings is None
+    ), "Provide either specs_path or settings, but not both"
+
+    selected_protocols = _normalize_protocols(protocols)
+
+    lifespan = _create_lifespan(
+        hub=hub,
+        logger=logger,
+        specs_path=specs_path,
+        settings=settings,
+        tool_settings=tool_settings,
+        mcp_prefix=mcp_prefix,
+        mcp_name=mcp_name,
+        mcp_description=mcp_description,
+        a2a_tool_name=a2a_tool_name,
+        a2a_tool_description=a2a_tool_description,
+        selected_protocols=selected_protocols,
+        agent_id=agent_id,
+        participant_id=participant_id,
+    )
+
+    _attach_lifespan(app, lifespan)
+    _configure_cors(
+        app,
+        allow_origins=allow_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_methods=allow_methods,
+        allow_headers=allow_headers,
+        allow_credentials=allow_credentials,
+    )
+    _include_protocol_routers(
+        app,
+        selected_protocols=selected_protocols,
+        openai_prefix=openai_prefix,
+        mcp_prefix=mcp_prefix,
+        a2a_prefix=a2a_prefix,
+    )
+
+
+def agents_server(
+    hub: HuggingfaceHub,
+    name: str,
+    version: str,
+    host: str,
+    port: int,
+    reload: bool,
+    specs_path: str | None,
+    settings: OrchestratorSettings | None,
+    tool_settings: ToolSettingsContext | None,
+    mcp_prefix: str,
+    openai_prefix: str,
+    mcp_name: str,
+    logger: Logger,
+    mcp_description: str | None = None,
+    a2a_prefix: str = "/a2a",
+    a2a_tool_name: str = "run",
+    a2a_tool_description: str | None = None,
+    agent_id: UUID | None = None,
+    participant_id: UUID | None = None,
+    allow_origins: list[str] | None = None,
+    allow_origin_regex: str | None = None,
+    allow_methods: list[str] | None = None,
+    allow_headers: list[str] | None = None,
+    allow_credentials: bool = False,
+    protocols: Mapping[str, set[str]] | None = None,
+) -> "Server":
+    """Build a configured Uvicorn server for Avalan agents."""
+    assert (specs_path is None) ^ (
+        settings is None
+    ), "Provide either specs_path or settings, but not both"
+
+    from uvicorn import Config, Server
+
+    logger.debug("Creating %s server", name)
+    selected_protocols = _normalize_protocols(protocols)
+    lifespan = _create_lifespan(
+        hub=hub,
+        logger=logger,
+        specs_path=specs_path,
+        settings=settings,
+        tool_settings=tool_settings,
+        mcp_prefix=mcp_prefix,
+        mcp_name=mcp_name,
+        mcp_description=mcp_description,
+        a2a_tool_name=a2a_tool_name,
+        a2a_tool_description=a2a_tool_description,
+        selected_protocols=selected_protocols,
+        agent_id=agent_id,
+        participant_id=participant_id,
+    )
+    app = FastAPI(title=name, version=version, lifespan=lifespan)
+
+    _configure_cors(
+        app,
+        allow_origins=allow_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_methods=allow_methods,
+        allow_headers=allow_headers,
+        allow_credentials=allow_credentials,
+    )
+
+    logger.debug("Adding routes to %s server", name)
+    _include_protocol_routers(
+        app,
+        selected_protocols=selected_protocols,
+        openai_prefix=openai_prefix,
+        mcp_prefix=mcp_prefix,
+        a2a_prefix=a2a_prefix,
+    )
 
     logger.debug("Starting %s server at %s:%d", name, host, port)
     config = Config(app, host=host, port=port, reload=reload)

--- a/tests/server/register_agent_endpoints_test.py
+++ b/tests/server/register_agent_endpoints_test.py
@@ -1,0 +1,153 @@
+import os
+import sys
+from contextlib import asynccontextmanager
+from logging import Logger
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+from uuid import UUID
+
+import pytest
+
+from avalan.server import register_agent_endpoints
+
+
+MODULE = register_agent_endpoints.__module__
+SERVER_MODULE = sys.modules[MODULE]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_register_agent_endpoints_wraps_existing_lifespan() -> None:
+    logger = MagicMock(spec=Logger)
+    resource_store_instance = MagicMock(name="resource_store")
+    hub = MagicMock(name="hub")
+    generated_participant_id = UUID(int=5)
+    existing_events: list[str] = []
+
+    @asynccontextmanager
+    async def existing_lifespan(app):
+        existing_events.append("enter")
+        yield
+        existing_events.append("exit")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(),
+        include_router=MagicMock(),
+        add_middleware=MagicMock(),
+        router=SimpleNamespace(lifespan_context=existing_lifespan),
+    )
+
+    loader_instance = MagicMock(name="loader_instance")
+
+    with (
+        patch.object(
+            SERVER_MODULE.mcp_router,
+            "MCPResourceStore",
+            return_value=resource_store_instance,
+        ) as resource_store_cls,
+        patch.object(
+            SERVER_MODULE, "uuid4", return_value=generated_participant_id
+        ),
+        patch.object(
+            SERVER_MODULE, "OrchestratorLoader", return_value=loader_instance
+        ) as loader_cls,
+        patch.dict(os.environ, {}, clear=True),
+    ):
+        register_agent_endpoints(
+            app,
+            hub=hub,
+            logger=logger,
+            specs_path="agent.yaml",
+            settings=None,
+            tool_settings="tools",
+            mcp_prefix="/mcp",
+            openai_prefix="/openai",
+            mcp_name="run",
+        )
+
+        assert app.router.lifespan_context is not None
+
+        async with app.router.lifespan_context(app):
+            assert os.environ["TOKENIZERS_PARALLELISM"] == "false"
+            ctx = app.state.ctx
+            assert ctx.specs_path == "agent.yaml"
+            assert ctx.settings is None
+            assert ctx.tool_settings == "tools"
+            loader = app.state.loader
+            assert loader is loader_instance
+            loader_cls.assert_called_once()
+            assert loader_cls.call_args.kwargs["hub"] is hub
+            assert loader_cls.call_args.kwargs["logger"] is logger
+            assert (
+                loader_cls.call_args.kwargs["participant_id"]
+                == generated_participant_id
+            )
+            assert loader_cls.call_args.kwargs["stack"] is app.state.stack
+            assert app.state.logger is logger
+            assert app.state.agent_id is None
+            assert app.state.mcp_resource_store is resource_store_instance
+            assert app.state.mcp_resource_base_path == "/mcp"
+            assert app.state.mcp_tool_name == "run"
+
+    assert existing_events == ["enter", "exit"]
+    resource_store_cls.assert_called_once_with()
+
+
+def test_register_agent_endpoints_normalizes_protocols() -> None:
+    logger = MagicMock(spec=Logger)
+    hub = MagicMock(name="hub")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(),
+        include_router=MagicMock(),
+        add_middleware=MagicMock(),
+        router=SimpleNamespace(lifespan_context=None),
+    )
+
+    modules: dict[str, object] = {}
+
+    def import_module(name: str):
+        module = SimpleNamespace(router=f"router:{name}")
+        modules[name] = module
+        return module
+
+    sys.modules.pop("avalan.server.routers.chat", None)
+    sys.modules.pop("avalan.server.routers.responses", None)
+    sys.modules.pop("avalan.server.routers.engine", None)
+
+    with (
+        patch.object(SERVER_MODULE.mcp_router, "MCPResourceStore"),
+        patch.object(SERVER_MODULE.mcp_router, "create_router") as create_router,
+        patch.object(SERVER_MODULE, "OrchestratorLoader"),
+        patch.object(
+            SERVER_MODULE, "import_module", side_effect=import_module
+        ) as importer,
+    ):
+        register_agent_endpoints(
+            app,
+            hub=hub,
+            logger=logger,
+            specs_path=None,
+            settings="settings",
+            tool_settings=None,
+            mcp_prefix="/mcp",
+            openai_prefix="/openai",
+            mcp_name="run",
+            protocols={"openai": {"RESPONSES"}, "mcp": set()},
+        )
+
+        called_module_names = [
+            call.args[0] for call in importer.call_args_list
+        ]
+        assert "avalan.server.routers.responses" in called_module_names
+        assert "avalan.server.routers.engine" in called_module_names
+        assert "avalan.server.routers.chat" not in called_module_names
+        create_router.assert_called_once_with()
+        app.include_router.assert_any_call(modules["avalan.server.routers.engine"].router)
+        app.include_router.assert_any_call(
+            modules["avalan.server.routers.responses"].router, prefix="/openai"
+        )

--- a/tests/server/responses_test.py
+++ b/tests/server/responses_test.py
@@ -48,6 +48,10 @@ class ResponsesEndpointTestCase(IsolatedAsyncioTestCase):
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
+        sys.modules.pop("avalan.server.routers.responses", None)
+        sys.modules.pop("avalan.server.routers", None)
+        sys.modules.pop("avalan.server", None)
+
         self.FastAPI = FastAPI
         self.TestClient = TestClient
 


### PR DESCRIPTION
## Summary
- add `register_agent_endpoints` so existing FastAPI applications can mount Avalan agent routers and reuse the shared lifespan setup
- document how to embed the OpenAI/MCP/A2A endpoints in another FastAPI service
- extend server tests to cover the new helper and stabilize the responses test module imports

## Testing
- `poetry run pytest --verbose -s`


------
https://chatgpt.com/codex/tasks/task_e_68e5ca5970488323ae1bd9059fd5a298