### PR TITLE
Fix mypy signatures in Elasticsearch and S3Vectors permanent memory backends

### DIFF
--- a/src/avalan/memory/permanent/elasticsearch/message.py
+++ b/src/avalan/memory/permanent/elasticsearch/message.py
@@ -9,6 +9,7 @@ from ....memory.permanent import (
     PermanentMessageMemory,
     VectorFunction,
 )
+from ....model.nlp.sentence import SentenceTransformerModel
 from . import ElasticsearchMemory
 
 from datetime import datetime, timezone
@@ -26,12 +27,12 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         *,
         client: Any,
         logger: Logger,
-        sentence_model: Any | None = None,
+        sentence_model: SentenceTransformerModel | None = None,
     ) -> None:
         ElasticsearchMemory.__init__(
             self, index=index, client=client, logger=logger
         )
-        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)  # type: ignore[arg-type]
+        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)
 
     @classmethod
     async def create_instance(
@@ -40,7 +41,7 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         *,
         logger: Logger,
         es_client: Any | None = None,
-        sentence_model: Any | None = None,
+        sentence_model: SentenceTransformerModel | None = None,
     ) -> "ElasticsearchMessageMemory":
         if es_client is None:
             es_client = AsyncElasticsearch()
@@ -52,7 +53,7 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         )
 
     async def create_session(
-        self, *, agent_id: UUID, participant_id: UUID
+        self, agent_id: UUID, participant_id: UUID
     ) -> UUID:
         now_utc = datetime.now(timezone.utc)
         session = self._build_session(
@@ -75,7 +76,6 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
 
     async def continue_session_and_get_id(
         self,
-        *,
         agent_id: UUID,
         participant_id: UUID,
         session_id: UUID,
@@ -92,7 +92,6 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
     async def append_with_partitions(
         self,
         engine_message: EngineMessage,
-        *,
         partitions: list[TextPartition],
     ) -> None:
         assert engine_message and partitions
@@ -143,7 +142,6 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         self,
         session_id: UUID,
         participant_id: UUID,
-        *,
         limit: int | None = None,
     ) -> list[EngineMessage]:
         response = await self._call_client(
@@ -175,7 +173,6 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
 
     async def search_messages(
         self,
-        *,
         agent_id: UUID,
         function: VectorFunction,
         participant_id: UUID,
@@ -184,7 +181,7 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
         session_id: UUID | None,
         exclude_session_id: UUID | None,
         limit: int | None = None,
-    ) -> list[EngineMessageScored]:
+    ) -> list[EngineMessage]:
         assert agent_id and participant_id and search_partitions
         query = search_partitions[0].embeddings.tolist()
         filt = {
@@ -201,7 +198,7 @@ class ElasticsearchMessageMemory(ElasticsearchMemory, PermanentMessageMemory):
             function=str(function),
             filter=filt,
         )
-        results: list[EngineMessageScored] = []
+        results: list[EngineMessage] = []
         for item in response.get("Items", []):
             msg_id = item.get("Metadata", {}).get("message_id")
             if not msg_id:

--- a/src/avalan/memory/permanent/elasticsearch/raw.py
+++ b/src/avalan/memory/permanent/elasticsearch/raw.py
@@ -8,6 +8,7 @@ from ....memory.permanent import (
 )
 from . import ElasticsearchMemory, to_thread  # noqa: F401
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from logging import Logger
 from typing import Any
@@ -51,12 +52,11 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
         self,
         namespace: str,
         participant_id: UUID,
-        *,
         memory_type: MemoryType,
         data: str,
         identifier: str,
         partitions: list[TextPartition],
-        symbols: dict | None = None,
+        symbols: Mapping[str, Any] | None = None,
         model_id: str | None = None,
         title: str | None = None,
         description: str | None = None,
@@ -115,7 +115,6 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
 
     async def search_memories(
         self,
-        *,
         search_partitions: list[TextPartition],
         participant_id: UUID,
         namespace: str,
@@ -212,7 +211,5 @@ class ElasticsearchRawMemory(ElasticsearchMemory, PermanentMemory):
             )
         return memories
 
-    async def search(
-        self, query: str
-    ) -> list[PermanentMemoryPartition] | None:
+    async def search(self, query: str) -> list[Memory] | None:
         raise NotImplementedError()

--- a/src/avalan/memory/permanent/s3vectors/message.py
+++ b/src/avalan/memory/permanent/s3vectors/message.py
@@ -10,6 +10,7 @@ from ....memory.permanent import (
     PermanentMessageMemory,
     VectorFunction,
 )
+from ....model.nlp.sentence import SentenceTransformerModel
 from . import S3VectorsMemory
 
 from datetime import datetime, timezone
@@ -29,7 +30,7 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         *,
         client: Any,
         logger: Logger,
-        sentence_model: Any | None = None,
+        sentence_model: SentenceTransformerModel | None = None,
     ) -> None:
         S3VectorsMemory.__init__(
             self,
@@ -38,7 +39,7 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
             client=client,
             logger=logger,
         )
