### PR TITLE
Improve typing in CLI entrypoint and tqdm Rich progress integration

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -52,7 +52,12 @@ from ..utils import logger_replace
 
 import gettext
 import sys
-from argparse import ArgumentParser, Namespace, _SubParsersAction
+from argparse import (
+    ArgumentParser,
+    Namespace,
+    _ArgumentGroup,
+    _SubParsersAction,
+)
 from asyncio import run as run_in_loop
 from asyncio.exceptions import CancelledError
 from dataclasses import fields
@@ -74,7 +79,7 @@ from os.path import join
 from pathlib import Path
 from subprocess import run
 from tomllib import load as toml_load
-from typing import Optional, get_args, get_origin
+from typing import Callable, Protocol, TextIO, cast, get_args, get_origin
 from typing import get_args as get_type_args
 from uuid import uuid4
 from warnings import filterwarnings
@@ -85,12 +90,25 @@ from rich.prompt import Confirm, Prompt
 from rich.theme import Theme as RichTheme
 from torch.cuda import device_count, is_available, set_device
 from torch.distributed import destroy_process_group
-from transformers.utils import (
-    is_flash_attn_2_available,
-    is_torch_flex_attn_available,
+from transformers import utils as transformer_utils
+from transformers.utils import logging as hf_logging
+
+
+class Translator(Protocol):
+    """Represent the translation helpers needed by the CLI."""
+
+    def gettext(self, message: str) -> str: ...
+
+    def ngettext(self, singular: str, plural: str, n: int) -> str: ...
+
+
+is_flash_attn_2_available = cast(
+    Callable[[], bool],
+    getattr(transformer_utils, "is_flash_attn_2_available", lambda: False),
 )
-from transformers.utils import (
-    logging as hf_logging,
+is_torch_flex_attn_available = cast(
+    Callable[[], bool],
+    getattr(transformer_utils, "is_torch_flex_attn_available", lambda: False),
 )
 
 
@@ -108,6 +126,7 @@ class CLI:
 
         cache_dir = HuggingfaceHub.DEFAULT_CACHE_DIR
         default_locale, _ = getlocale()
+        default_locale = default_locale or "en_US"
         default_locales_path = join(
             Path(__file__).resolve().parents[3], "locale"
         )
@@ -142,7 +161,7 @@ class CLI:
         cache_dir: str,
         default_locales_path: str,
         default_locale: str,
-    ):
+    ) -> ArgumentParser:
         default_attention = CLI._default_attention(default_device)
         global_parser = ArgumentParser(add_help=False)
         global_parser.add_argument(
@@ -1638,7 +1657,7 @@ class CLI:
     @staticmethod
     def _get_translator(
         app_name: str, locales_path: str, locale: str
-    ) -> object:
+    ) -> Translator:
         """Return translation object for ``locale`` or ``gettext`` fallback."""
         try:
             return translation(
@@ -1764,7 +1783,7 @@ class CLI:
     @staticmethod
     def _add_agent_settings_arguments(
         parser: ArgumentParser,
-    ) -> ArgumentParser:
+    ) -> _ArgumentGroup:
         group = parser.add_argument_group("inline agent settings")
         group.add_argument("--engine-uri", type=str, help="Agent engine URI")
         group.add_argument("--name", type=str, help="Agent name")
@@ -1886,7 +1905,7 @@ class CLI:
     @staticmethod
     def _add_tool_settings_arguments(
         parser: ArgumentParser, *, prefix: str, settings_cls: type
-    ) -> ArgumentParser:
+    ) -> _ArgumentGroup:
         """Add dataclass based tool options to ``parser``."""
         group = parser.add_argument_group(f"{prefix} tool settings")
 
@@ -1900,7 +1919,7 @@ class CLI:
             if origin is not None:
                 if origin is list or origin is tuple:
                     ftype = args[0]
-                elif origin is Optional or type(None) in args:
+                elif type(None) in args:
                     ftype = next((a for a in args if a is not type(None)), str)
                 elif origin.__name__ == "Literal":
                     ftype = type(args[0])
@@ -1980,8 +1999,12 @@ class CLI:
         assert self._logger is not None and isinstance(self._logger, Logger)
         theme = FancyTheme(translator.gettext, translator.ngettext)
         _ = theme._
+        rich_theme_styles = {
+            str(data_key): style
+            for data_key, style in theme.get_styles().items()
+        }
         console = Console(
-            theme=RichTheme(styles=theme.get_styles()), record=args.record
+            theme=RichTheme(styles=rich_theme_styles), record=args.record
         )
 
         if args.help_full:
@@ -1992,14 +2015,14 @@ class CLI:
 
         if requires_token:
             if not access_token:
-                prompt_kwargs = {}
+                prompt_stream: TextIO | None = None
                 if has_input(console):
                     try:
