### PR TITLE
Limit MLX dependency install to Python 3.12 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,13 @@ jobs:
       - name: Install optional dependencies
         id: install-opt-deps
         run: >
-          poetry run pip install "mlx[cpu]==0.28.0" "mlx-lm==0.26.3" "beautifulsoup4==4.14.2" "pypdf==6.1.1"
+          poetry run pip install "beautifulsoup4==4.14.2" "pypdf==6.1.1"
+
+      - name: Install MLX dependencies (Python 3.12 only)
+        id: install-mlx-deps
+        if: matrix.python == '3.12'
+        run: >
+          poetry run pip install "mlx[cpu]==0.28.0" "mlx-lm==0.26.3"
 
       - name: Install dependencies
         id: install-deps


### PR DESCRIPTION
### Motivation
- Tests on the Python 3.11 CI job were crashing with a segmentation fault after model tests, likely caused by loading MLX native wheels; the change avoids installing those native MLX packages on the 3.11 matrix job.

### Description
- Update `.github/workflows/test.yml` to split optional dependency installation so `beautifulsoup4` and `pypdf` are always installed, and install `mlx[cpu]` and `mlx-lm` only in a new step guarded by `if: matrix.python == '3.12'`.

### Testing
- Ran `make lint` which completed successfully (formatters and `ruff` fixes applied).; Ran `poetry run pytest --verbose -s` which passed (`1574 passed, 11 skipped, 7 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7c67dbcc83239750362406f4e64e)