### PR TITLE
Enable mypy checks for CLI and use framework `Theme` type in handlers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,6 @@ python_version = "3.11"
 [[tool.mypy.overrides]]
 module = [
   "avalan.agent.*",
-  "avalan.cli.*",
   "avalan.model.*",
   "avalan.tool.*",
 ]

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -23,6 +23,7 @@ from ..cli.commands.model import (
     model_uninstall,
 )
 from ..cli.commands.tokenizer import tokenize
+from ..cli.theme import Theme
 from ..cli.theme.fancy import FancyTheme
 from ..entities import (
     AttentionImplementation,
@@ -81,7 +82,7 @@ from warnings import filterwarnings
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.prompt import Confirm, Prompt
-from rich.theme import Theme
+from rich.theme import Theme as RichTheme
 from torch.cuda import device_count, is_available, set_device
 from torch.distributed import destroy_process_group
 from transformers.utils import (
@@ -1980,7 +1981,7 @@ class CLI:
         theme = FancyTheme(translator.gettext, translator.ngettext)
         _ = theme._
         console = Console(
-            theme=Theme(styles=theme.get_styles()), record=args.record
+            theme=RichTheme(styles=theme.get_styles()), record=args.record
         )
 
         if args.help_full:

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -5,6 +5,7 @@ from ...agent.orchestrator.response.orchestrator_response import (
 )
 from ...cli import confirm_tool_call, get_input, has_input
 from ...cli.commands.model import token_generation
+from ...cli.theme import Theme
 from ...entities import (
     Backend,
     GenerationCacheStrategy,
@@ -34,7 +35,6 @@ from rich.console import Console
 from rich.live import Live
 from rich.prompt import Confirm, Prompt
 from rich.syntax import Syntax
-from rich.theme import Theme
 
 
 def _parse_permanent_memory_items(

--- a/src/avalan/cli/commands/cache.py
+++ b/src/avalan/cli/commands/cache.py
@@ -1,5 +1,6 @@
 from ...cli import confirm
 from ...cli.download import create_live_tqdm_class
+from ...cli.theme import Theme
 from ...model.hubs import HubAccessDeniedException
 from ...model.hubs.huggingface import HuggingfaceHub
 
@@ -7,7 +8,6 @@ from argparse import Namespace
 
 from rich.console import Console
 from rich.padding import Padding
-from rich.theme import Theme
 
 
 def cache_delete(

--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -1,6 +1,7 @@
 from ...cli import get_input
 from ...cli.commands import get_model_settings
 from ...cli.commands.model import model_display
+from ...cli.theme import Theme
 from ...entities import DistanceType, Modality, SearchMatch, Similarity
 from ...memory.partitioner.code import CodePartitioner
 from ...memory.partitioner.text import TextPartition, TextPartitioner
@@ -23,7 +24,6 @@ from markitdown import DocumentConverterResult, MarkItDown
 from numpy import abs, corrcoef, dot, sum, vstack
 from numpy.linalg import norm
 from rich.console import Console
-from rich.theme import Theme
 
 
 async def memory_document_index(

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -2,6 +2,7 @@ from ...agent import Specification
 from ...agent.orchestrator import Orchestrator
 from ...cli import confirm, get_input, has_input
 from ...cli.commands.cache import cache_delete, cache_download
+from ...cli.theme import Theme
 from ...entities import (
     GenerationSettings,  # noqa: F401
     Modality,
@@ -42,7 +43,6 @@ from rich.live import Live
 from rich.padding import Padding
 from rich.prompt import Prompt
 from rich.spinner import Spinner
-from rich.theme import Theme
 
 _HAS_INPUT = has_input
 

--- a/src/avalan/cli/commands/tokenizer.py
+++ b/src/avalan/cli/commands/tokenizer.py
@@ -1,4 +1,5 @@
 from ...cli import get_input
+from ...cli.theme import Theme
 from ...entities import Token, TransformerEngineSettings
 from ...model.hubs.huggingface import HuggingfaceHub
 from ...model.nlp.text.generation import TextGenerationModel
@@ -7,7 +8,6 @@ from argparse import Namespace
 from logging import Logger
 
 from rich.console import Console
-from rich.theme import Theme
 
 
 async def tokenize(


### PR DESCRIPTION
### Motivation
- Surface and fix strict typing issues in the CLI by removing the blanket mypy ignore for the `avalan.cli` package so errors are visible to address. 
- Use the framework `Theme` protocol for command handler signatures to avoid spurious `attr-defined`/type errors when handlers call theme-specific methods.

### Description
- Removed `"avalan.cli.*"` from the `[[tool.mypy.overrides]]` ignore list in `pyproject.toml` so mypy now checks the CLI code. 
- Updated command modules to use the framework theme protocol by importing `Theme` from `avalan.cli.theme` in `src/avalan/cli/commands/{cache.py,tokenizer.py,model.py,agent.py,memory.py}`. 
- Adjusted CLI bootstrap in `src/avalan/cli/__main__.py` to import the package `Theme` protocol and alias Rich’s concrete class as `RichTheme`, and changed console construction to `Console(theme=RichTheme(styles=theme.get_styles()), ...)` so runtime use remains correct while handler signatures use the CLI `Theme` protocol. 
- Changes grouped and committed under message `Use CLI theme type in command handlers` and touch the CLI imports and typing only.

### Testing
- Ran `make lint`, which completed successfully (formatting with `ruff`/`black` and `ruff check --fix`).
- Ran the full test suite with `poetry run pytest --verbose -s`, which passed (`1576 passed, 11 skipped`).
- Ran mypy on the CLI with `poetry run mypy src/avalan/cli`, which now surfaces type errors and currently fails with `368` errors across `9` files (these are the remaining issues to address next).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4864aaa88323b8b80726ccfc9366)