### PR TITLE
Use runtime import and fallback for tiktoken encoding; update mypy overrides and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,12 +232,15 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = [
   "a2a",
+  "aioboto3",
   "anyio",
   "boto3",
   "boto3.*",
   "botocore",
   "botocore.*",
   "bs4",
+  "entmax",
+  "faiss",
   "fastapi",
   "fastapi.*",
   "huggingface_hub",
@@ -248,9 +251,16 @@ module = [
   "keyring.*",
   "markitdown",
   "numpy",
+  "pgvector.*",
+  "psutil",
   "pypdf",
   "rich",
   "rich.*",
+  "tokenizers",
+  "tiktoken",
+  "tiktoken.*",
+  "torchaudio",
+  "torchaudio.*",
   "torch",
   "torch.*",
   "tqdm",
@@ -260,3 +270,7 @@ module = [
   "uvicorn",
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["tiktoken", "tiktoken.*"]
+follow_imports = "skip"

--- a/src/avalan/model/nlp/text/vendor/__init__.py
+++ b/src/avalan/model/nlp/text/vendor/__init__.py
@@ -12,14 +12,19 @@ from .....tool.manager import ToolManager
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from dataclasses import replace
+from importlib import import_module
 from logging import Logger, getLogger
-from typing import Literal
+from typing import Literal, Protocol
 
 from diffusers import DiffusionPipeline
-from tiktoken import encoding_for_model, get_encoding
 from torch import Tensor
 from transformers import PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
+
+
+class _TiktokenEncoding(Protocol):
+    def encode(self, text: str) -> list[int]:
+        """Encode the provided text into token IDs."""
 
 
 class TextGenerationVendorModel(TextGenerationModel, ABC):
@@ -68,16 +73,27 @@ class TextGenerationVendorModel(TextGenerationModel, ABC):
     ) -> dict[str, Tensor] | BatchEncoding | Tensor:
         raise NotImplementedError()
 
+    @staticmethod
+    def _resolve_encoding(
+        model_id: str, default_model: str
+    ) -> _TiktokenEncoding:
+        tiktoken = import_module("tiktoken")
+        encoding_for_model = getattr(tiktoken, "encoding_for_model")
+        get_encoding = getattr(tiktoken, "get_encoding")
+        try:
+            return encoding_for_model(model_id)
+        except KeyError:
+            return get_encoding(default_model)
+
     def input_token_count(
         self,
         input: Input,
         system_prompt: str | None = None,
         developer_prompt: str | None = None,
     ) -> int:
-        try:
-            encoding = encoding_for_model(self._model_id)
-        except KeyError:
-            encoding = get_encoding(self._TIKTOKEN_DEFAULT_MODEL)
+        encoding = self._resolve_encoding(
+            self._model_id, self._TIKTOKEN_DEFAULT_MODEL
+        )
 
         messages = self._messages(
             input, system_prompt, developer_prompt, tool=None

--- a/tests/model/nlp/text_generation_vendor_model_test.py
+++ b/tests/model/nlp/text_generation_vendor_model_test.py
@@ -76,6 +76,38 @@ class InputTokenCountTestCase(TestCase):
         )
         self.model = DummyVendorModel("m", self.settings, logger=getLogger())
 
+    def test_resolve_encoding_with_model_specific_encoding(self):
+        tiktoken = MagicMock()
+        encoding = MagicMock()
+        tiktoken.encoding_for_model.return_value = encoding
+
+        with patch(
+            "avalan.model.nlp.text.vendor.import_module",
+            return_value=tiktoken,
+        ) as import_module_mock:
+            resolved = self.model._resolve_encoding("m", "cl100k_base")
+
+        import_module_mock.assert_called_once_with("tiktoken")
+        tiktoken.encoding_for_model.assert_called_once_with("m")
+        tiktoken.get_encoding.assert_not_called()
+        self.assertIs(resolved, encoding)
+
+    def test_resolve_encoding_falls_back_to_default_encoding(self):
+        tiktoken = MagicMock()
+        encoding = MagicMock()
+        tiktoken.encoding_for_model.side_effect = KeyError("missing")
+        tiktoken.get_encoding.return_value = encoding
+
+        with patch(
+            "avalan.model.nlp.text.vendor.import_module",
+            return_value=tiktoken,
+        ):
+            resolved = self.model._resolve_encoding("m", "cl100k_base")
+
+        tiktoken.encoding_for_model.assert_called_once_with("m")
+        tiktoken.get_encoding.assert_called_once_with("cl100k_base")
+        self.assertIs(resolved, encoding)
+
     def test_input_token_count_with_model_encoding(self):
         encoding = MagicMock()
         encoding.encode.side_effect = lambda text: list(text)
@@ -83,36 +115,24 @@ class InputTokenCountTestCase(TestCase):
             Message(role=MessageRole.USER, content="hi"),
             Message(role=MessageRole.USER, content="there"),
         ]
-        with (
-            patch(
-                "avalan.model.nlp.text.vendor.encoding_for_model",
-                return_value=encoding,
-            ) as efm,
-            patch("avalan.model.nlp.text.vendor.get_encoding") as ge,
-        ):
+        with patch.object(
+            self.model, "_resolve_encoding", return_value=encoding
+        ) as resolve:
             self.model._messages = MagicMock(return_value=messages)
             count = self.model.input_token_count("in")
-        efm.assert_called_once_with("m")
-        ge.assert_not_called()
+        resolve.assert_called_once_with("m", "cl100k_base")
         self.assertEqual(count, len("hi") + len("there"))
 
     def test_input_token_count_fallback_encoding(self):
         encoding = MagicMock()
         encoding.encode.side_effect = lambda text: list(text)
         messages = [Message(role=MessageRole.USER, content="a")]
-        with (
-            patch(
-                "avalan.model.nlp.text.vendor.encoding_for_model",
-                side_effect=KeyError,
-            ),
-            patch(
-                "avalan.model.nlp.text.vendor.get_encoding",
-                return_value=encoding,
-            ) as ge,
-        ):
+        with patch.object(
+            self.model, "_resolve_encoding", return_value=encoding
+        ) as resolve:
             self.model._messages = MagicMock(return_value=messages)
             count = self.model.input_token_count("in")
-        ge.assert_called_once()
+        resolve.assert_called_once_with("m", "cl100k_base")
         self.assertEqual(count, 1)
 
 


### PR DESCRIPTION
### Motivation

- Prevent hard dependency on `tiktoken` at import time and support different `tiktoken` API behaviors by resolving encodings at runtime.
- Reduce mypy noise from third-party packages by adding missing modules to `ignore_missing_imports` and providing a specific `tiktoken` override.

### Description

- Added a runtime resolver `_resolve_encoding` that `import_module("tiktoken")` and uses `encoding_for_model` with a `get_encoding` fallback, and defined a `_TiktokenEncoding` `Protocol` for typing.
- Replaced direct top-level imports/usage of `encoding_for_model`/`get_encoding` with `_resolve_encoding` in `TextGenerationVendorModel.input_token_count` and removed the hard import of `tiktoken` from the module.
- Updated tests in `tests/model/nlp/text_generation_vendor_model_test.py` to add unit tests for `_resolve_encoding` and to patch `self.model._resolve_encoding` in existing token-count tests instead of module-level functions.
- Expanded `[[tool.mypy.overrides]]` in `pyproject.toml` to ignore many third-party modules and added a `tiktoken` override with `follow_imports = "skip"`.

### Testing

- Ran the unit tests in `tests/model/nlp/text_generation_vendor_model_test.py` which include the new `_resolve_encoding` tests and updated token-count tests, and they passed.
- Ran the test suite locally with `pytest` for the modified modules and no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc313932083238cca038870a6102c)