### PR TITLE
Tighten typing in avalan.memory (partitioner + permanent)

### DIFF
--- a/src/avalan/memory/partitioner/code.py
+++ b/src/avalan/memory/partitioner/code.py
@@ -3,7 +3,7 @@ from ...utils import _j
 
 from dataclasses import dataclass
 from logging import Logger
-from typing import Literal
+from typing import Literal, cast
 
 from tree_sitter import Language, Node, Parser
 from tree_sitter_python import language as python
@@ -80,6 +80,7 @@ class CodePartitioner:
         if root_node.children and root_node.children[0].is_error:
             error_node = root_node.children[0]
             error_name = error_node.grammar_name
+            assert error_node.text is not None
             error_message = error_node.text.decode(encoding)
             error_row, error_column = error_node.start_point
             raise PartitionerException(
@@ -133,12 +134,16 @@ class CodePartitioner:
         for child_node in node.children:
             if child_node.type == "class_definition":
                 class_name_node = child_node.child_by_field_name("name")
-                current_class_name = (
-                    class_name_node.text.decode(encoding)
-                    if class_name_node
-                    else None
+                assert class_name_node and class_name_node.text is not None
+                current_class_name = class_name_node.text.decode(encoding)
+                class_id = _j(
+                    ".",
+                    [
+                        part
+                        for part in (current_namespace, current_class_name)
+                        if part is not None
+                    ],
                 )
-                class_id = _j(".", [current_namespace, current_class_name])
                 child_symbols = current_symbols + [
                     Symbol(symbol_type="class", id=class_id)
                 ]
@@ -215,11 +220,8 @@ class CodePartitioner:
         results = []
         if node.type == "class_definition":
             class_name_node = node.child_by_field_name("name")
-            class_name = (
-                class_name_node.text.decode(encoding)
-                if class_name_node
-                else None
-            )
+            assert class_name_node and class_name_node.text is not None
+            class_name = class_name_node.text.decode(encoding)
             for child in node.children:
                 functs = cls._get_functions(
                     current_namespace,
@@ -262,6 +264,10 @@ class CodePartitioner:
         )
         params_node = node.child_by_field_name("parameters")
         return_type_node = node.child_by_field_name("return_type")
+        return_type: str | None = None
+        if return_type_node:
+            assert return_type_node.text is not None
+            return_type = return_type_node.text.decode(encoding)
         return Function(
             id=function_id,
             namespace=current_namespace,
@@ -272,11 +278,7 @@ class CodePartitioner:
                 if params_node
                 else None
             ),
-            return_type=(
-                return_type_node.text.decode(encoding)
-                if return_type_node
-                else None
-            ),
+            return_type=return_type,
         )
 
     @staticmethod
@@ -291,38 +293,47 @@ class CodePartitioner:
             "async_function_definition",
         )
         function_name_node = node.child_by_field_name("name")
-        assert function_name_node
+        assert function_name_node and function_name_node.text is not None
         function_name = function_name_node.text.decode(encoding)
         assert function_name
         function_id = _j(
-            ".", [current_namespace, current_class_name, function_name]
+            ".",
+            [
+                part
+                for part in (
+                    current_namespace,
+                    current_class_name,
+                    function_name,
+                )
+                if part is not None
+            ],
         )
         return function_id, function_name
 
     @staticmethod
-    def _get_parameters(
-        node: Node, encoding: Encoding
-    ) -> list[dict[str, str | None]]:
+    def _get_parameters(node: Node, encoding: Encoding) -> list[Parameter]:
         assert node
-        parameters = []
+        parameters: list[Parameter] = []
         for child in node.children:
             if child.type in (
                 "default_parameter",
                 "typed_default_parameter",
                 "typed_parameter",
             ):
-                param_type = child.child_by_field_name("type").text.decode(
-                    encoding
-                )
-                param_name = None
+                type_node = child.child_by_field_name("type")
+                assert type_node and type_node.text is not None
+                param_type = type_node.text.decode(encoding)
+                param_name: str | None = None
                 if child.named_child_count:
                     for parameter_child in child.children:
                         if parameter_child.type == "identifier":
+                            assert parameter_child.text is not None
                             param_name = parameter_child.text.decode(encoding)
                             break