-                        prompt_kwargs["stream"] = open(args.tty)
+                        prompt_stream = open(args.tty)
                     except OSError:
                         pass
                 access_token = Prompt.ask(
-                    theme.ask_access_token(), **prompt_kwargs
+                    theme.ask_access_token(), stream=prompt_stream
                 )
             assert access_token
         else:
@@ -2109,7 +2132,7 @@ class CLI:
                 theme.welcome(
                     self._site.geturl(),
                     self._name,
-                    self._version,
+                    str(self._version),
                     self._license,
                     user,
                 )

--- a/src/avalan/cli/download.py
+++ b/src/avalan/cli/download.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rich.console import RenderableType
 from rich.progress import Progress
 from tqdm.std import tqdm as std_tqdm
@@ -19,13 +21,13 @@ def create_live_tqdm_class(
     https://github.com/tqdm/tqdm/blob/master/tqdm/rich.py """
 
 
-class tqdm_rich_progress(std_tqdm):
-    def __init__(self, *args: object, **kwargs: object) -> None:
+class tqdm_rich_progress(std_tqdm):  # type: ignore[misc]
+    def __init__(self, *args: object, **kwargs: Any) -> None:
         sanitized_kwargs = {**kwargs}
         sanitized_kwargs.pop("progress", None)
         sanitized_kwargs.pop("options", None)
 
-        super().__init__(*args, **sanitized_kwargs)  # type: ignore[misc]
+        super().__init__(*args, **sanitized_kwargs)
         if self.disable:
             return
 
@@ -33,11 +35,14 @@ class tqdm_rich_progress(std_tqdm):
 
         progress = options.pop("progress")
         assert isinstance(progress, tuple)
-        progress_options = {
-            **{"transient": not self.leave},
-            **(options.pop("options", None) or {}),
+        raw_progress_options = options.pop("options", None)
+        assert raw_progress_options is None or isinstance(
+            raw_progress_options, dict
+        )
+        progress_options: dict[str, Any] = {
+            "transient": not self.leave,
+            **(raw_progress_options or {}),
         }
-        assert isinstance(progress_options, dict)
 
         self._progress = Progress(*progress, **progress_options)
         self._progress.__enter__()
@@ -64,5 +69,8 @@ class tqdm_rich_progress(std_tqdm):
 
     def reset(self, total: int | float | None = None) -> None:
         if hasattr(self, "_progress"):
-            self._progress.reset(total=total)
+            try:
+                self._progress.reset(self._task_id, total=total)
+            except TypeError:
+                self._progress.reset(total=total)
         super().reset(total=total)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -135,5 +135,5 @@ class CliDownloadTestCase(TestCase):
             super_close.assert_called_once()
 
             bar.reset(total=2)
-            bar._progress.reset.assert_called_once_with(total=2)
+            bar._progress.reset.assert_called_once_with(1, total=2)
             super_reset.assert_called_once_with(total=2)


### PR DESCRIPTION
### Motivation
- Reduce mypy errors in the `avalan.cli` module so it can be progressively removed from the mypy overrides that ignore errors. 
- Make runtime behavior around optional `transformers.utils` helpers and Rich progress usage more robust and clearly typed for tests and static checking.

### Description
- Add a `Translator` `Protocol` and tighten types in `src/avalan/cli/__main__.py`, including return annotations for `_create_parser` and `_get_translator`, replacing loose `Optional` checks, normalizing `default_locale`, and converting theme style keys to `str` for `RichTheme` usage. 
- Make `transformers.utils` lookups resilient and test-friendly by binding `is_flash_attn_2_available` and `is_torch_flex_attn_available` as module-level callables (with proper `Callable[[], bool]` typing) so tests can patch them. 
- Fix CLI prompt typing by using a typed `TextIO` variable for the prompt `stream` and pass it to `Prompt.ask` explicitly. 
- Tighten typing and behavior in `src/avalan/cli/download.py` by importing `Any`, annotating `kwargs` as `Any`, making `progress_options` explicitly `dict[str, Any]`, and calling `Progress.reset` with the task id (with a `TypeError` fallback for older signatures). 
- Adjust the unit test expectation in `tests/utils_test.py` to match the Rich `Progress.reset(task_id, ...)` call signature.

### Testing
- Ran `make lint` and automatic format/fixters (`ruff`, `black`) with no outstanding lint failures. 
- Ran targeted mypy on modified files with `poetry run mypy src/avalan/cli/download.py src/avalan/cli/__main__.py` which reported no issues for those changed files. 
- Ran `poetry run mypy src/avalan/cli --hide-error-context --no-color-output` which still reports remaining CLI mypy issues across other files (work will continue module-by-module). 
- Ran the full test suite with `poetry run pytest --verbose -s`, which passed (1576 passed, 11 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd974188ec8323a4a2e815a75f136f)