-        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)  # type: ignore[arg-type]
+        PermanentMessageMemory.__init__(self, sentence_model=sentence_model)
 
     @classmethod
     async def create_instance(
@@ -48,7 +49,7 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         *,
         logger: Logger,
         aws_client: Any | None = None,
-        sentence_model: Any | None = None,
+        sentence_model: SentenceTransformerModel | None = None,
     ) -> "S3VectorsMessageMemory":
         if aws_client is None:
             aws_client = boto_client("s3vectors")
@@ -61,23 +62,25 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         )
 
     async def create_session(
-        self, *, agent_id: UUID, participant_id: UUID
+        self, agent_id: UUID, participant_id: UUID
     ) -> UUID:
+        del agent_id
+        del participant_id
         return uuid4()
 
     async def continue_session_and_get_id(
         self,
-        *,
         agent_id: UUID,
         participant_id: UUID,
         session_id: UUID,
     ) -> UUID:
+        del agent_id
+        del participant_id
         return session_id
 
     async def append_with_partitions(
         self,
         engine_message: EngineMessage,
-        *,
         partitions: list[TextPartition],
     ) -> None:
         assert engine_message and partitions
@@ -97,20 +100,18 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         await self._put_object(
             Bucket=self._bucket,
             Key=key,
-            Body=dumps(
-                {
-                    "id": str(message.id),
-                    "agent_id": str(message.agent_id),
-                    "model_id": message.model_id,
-                    "session_id": (
-                        str(message.session_id) if message.session_id else None
-                    ),
-                    "author": str(message.author),
-                    "data": message.data,
-                    "partitions": message.partitions,
-                    "created_at": message.created_at.isoformat(),
-                }
-            ).encode(),
+            Body=dumps({
+                "id": str(message.id),
+                "agent_id": str(message.agent_id),
+                "model_id": message.model_id,
+                "session_id": (
+                    str(message.session_id) if message.session_id else None
+                ),
+                "author": str(message.author),
+                "data": message.data,
+                "partitions": message.partitions,
+                "created_at": message.created_at.isoformat(),
+            }).encode(),
         )
         for row in message_partitions:
             await self._put_vector(
@@ -131,9 +132,9 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         self,
         session_id: UUID,
         participant_id: UUID,
-        *,
         limit: int | None = None,
     ) -> list[EngineMessage]:
+        del participant_id
         prefix = f"{self._collection}/{session_id}/"
         response = await self._call_client(
             self._client.list_objects_v2, Bucket=self._bucket, Prefix=prefix
@@ -159,7 +160,6 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
 
     async def search_messages(
         self,
-        *,
         agent_id: UUID,
         function: VectorFunction,
         participant_id: UUID,
@@ -168,7 +168,9 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
         session_id: UUID | None,
         exclude_session_id: UUID | None,
         limit: int | None = None,
-    ) -> list[EngineMessageScored]:
+    ) -> list[EngineMessage]:
+        del search_user_messages
+        del exclude_session_id
         assert agent_id and participant_id and search_partitions
         query = search_partitions[0].embeddings.tolist()
         filt = {
@@ -186,7 +188,7 @@ class S3VectorsMessageMemory(S3VectorsMemory, PermanentMessageMemory):
             Function=str(function),
             Filter=filt,
         )
-        results: list[EngineMessageScored] = []
+        results: list[EngineMessage] = []
         for item in response.get("Items", []):
             msg_id = item.get("Metadata", {}).get("message_id")
             if not msg_id:

