### PR TITLE
Fix strict mypy types in MemorySource and HuggingfaceHub

### DIFF
--- a/src/avalan/memory/source.py
+++ b/src/avalan/memory/source.py
@@ -89,10 +89,13 @@ class MemorySource:
 
         if self._is_pdf(url, content_type, data):
             metadata = PdfReader(BytesIO(data)).metadata
-            metadata_title = (
+            metadata_title_raw = (
                 metadata["/Title"]
                 if metadata and "/Title" in metadata
                 else None
+            )
+            metadata_title = (
+                str(metadata_title_raw) if metadata_title_raw else None
             )
             title = metadata_title or title or self._markdown_title(markdown)
             description = description or self._markdown_description(markdown)

--- a/src/avalan/model/hubs/huggingface.py
+++ b/src/avalan/model/hubs/huggingface.py
@@ -52,7 +52,7 @@ class HuggingfaceHub:
             endpoint=endpoint,
             token=access_token,
             library_name=name(),
-            library_version=version(),
+            library_version=str(version()),
         )
         self._cache_dir = expanduser(cache_dir)
         self._domain = urlparse(endpoint).netloc
@@ -60,7 +60,7 @@ class HuggingfaceHub:
 
     def cache_delete(
         self, model_id: str, revisions: list[str] | None = None
-    ) -> (HubCacheDeletion | None, Callable[[], None] | None):
+    ) -> tuple[HubCacheDeletion | None, Callable[[], None] | None]:
         scan_results = scan_cache_dir(self._cache_dir)
         delete_revisions = [
             revision.commit_hash
@@ -126,7 +126,9 @@ class HuggingfaceHub:
                 )
                 for info in scan_results.repos
             ],
-            key=lambda m: m.size_on_disk if sort_models_by_size else m.name,
+            key=lambda m: (
+                m.size_on_disk if sort_models_by_size else m.model_id
+            ),
             reverse=sort_models_by_size,
         )
         return model_caches
@@ -143,7 +145,7 @@ class HuggingfaceHub:
         model_id: str,
         *,
         workers: int = 8,
-        tqdm_class: type[tqdm] | Callable[..., tqdm] | None = None,
+        tqdm_class: type[tqdm] | None = None,
         local_dir: str | None = None,
         local_dir_use_symlinks: bool | None = None,
     ) -> str:
@@ -255,7 +257,7 @@ class HuggingfaceHub:
                 else None
             ),
             pipeline_tag=model_info.pipeline_tag,
-            tags=model_info.tags,
+            tags=model_info.tags or [],
             architectures=(
                 model_info.config["architectures"]
                 if model_info.config and "architectures" in model_info.config
@@ -279,14 +281,20 @@ class HuggingfaceHub:
                 else None
             ),
             gated=model_info.gated,
-            private=model_info.private,
+            private=bool(model_info.private),
             disabled=model_info.disabled,
-            last_downloads=model_info.downloads,
-            downloads=model_info.downloads_all_time or model_info.downloads,
-            likes=model_info.likes,
+            last_downloads=model_info.downloads or 0,
+            downloads=(
+                model_info.downloads_all_time or model_info.downloads or 0
+            ),
+            likes=model_info.likes or 0,
             ranking=model_info.trending_score,
-            author=model_info.author,
-            created_at=model_info.created_at,
-            updated_at=model_info.last_modified or model_info.created_at,
+            author=model_info.author or "",
+            created_at=model_info.created_at or datetime.fromtimestamp(0),
+            updated_at=(
+                model_info.last_modified
+                or model_info.created_at
+                or datetime.fromtimestamp(0)
+            ),
         )
         return model


### PR DESCRIPTION
### Motivation

- Remove strict-mypy type mismatches that prevented removing module overrides by normalizing ambiguous external types and tightening internal annotations.
- Ensure PDF metadata and Hugging Face hub mappings satisfy `mypy --strict` without silencing whole modules.

### Description

- Normalize PDF metadata title in `MemorySource` by introducing `metadata_title_raw` and converting it to `str | None` before assigning to the document title. (`src/avalan/memory/source.py`)
- Tighten `HuggingfaceHub` interactions to satisfy strict typing by casting `version()` to `str`, changing `cache_delete` return type to `tuple[...]`, using `model_id` for sort fallback, narrowing `tqdm_class` to `type[tqdm] | None`, and providing safe non-optional defaults for mapped `ModelInfo` fields (`tags`, `private`, numeric counts, `author`, `created_at`, `updated_at`). (`src/avalan/model/hubs/huggingface.py`)

### Testing

- Ran `make lint` (formatters and ruff) and auto-fixes, which completed with no remaining ruff errors. — Passed.
- Ran `mypy` checks for the modified files using a strict subset config (`/tmp/mypy_strict_subset.toml`) and observed `Success: no issues found` for those files. — Passed.
- Ran targeted pytest for the changed areas: `tests/memory/test_source.py` and `tests/model/hubs/huggingface_test.py`, all tests passed. — Passed (32 passed, 5 skipped in that run).
- Ran the full test suite with `poetry run pytest --verbose -s`, which completed successfully. — Passed (1574 passed, 11 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb39213ac83239927b87c779ab438)