### PR TITLE
Stabilize vendor engine load test

### DIFF
--- a/tests/model/model_manager_test.py
+++ b/tests/model/model_manager_test.py
@@ -1,5 +1,7 @@
 from logging import Logger
 from os import environ
+from sys import modules
+from types import ModuleType
 from unittest import TestCase, main
 from unittest.mock import MagicMock, patch
 
@@ -391,16 +393,28 @@ class ManagerLoadEngineTestCase(TestCase):
                     engine_uri = manager.parse_uri(uri)
                     settings = TransformerEngineSettings()
                     manager._stack.enter_context = MagicMock()
-                    with patch(path) as Model:
-                        result = manager.load_engine(
-                            engine_uri,
-                            settings,
-                            (
-                                Modality.EMBEDDING
-                                if is_sentence
-                                else Modality.TEXT_GENERATION
-                            ),
+                    if vendor in {"local", "sentence"}:
+                        context = patch(path)
+                    else:
+                        module_name, class_name = path.rsplit(".", 1)
+                        fake_module = ModuleType(module_name)
+                        fake_model = MagicMock(name=class_name)
+                        setattr(fake_module, class_name, fake_model)
+                        context = patch.dict(
+                            modules, {module_name: fake_module}
                         )
+
+                    with context:
+                        with patch(path) as Model:
+                            result = manager.load_engine(
+                                engine_uri,
+                                settings,
+                                (
+                                    Modality.EMBEDDING
+                                    if is_sentence
+                                    else Modality.TEXT_GENERATION
+                                ),
+                            )
                         expected_kwargs = dict(
                             model_id=model_id,
                             settings=settings,


### PR DESCRIPTION
### Motivation

- The vendor engine-load unit test imported real third-party vendor modules during patching which caused flaky failures (for example triggering `tiktoken` / HF network requests and an `IndentationError`).
- The change isolates the test from external imports and network access so it no longer depends on third-party packages being present or reachable.

### Description

- Updated `ManagerLoadEngineTestCase.test_load_engine_per_vendor` to inject a fake module into `sys.modules` for non-local/non-sentence vendors before applying `patch(path)` to avoid importing real vendor packages. 
- Added `from sys import modules` and `from types import ModuleType` imports to support creating and inserting fake modules. 
- Kept direct `patch(path)` behavior for `local` and `sentence` vendors and preserved existing assertions validating constructor args and context manager usage.

### Testing

- Ran `make lint` which reformatted files and reported all checks passed. 
- Ran the targeted test with `poetry run pytest --verbose -s tests/model/model_manager_test.py::ManagerLoadEngineTestCase::test_load_engine_per_vendor` which passed. 
- Ran the full test suite with `poetry run pytest --verbose -s` which completed successfully with all tests passing (1574 passed, 11 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba174d9f8832394adaacd30a8a606)