### PR TITLE
Advance memory mypy cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ python_version = "3.11"
 module = [
   "avalan.agent.*",
   "avalan.cli.*",
-  "avalan.memory.*",
   "avalan.model.*",
   "avalan.tool.*",
 ]

--- a/src/avalan/memory/__init__.py
+++ b/src/avalan/memory/__init__.py
@@ -1,4 +1,3 @@
-from ..compat import override
 from ..entities import EngineMessage
 
 from abc import ABC, abstractmethod
@@ -32,7 +31,7 @@ class MemoryStore(ABC, Generic[T]):
 
 
 class MessageMemory(MemoryStore[EngineMessage], ABC):
-    def search(self, query: str) -> list[EngineMessage] | None:
+    async def search(self, query: str) -> list[EngineMessage] | None:
         raise NotImplementedError()
 
 
@@ -40,19 +39,24 @@ class RecentMessageMemory(MessageMemory):
     _lock: Lock
     _data: list[EngineMessage]
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self) -> None:
         self._lock = Lock()
-        self.reset()
-        super().__init__(**kwargs)
+        self._data = []
+        super().__init__()
 
-    @override
-    def append(self, data: EngineMessage) -> None:
+    async def append(self, agent_id: UUID, data: EngineMessage) -> None:
+        del agent_id
         with self._lock:
             self._data.append(data)
 
-    def reset(self) -> None:
+    async def reset(self) -> None:
         with self._lock:
             self._data = []
+
+    async def search(self, query: str) -> list[EngineMessage] | None:
+        del query
+        with self._lock:
+            return list(self._data)
 
     @property
     def size(self) -> int:

--- a/src/avalan/memory/manager.py
+++ b/src/avalan/memory/manager.py
@@ -225,7 +225,9 @@ class MemoryManager:
                 )
 
         if self._recent_message_memory:
-            self._recent_message_memory.append(engine_message)
+            await self._recent_message_memory.append(
+                self._agent_id, engine_message
+            )
 
         self._logger.debug("<Memory> Message appended")
 
@@ -268,9 +270,11 @@ class MemoryManager:
                     limit=load_recent_messages_limit,
                 )
             )
-            self._recent_message_memory.reset()
+            await self._recent_message_memory.reset()
             for message in messages:
-                self._recent_message_memory.append(message)
+                await self._recent_message_memory.append(
+                    self._agent_id, message
+                )
 
         self._logger.debug("Session %s continued", session_id)
         if self._permanent_message_memory and self._event_manager:
@@ -305,7 +309,7 @@ class MemoryManager:
             )
 
         if self._recent_message_memory:
-            self._recent_message_memory.reset()
+            await self._recent_message_memory.reset()
 
         self._logger.debug("Session started")
         if self._permanent_message_memory and self._event_manager:

--- a/src/avalan/memory/partitioner/text.py
+++ b/src/avalan/memory/partitioner/text.py
@@ -1,11 +1,10 @@
-from ...compat import override
 from ...entities import TextPartition
 from ...filters import Partitioner
 from ...model.nlp.sentence import SentenceTransformerModel
 
+from collections.abc import Callable
 from logging import Logger
 from re import split
-from typing import Callable
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
@@ -23,11 +22,10 @@ class TextPartitioner(Partitioner):
         self,
         model: SentenceTransformerModel,
         logger: Logger,
-        *args,
         max_tokens: int,
         overlap_size: int,
         window_size: int,
-    ):
+    ) -> None:
         assert model and model.tokenizer
         self._model = model
         self._tokenizer = model.tokenizer