--- a/src/avalan/memory/permanent/s3vectors/raw.py
+++ b/src/avalan/memory/permanent/s3vectors/raw.py
@@ -10,6 +10,7 @@ from ....memory.permanent import (
 from . import S3VectorsMemory
 
 from asyncio import to_thread  # noqa: F401
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from json import dumps, loads
 from logging import Logger
@@ -66,12 +67,11 @@ class S3VectorsRawMemory(S3VectorsMemory, PermanentMemory):
         self,
         namespace: str,
         participant_id: UUID,
-        *,
         memory_type: MemoryType,
         data: str,
         identifier: str,
         partitions: list[TextPartition],
-        symbols: dict | None = None,
+        symbols: Mapping[str, Any] | None = None,
         model_id: str | None = None,
         title: str | None = None,
         description: str | None = None,
@@ -97,22 +97,20 @@ class S3VectorsRawMemory(S3VectorsMemory, PermanentMemory):
         await self._put_object(
             Bucket=self._bucket,
             Key=f"{self._collection}/{entry.id}.json",
-            Body=dumps(
-                {
-                    "id": str(entry.id),
-                    "model_id": entry.model_id,
-                    "type": str(entry.type),
-                    "participant_id": str(entry.participant_id),
-                    "namespace": entry.namespace,
-                    "identifier": entry.identifier,
-                    "data": entry.data,
-                    "partitions": entry.partitions,
-                    "symbols": entry.symbols,
-                    "created_at": entry.created_at.isoformat(),
-                    "title": entry.title,
-                    "description": entry.description,
-                }
-            ).encode(),
+            Body=dumps({
+                "id": str(entry.id),
+                "model_id": entry.model_id,
+                "type": str(entry.type),
+                "participant_id": str(entry.participant_id),
+                "namespace": entry.namespace,
+                "identifier": entry.identifier,
+                "data": entry.data,
+                "partitions": entry.partitions,
+                "symbols": entry.symbols,
+                "created_at": entry.created_at.isoformat(),
+                "title": entry.title,
+                "description": entry.description,
+            }).encode(),
         )
         for row in partition_rows:
             await self._put_vector(
@@ -133,7 +131,6 @@ class S3VectorsRawMemory(S3VectorsMemory, PermanentMemory):
 
     async def search_memories(
         self,
-        *,
         search_partitions: list[TextPartition],
         participant_id: UUID,
         namespace: str,
@@ -230,7 +227,5 @@ class S3VectorsRawMemory(S3VectorsMemory, PermanentMemory):
             )
         return memories
 
-    async def search(
-        self, query: str
-    ) -> list[PermanentMemoryPartition] | None:
+    async def search(self, query: str) -> list[Memory] | None:
         raise NotImplementedError()


### PR DESCRIPTION
### Motivation
- Remove mypy override exceptions by fixing signature and typing mismatches in permanent memory backends so they correctly implement the abstract contracts.
- Ensure concrete implementations accept the same parameter shapes and types as the base `PermanentMemory`/`PermanentMessageMemory` abstractions to satisfy static type checking.

### Description
- Updated `append_with_partitions` signatures in `ElasticsearchRawMemory` and `S3VectorsRawMemory` to remove unexpected keyword-only parameters and use `symbols: Mapping[str, Any] | None` to match the base `PermanentMemory` contract (files: `src/avalan/memory/permanent/elasticsearch/raw.py`, `src/avalan/memory/permanent/s3vectors/raw.py`).
- Aligned `search()` return annotation with `MemoryStore` by returning `list[Memory] | None` in raw memory backends (files: `.../elasticsearch/raw.py`, `.../s3vectors/raw.py`).
- Standardized message memory typing by replacing broad `Any` with `SentenceTransformerModel | None` for the sentence-model parameter and removed obsolete `type: ignore` comments (files: `src/avalan/memory/permanent/elasticsearch/message.py`, `src/avalan/memory/permanent/s3vectors/message.py`).
- Adjusted `create_session`, `continue_session_and_get_id`, `append_with_partitions`, `get_recent_messages`, and `search_messages` signatures to match the abstract base method parameter ordering (removed keyword-only markers) and aligned declared return types where appropriate (files: `.../elasticsearch/message.py`, `.../s3vectors/message.py`).

### Testing
- Ran `poetry run mypy` on the modified files: `src/avalan/memory/permanent/elasticsearch/raw.py`, `src/avalan/memory/permanent/elasticsearch/message.py`, `src/avalan/memory/permanent/s3vectors/raw.py`, and `src/avalan/memory/permanent/s3vectors/message.py` (passed).
- Ran `poetry run mypy` for the `elasticsearch` and `s3vectors` packages (passed for those packages).
- Ran formatter/linter: `make lint` / `ruff` / `black` formatting and checks (passed after small reformat fixes).
- Ran full test suite: `poetry run pytest --verbose -s` (all tests passed: 1576 passed, 11 skipped).
- Ran `poetry run mypy` across `src/avalan/memory/permanent/{elasticsearch,s3vectors,pgsql}` which shows remaining type errors only in the `pgsql` backend sources; non-PgSQL permanent backends are now clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd058e75f48323a622a377a7680d1b)