### PR TITLE
Fix mypy types for pgsql memory

### DIFF
--- a/src/avalan/memory/permanent/pgsql/__init__.py
+++ b/src/avalan/memory/permanent/pgsql/__init__.py
@@ -1,5 +1,5 @@
 from ....entities import EngineMessage, EngineMessageScored, Message
-from ....memory import MemoryChunk, MemoryStore
+from ....memory import MemoryStore
 from ....memory.permanent import (
     PermanentMessage,
     PermanentMessageScored,
@@ -9,7 +9,7 @@ from ....memory.permanent import (
 
 from logging import Logger
 from time import perf_counter
-from typing import TypeVar
+from typing import Any, Literal, TypeVar, cast, overload
 
 from pgvector.psycopg import register_vector_async
 from psycopg import AsyncConnection, AsyncCursor
@@ -18,13 +18,17 @@ from psycopg.types import TypeInfo
 from psycopg_pool import AsyncConnectionPool
 
 T = TypeVar("T")
+U = TypeVar("U")
+QueryParams = tuple[object, ...]
 
 
 class BasePgsqlMemory(MemoryStore[T]):
-    _database: AsyncConnection
+    _database: AsyncConnectionPool[Any]
     _logger: Logger
 
-    def __init__(self, database: AsyncConnectionPool, logger: Logger):
+    def __init__(
+        self, database: AsyncConnectionPool[Any], logger: Logger
+    ) -> None:
         self._database = database
         self._logger = logger
 
@@ -35,7 +39,10 @@ class BasePgsqlMemory(MemoryStore[T]):
         raise NotImplementedError()
 
     async def _execute(
-        self, cursor: AsyncCursor, query: str, parameters: tuple | None
+        self,
+        cursor: AsyncCursor[Any],
+        query: str,
+        parameters: QueryParams | None,
     ) -> None:
         self._logger.debug("Executing query: %s with %s", query, parameters)
         start = perf_counter()
@@ -45,8 +52,8 @@ class BasePgsqlMemory(MemoryStore[T]):
         )
 
     async def _fetch_all(
-        self, entity: type[T], query: str, parameters: tuple
-    ) -> list[T]:
+        self, entity: type[U], query: str, parameters: QueryParams
+    ) -> list[U]:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await self._execute(cursor, query, parameters)
@@ -59,15 +66,18 @@ class BasePgsqlMemory(MemoryStore[T]):
                 )
 
     async def _fetch_one(
-        self, entity: type[T], query: str, parameters: tuple
-    ) -> T:
+        self, entity: type[U], query: str, parameters: QueryParams
+    ) -> U:
         result = await self._try_fetch_one(entity, query, parameters)
         if result is None:
             raise RecordNotFoundException()
         return result
 
     async def _fetch_field(
-        self, field: str, query: str, parameters: tuple | None = None
+        self,
+        field: str,
+        query: str,
+        parameters: QueryParams | None = None,
     ) -> str | None:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
@@ -77,7 +87,7 @@ class BasePgsqlMemory(MemoryStore[T]):
                 row = dict(result) if result is not None else None
                 return row[field] if row else None
 
-    async def _has_one(self, query: str, parameters: tuple) -> bool:
+    async def _has_one(self, query: str, parameters: QueryParams) -> bool:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await self._execute(cursor, query, parameters)
@@ -86,8 +96,8 @@ class BasePgsqlMemory(MemoryStore[T]):
                 return result is not None
 
     async def _try_fetch_one(
-        self, entity: type[T], query: str, parameters: tuple
-    ) -> T | None:
+        self, entity: type[U], query: str, parameters: QueryParams
+    ) -> U | None:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await self._execute(cursor, query, parameters)
@@ -96,20 +106,21 @@ class BasePgsqlMemory(MemoryStore[T]):
                 return entity(**dict(result)) if result is not None else None
 
     async def _update_and_fetch_one(
-        self, entity: type[T], query: str, parameters: tuple
-    ) -> T:
+        self, entity: type[U], query: str, parameters: QueryParams
+    ) -> U:
         row = await self._update_and_fetch_row(query, parameters)
         return entity(**row)
 
     async def _update_and_fetch_field(
-        self, field: str, query: str, parameters: tuple
+        self, field: str, query: str, parameters: QueryParams
     ) -> str:
         row = await self._update_and_fetch_row(query, parameters)