@@ -40,7 +38,6 @@ class TextPartitioner(Partitioner):
 
     def configure(
         self,
-        *args,
         max_tokens: int,
         overlap_size: int,
         window_size: int,
@@ -60,12 +57,10 @@ class TextPartitioner(Partitioner):
         self._window_size = window_size
         self._overlap_size = overlap_size
 
-    @override
     @property
-    def sentence_model(self) -> Callable:
+    def sentence_model(self) -> Callable[[str], object]:
         return self._model
 
-    @override
     async def __call__(
         self,
         text: str,

--- a/tests/memory/memory_manager_test.py
+++ b/tests/memory/memory_manager_test.py
@@ -304,7 +304,7 @@ class MemoryManagerInitTestCase(IsolatedAsyncioTestCase):
 
 
 class MemoryManagerPropertyTestCase(IsolatedAsyncioTestCase):
-    def test_recent_messages_property(self):
+    async def test_recent_messages_property(self):
         tp = AsyncMock()
         rm = RecentMessageMemory()
         msg = EngineMessage(
@@ -312,7 +312,7 @@ class MemoryManagerPropertyTestCase(IsolatedAsyncioTestCase):
             model_id="m",
             message=Message(role=MessageRole.USER, content="hi"),
         )
-        rm.append(msg)
+        await rm.append(msg.agent_id, msg)
         manager = MemoryManager(
             agent_id=uuid4(),
             participant_id=uuid4(),

--- a/tests/memory/memory_store_test.py
+++ b/tests/memory/memory_store_test.py
@@ -1,4 +1,4 @@
-from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest import IsolatedAsyncioTestCase
 from uuid import uuid4
 
 from avalan.entities import EngineMessage, Message, MessageRole
@@ -36,15 +36,15 @@ class MemoryStoreTestCase(IsolatedAsyncioTestCase):
             await memory.search("query")
 
 
-class MessageMemoryTestCase(TestCase):
-    def test_search_not_implemented(self):
+class MessageMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_search_not_implemented(self):
         memory = DummyMessageMemory()
         with self.assertRaises(NotImplementedError):
-            memory.search("query")
+            await memory.search("query")
 
 
-class RecentMessageMemoryTestCase(TestCase):
-    def test_size_property(self):
+class RecentMessageMemoryTestCase(IsolatedAsyncioTestCase):
+    async def test_size_property(self):
         memory = RecentMessageMemory()
         self.assertEqual(memory.size, 0)
 
@@ -53,11 +53,11 @@ class RecentMessageMemoryTestCase(TestCase):
             model_id="m",
             message=Message(role=MessageRole.USER, content="hi"),
         )
-        memory.append(msg)
+        await memory.append(msg.agent_id, msg)
         self.assertEqual(memory.size, 1)
 
-        memory.append(msg)
+        await memory.append(msg.agent_id, msg)
         self.assertEqual(memory.size, 2)
 
-        memory.reset()
+        await memory.reset()
         self.assertEqual(memory.size, 0)


### PR DESCRIPTION
### Motivation
- Remove the memory package from the mypy ignore list so the `avalan.memory` module is fully type-checked by mypy. 
- Progressively fix typing mismatches between the abstract `MemoryStore` contract and concrete implementations so the memory subsystem can be verified by static type checks.

### Description
- Removed `"avalan.memory.*"` from the `[[tool.mypy.overrides]]` ignore list in `pyproject.toml` so mypy will check the memory package.
- Converted `MemoryStore` method signatures to async (`append`, `reset`, `search`) and updated `MessageMemory`/`RecentMessageMemory` to match the async contract, including adding `agent_id: UUID` to `append` where appropriate.
- Implemented `RecentMessageMemory` as an async-compatible in-memory store with thread-safe access and an async `search` implementation.
- Updated `MemoryManager` call sites to `await` recent-memory operations (`append`/`reset`) and revised text partitioner typing by removing untyped varargs/decorators and adding explicit return annotations for `sentence_model`/`__init__`.
- Updated unit tests to call the new async memory APIs (changed test cases to `IsolatedAsyncioTestCase` and use `await` for `append`/`reset`/`search`).

### Testing
- Ran `make lint` and automatic formatters/linters: succeeded.
- Ran targeted memory tests with `poetry run pytest tests/memory/memory_store_test.py tests/memory/memory_manager_test.py`: all tests passed (26 passed).
- Ran full test suite with `poetry run pytest --verbose -s`: succeeded (1576 passed, 11 skipped).
- Ran mypy on the memory package with `poetry run mypy src/avalan/memory`: still failing (mypy errors remain, primarily in `partitioner/code.py` and `memory/permanent/*`), but the error count was reduced in this iteration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcecdc839c8323914e627c0ea95561)