### PR TITLE
Enable mypy for deploy: type AWS module and remove deploy override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ python_version = "3.11"
 module = [
   "avalan.agent.*",
   "avalan.cli.*",
-  "avalan.deploy.*",
   "avalan.memory.*",
   "avalan.model.*",
   "avalan.server.*",
@@ -235,6 +234,9 @@ module = [
   "a2a",
   "anyio",
   "boto3",
+  "boto3.*",
+  "botocore",
+  "botocore.*",
   "bs4",
   "fastapi",
   "fastapi.*",

--- a/src/avalan/deploy/aws.py
+++ b/src/avalan/deploy/aws.py
@@ -1,8 +1,7 @@
 from asyncio import AbstractEventLoop, get_running_loop
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, cast
 
-from boto3 import client
 from boto3.session import Session
 from botocore.exceptions import ClientError
 
@@ -33,10 +32,10 @@ class AsyncWaiter:
 class AsyncClient:
     def __init__(
         self,
-        client: client,
+        client: Any,
         loop: AbstractEventLoop | None = None,
         executor: ThreadPoolExecutor | None = None,
-    ):
+    ) -> None:
         self._client = client
         self._loop = loop or get_running_loop()
         self._executor = executor or ThreadPoolExecutor()
@@ -46,7 +45,7 @@ class AsyncClient:
         if not callable(attr):
             return attr
 
-        async def fn(*args, **kwargs):
+        async def fn(*args: Any, **kwargs: Any) -> Any:
             result = await self._loop.run_in_executor(
                 self._executor, lambda: attr(*args, **kwargs)
             )
@@ -63,12 +62,14 @@ class Aws:
     _session: Session
 
     def __init__(
-        self, settings: dict | None = None, token_pair: str | None = None
-    ):
+        self,
+        settings: dict[str, str] | None = None,
+        token_pair: str | None = None,
+    ) -> None:
         if settings and "token_pair" in settings and not token_pair:
             token_pair = settings.pop("token_pair")
 
-        aws_settings = {}
+        aws_settings: dict[str, str] = {}
 
         if token_pair:
             access_key, secret_key = token_pair.split(":", 1)
@@ -85,42 +86,56 @@ class Aws:
         self._rds = AsyncClient(self._session.client("rds"))
 
     async def get_vpc_id(self, name: str) -> str:
