### PR TITLE
Await asynchronous engine/model cleanup on orchestrator exit

### DIFF
--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -28,6 +28,7 @@ from .response.orchestrator_response import OrchestratorResponse
 
 from contextlib import ExitStack
 from dataclasses import asdict
+from inspect import isawaitable
 from json import dumps
 from logging import Logger
 from time import perf_counter
@@ -48,6 +49,7 @@ class Orchestrator:
     _event_manager: EventManager
     _engine_agents: dict[EngineEnvironment, EngineAgent] = {}
     _engines_stack: ExitStack = ExitStack()
+    _engines: list[Engine]
     _operation_step: int | None = None
     _model_ids: set[str] = set()
     _call_options: dict | None = None
@@ -92,6 +94,7 @@ class Orchestrator:
         self._call_options = call_options
         self._user = user
         self._user_template = user_template
+        self._engines = []
 
     @property
     def engine_agent(self) -> EngineAgent | None:
@@ -274,6 +277,7 @@ class Orchestrator:
                     raise NotImplementedError()
 
                 self._engines_stack.enter_context(engine)
+                self._engines.append(engine)
                 agent = TemplateEngineAgent(
                     engine,
                     self._memory,
@@ -304,7 +308,15 @@ class Orchestrator:
         if self._exit_memory:
             self._memory.__exit__(exc_type, exc_value, traceback)
 
-        return self._engines_stack.__exit__(exc_type, exc_value, traceback)
+        result = self._engines_stack.__exit__(exc_type, exc_value, traceback)
+        for engine in self._engines:
+            wait_closed = getattr(engine, "wait_closed", None)
+            if wait_closed:
+                close_result = wait_closed()
+                if isawaitable(close_result):
+                    await close_result
+        self._engines.clear()
+        return result
 
     async def sync_messages(self) -> None:
         if self._last_engine_agent:

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -70,6 +70,7 @@ class Engine(ABC):
     _parameter_types: set[str] | None = None
     _parameter_count: int | None = None
     _exit_stack: AsyncExitStack = AsyncExitStack()
+    _pending_exit_task: asyncio.Task[None] | None = None
 
     DTYPE_SIZES: dict[str, int] = {
         "bool": 1,
@@ -283,8 +284,17 @@ class Engine(ABC):
         except RuntimeError:
             asyncio.run(self._exit_stack.aclose())
         else:
-            loop.create_task(self._exit_stack.aclose())
+            self._pending_exit_task = loop.create_task(
+                self._exit_stack.aclose()
+            )
         return False
+
+    async def wait_closed(self) -> None:
+        """Wait for any asynchronous close task scheduled by __exit__."""
+        if self._pending_exit_task is None:
+            return
+        await self._pending_exit_task
+        self._pending_exit_task = None
 
     def _load(
         self, *args, load_tokenizer: bool, tokenizer_name_or_path: str | None

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -85,6 +85,7 @@ class ModelManager(ContextDecorator):
     _logger: Logger
     _secrets: KeyringSecrets
     _event_manager: EventManager | None
+    _pending_exit_task: asyncio.Task[None] | None
 
     def __init__(
         self,
@@ -97,6 +98,7 @@ class ModelManager(ContextDecorator):
         self._stack = AsyncExitStack()
         self._secrets = secrets or KeyringSecrets()
         self._event_manager = event_manager
+        self._pending_exit_task = None
 
     def __enter__(self):
         return self
@@ -112,7 +114,7 @@ class ModelManager(ContextDecorator):
         except RuntimeError:
             asyncio.run(self._stack.aclose())
         else:
-            loop.create_task(self._stack.aclose())
+            self._pending_exit_task = loop.create_task(self._stack.aclose())
         return False
 
     async def __aenter__(self) -> "ModelManager":
@@ -124,6 +126,9 @@ class ModelManager(ContextDecorator):
         exc_value: BaseException | None,
         traceback: Any | None,
     ) -> bool:
+        if self._pending_exit_task is not None:
+            await self._pending_exit_task
+            self._pending_exit_task = None
         return await self._stack.__aexit__(exc_type, exc_value, traceback)
 
     async def __call__(

--- a/tests/agent/orchestrator_test.py
+++ b/tests/agent/orchestrator_test.py
@@ -140,8 +140,12 @@ class OrchestratorCallTestCase(unittest.IsolatedAsyncioTestCase):
         self.memory.has_permanent_message = True
         self.memory.has_recent_message = False
         self.orch._engines_stack.__exit__ = MagicMock(return_value="done")
+        engine = MagicMock()
+        engine.wait_closed = AsyncMock()
+        self.orch._engines = [engine]
         result = await self.orch.__aexit__(None, None, None)
         self.memory.__exit__.assert_called_once_with(None, None, None)
+        engine.wait_closed.assert_awaited_once()
         self.assertEqual(result, "done")
 
 

--- a/tests/model/engine_more_coverage_test.py
+++ b/tests/model/engine_more_coverage_test.py
@@ -84,17 +84,9 @@ class ContextAsyncExitTestCase(IsolatedAsyncioTestCase):
             EngineSettings(auto_load_model=False, auto_load_tokenizer=False),
         )
         engine._exit_stack = AsyncMock()
-        loop = asyncio.get_running_loop()
-
-        def fake_create_task(coro: object) -> None:
-            assert isinstance(coro, object)
-            coro.close()  # type: ignore[attr-defined]
-
-        with patch.object(
-            loop, "create_task", side_effect=fake_create_task
-        ) as ct:
-            engine.__exit__(None, None, None)
-            ct.assert_called_once()
+        engine.__exit__(None, None, None)
+        await asyncio.sleep(0)
+        engine._exit_stack.aclose.assert_awaited_once()
 
 
 class MlxLoadTestCase(TestCase):


### PR DESCRIPTION
### Motivation
- Ensure asynchronous close tasks started in `Engine.__exit__` and `ModelManager.__exit__` are awaited to avoid dangling tasks and resource leaks during shutdown.
- Make the orchestrator wait for engine-specific close logic to complete when exiting its context so message/engine lifecycle completes predictably.

### Description
- Added an `_engines` list to `Orchestrator` and record engines loaded in `__aenter__`, and in `__aexit__` iterate the list to call each engine's `wait_closed` and await it if present, then clear the list; imported `isawaitable` to guard awaiting close results.
- In `Engine`, added `_pending_exit_task` and assign the task returned by `loop.create_task(self._exit_stack.aclose())` in `__exit__`, and added an async `wait_closed` method to await the pending task and clear it.
- In `ModelManager`, added `_pending_exit_task`, store the scheduled close task in `__exit__`, and `__aexit__` now awaits the pending task before delegating to the stack `__aexit__`.
- Updated tests to assert that engine close paths are awaited: `tests/agent/orchestrator_test.py` now checks `engine.wait_closed` is awaited, and `tests/model/engine_more_coverage_test.py` verifies the engine `_exit_stack.aclose` was awaited.

### Testing
- Ran the updated orchestrator unit test `tests/agent/orchestrator_test.py::OrchestratorCallTestCase::test_aexit_saves_message` and it passed, confirming `wait_closed` was awaited. 
- Ran the updated engine async exit test `tests/model/engine_more_coverage_test.py::ContextAsyncExitTestCase::test_exit_with_running_loop` and it passed, confirming `_exit_stack.aclose` was awaited.
- Ran the project test suite for the modified modules with `pytest` and the modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9823875083239c528c7b943517c5)