### PR TITLE
Fix MCP tool call payload handling

### DIFF
--- a/src/avalan/server/routers/mcp.py
+++ b/src/avalan/server/routers/mcp.py
@@ -1054,12 +1054,14 @@ def _tool_call_event_item(event: Event) -> dict[str, JSONValue] | None:
             }
     if isinstance(event.payload, list) and event.payload:
         call = event.payload[0]
+    elif isinstance(event.payload, dict):
+        calls = event.payload.get("calls")
+        if isinstance(calls, list) and calls:
+            call = calls[0]
+        else:
+            call = event.payload.get("call")
     else:
-        call = (
-            event.payload.get("call")
-            if isinstance(event.payload, dict)
-            else None
-        )
+        call = None
     if call is None:
         return None
     return {

--- a/tests/server/mcp_router_test.py
+++ b/tests/server/mcp_router_test.py
@@ -337,6 +337,13 @@ class MCPUtilityTestCase(TestCase):
         dict_item = mcp_router._tool_call_event_item(dict_event)
         self.assertEqual(dict_item["name"], "run")
 
+        dict_calls_event = Event(
+            type=EventType.TOOL_PROCESS,
+            payload={"calls": [call]},
+        )
+        dict_calls_item = mcp_router._tool_call_event_item(dict_calls_event)
+        self.assertEqual(dict_calls_item["id"], "c1")
+
         none_event = Event(type=EventType.TOOL_PROCESS, payload=None)
         self.assertIsNone(mcp_router._tool_call_event_item(none_event))
 


### PR DESCRIPTION
## Summary
- Update `_tool_call_event_item` in `src/avalan/server/routers/mcp.py` to handle `EventType.TOOL_PROCESS` payloads that provide `calls` as a list by extracting the first call so MCP tool-call notifications are emitted for streaming tool calls.
- Add test coverage in `tests/server/mcp_router_test.py` for the `payload={'calls': [call]}` variant to ensure the new code path is exercised.

## Testing
- Ran `make lint`, which reformatted files but `mypy` failed due to a missing plugin error: `pyproject.toml:1:1: error: Error importing plugin "pydantic.mypy": No module named 'pydantic'`.
- Ran `poetry run pytest --verbose -s` and the test suite passed: `1566 passed, 11 skipped, 5 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625a2d705483239e953e70f583ddb3)