### PR TITLE
Improve server typing for mypy cleanup

### DIFF
--- a/src/avalan/server/entities.py
+++ b/src/avalan/server/entities.py
@@ -2,7 +2,7 @@ from ..entities import MessageRole, OrchestratorSettings
 from ..tool.context import ToolSettingsContext
 
 from dataclasses import dataclass
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
@@ -157,7 +157,9 @@ class ChatCompletionRequest(BaseModel):
         None, description="Format to use for model response"
     )
     tools: list[Tool] | None = None
-    tool_choice: Literal["auto", "none", "required"] | str | dict | None = None
+    tool_choice: (
+        Literal["auto", "none", "required"] | str | dict[str, object] | None
+    ) = None
 
 
 class ResponsesRequest(BaseModel):
@@ -172,7 +174,7 @@ class ResponsesRequest(BaseModel):
     response_format: ResponseFormat | None = None
 
     @property
-    def messages(self) -> list[ChatMessage]:  # type: ignore[override]
+    def messages(self) -> list[ChatMessage]:
         return self.input
 
 
@@ -225,7 +227,7 @@ class ModelInfo(BaseModel):
     object: str = "model"
     created: int
     owned_by: str
-    permission: list[dict]
+    permission: list[dict[str, Any]]
 
 
 class ModelList(BaseModel):

--- a/src/avalan/server/routers/__init__.py
+++ b/src/avalan/server/routers/__init__.py
@@ -1,4 +1,7 @@
 from ...agent.orchestrator import Orchestrator
