### PR TITLE
Deterministic AsyncExitStack cleanup in Engine and ModelManager

### DIFF
--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -14,8 +14,8 @@ from ..model import (
     TokenizerNotSupportedException,
 )
 from ..model.vendor import TextGenerationVendor
+from .exit_stack import close_async_exit_stack
 
-import asyncio
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from importlib.util import find_spec
@@ -278,12 +278,7 @@ class Engine(ABC):
                 "Restored transformers logging level to %s",
                 self._transformers_logging_level,
             )
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(self._exit_stack.aclose())
-        else:
-            loop.create_task(self._exit_stack.aclose())
+        close_async_exit_stack(self._exit_stack)
         return False
 
     def _load(

--- a/src/avalan/model/exit_stack.py
+++ b/src/avalan/model/exit_stack.py
@@ -1,0 +1,19 @@
+import asyncio
+from contextlib import AsyncExitStack
+from threading import Thread
+
+
+def close_async_exit_stack(exit_stack: AsyncExitStack) -> None:
+    """Close an async exit stack from sync code in a deterministic way."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(exit_stack.aclose())
+        return
+
+    def close_in_background() -> None:
+        asyncio.run(exit_stack.aclose())
+
+    thread = Thread(target=close_in_background, daemon=False)
+    thread.start()
+    thread.join()

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -39,9 +39,9 @@ from ..model.vision.segmentation import SemanticSegmentationModel
 from ..model.vision.text import ImageTextToTextModel, ImageToTextModel
 from ..secrets import KeyringSecrets
 from .call import ModelCall
+from .exit_stack import close_async_exit_stack
 from .modalities import ModalityRegistry
 
-import asyncio
 from argparse import Namespace
 from contextlib import AsyncExitStack, ContextDecorator
 from logging import Logger
@@ -107,12 +107,7 @@ class ModelManager(ContextDecorator):
         exc_value: BaseException | None,
         traceback: Any | None,
     ):
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(self._stack.aclose())
-        else:
-            loop.create_task(self._stack.aclose())
+        close_async_exit_stack(self._stack)
         return False
 
     async def __aenter__(self) -> "ModelManager":

--- a/tests/model/engine_more_coverage_test.py
+++ b/tests/model/engine_more_coverage_test.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib.machinery
 import logging
 import sys
@@ -84,17 +83,8 @@ class ContextAsyncExitTestCase(IsolatedAsyncioTestCase):
             EngineSettings(auto_load_model=False, auto_load_tokenizer=False),
         )
         engine._exit_stack = AsyncMock()
-        loop = asyncio.get_running_loop()
-
-        def fake_create_task(coro: object) -> None:
-            assert isinstance(coro, object)
-            coro.close()  # type: ignore[attr-defined]
-
-        with patch.object(
-            loop, "create_task", side_effect=fake_create_task
-        ) as ct:
-            engine.__exit__(None, None, None)
-            ct.assert_called_once()
+        engine.__exit__(None, None, None)
+        engine._exit_stack.aclose.assert_awaited_once()
 
 
 class MlxLoadTestCase(TestCase):


### PR DESCRIPTION
### Motivation
- Tests running under Python 3.11 were crashing around synchronous context-manager exit paths that scheduled `AsyncExitStack.aclose()` on a running event loop, so cleanup must be deterministic from sync `__exit__` methods. 

### Description
- Add `close_async_exit_stack(exit_stack: AsyncExitStack)` helper that closes an `AsyncExitStack` deterministically by using `asyncio.run()` when no running loop exists or running the close in a dedicated thread when a loop is active (`src/avalan/model/exit_stack.py`).
- Replace ad-hoc event-loop scheduling in `Engine.__exit__` and `ModelManager.__exit__` with the new helper to ensure synchronous context cleanup is executed predictably (`src/avalan/model/engine.py`, `src/avalan/model/manager.py`).
- Update the async-exit coverage test to assert the new deterministic behavior by expecting `aclose()` to be awaited (`tests/model/engine_more_coverage_test.py`).

### Testing
- Ran `make lint`, which completed successfully and reformatted/fixed files as needed. 
- Ran the full test suite with `poetry run pytest --verbose -s`, which passed: `1574 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9823875083239c528c7b943517c5)