### PR TITLE
CI: Install mlx-lm only on Python 3.12 to avoid cross-version installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,13 @@ jobs:
       - name: Install optional dependencies
         id: install-opt-deps
         run: >
-          poetry run pip install "mlx[cpu]==0.28.0" "mlx-lm==0.26.3" "beautifulsoup4==4.14.2" "pypdf==6.1.1"
+          poetry run pip install "mlx[cpu]==0.28.0" "beautifulsoup4==4.14.2" "pypdf==6.1.1"
+
+      - name: Install MLX-LM dependencies (Python 3.12 only)
+        id: install-mlxlm-deps
+        if: matrix.python == '3.12'
+        run: >
+          poetry run pip install "mlx-lm==0.26.3"
 
       - name: Install dependencies
         id: install-deps


### PR DESCRIPTION
### Motivation
- Prevent installing `mlx-lm` on non-3.12 runners to avoid compatibility issues and reduce unnecessary dependency installs.
- Make the optional dependency installation step conditional on the Python matrix to keep the workflow deterministic across Python versions.

### Description
- Removed `mlx-lm==0.26.3` from the consolidated `Install optional dependencies` step.
- Added a new conditional step `Install MLX-LM dependencies (Python 3.12 only)` that runs `poetry run pip install "mlx-lm==0.26.3"` when `matrix.python == '3.12'`.
- Kept other optional packages (`mlx[cpu]`, `beautifulsoup4`, `pypdf`) installed in the original optional dependencies step.

### Testing
- The workflow runs the test suite with `poetry run pytest --cov=src/ --cov-report=xml` as part of the CI job.
- CI tests ran as part of the workflow and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7c67dbcc83239750362406f4e64e)