+from ...agent.orchestrator.response.orchestrator_response import (
+    OrchestratorResponse,
+)
 from ...entities import (
     GenerationSettings,
     Message,
@@ -11,20 +14,35 @@ from ...entities import (
 from ...entities import (
     ToolCallToken as ToolCallToken,
 )
-from ...server.entities import ChatCompletionRequest, ContentImage, ContentText
+from ...server.entities import (
+    ChatCompletionRequest,
+    ContentImage,
+    ContentText,
+    ResponsesRequest,
+)
 
 from logging import Logger
 from time import time
+from typing import TypeAlias, cast
 from uuid import uuid4
 
 from fastapi import HTTPException
 
+MessageContentInput: TypeAlias = (
+    str | ContentImage | ContentText | list[ContentImage | ContentText]
+)
+MessageContentOutput: TypeAlias = (
+    MessageContentText
+    | MessageContentImage
+    | list[MessageContentText | MessageContentImage]
+)
+
 
 async def orchestrate(
-    request: ChatCompletionRequest,
+    request: ChatCompletionRequest | ResponsesRequest,
     logger: Logger,
     orchestrator: Orchestrator,
-):
+) -> tuple[OrchestratorResponse, str, int]:
     messages = [
         Message(role=req.role, content=to_message_content(req.content))
         for req in request.messages
@@ -40,7 +58,7 @@ async def orchestrate(
     timestamp = int(time())
 
     settings = GenerationSettings(
-        use_async_generator=request.stream,
+        use_async_generator=bool(request.stream),
         temperature=request.temperature,
         max_new_tokens=request.max_tokens,
         stop_strings=request.stop,
@@ -56,15 +74,17 @@ async def orchestrate(
     )
 
     response = await orchestrator(messages, settings=settings)
-    return response, response_id, timestamp
+    return response, str(response_id), timestamp
 
 
-def to_message_content(item):
+def to_message_content(item: MessageContentInput) -> MessageContentOutput:
     if isinstance(item, list):
         return [
-            to_message_content(i)
+            cast(
+                MessageContentText | MessageContentImage, to_message_content(i)
+            )
             for i in item
-            if isinstance(i, (ContentImage, ContentText, str))
+            if isinstance(i, (ContentImage, ContentText))
         ]
     if isinstance(item, ContentImage):
         return MessageContentImage(type=item.type, image_url=item.image_url)

--- a/src/avalan/server/routers/chat.py
+++ b/src/avalan/server/routers/chat.py
@@ -16,6 +16,7 @@ from ..sse import sse_headers, sse_message
 from . import orchestrate
 
 from logging import Logger
+from typing import AsyncIterator
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
@@ -31,7 +32,7 @@ async def create_chat_completion(
     request: ChatCompletionRequest,
     logger: Logger = Depends(di_get_logger),
     orchestrator: Orchestrator = Depends(di_get_orchestrator),
-):
+) -> ChatCompletionResponse | StreamingResponse:
     assert orchestrator and isinstance(orchestrator, Orchestrator)
     assert logger and isinstance(logger, Logger)
     assert request and request.messages
@@ -56,18 +57,20 @@ async def create_chat_completion(
     # Streaming through SSE (server-sent events with text/event-stream)
     if request.stream:
 
-        async def generate_chunks():
+        async def generate_chunks() -> AsyncIterator[str]:
             async for token in response:
                 if isinstance(token, Event):
                     continue
-                elif isinstance(token, (ReasoningToken, ToolCallToken)):
-                    token = token.token
+                if isinstance(token, (ReasoningToken, ToolCallToken)):
+                    token_text = token.token
+                else:
+                    token_text = str(token)
 
                 choice = ChatCompletionChunkChoice(
-                    delta=ChatCompletionChunkChoiceDelta(content=token)
+                    delta=ChatCompletionChunkChoiceDelta(content=token_text)
                 )
                 chunk = ChatCompletionChunk(
-                    id=str(response_id),
+                    id=response_id,
                     created=timestamp,
                     model=request.model,
                     choices=[choice],
@@ -78,7 +81,7 @@ async def create_chat_completion(
             await orchestrator.sync_messages()
 
         logger.debug(
-            f"Generating event-stream stream for response {response_id}"
+            "Generating event-stream stream for response %s", response_id
         )
 
         return StreamingResponse(
@@ -98,17 +101,19 @@ async def create_chat_completion(
         for i in range(request.n or 1)
     ]
     usage = ChatCompletionUsage()
-    response = ChatCompletionResponse(
-        id=str(response_id),
+    final_response = ChatCompletionResponse(
+        id=response_id,
         created=timestamp,
         model=request.model,
         choices=choices,
         usage=usage,
     )
     logger.debug(
-        "Generated chat completion response #%s %r", response_id, response
+        "Generated chat completion response #%s %r",
+        response_id,
+        final_response,
     )
 
     await orchestrator.sync_messages()
 
-    return response
+    return final_response

--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -16,6 +16,7 @@ from . import orchestrate
 
 from enum import Enum, auto
 from logging import Logger
+from typing import Any, AsyncIterator, cast
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
@@ -30,12 +31,12 @@ class ResponseState(Enum):
 router = APIRouter(tags=["responses"])
 
 
-@router.post("/responses")
+@router.post("/responses", response_model=None)
 async def create_response(
     request: ResponsesRequest,
     logger: Logger = Depends(di_get_logger),
     orchestrator: Orchestrator = Depends(di_get_orchestrator),
-):
+) -> dict[str, Any] | StreamingResponse:
     assert orchestrator and isinstance(orchestrator, Orchestrator)
     assert logger and isinstance(logger, Logger)
     assert request and request.messages
@@ -46,22 +47,20 @@ async def create_response(
 
     if request.stream:
 
-        async def generate():
+        async def generate() -> AsyncIterator[str]:
             seq = 0
 
             yield sse_message(
-                to_json(
-                    {
-                        "type": "response.created",
-                        "response": {
-                            "id": str(response_id),
-                            "created_at": timestamp,
-                            "model": request.model,
-                            "type": "response",
-                            "status": "in_progress",
-                        },
-                    }
-                ),
+                to_json({
+                    "type": "response.created",
+                    "response": {
+                        "id": str(response_id),
+                        "created_at": timestamp,
+                        "model": request.model,
+                        "type": "response",
+                        "status": "in_progress",
+                    },
+                }),
                 event="response.created",
             )
 
@@ -69,18 +68,13 @@ async def create_response(
             tool_call_id: str | None = None
 
             async for token in response:
-                is_event = isinstance(token, Event)
-                if is_event and token.type not in (
-                    EventType.TOOL_PROCESS,
-                    EventType.TOOL_RESULT,
-                ):
-                    continue
-
                 call_id: str | None = None
-                if is_event and token.type in (
-                    EventType.TOOL_PROCESS,
-                    EventType.TOOL_RESULT,
-                ):
+                if isinstance(token, Event):
+                    if token.type not in (
+                        EventType.TOOL_PROCESS,
+                        EventType.TOOL_RESULT,
+                    ):
+                        continue
                     call_id = _tool_call_event_item(token)["id"]
                 elif (
                     isinstance(token, ToolCallToken) and token.call is not None
@@ -149,15 +143,13 @@ def _token_to_sse(
     if isinstance(token, ReasoningToken):
         events.append(
             sse_message(
-                to_json(
-                    {
-                        "type": "response.reasoning_text.delta",
-                        "delta": token.token,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "sequence_number": seq,
-                    }
-                ),
+                to_json({
+                    "type": "response.reasoning_text.delta",
+                    "delta": token.token,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "sequence_number": seq,
+                }),
                 event="response.reasoning_text.delta",
             )
         )
@@ -180,17 +172,15 @@ def _token_to_sse(
 
         events.append(
             sse_message(
-                to_json(
-                    {
-                        **delta_obj,
-                        "type": "response.function_call_arguments.delta",
-                        "delta": to_json(delta_obj),
-                        "id": item["id"],
-                        "output_index": 0,
-                        "content_index": 0,
-                        "sequence_number": seq,
-                    }
-                ),
+                to_json({
+                    **delta_obj,
+                    "type": "response.function_call_arguments.delta",
+                    "delta": to_json(delta_obj),
+                    "id": item["id"],
+                    "output_index": 0,
+                    "content_index": 0,
+                    "sequence_number": seq,
+                }),
                 event="response.function_call_arguments.delta",
             )
         )
@@ -203,50 +193,42 @@ def _token_to_sse(
             }
             events.append(
                 sse_message(
-                    to_json(
-                        {
-                            "type": "response.function_call_arguments.delta",
-                            "delta": to_json(delta_obj),
-                            "id": str(token.call.id),
-                            "output_index": 0,
-                            "content_index": 0,
-                            "sequence_number": seq,
-                        }
-                    ),
+                    to_json({
+                        "type": "response.function_call_arguments.delta",
+                        "delta": to_json(delta_obj),
+                        "id": str(token.call.id),
+                        "output_index": 0,
+                        "content_index": 0,
+                        "sequence_number": seq,
+                    }),
                     event="response.function_call_arguments.delta",
                 )
             )
         else:
             events.append(
                 sse_message(
-                    to_json(
-                        {
-                            "type": "response.custom_tool_call_input.delta",
-                            "delta": token.token,
-                            "output_index": 0,
-                            "content_index": 0,
-                            "sequence_number": seq,
-                        }
-                    ),
+                    to_json({
+                        "type": "response.custom_tool_call_input.delta",
+                        "delta": token.token,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "sequence_number": seq,
+                    }),
                     event="response.custom_tool_call_input.delta",
                 )
             )
     else:
         events.append(
             sse_message(
-                to_json(
-                    {
-                        "type": "response.output_text.delta",
-                        "delta": (
-                            token.token
-                            if isinstance(token, Token)
-                            else str(token)
-                        ),
-                        "output_index": 0,
-                        "content_index": 0,
-                        "sequence_number": seq,
-                    }
-                ),
+                to_json({
+                    "type": "response.output_text.delta",
+                    "delta": (
+                        token.token if isinstance(token, Token) else str(token)
+                    ),
+                    "output_index": 0,
+                    "content_index": 0,
+                    "sequence_number": seq,
+                }),
                 event="response.output_text.delta",
             )
         )
@@ -259,8 +241,6 @@ def _switch_state(
     current_tool_call_id: str | None,
     new_tool_call_id: str | None,
 ) -> list[str]:
-    new_state: ResponseState | None
-
     events: list[str] = []
     changed = state is not new_state or (
         state is ResponseState.TOOL_CALLING
@@ -295,7 +275,13 @@ def _switch_state(
 
 
 def _new_state(
-    token: ReasoningToken | ToolCallToken | Token | TokenDetail | str | None,
+    token: ReasoningToken
+    | ToolCallToken
+    | Token
+    | TokenDetail
+    | Event
+    | str
+    | None,
 ) -> ResponseState | None:
     if isinstance(token, ReasoningToken):
         new_state = ResponseState.REASONING
@@ -321,13 +307,11 @@ def _output_item_added(state: ResponseState, id: str | None = None) -> str:
     if id is not None:
         item["id"] = id
     return sse_message(
-        to_json(
-            {
-                "type": "response.output_item.added",
-                "output_index": 0,
-                "item": item,
-            }
-        ),
+        to_json({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": item,
+        }),
         event="response.output_item.added",
     )
 
@@ -341,13 +325,11 @@ def _output_item_done(id: str | None = None) -> str:
 
 def _reasoning_text_done() -> str:
     return sse_message(
-        to_json(
-            {
-                "type": "response.reasoning_text.done",
-                "output_index": 0,
-                "content_index": 0,
-            }
-        ),
+        to_json({
+            "type": "response.reasoning_text.done",
+            "output_index": 0,
+            "content_index": 0,
+        }),
         event="response.reasoning_text.done",
     )
 
@@ -368,13 +350,11 @@ def _custom_tool_call_input_done(id: str | None = None) -> str:
 
 def _output_text_done() -> str:
     return sse_message(
-        to_json(
-            {
-                "type": "response.output_text.done",
-                "output_index": 0,
-                "content_index": 0,
-            }
-        ),
+        to_json({
+            "type": "response.output_text.done",
+            "output_index": 0,
+            "content_index": 0,
+        }),
         event="response.output_text.done",
     )
 
@@ -384,14 +364,12 @@ def _content_part_added(part_type: str, id: str | None = None) -> str:
     if id is not None:
         part["id"] = id
     return sse_message(
-        to_json(
-            {
-                "type": "response.content_part.added",
-                "output_index": 0,
-                "content_index": 0,
-                "part": part,
-            }
-        ),
+        to_json({
+            "type": "response.content_part.added",
+            "output_index": 0,
+            "content_index": 0,
+            "part": part,
+        }),
         event="response.content_part.added",
     )
 
@@ -407,15 +385,21 @@ def _content_part_done(id: str | None = None) -> str:
     return sse_message(to_json(data), event="response.content_part.done")
 
 
-def _tool_call_event_item(event: Event) -> dict:
+def _tool_call_event_item(event: Event) -> dict[str, Any]:
+    payload = cast(Any, event.payload)
     tool_result = (
-        event.payload["result"]
-        if event.type == EventType.TOOL_RESULT and "result" in event.payload
+        payload["result"]
+        if event.type == EventType.TOOL_RESULT
+        and isinstance(payload, dict)
+        and "result" in payload
         else None
     )
-    tool_call = (
-        tool_result.call if tool_result is not None else event.payload[0]
-    )
+    if tool_result is not None:
+        tool_call = tool_result.call
+    elif isinstance(payload, list):
+        tool_call = payload[0]
+    else:
+        tool_call = cast(dict[Any, Any], payload)[0]
     item = {
         "type": "function_call",
         "id": str(tool_call.id),


### PR DESCRIPTION
### Motivation
- Remove strict mypy overrides for server modules by tightening types and narrowing unions so mypy can analyze `avalan.server` code without ignore rules.
- Preserve existing runtime behavior while making FastAPI endpoint annotations and SSE/event handling type-safe.

### Description
- Tightened request/response entity types in `src/avalan/server/entities.py`, including `tool_choice`, `permission`, and `ResponsesRequest.messages` to use concrete typed dicts and remove `type: ignore` usage.
- Added explicit `TypeAlias` definitions and return type to `server.routers.orchestrate`, normalized `use_async_generator` and improved `to_message_content` typing in `src/avalan/server/routers/__init__.py`.
- Strengthened `chat` router typing and streaming handling in `src/avalan/server/routers/chat.py` by annotating the async generator, avoiding mixed-type reassignment for tokens, and returning an explicitly typed final response object.
- Updated `responses` router in `src/avalan/server/routers/responses.py` to use `response_model=None` for FastAPI compatibility, annotate the streaming generator, narrow event handling, and make `_tool_call_event_item` robust to both dict- and list-shaped event payloads.

### Testing
- Ran formatting and linting with `make lint` (which runs `ruff` and `black`) and `ruff --fix`, all checks passed.
- Ran mypy for the server subset with `poetry run mypy --config-file /tmp/pyproject_server.toml src/avalan/server/entities.py src/avalan/server/routers/__init__.py src/avalan/server/routers/chat.py src/avalan/server/routers/responses.py` and it reported `Success: no issues found`.
- Executed targeted tests with `poetry run pytest -q tests/server/create_response_sse_test.py::CreateResponseSSEEventsTestCase::test_custom_tool_call_call_wraps_items_with_id tests/server/create_response_sse_test.py::CreateResponseSSEEventsTestCase::test_streaming_includes_tool_call_token_with_call` and both passed.
- Ran the full test suite with `poetry run pytest --verbose -s` and observed `1574 passed, 11 skipped, 7 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbaf4447b883238d18085e72ee8ef7)