### PR TITLE
Tighten server typing and narrow mypy override scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ module = [
   "avalan.cli.*",
   "avalan.memory.*",
   "avalan.model.*",
-  "avalan.server.*",
+  "avalan.server.routers.mcp",
   "avalan.tool.*",
 ]
 ignore_errors = true

--- a/src/avalan/server/__init__.py
+++ b/src/avalan/server/__init__.py
@@ -8,11 +8,15 @@ from .entities import OrchestratorContext
 from .routers import mcp as mcp_router
 
 from collections.abc import AsyncIterator, Callable
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import (
+    AbstractAsyncContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+)
 from importlib import import_module
 from importlib.util import find_spec
 from logging import Logger
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Mapping, cast
 from uuid import UUID, uuid4
 
 from fastapi import FastAPI, Request
@@ -91,9 +95,9 @@ def _create_lifespan(
     selected_protocols: Mapping[str, set[str]],
     agent_id: UUID | None,
     participant_id: UUID | None,
-) -> Callable[[FastAPI], AsyncIterator[None]]:
+) -> Callable[[FastAPI], AbstractAsyncContextManager[None]]:
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("Initializing app lifespan")
         from os import environ
 
@@ -199,7 +203,8 @@ def _include_protocol_routers(
 
 
 def _attach_lifespan(
-    app: FastAPI, lifespan: Callable[[FastAPI], AsyncIterator[None]]
+    app: FastAPI,
+    lifespan: Callable[[FastAPI], AbstractAsyncContextManager[None]],
 ) -> None:
     existing = app.router.lifespan_context
 
@@ -208,7 +213,7 @@ def _attach_lifespan(
         return
 
     @asynccontextmanager
-    async def combined(app_: FastAPI):
+    async def combined(app_: FastAPI) -> AsyncIterator[None]:
         async with existing(app_):
             async with lifespan(app_):
                 yield
@@ -404,6 +409,4 @@ async def di_get_orchestrator(request: Request) -> Orchestrator:
         orchestrator = await stack.enter_async_context(orchestrator_cm)
         request.app.state.orchestrator = orchestrator
         request.app.state.agent_id = orchestrator.id
-    orchestrator = request.app.state.orchestrator
-    assert orchestrator is not None
-    return orchestrator
+    return cast(Orchestrator, request.app.state.orchestrator)

--- a/src/avalan/server/a2a/router.py
+++ b/src/avalan/server/a2a/router.py
@@ -643,11 +643,12 @@ class A2AResponseTranslator:
 
     async def _handle_tool_process(self, event: Event) -> list[dict[str, Any]]:
         events: list[dict[str, Any]] = []
-        payload = event.payload or []
+        payload: dict[str, Any] | list[Any] = event.payload or []
         if isinstance(payload, dict):
-            calls: Iterable[ToolCall] = payload.get("calls", [])  # type: ignore[assignment]
+            raw_calls = payload.get("calls", [])
+            calls = raw_calls if isinstance(raw_calls, list) else []
         else:
-            calls = payload  # type: ignore[assignment]
+            calls = payload
         for call in calls:
             if not isinstance(call, ToolCall):
                 continue
@@ -908,11 +909,12 @@ class A2AStreamEventConverter:
             overview = await self._store.get_task_overview(self._task_id)
             metadata = overview.get("metadata") or {}
             self._cached_response_id = metadata.get("jsonrpc_id")
-        return (
-            None
-            if self._cached_response_id is _STREAM_RESPONSE_ID_UNSET
-            else self._cached_response_id
-        )
+        if self._cached_response_id is _STREAM_RESPONSE_ID_UNSET:
+            return None
+        response_id = self._cached_response_id
+        if isinstance(response_id, (str, int)):
+            return response_id
+        return None
 
     async def _task_result(self, event: dict[str, Any]) -> a2a_types.Task:
         overview = await self._store.get_task_overview(self._task_id)
@@ -1105,7 +1107,7 @@ async def create_task(
     logger: Logger = Depends(_di_get_logger),
     orchestrator: Orchestrator = Depends(_di_get_orchestrator),
     store: TaskStore = Depends(di_get_task_store),
-):
+) -> Any:
     try:
         raw_payload = await request.json()
     except (JSONDecodeError, ValueError) as exc:
@@ -1238,7 +1240,7 @@ async def create_task(
 async def get_task(
     task_id: str,
     store: TaskStore = Depends(di_get_task_store),
-):
+) -> Any:
     task = await store.get_task(task_id)
     return _coerce("Task", task)
 
@@ -1248,7 +1250,7 @@ async def list_task_events(
     task_id: str,
     after: int | None = Query(None),
     store: TaskStore = Depends(di_get_task_store),
-):
+) -> Any:
     events = await store.get_events(task_id, after=after)
     return _coerce_list("TaskEvent", events)
 