-        response = await self._ec2.describe_vpcs(
-            Filters=[{"Name": "tag:Name", "Values": [name]}]
+        response = cast(
+            dict[str, Any],
+            await self._ec2.describe_vpcs(
+                Filters=[{"Name": "tag:Name", "Values": [name]}]
+            ),
         )
-        vpcs = response.get("Vpcs", [])
+        vpcs = cast(list[dict[str, Any]], response.get("Vpcs", []))
         if not vpcs:
             raise DeployError(f"VPC {name!r} not found")
-        return vpcs[0]["VpcId"]
+        return str(vpcs[0]["VpcId"])
 
     async def create_vpc_if_missing(self, name: str, cidr: str) -> str:
         """Return an existing VPC id or create a new VPC."""
         try:
             return await self.get_vpc_id(name)
         except DeployError:
-            response = await self._ec2.create_vpc(CidrBlock=cidr)
-            vpc_id = response["Vpc"]["VpcId"]
+            response = cast(
+                dict[str, Any], await self._ec2.create_vpc(CidrBlock=cidr)
+            )
+            vpc = cast(dict[str, Any], response["Vpc"])
+            vpc_id = str(vpc["VpcId"])
             await self._ec2.create_tags(
                 Resources=[vpc_id], Tags=[{"Key": "Name", "Value": name}]
             )
-            waiter = await self._ec2.get_waiter("vpc_available")
+            waiter = cast(
+                AsyncWaiter, await self._ec2.get_waiter("vpc_available")
+            )
             await waiter.wait(VpcIds=[vpc_id])
             return vpc_id
 
     async def get_security_group(self, name: str, vpc_id: str) -> str:
-        response = await self._ec2.describe_security_groups(
-            Filters=[{"Name": "group-name", "Values": [name]}]
+        response = cast(
+            dict[str, Any],
+            await self._ec2.describe_security_groups(
+                Filters=[{"Name": "group-name", "Values": [name]}]
+            ),
         )
-        groups = response.get("SecurityGroups", [])
+        groups = cast(list[dict[str, Any]], response.get("SecurityGroups", []))
         if groups:
-            return groups[0]["GroupId"]
+            return str(groups[0]["GroupId"])
 
-        response = await self._ec2.create_security_group(
-            GroupName=name,
-            Description="avalan deployment",
-            VpcId=vpc_id,
+        response = cast(
+            dict[str, Any],
+            await self._ec2.create_security_group(
+                GroupName=name,
+                Description="avalan deployment",
+                VpcId=vpc_id,
+            ),
         )
-        return response["GroupId"]
+        return str(response["GroupId"])
 
     async def configure_security_group(self, group_id: str, port: int) -> None:
         try:
@@ -138,9 +153,28 @@ class Aws:
     async def create_rds_if_missing(
         self, db_id: str, instance_class: str, sg_id: str, storage: int
     ) -> str:
+        not_found_error = getattr(
+            getattr(self._rds, "exceptions", object()),
+            "DBInstanceNotFoundFault",
+            None,
+        )
+
         try:
             await self._rds.describe_db_instances(DBInstanceIdentifier=db_id)
-        except self._rds.exceptions.DBInstanceNotFoundFault:
+        except Exception as exc:
+            is_not_found = bool(
+                not_found_error
+                and isinstance(exc, cast(type[BaseException], not_found_error))
+            )
+            if isinstance(exc, ClientError):
+                is_not_found = (
+                    is_not_found
+                    or cast(str, exc.response["Error"]["Code"])
+                    == "DBInstanceNotFound"
+                )
+            if not is_not_found:
+                raise
+
             await self._rds.create_db_instance(
                 DBInstanceIdentifier=db_id,
                 DBInstanceClass=instance_class,
@@ -151,7 +185,10 @@ class Aws:
                 VpcSecurityGroupIds=[sg_id],
                 Tags=[{"Key": "Name", "Value": db_id}],
             )
-            waiter = await self._rds.get_waiter("db_instance_available")
+            waiter = cast(
+                AsyncWaiter,
+                await self._rds.get_waiter("db_instance_available"),
+            )
             await waiter.wait(DBInstanceIdentifier=db_id)
         return db_id
 
@@ -166,35 +203,53 @@ class Aws:
         port: int,
     ) -> str:
         user_data = self._create_user_data(agent_path, port)
-        response = await self._ec2.describe_instances(
-            Filters=[{"Name": "tag:Name", "Values": [instance_name]}]
+        response = cast(
+            dict[str, Any],
+            await self._ec2.describe_instances(
+                Filters=[{"Name": "tag:Name", "Values": [instance_name]}]
+            ),
         )
-        reservations = response.get("Reservations", [])
+        reservations = cast(
+            list[dict[str, Any]], response.get("Reservations", [])
+        )
         if reservations:
-            return reservations[0]["Instances"][0]["InstanceId"]
+            instances = cast(
+                list[dict[str, Any]], reservations[0].get("Instances", [])
+            )
+            if instances:
+                return str(instances[0]["InstanceId"])
 
-        response = await self._ec2.describe_subnets(
-            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+        response = cast(
+            dict[str, Any],
+            await self._ec2.describe_subnets(
+                Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+            ),
         )
+        subnets = cast(list[dict[str, Any]], response.get("Subnets", []))
+        assert subnets, "No subnet found for VPC"
+        subnet = str(subnets[0]["SubnetId"])
 
-        subnet = response["Subnets"][0]["SubnetId"]
-
-        response = await self._ec2.run_instances(
-            ImageId=ami_id,
-            InstanceType=instance_type,
-            MinCount=1,
-            MaxCount=1,
-            SecurityGroupIds=[sg_id],
-            SubnetId=subnet,
-            UserData=user_data,
-            TagSpecifications=[
-                {
-                    "ResourceType": "instance",
-                    "Tags": [{"Key": "Name", "Value": instance_name}],
-                }
-            ],
+        response = cast(
+            dict[str, Any],
+            await self._ec2.run_instances(
+                ImageId=ami_id,
+                InstanceType=instance_type,
+                MinCount=1,
+                MaxCount=1,
+                SecurityGroupIds=[sg_id],
+                SubnetId=subnet,
+                UserData=user_data,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": instance_name}],
+                    }
+                ],
+            ),
         )
-        return response["Instances"][0]["InstanceId"]
+        instances = cast(list[dict[str, Any]], response.get("Instances", []))
+        assert instances, "No instance returned by EC2"
+        return str(instances[0]["InstanceId"])
 
     def _create_user_data(self, agent_path: str, port: int) -> str:
         cmd = f"avalan agent serve {agent_path} --host 0.0.0.0 --port {port}\n"


### PR DESCRIPTION
### Motivation
- Remove the `avalan.deploy.*` mypy override so deploy code is statically checked under the repository-wide strict mypy configuration.
- Keep third-party stubs ignored for libraries lacking py.typed stubs while ensuring first-party code is fully typed and checked.

### Description
- Removed `"avalan.deploy.*"` from the `[[tool.mypy.overrides]]` ignore list in `pyproject.toml` and added `boto3.*`, `botocore`, and `botocore.*` to the third-party ignores to handle missing stubs.
- Heavily typed `src/avalan/deploy/aws.py` by adding explicit return annotations, typed parameters and local dictionaries (`dict[str, str]`), and explicit `-> None`/`-> str` where appropriate.
- Wrapped and cast AWS client responses using `cast(...)` and normalized extracted IDs to `str` to satisfy mypy and make runtime behavior explicit and safe.
- Made RDS-not-found handling robust by detecting boto3 dynamic exception types and falling back to inspecting `ClientError` `response["Error"]["Code"]`, preserving previous semantics used in tests.

### Testing
- Ran `make lint` and autofixes (`ruff`/`black`) which completed successfully.
- Ran `poetry run mypy src/avalan` which reported success with no errors.
- Ran `poetry run pytest --verbose -s tests/deploy/aws_test.py` which passed all tests in that file.
- Ran the full test suite with `poetry run pytest --verbose -s` which passed (`1574 passed, 11 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba7674a388323b5ec47b26e3af6c4)