### PR TITLE
Improve CLI typing for mypy

### DIFF
--- a/src/avalan/cli/__init__.py
+++ b/src/avalan/cli/__init__.py
@@ -6,6 +6,7 @@ from io import UnsupportedOperation
 from json import dumps
 from select import select
 from sys import stdin
+from typing import TextIO
 
 from rich.console import Console
 from rich.live import Live
@@ -48,13 +49,11 @@ def confirm_tool_call(
     live: Live | None = None,
 ) -> str:
     prompt = "Execute tool call?"
-    options = {
-        "choices": ["y", "a", "n"],
-        "default": "n",
-        "console": console,
-        "show_choices": True,
-        "show_default": True,
-    }
+    choices = ["y", "a", "n"]
+    default = "n"
+    show_choices = True
+    show_default = True
+    stream: TextIO | None = None
 
     with _pause_live(live) if live else nullcontext():
         call_element = Syntax(
@@ -65,22 +64,39 @@ def confirm_tool_call(
         if live:
             prompt_element = Text.from_markup(prompt, style="prompt")
             prompt_element.end = ""
-            choices = "/".join(options["choices"])
+            choices_display = "/".join(choices)
             prompt_element.append(" ")
-            prompt_element.append(f"[{choices}]", "prompt.choices")
+            prompt_element.append(f"[{choices_display}]", "prompt.choices")
 
-            if options["show_default"]:
-                default = Text(f"({options['default']})", "prompt.default")
+            if show_default:
+                default_element = Text(f"({default})", "prompt.default")
                 prompt_element.append(" ")
-                prompt_element.append(default)
+                prompt_element.append(default_element)
 
             console.print(prompt_element)
 
         stdin_is_tty = stdin.isatty()
         with open(tty_path) if not stdin_is_tty else nullcontext() as tty:
             if not stdin_is_tty:
-                options["stream"] = tty
-            return Prompt.ask(prompt, **options)
+                stream = tty
+            if stream is not None:
+                return Prompt.ask(
+                    prompt,
+                    choices=choices,
+                    default=default,
+                    console=console,
+                    show_choices=show_choices,
+                    show_default=show_default,
+                    stream=stream,
+                )
+            return Prompt.ask(
+                prompt,
+                choices=choices,
+                default=default,
+                console=console,
+                show_choices=show_choices,
+                show_default=show_default,
+            )
 
 
 def has_input(console: Console) -> bool:
@@ -123,10 +139,15 @@ def get_input(
                 if is_input_available and force_prompt
                 else nullcontext()
             ) as tty:
-                kwargs = {}
+                input_stream: TextIO | None = None
                 if is_input_available and force_prompt:
-                    kwargs["stream"] = tty
-                input_string = PromptWithoutPrefix.ask(full_prompt, **kwargs)
+                    input_stream = tty
+                if input_stream is not None:
+                    input_string = PromptWithoutPrefix.ask(
+                        full_prompt, stream=input_stream
+                    )
+                else:
+                    input_string = PromptWithoutPrefix.ask(full_prompt)
             if strip_prompt:
                 input_string = input_string.strip()
         except EOFError:

--- a/src/avalan/cli/commands/__init__.py
+++ b/src/avalan/cli/commands/__init__.py
@@ -11,7 +11,7 @@ def get_model_settings(
     logger: Logger,
     engine_uri: EngineUri,
     modality: Modality | None = None,
-) -> dict:
+) -> dict[str, object]:
     """Return settings used to load a model."""
     modality = (
         modality

--- a/src/avalan/cli/download.py
+++ b/src/avalan/cli/download.py
@@ -3,9 +3,11 @@ from rich.progress import Progress
 from tqdm.std import tqdm as std_tqdm
 
 
-def create_live_tqdm_class(progress_template: tuple[RenderableType, ...]):
+def create_live_tqdm_class(
+    progress_template: tuple[RenderableType, ...],
+) -> type["tqdm_rich_progress"]:
     class LiveTqdm(tqdm_rich_progress):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             extended_kwargs = {**kwargs}
             extended_kwargs.setdefault("progress", progress_template)
             super().__init__(*args, **extended_kwargs)
@@ -18,22 +20,24 @@ def create_live_tqdm_class(progress_template: tuple[RenderableType, ...]):
 
 
 class tqdm_rich_progress(std_tqdm):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         sanitized_kwargs = {**kwargs}
         sanitized_kwargs.pop("progress", None)
         sanitized_kwargs.pop("options", None)
 
-        super().__init__(*args, **sanitized_kwargs)
+        super().__init__(*args, **sanitized_kwargs)  # type: ignore[misc]
         if self.disable:
             return
 
         options = {**{"options": None, "progress": None}, **kwargs}
 
         progress = options.pop("progress")
+        assert isinstance(progress, tuple)
         progress_options = {
             **{"transient": not self.leave},
             **(options.pop("options", None) or {}),
         }
+        assert isinstance(progress_options, dict)
 
         self._progress = Progress(*progress, **progress_options)
         self._progress.__enter__()
@@ -41,24 +45,24 @@ class tqdm_rich_progress(std_tqdm):
             self.desc or "", **self.format_dict
         )
 
-    def close(self):
+    def close(self) -> None:
         if self.disable:
             return
         self.display()
         self._progress.__exit__(None, None, None)
         super().close()
 
-    def clear(self, *_, **__):
+    def clear(self, *_: object, **__: object) -> None:
         pass
 
-    def display(self, *_, **__):
+    def display(self, *_: object, **__: object) -> None:
         if not hasattr(self, "_progress"):
             return
         self._progress.update(
             self._task_id, completed=self.n, description=self.desc
         )
 
-    def reset(self, total=None):
+    def reset(self, total: int | float | None = None) -> None:
         if hasattr(self, "_progress"):
             self._progress.reset(total=total)
         super().reset(total=total)


### PR DESCRIPTION
### Motivation
- The `avalan.memory` module is mypy-clean, so progress moved to reducing typing issues in the next area (`avalan.cli`) to allow removal of overrides and enable stricter mypy checks.
- Tighten dynamic kwargs and untyped interactions in CLI prompt helpers and tqdm live-progress helpers so mypy can reason about them under strict settings.

### Description
- Reworked `confirm_tool_call` and `get_input` in `src/avalan/cli/__init__.py` to use explicit typed variables and explicit `stream` handling instead of a loose `options` dict and **kwargs,** and added `TextIO`-typed local variables for clarity.
- Added explicit function/type signatures, assertions and return annotations to the tqdm helpers in `src/avalan/cli/download.py`, and guarded untyped super-calls to make the control flow and expected types explicit.
- Narrowed the return annotation for `get_model_settings` in `src/avalan/cli/commands/__init__.py` to `dict[str, object]` instead of an unparameterized `dict`.
- Minor formatting and typing cleanups to satisfy linters and reduce mypy false positives.

### Testing
- Ran `make lint` and autofixers, which completed successfully. (passed)
- Ran `poetry run mypy src/avalan/memory` to confirm the memory module is clean under mypy strict settings, which returned no issues. (passed)
- Ran targeted CLI tests with `poetry run pytest --verbose -s tests/cli/input_test.py tests/cli/download_test.py tests/cli/get_model_settings_test.py`, which passed. (passed)
- Ran the full test suite with `poetry run pytest --verbose -s`, which completed successfully with all tests passing. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd442fbfa48323842712138d59e25f)