@@ -1258,7 +1260,7 @@ async def get_artifact(
     task_id: str,
     artifact_id: str,
     store: TaskStore = Depends(di_get_task_store),
-):
+) -> Any:
     artifact = await store.get_artifact(task_id, artifact_id)
     return _coerce("TaskArtifact", artifact)
 
@@ -1267,7 +1269,7 @@ async def get_artifact(
 async def agent_card(
     request: Request,
     orchestrator: Orchestrator = Depends(_di_get_orchestrator),
-):
+) -> Any:
     interface_url = str(request.url_for("create_task"))
     card = _build_agent_card(
         orchestrator,
@@ -1282,7 +1284,7 @@ async def agent_card(
 async def well_known_agent_card(
     request: Request,
     orchestrator: Orchestrator = Depends(_di_get_orchestrator),
-):
+) -> Any:
     interface_url = str(request.url_for("create_task"))
     card = _build_agent_card(
         orchestrator,
@@ -1315,12 +1317,12 @@ def _call_identifier(item: Token | TokenDetail | Event | str) -> str | None:
         return str(item.call.id)
     if isinstance(item, Event):
         if item.type is EventType.TOOL_PROCESS:
-            payload = item.payload or []
+            payload: dict[str, Any] | list[Any] = item.payload or []
             if isinstance(payload, dict):
                 candidates = payload.get("calls", [])
             else:
                 candidates = payload
-            if candidates:
+            if isinstance(candidates, list) and candidates:
                 call = candidates[0]
                 if isinstance(call, ToolCall):
                     return str(call.id)


### PR DESCRIPTION
### Motivation
- Allow strict mypy checking of server modules by removing a broad `ignore_errors` override for `avalan.server.*` and isolating MCP router typing debt. 
- Fix several typing mismatches in server lifecycle and A2A router code that prevented running mypy under the strict config.

### Description
- Narrow the mypy override in `pyproject.toml` from `avalan.server.*` to `avalan.server.routers.mcp` so the rest of `avalan.server` is checked by mypy. 
- In `src/avalan/server/__init__.py` import `AbstractAsyncContextManager` and `cast`, change `_create_lifespan` to return a `Callable[[FastAPI], AbstractAsyncContextManager[None]]`, add explicit async iterator annotations for nested lifespan helpers, and use `cast(Orchestrator, ...)` in `di_get_orchestrator` to keep runtime behavior while satisfying mypy. 
- In `src/avalan/server/a2a/router.py` tighten types for event payloads by annotating `payload` as `dict[str, Any] | list[Any]`, safely extract `calls` (ensure it is a list), normalize the cached response id with robust type checks, and add explicit `-> Any` return annotations on several FastAPI route handlers to satisfy strict typing. 
- Run automatic formatting and lint fixes (ruff/black) as part of the changes.

### Testing
- Ran `poetry run mypy` and it completed successfully with no issues in checked source files. 
- Ran `make lint` (ruff/black + ruff fixes) and the formatting/lint checks completed successfully. 
- Executed focused server test files with pytest using `poetry run pytest --verbose -s tests/server/orchestrator_di_test.py tests/server/chat_router_unit_test.py tests/server/a2a_router_unit_extra_test.py tests/server/test_a2a.py` and all recorded tests passed (49 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4b153dac8323af9544c0c01b6caa)