-        return row[field]
+        value = row[field]
+        return value if isinstance(value, str) else str(value)
 
     async def _update_and_fetch_row(
-        self, query: str, parameters: tuple
-    ) -> dict:
+        self, query: str, parameters: QueryParams
+    ) -> dict[str, Any]:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await self._execute(cursor, query, parameters)
@@ -119,51 +130,51 @@ class BasePgsqlMemory(MemoryStore[T]):
                     raise RecordNotSavedException()
                 return dict(result)
 
-    async def _update(self, query: str, parameters: tuple) -> None:
+    async def _update(self, query: str, parameters: QueryParams) -> None:
         async with self._database.connection() as connection:
             async with connection.cursor() as cursor:
                 await self._execute(cursor, query, parameters)
                 await cursor.close()
 
 
-class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
+class PgsqlMemory(BasePgsqlMemory[T]):
     _composite_types: list[str] | None
 
     @classmethod
     async def create_instance_from_pool(
         cls,
-        pool: AsyncConnectionPool,
+        pool: AsyncConnectionPool[Any],
         *,
         logger: Logger,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> "PgsqlMemory[T]":
         memory = cls(dsn=None, pool=pool, logger=logger, **kwargs)
         return memory
 
     def __init__(
         self,
         dsn: str | None,
-        *args,
-        pool: AsyncConnectionPool | None = None,
+        logger: Logger,
+        pool: AsyncConnectionPool[Any] | None = None,
         composite_types: list[str] | None = None,
         pool_minimum: int | None = None,
         pool_maximum: int | None = None,
-        logger: Logger,
-        **kwargs,
-    ):
-        assert pool or (
-            dsn
-            and pool_minimum
-            and pool_minimum
-            and pool_minimum > 0
-            and pool_maximum > pool_minimum
-        )
+        **kwargs: Any,
+    ) -> None:
+        self._composite_types = composite_types
+        if pool is None:
+            assert dsn is not None
+            assert pool_minimum is not None
+            assert pool_maximum is not None
+            assert pool_minimum > 0
+            assert pool_maximum > pool_minimum
 
         if pool:
-            super().__init__(database=pool, logger=logger, **kwargs)
+            super().__init__(database=pool, logger=logger)
         else:
-            self._composite_types = composite_types
-
+            assert dsn is not None
+            assert pool_minimum is not None
+            assert pool_maximum is not None
             if "//" not in dsn:
                 dsn = f"postgresql://{dsn}"
 
@@ -174,10 +185,12 @@ class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
                 configure=self._configure_connection,
                 open=False,
             )
-            super().__init__(database=database, logger=logger, **kwargs)
+            super().__init__(database=database, logger=logger)
 
-    async def _configure_connection(self, connection: AsyncConnection):
-        connection.row_factory = dict_row
+    async def _configure_connection(
+        self, connection: AsyncConnection[Any]
+    ) -> None:
+        connection.row_factory = cast(Any, dict_row)
         await connection.set_autocommit(True)
         if self._composite_types:
             for composite_type_name in self._composite_types:
@@ -189,27 +202,55 @@ class PgsqlMemory(BasePgsqlMemory[MemoryChunk[T]]):
         await register_vector_async(connection)
 
     @staticmethod
+    @overload
+    def _to_engine_messages(
+        messages: list[PermanentMessage],
+        *,
+        limit: int | None,
+        reverse: bool = False,
+        scored: Literal[False] = False,
+    ) -> list[EngineMessage]: ...
+
+    @staticmethod
+    @overload
+    def _to_engine_messages(
+        messages: list[PermanentMessageScored],
+        *,
+        limit: int | None,
+        reverse: bool = False,
+        scored: Literal[True],
+    ) -> list[EngineMessageScored]: ...
+
+    @staticmethod
     def _to_engine_messages(
         messages: list[PermanentMessage] | list[PermanentMessageScored],
-        *args,
+        *,
         limit: int | None,
         reverse: bool = False,
         scored: bool = False,
     ) -> list[EngineMessage] | list[EngineMessageScored]:
