### PR TITLE
Bump GitHub Actions cache keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-v10
+          key: poetry-v11
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-v10-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-v11-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install optional dependencies
         id: install-opt-deps


### PR DESCRIPTION
### Motivation
- Force GitHub Actions to refresh cached Poetry installation and virtualenv as a mitigation for a segmentation fault observed when running tests on Python `3.11` by changing cache key versions.

### Description
- Update `.github/workflows/test.yml` to bump the cache key prefixes from `poetry-v10` to `poetry-v11` and from `venv-v10-${{ runner.os }}-...` to `venv-v11-${{ runner.os }}-...`.

### Testing
- Ran `make lint` and `poetry run pytest --verbose -s`, and the linting and test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8b3c0860832395e662f4ab3323eb)