+                assert param_name is not None
                 parameters.append(
                     Parameter(
-                        parameter_type=child.type,
+                        parameter_type=cast(ParameterType, child.type),
                         name=param_name,
                         type=param_type,
                     )
@@ -332,9 +343,10 @@ class CodePartitioner:
                 "identifier",
                 "keyword_separator",
             ):
+                assert child.text is not None
                 parameters.append(
                     Parameter(
-                        parameter_type=child.type,
+                        parameter_type=cast(ParameterType, child.type),
                         name=child.text.decode(encoding),
                         type=None,
                     )

--- a/src/avalan/memory/partitioner/code.py
+++ b/src/avalan/memory/partitioner/code.py
@@ -74,9 +74,6 @@ class CodePartitioner:
         tree = parser.parse(input.encode(encoding), encoding=encoding)
         root_node = tree.root_node
 
-        self._logger.debug("Parsing %s code for functions", language_name)
-        functions = self._get_functions(namespace, root_node, encoding)
-
         if root_node.children and root_node.children[0].is_error:
             error_node = root_node.children[0]
             error_name = error_node.grammar_name
@@ -87,6 +84,9 @@ class CodePartitioner:
                 f'{error_name}: "{error_message}" at'
                 f" {error_row},{error_column}"
             )
+
+        self._logger.debug("Parsing %s code for functions", language_name)
+        functions = self._get_functions(namespace, root_node, encoding)
 
         self._logger.debug("Partitioning %s code", language_name)
         partitions = self._partition(
@@ -134,8 +134,11 @@ class CodePartitioner:
         for child_node in node.children:
             if child_node.type == "class_definition":
                 class_name_node = child_node.child_by_field_name("name")
-                assert class_name_node and class_name_node.text is not None
-                current_class_name = class_name_node.text.decode(encoding)
+                current_class_name = (
+                    class_name_node.text.decode(encoding)
+                    if class_name_node and class_name_node.text is not None
+                    else None
+                )
                 class_id = _j(
                     ".",
                     [
@@ -220,8 +223,11 @@ class CodePartitioner:
         results = []
         if node.type == "class_definition":
             class_name_node = node.child_by_field_name("name")
-            assert class_name_node and class_name_node.text is not None
-            class_name = class_name_node.text.decode(encoding)
+            class_name = (
+                class_name_node.text.decode(encoding)
+                if class_name_node and class_name_node.text is not None
+                else current_class_name
+            )
             for child in node.children:
                 functs = cls._get_functions(
                     current_namespace,

--- a/src/avalan/memory/permanent/__init__.py
+++ b/src/avalan/memory/permanent/__init__.py
@@ -1,23 +1,23 @@
-from ...compat import override
 from ...entities import (
     EngineMessage,
     MessageContentImage,
     MessageContentText,
     MessageRole,
+    TextPartition,
 )
 from ...memory import MemoryStore as MemoryStoreBase
 from ...memory import MessageMemory
-from ...memory.partitioner.text import TextPartition
 from ...model.nlp.sentence import SentenceTransformerModel
 
 from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from numpy import ndarray
+from numpy.typing import NDArray
 
 Order = Literal["asc", "desc"]
 
@@ -67,7 +67,7 @@ class Memory:
     identifier: str
     data: str | None = None
     partitions: int
-    symbols: dict | None
+    symbols: dict[str, Any] | None
     created_at: datetime
     title: str | None = None
     description: str | None = None
@@ -103,7 +103,7 @@ class PermanentMessagePartition:
     message_id: UUID
     partition: int
     data: str
-    embedding: ndarray
+    embedding: NDArray[Any]
     created_at: datetime
 
 
@@ -113,7 +113,7 @@ class PermanentMemoryPartition:
     memory_id: UUID
     partition: int
     data: str
-    embedding: ndarray
+    embedding: NDArray[Any]
     created_at: datetime
 
 
@@ -122,8 +122,8 @@ class Hyperedge:
     id: UUID
     relation: str
     surface_text: str
-    embedding: ndarray
-    symbols: dict | None = None
+    embedding: NDArray[Any]
+    symbols: dict[str, Any] | None = None
     created_at: datetime
 
 
@@ -140,8 +140,8 @@ class Entity:
     id: UUID
     name: str
     type: str | None = None
-    embedding: ndarray
-    symbols: dict | None = None
+    embedding: NDArray[Any]
+    symbols: dict[str, Any] | None = None
     participant_id: UUID | None = None
     namespace: str | None = None
     created_at: datetime
@@ -157,13 +157,13 @@ class HyperedgeEntity:
 
 class PermanentMessageMemory(MessageMemory):
     _session_id: UUID | None = None
-    _sentence_model: SentenceTransformerModel
+    _sentence_model: SentenceTransformerModel | None
 
     def __init__(
         self,
-        sentence_model: SentenceTransformerModel,
-        **kwargs,
-    ):
+        sentence_model: SentenceTransformerModel | None,
+        **kwargs: Any,
+    ) -> None:
         self._sentence_model = sentence_model
         super().__init__(**kwargs)
 
@@ -175,7 +175,7 @@ class PermanentMessageMemory(MessageMemory):
     def session_id(self) -> UUID | None:
         return self._session_id
 
-    def reset(self) -> None:
+    async def reset(self) -> None:
         raise NotImplementedError()
 
     async def reset_session(
@@ -197,8 +197,9 @@ class PermanentMessageMemory(MessageMemory):
             session_id=session_id,
         )
 
-    @override
-    def append(self, data: EngineMessage) -> None:
+    async def append(self, agent_id: UUID, data: EngineMessage) -> None:
+        del agent_id
+        del data
         raise NotImplementedError()
 
     @abstractmethod
@@ -210,7 +211,6 @@ class PermanentMessageMemory(MessageMemory):
     @abstractmethod
     async def continue_session_and_get_id(
         self,
-        *args,
         agent_id: UUID,
         participant_id: UUID,
         session_id: UUID,
@@ -221,7 +221,6 @@ class PermanentMessageMemory(MessageMemory):
     async def append_with_partitions(
         self,
         engine_message: EngineMessage,
-        *args,
         partitions: list[TextPartition],
     ) -> None:
         raise NotImplementedError()
@@ -231,7 +230,6 @@ class PermanentMessageMemory(MessageMemory):
         self,
         session_id: UUID,
         participant_id: UUID,
-        *args,
         limit: int | None = None,
     ) -> list[EngineMessage]:
         raise NotImplementedError()
@@ -239,15 +237,14 @@ class PermanentMessageMemory(MessageMemory):
     @abstractmethod
     async def search_messages(
         self,
-        *args,
         agent_id: UUID,
         function: VectorFunction,
-        limit: int | None = None,
         participant_id: UUID,
         search_partitions: list[TextPartition],
         search_user_messages: bool,
         session_id: UUID | None,
         exclude_session_id: UUID | None,
+        limit: int | None = None,
     ) -> list[EngineMessage]:
         raise NotImplementedError()
 
@@ -267,7 +264,7 @@ class PermanentMessageMemory(MessageMemory):
             content.text
             if isinstance(content, MessageContentText)
             else (
-                content.image_url
+                str(content.image_url)
                 if isinstance(content, MessageContentImage)
                 else str(content)
             )
@@ -317,19 +314,22 @@ class PermanentMessageMemory(MessageMemory):
 
 
 class PermanentMemory(MemoryStoreBase[Memory]):
-    _sentence_model: SentenceTransformerModel
+    _sentence_model: SentenceTransformerModel | None
 
     def __init__(
-        self, sentence_model: SentenceTransformerModel, **kwargs
+        self,
+        sentence_model: SentenceTransformerModel | None,
+        **kwargs: Any,
     ) -> None:
         self._sentence_model = sentence_model
         super().__init__(**kwargs)
 
-    @override
-    def append(self, data: EngineMessage) -> None:
+    async def append(self, agent_id: UUID, data: Memory) -> None:
+        del agent_id
+        del data
         raise NotImplementedError()
 
-    def reset(self) -> None:
+    async def reset(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -337,12 +337,11 @@ class PermanentMemory(MemoryStoreBase[Memory]):
         self,
         namespace: str,
         participant_id: UUID,
-        *args,
         memory_type: MemoryType,
         data: str,
         identifier: str,
         partitions: list[TextPartition],
-        symbols: dict | None = None,
+        symbols: Mapping[str, Any] | None = None,
         model_id: str | None = None,
         title: str | None = None,
         description: str | None = None,
@@ -352,7 +351,6 @@ class PermanentMemory(MemoryStoreBase[Memory]):
     @abstractmethod
     async def search_memories(
         self,
-        *args,
         search_partitions: list[TextPartition],
         participant_id: UUID,
         namespace: str,
@@ -380,7 +378,7 @@ class PermanentMemory(MemoryStoreBase[Memory]):
         partitions: list[TextPartition],
         *,
         created_at: datetime,
-        symbols: dict | None = None,
+        symbols: Mapping[str, Any] | None = None,
         model_id: str | None = None,
         memory_id: UUID | None = None,
         title: str | None = None,
@@ -397,7 +395,7 @@ class PermanentMemory(MemoryStoreBase[Memory]):
             identifier=identifier,
             data=data,
             partitions=len(partitions),
-            symbols=symbols,
+            symbols=dict(symbols) if symbols is not None else None,
             created_at=created_at,
             title=title,
             description=description,
@@ -417,10 +415,10 @@ class PermanentMemory(MemoryStoreBase[Memory]):
 
 
 class RecordNotFoundException(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         super(RecordNotFoundException, self).__init__("record_not_found")
 
 
 class RecordNotSavedException(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         super(RecordNotSavedException, self).__init__("record_not_saved")

--- a/src/avalan/memory/permanent/elasticsearch/message.py
+++ b/src/avalan/memory/permanent/elasticsearch/message.py
@@ -3,8 +3,8 @@ from ....entities import (
     EngineMessageScored,
     Message,
     MessageRole,
+    TextPartition,
 )
-from ....memory.partitioner.text import TextPartition
 from ....memory.permanent import (
     PermanentMessageMemory,
     VectorFunction,
@@ -178,12 +178,12 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         *,
         agent_id: UUID,
         function: VectorFunction,
-        limit: int | None = None,
         participant_id: UUID,
         search_partitions: list[TextPartition],
         search_user_messages: bool,
         session_id: UUID | None,
         exclude_session_id: UUID | None,
+        limit: int | None = None,
     ) -> list[EngineMessageScored]:
         assert agent_id and participant_id and search_partitions
         query = search_partitions[0].embeddings.tolist()

--- a/src/avalan/memory/permanent/elasticsearch/raw.py
+++ b/src/avalan/memory/permanent/elasticsearch/raw.py
@@ -1,4 +1,4 @@
-from ....memory.partitioner.text import TextPartition
+from ....entities import TextPartition
 from ....memory.permanent import (
     Memory,
     MemoryType,

--- a/src/avalan/memory/permanent/pgsql/message.py
+++ b/src/avalan/memory/permanent/pgsql/message.py
@@ -1,5 +1,4 @@
-from ....entities import EngineMessage, EngineMessageScored
-from ....memory.partitioner.text import TextPartition
+from ....entities import EngineMessage, EngineMessageScored, TextPartition
 from ....memory.permanent import (
     PermanentMessage,
     PermanentMessageMemory,

--- a/src/avalan/memory/permanent/pgsql/raw.py
+++ b/src/avalan/memory/permanent/pgsql/raw.py
@@ -1,4 +1,4 @@
-from ....memory.partitioner.text import TextPartition
+from ....entities import TextPartition
 from ....memory.permanent import (
     Entity,
     Hyperedge,

--- a/src/avalan/memory/permanent/s3vectors/message.py
+++ b/src/avalan/memory/permanent/s3vectors/message.py
@@ -4,8 +4,8 @@ from ....entities import (
     EngineMessageScored,
     Message,
     MessageRole,
+    TextPartition,
 )
-from ....memory.partitioner.text import TextPartition
 from ....memory.permanent import (
     PermanentMessageMemory,
     VectorFunction,
@@ -162,12 +162,12 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         *,
         agent_id: UUID,
         function: VectorFunction,
-        limit: int | None = None,
         participant_id: UUID,
         search_partitions: list[TextPartition],
         search_user_messages: bool,
         session_id: UUID | None,
         exclude_session_id: UUID | None,
+        limit: int | None = None,
     ) -> list[EngineMessageScored]:
         assert agent_id and participant_id and search_partitions
         query = search_partitions[0].embeddings.tolist()

--- a/src/avalan/memory/permanent/s3vectors/raw.py
+++ b/src/avalan/memory/permanent/s3vectors/raw.py
@@ -1,5 +1,5 @@
 from ....deploy.aws import AsyncClient
-from ....memory.partitioner.text import TextPartition
+from ....entities import TextPartition
 from ....memory.permanent import (
     Memory,
     MemoryType,

--- a/tests/memory/permanent/base_memory_test.py
+++ b/tests/memory/permanent/base_memory_test.py
@@ -43,14 +43,6 @@ class PermanentMessageMemorySyncTestCase(TestCase):
         self.assertTrue(self.memory.has_session)
         self.assertEqual(self.memory.session_id, sid)
 
-    def test_reset_raises(self):
-        with self.assertRaises(NotImplementedError):
-            self.memory.reset()
-
-    def test_append_raises(self):
-        with self.assertRaises(NotImplementedError):
-            self.memory.append(MagicMock())
-
 
 class PermanentMessageMemoryAsyncTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
@@ -100,6 +92,18 @@ class PermanentMessageMemoryAsyncTestCase(IsolatedAsyncioTestCase):
                 self.memory, msg, partitions=[]
             )
 
+    async def test_append_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            await PermanentMessageMemory.append(
+                self.memory,
+                agent_id=uuid4(),
+                data=MagicMock(spec=EngineMessage),
+            )
+
+    async def test_reset_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            await PermanentMessageMemory.reset(self.memory)
+
     async def test_get_recent_messages_not_implemented(self):
         with self.assertRaises(NotImplementedError):
             await PermanentMessageMemory.get_recent_messages(
@@ -131,13 +135,17 @@ class PermanentMemoryTestCase(IsolatedAsyncioTestCase):
     def test_init(self):
         self.assertIs(self.memory._sentence_model, self.model)
 
-    def test_append_raises(self):
+    async def test_append_not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            self.memory.append(MagicMock())
+            await PermanentMemory.append(
+                self.memory,
+                agent_id=uuid4(),
+                data=MagicMock(),
+            )
 
-    def test_reset_raises(self):
+    async def test_reset_not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            self.memory.reset()
+            await PermanentMemory.reset(self.memory)
 
     async def test_append_with_partitions_not_implemented(self):
         part = TextPartition(


### PR DESCRIPTION
### Motivation
- Reduce and localize mypy errors in the `avalan.memory` package so it can be removed from mypy overrides by improving type safety and aligning signatures with `MemoryStore`.

### Description
- Harden `CodePartitioner` by asserting tree-sitter `Node.text` presence, returning a typed `list[Parameter]` from `_get_parameters`, and building symbol ids from non-None parts to avoid `str | None` lists.
- Tighten `avalan.memory.permanent` types: switch embeddings to `NDArray[Any]`, make `symbols` a typed mapping `dict[str, Any] | None`, accept optional `SentenceTransformerModel`, and materialize `symbols` with `dict(symbols) if symbols is not None else None` when building records.
- Make base permanent-memory APIs async and signature-compatible with `MemoryStore` by updating `append`/`reset`/search/append-with-partitions method signatures and removing untyped decorator usage.
- Normalize message content conversion (`str(content.image_url)`) and replace local imports of `TextPartition` in several backend modules to import from `avalan.entities` to avoid implicit re-export typing issues.
- Update unit tests that rely on the base permanent-memory behaviors to exercise the new async signatures.

### Testing
- Ran `make lint` (formatting and ruff): passed (auto-fixed where needed). ✅
- Ran `poetry run mypy src/avalan/memory/partitioner/code.py src/avalan/memory/permanent/__init__.py`: no issues. ✅
- Ran `poetry run mypy src/avalan/memory`: still reports remaining errors concentrated in `pgsql`, `s3vectors`, and `elasticsearch` permanent-memory implementations (reduced and localized). ❌
- Ran focused pytest targets `tests/memory/partitioner/code_partitioner_test.py` and `tests/memory/permanent/base_memory_test.py`: all tested items passed. ✅
- Ran `tests/memory/permanent/pgsql_raw_memory_test.py::PgsqlRawMemoryTestCase::test_append_with_partitions`: passed. ✅
- Ran full test suite `poetry run pytest --verbose -s`: all tests passed (1576 passed, 11 skipped at time of run). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf484a0c083238e17e89f1d48e663)