-        engine_messages = [
-            (
+        if scored:
+            scored_messages = cast(list[PermanentMessageScored], messages)
+            engine_messages_scored: list[EngineMessageScored] = [
                 EngineMessageScored(
                     agent_id=m.agent_id,
                     model_id=m.model_id,
                     message=Message(role=m.author, content=m.data),
                     score=m.score,
                 )
-                if scored
-                else EngineMessage(
-                    agent_id=m.agent_id,
-                    model_id=m.model_id,
-                    message=Message(role=m.author, content=m.data),
-                )
+                for m in scored_messages
+            ]
+            if reverse:
+                engine_messages_scored.reverse()
+            if limit and len(engine_messages_scored) > limit:
+                engine_messages_scored = engine_messages_scored[:limit]
+            return engine_messages_scored
+
+        engine_messages = [
+            EngineMessage(
+                agent_id=m.agent_id,
+                model_id=m.model_id,
+                message=Message(role=m.author, content=m.data),
             )
             for m in messages
         ]

--- a/src/avalan/memory/permanent/pgsql/message.py
+++ b/src/avalan/memory/permanent/pgsql/message.py
@@ -1,4 +1,4 @@
-from ....entities import EngineMessage, EngineMessageScored, TextPartition
+from ....entities import EngineMessage, TextPartition
 from ....memory.permanent import (
     PermanentMessage,
     PermanentMessageMemory,
@@ -9,27 +9,25 @@ from ....memory.permanent.pgsql import PgsqlMemory
 
 from datetime import datetime, timezone
 from logging import Logger
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 from pgvector.psycopg import Vector
 
 
-class PgsqlMessageMemory(
-    PgsqlMemory[PermanentMessage], PermanentMessageMemory
-):
+class PgsqlMessageMemory(PgsqlMemory[EngineMessage], PermanentMessageMemory):
     """PostgreSQL-backed implementation of :class:`PermanentMessageMemory`."""
 
     @classmethod
     async def create_instance(
         cls,
         dsn: str,
-        *args,
         logger: Logger,
         pool_minimum: int = 1,
         pool_maximum: int = 10,
         pool_open: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> "PgsqlMessageMemory":
         """Create a memory store backed by a PostgreSQL connection."""
         memory = cls(
             dsn=dsn,
@@ -44,7 +42,7 @@ class PgsqlMessageMemory(
         return memory
 
     async def create_session(
-        self, *args, agent_id: UUID, participant_id: UUID
+        self, agent_id: UUID, participant_id: UUID
     ) -> UUID:
         """Create a new session for a participant."""
         now_utc = datetime.now(timezone.utc)
@@ -80,13 +78,12 @@ class PgsqlMessageMemory(
 
     async def continue_session_and_get_id(
         self,
-        *args,
         agent_id: UUID,
         participant_id: UUID,
         session_id: UUID,
     ) -> UUID:
         """Continue an existing session if it belongs to the participant."""
-        session_id = await self._fetch_field(
+        session_value = await self._fetch_field(
             "id",
             """
             SELECT "sessions"."id"
@@ -98,13 +95,16 @@ class PgsqlMessageMemory(
         """,
             (str(agent_id), str(participant_id), str(session_id)),
         )
-        assert session_id
-        return session_id if isinstance(session_id, UUID) else UUID(session_id)
+        assert session_value
+        return (
+            session_value
+            if isinstance(session_value, UUID)
+            else UUID(session_value)
+        )
 
     async def append_with_partitions(
         self,
         engine_message: EngineMessage,
-        *args,
         partitions: list[TextPartition],
     ) -> None:
         """Persist a message and its partitions."""
@@ -196,7 +196,6 @@ class PgsqlMessageMemory(
         self,
         session_id: UUID,
         participant_id: UUID,
-        *args,
         limit: int | None = None,
     ) -> list[EngineMessage]:
         """Retrieve recent messages for a session."""
@@ -230,16 +229,15 @@ class PgsqlMessageMemory(
 
     async def search_messages(
         self,
-        *args,
         agent_id: UUID,
         function: VectorFunction,
-        limit: int | None = None,
         participant_id: UUID,
         search_partitions: list[TextPartition],
         search_user_messages: bool,
         session_id: UUID | None,
         exclude_session_id: UUID | None,
-    ) -> list[EngineMessageScored]:
+        limit: int | None = None,
+    ) -> list[EngineMessage]:
         """Search messages using a similarity function."""
         assert agent_id and participant_id and search_partitions
         search_function = str(function)
@@ -296,4 +294,4 @@ class PgsqlMessageMemory(
             limit=limit_value,
             scored=True,
         )
-        return engine_messages
+        return cast(list[EngineMessage], engine_messages)

--- a/src/avalan/memory/permanent/pgsql/raw.py
+++ b/src/avalan/memory/permanent/pgsql/raw.py
@@ -10,10 +10,12 @@ from ....memory.permanent import (
 )
 from ....memory.permanent.pgsql import PgsqlMemory
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from json import dumps
 from logging import Logger
+from typing import Any
 from uuid import UUID, uuid4
 
 from pgvector.psycopg import Vector
@@ -24,13 +26,12 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
     async def create_instance(
         cls,
         dsn: str,
-        *args,
         logger: Logger,
         pool_minimum: int = 1,
         pool_maximum: int = 10,
         pool_open: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> "PgsqlRawMemory":
         memory = cls(
             dsn=dsn,
             logger=logger,
@@ -46,12 +47,11 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
         self,
         namespace: str,
         participant_id: UUID,
-        *args,
         memory_type: MemoryType,
         data: str,
         identifier: str,
         partitions: list[TextPartition],
-        symbols: dict | None = None,
+        symbols: Mapping[str, Any] | None = None,
         model_id: str | None = None,
         title: str | None = None,
         description: str | None = None,
@@ -154,7 +154,7 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
         namespace: str
         identifier: str
         partitions: int
-        symbols: dict | None
+        symbols: dict[str, Any] | None
         created_at: datetime
         title: str | None
         description: str | None
@@ -216,7 +216,6 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
 
     async def search_memories(
         self,
-        *args,
         search_partitions: list[TextPartition],
         participant_id: UUID,
         namespace: str,
@@ -403,4 +402,5 @@ class PgsqlRawMemory(PgsqlMemory[Memory], PermanentMemory):
                         ),
                     )
                     await cursor.close()
-        return UUID(entity_id) if isinstance(entity_id, str) else entity_id
+        assert entity_id is not None
+        return entity_id if isinstance(entity_id, UUID) else UUID(entity_id)


### PR DESCRIPTION
### Motivation

- Remove mypy errors in the `avalan.memory` area (PostgreSQL-backed permanent memory) so the module can be removed from `[[tool.mypy.overrides]]` that ignore errors.  
- Harden typing around DB pool/cursor usage and result mapping to satisfy strict mypy and to make runtime conversions explicit.

### Description

- Introduced `QueryParams` and widened pool/cursor types to `AsyncConnectionPool[Any]` / `AsyncCursor[Any]` and tightened helper generics by adding `U` to make `_fetch_*` helpers return the correct concrete types in `src/avalan/memory/permanent/pgsql/__init__.py`.  
- Reworked `PgsqlMemory` constructor and `_configure_connection` to use explicit `logger` and `pool` parameters, assert required values when building pools, and cast `dict_row` to satisfy row-factory typing.  
- Added precise overloads for `_to_engine_messages` and separated scored vs non-scored branches to return `list[EngineMessageScored]` or `list[EngineMessage]` respectively, with safe `cast` where needed.  
- Aligned signatures in `PgsqlRawMemory` and `PgsqlMessageMemory` to match the abstract base contracts (removed permissive `*args` variants, used `Mapping[str, Any] | None` for `symbols`, added return annotations, and fixed session id handling) in `src/avalan/memory/permanent/pgsql/raw.py` and `src/avalan/memory/permanent/pgsql/message.py`.

### Testing

- Ran lint/formatting: `poetry run ruff format` and `poetry run black` and `poetry run ruff check --fix` which completed successfully.  
- Ran static type checks: `poetry run mypy src/avalan/memory` and `poetry run mypy src/avalan/memory/permanent/pgsql/*.py` which returned no issues for the memory package.  
- Ran the full test-suite: `poetry run pytest --verbose -s` which completed successfully (`1576 passed, 11 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2d983c208323af5822d63c78f5ad)