### PR TITLE
Improve CLI typing baseline

### DIFF
--- a/src/avalan/cli/commands/memory.py
+++ b/src/avalan/cli/commands/memory.py
@@ -2,9 +2,15 @@ from ...cli import get_input
 from ...cli.commands import get_model_settings
 from ...cli.commands.model import model_display
 from ...cli.theme import Theme
-from ...entities import DistanceType, Modality, SearchMatch, Similarity
+from ...entities import (
+    DistanceType,
+    Modality,
+    SearchMatch,
+    Similarity,
+    TextPartition,
+)
 from ...memory.partitioner.code import CodePartitioner
-from ...memory.partitioner.text import TextPartition, TextPartitioner
+from ...memory.partitioner.text import TextPartitioner
 from ...memory.permanent import MemoryType
 from ...memory.permanent.pgsql.raw import PgsqlRawMemory
 from ...memory.source import MemorySource
@@ -13,6 +19,7 @@ from ...model.manager import ModelManager
 
 from argparse import Namespace
 from asyncio import to_thread
+from collections.abc import Callable
 from io import BytesIO
 from logging import Logger
 from pathlib import Path
@@ -121,6 +128,7 @@ async def memory_document_index(
                 else:
                     title = Path(source).name
 
+            partitions: list[TextPartition]
             if is_url or args.partitioner == "text":
                 partitioner = TextPartitioner(
                     stm,
@@ -139,7 +147,7 @@ async def memory_document_index(
                     args.encoding,
                     args.partition_max_tokens,
                 )
-                partitions: list[TextPartition] = []
+                partitions = []
                 for cp in code_partitions:
                     embeddings = await stm(cp.data)
                     tokens = stm.token_count(cp.data)
@@ -195,7 +203,7 @@ async def memory_embeddings(
     sort_by: DistanceType = args.sort or DistanceType.L2
     tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
-    sort_key = {
+    sort_key: Callable[[Similarity], float] = {
         DistanceType.COSINE: lambda s: s.cosine_distance,
         DistanceType.DOT: lambda s: s.inner_product,
         DistanceType.L1: lambda s: s.l1_distance,
@@ -358,6 +366,7 @@ async def memory_embeddings(
                 index = IndexFlatL2(input_string_embeddings.shape[0])
 
                 if partitioner:
+                    assert knowledge_partitions is not None
                     knowledge_stack = vstack(
                         [kp.embeddings for kp in knowledge_partitions]
                     ).astype("float32", copy=False)

--- a/src/avalan/cli/commands/tokenizer.py
+++ b/src/avalan/cli/commands/tokenizer.py
@@ -6,8 +6,9 @@ from ...model.nlp.text.generation import TextGenerationModel
 
 from argparse import Namespace
 from logging import Logger
+from typing import Callable, cast
 
-from rich.console import Console
+from rich.console import Console, RenderableType
 
 
 async def tokenize(
@@ -56,8 +57,12 @@ async def tokenize(
         if args.save:
             paths = lm.save_tokenizer(args.save)
             total_files = len(paths)
-            console.print(theme.saved_tokenizer_files(args.save, total_files))
-            return
+            saved_tokenizer_files = cast(
+                Callable[[str, int], RenderableType],
+                theme.saved_tokenizer_files,
+            )
+            console.print(saved_tokenizer_files(args.save, total_files))
+            return None
 
         tty_path = getattr(args, "tty", "/dev/tty") or "/dev/tty"
 
@@ -70,7 +75,7 @@ async def tokenize(
         )
         if input_string:
             logger.debug("Loaded model %s", lm.config.__repr__())
-            tokens = lm.tokenize(input_string)
+            tokens = cast(list[Token], lm.tokenize(input_string))
 
             panel = theme.tokenizer_tokens(
                 tokens,
@@ -79,3 +84,6 @@ async def tokenize(
                 display_details=True,
             )
             console.print(panel)
+            return tokens
+
+    return None

--- a/src/avalan/cli/download.py
+++ b/src/avalan/cli/download.py
@@ -69,8 +69,5 @@ class tqdm_rich_progress(std_tqdm):  # type: ignore[misc]
 
     def reset(self, total: int | float | None = None) -> None:
         if hasattr(self, "_progress"):
-            try:
-                self._progress.reset(self._task_id, total=total)
-            except TypeError:
-                self._progress.reset(total=total)
+            self._progress.reset(self._task_id, total=total)
         super().reset(total=total)

--- a/src/avalan/cli/theme/__init__.py
+++ b/src/avalan/cli/theme/__init__.py
@@ -10,48 +10,40 @@ from ...entities import (
     SearchMatch,
     SentenceTransformerModelConfig,
     Similarity,
+    TextPartition,
     Token,
     TokenizerConfig,
     User,
 )
 from ...event import Event, EventStats
-from ...memory.partitioner.text import TextPartition
 from ...memory.permanent import Memory as Memory
 from ...memory.permanent import PermanentMemoryPartition
 
 from abc import ABC, abstractmethod
 from dataclasses import fields
 from datetime import datetime
-from enum import StrEnum
 from logging import Logger
-from typing import Callable, Generator, Literal
+from typing import Any, Callable, Generator, Literal, TypeAlias, cast
 from uuid import UUID
 
 from humanize import intcomma, intword, naturalsize, naturaltime
 from numpy import ndarray
 from rich.console import RenderableType
 
-Formatter = (
-    Callable[[datetime], str] | Callable[[float], str] | Callable[[int], str]
-)
+Formatter: TypeAlias = Callable[[datetime | float | int], str]
 Formatters = dict[Literal["datetime", "number", "quantity", "size"], Formatter]
 Spinner = Literal["cache_accessing", "connecting", "thinking", "downloading"]
-Data = StrEnum(
-    "Data",
-    {
-        **{field.name: field.name for field in fields(Model)},
-        **{field.name: field.name for field in fields(User)},
-    },
-)
+Data = str
 DataValue = datetime | float | int | str | None
-Stylers = dict[Data, Callable[[DataValue], str]]
+Styler: TypeAlias = Callable[[Data, DataValue, str | None, bool | str], str]
+Stylers = dict[Data, Styler]
 
 
 class Theme(ABC):
-    _all_spinners: dict[Spinner, str]
+    _all_spinners: dict[Spinner, str | None]
     _all_stylers: Stylers
-    _all_styles: dict[Data, str]
-    _icons: dict[Data, str]
+    _all_styles: dict[str, str]
+    _icons: dict[Data, str | None]
     _: Callable[[str], str]
 
     @property
@@ -59,7 +51,7 @@ class Theme(ABC):
         return {}
 
     @property
-    def icons(self) -> dict[Data, str]:
+    def icons(self) -> dict[str, str]:
         return {}
 
     @property
@@ -75,7 +67,7 @@ class Theme(ABC):
         return {}
 
     @property
-    def styles(self) -> dict[Data, str]:
+    def styles(self) -> dict[str, str]:
         return {}
 
     @abstractmethod
@@ -95,9 +87,10 @@ class Theme(ABC):
     def agent(
         self,
         agent: Orchestrator,
-        *args,
+        *args: object,
         models: list[Model | str],
-        cans_access: bool | None,
+        cans_access: bool | None = None,
+        can_access: bool | None = None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -181,8 +174,8 @@ class Theme(ABC):
     def memory_embeddings(
         self,
         input_string: str,
-        embeddings: ndarray,
-        *args,
+        embeddings: ndarray[Any, Any],
+        *args: object,
         total_tokens: int,
         minv: float,
         maxv: float,
@@ -208,14 +201,17 @@ class Theme(ABC):
     def memory_embeddings_search(
         self,
         matches: list[SearchMatch],
-        *args,
+        *args: object,
         match_preview_length: int = 300,
     ) -> RenderableType:
         raise NotImplementedError()
 
     @abstractmethod
     def memory_partitions(
-        self, partitions: list[TextPartition], *args, display_partitions: int
+        self,
+        partitions: list[TextPartition],
+        *args: object,
+        display_partitions: int,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -223,7 +219,7 @@ class Theme(ABC):
     def model(
         self,
         model: Model,
-        *args,
+        *args: object,
         can_access: bool | None = None,
         expand: bool = False,
         summary: bool = False,
@@ -234,8 +230,8 @@ class Theme(ABC):
     def model_display(
         self,
         model_config: ModelConfig | SentenceTransformerModelConfig | None,
-        tokenizer_config: TokenizerConfig,
-        *args,
+        tokenizer_config: TokenizerConfig | None,
+        *args: object,
         is_runnable: bool | None = None,
         summary: bool = False,
     ) -> RenderableType:
@@ -247,12 +243,14 @@ class Theme(ABC):
         participant_id: UUID,
         agent: Orchestrator,
         messages: list[EngineMessage],
-    ):
+    ) -> RenderableType:
         raise NotImplementedError()
 
     @abstractmethod
     def saved_tokenizer_files(
-        directory_path: str, total_files: int
+        self,
+        directory_path_or_total: str | int,
+        total_files: int | None = None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -262,7 +260,7 @@ class Theme(ABC):
         participant_id: UUID,
         agent: Orchestrator,
         messages: list[EngineMessageScored],
-    ):
+    ) -> RenderableType:
         raise NotImplementedError()
 
     @abstractmethod
@@ -284,8 +282,9 @@ class Theme(ABC):
         dtokens: list[Token],
         added_tokens: list[str] | None,
         special_tokens: list[str] | None,
+        display_details: bool = False,
         current_dtoken: Token | None = None,
-        dtokens_selected: list[Token] = [],
+        dtokens_selected: list[Token] | None = None,
     ) -> RenderableType:
         raise NotImplementedError()
 
@@ -296,7 +295,9 @@ class Theme(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def display_image_entity(self, ImageEntity) -> RenderableType:
+    def display_image_entity(
+        self, image_entity: ImageEntity
+    ) -> RenderableType:
         raise NotImplementedError()
 
     @abstractmethod
@@ -373,41 +374,60 @@ class Theme(ABC):
         self,
         translator: Callable[[str], str],
         translator_plurals: Callable[[str, str, int], str],
-        formatters: Formatters = {},
-        stylers: Stylers = {},
-        styles: dict[Data, str] = {},
-        spinners: dict[Spinner, str] = {},
-        icons: dict[Data, str] = {},
-        quantity_data: list[str] = [],
-    ):
-        data_keys = list(map(str, Data))
+        formatters: Formatters | None = None,
+        stylers: Stylers | None = None,
+        styles: dict[str, str] | None = None,
+        spinners: dict[Spinner, str] | None = None,
+        icons: dict[str, str] | None = None,
+        quantity_data: list[str] | None = None,
+    ) -> None:
+        data_keys = sorted(
+            set(field.name for field in fields(Model))
+            | set(field.name for field in fields(User))
+            | set(self.icons.keys())
+            | set((icons or {}).keys())
+        )
 
         formatters = {
             **{
-                "datetime": lambda v: naturaltime(v),
-                "number": lambda v: intcomma(v),
-                "quantity": lambda v: intword(v),
-                "size": lambda v: naturalsize(v),
+                "datetime": lambda v: naturaltime(cast(datetime, v)),
+                "number": lambda v: intcomma(cast(float | int, v)),
+                "quantity": lambda v: intword(cast(float | int, v)),
+                "size": lambda v: naturalsize(cast(float | int, v)),
             },
             **self.formatters,
+            **(formatters or {}),
         }
 
         all_icons = {
             **{data: None for data in data_keys},
             **self.icons,
-            **icons,
+            **(icons or {}),
         }
 
-        data_keys.extend(all_icons)
+        data_keys.extend(all_icons.keys())
         data_keys.extend(self.styles.keys())
 
         self._all_spinners = {
-            **{spinner: None for spinner in Spinner.__args__},
-            **self.spinners,
-        }
-        self._all_stylers = {
             **{
-                data: lambda data, value, prefix=None, icon=True: "".join(
+                "cache_accessing": None,
+                "connecting": None,
+                "thinking": None,
+                "downloading": None,
+            },
+            **self.spinners,
+            **(spinners or {}),
+        }
+        quantity_keys = quantity_data or self.quantity_data
+
+        def _build_styler(data_key: Data) -> Styler:
+            def _styler(
+                data: Data,
+                value: DataValue,
+                prefix: str | None = None,
+                icon: bool | str = True,
+            ) -> str:
+                return "".join(
                     [
                         prefix or "",
                         (
@@ -420,36 +440,46 @@ class Theme(ABC):
                         ),
                         f"[{data}]",
                         (
-                            formatters["quantity"](value)
-                            if data in quantity_data
+                            formatters["quantity"](cast(float | int, value))
+                            if data_key in quantity_keys
                             else (
-                                formatters["datetime"](value)
+                                formatters["datetime"](
+                                    cast(datetime | float | int, value)
+                                )
                                 if isinstance(value, datetime)
                                 else (
                                     formatters["number"](value)
                                     if isinstance(value, int)
                                     or isinstance(value, float)
-                                    else value
+                                    else str(value)
                                 )
                             )
                         ),
                         f"[/{data}]",
                     ]
                 )
-                for data in data_keys
-            },
+
+            return _styler
+
+        self._all_stylers = {
+            **{data: _build_styler(data) for data in data_keys},
             **self.stylers,
+            **(stylers or {}),
         }
-        self._all_styles = {**{data: "" for data in data_keys}, **self.styles}
+        self._all_styles = {
+            **{data: "" for data in data_keys},
+            **self.styles,
+            **(styles or {}),
+        }
         self._icons = all_icons
         self._ = translator
         self._n = translator_plurals
 
-    def get_styles(self) -> dict[Data, str]:
+    def get_styles(self) -> dict[str, str]:
         return self._all_styles
 
-    def get_spinner(self, spinner_name: str) -> Spinner:
-        return self._all_spinners[spinner_name]
+    def get_spinner(self, spinner_name: Spinner) -> str:
+        return cast(str, self._all_spinners[spinner_name])
 
     def __call__(self, item: Model | str) -> RenderableType:
         return self.model(item) if isinstance(item, Model) else str(item)
@@ -463,6 +493,6 @@ class Theme(ABC):
     ) -> str:
         return (
             self._all_stylers[data](data, value, prefix, icon)
-            if data in self._all_stylers and self._all_stylers[data]
+            if data in self._all_stylers
             else str(value)
         )

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -11,13 +11,13 @@ from ...entities import (
     SearchMatch,
     SentenceTransformerModelConfig,
     Similarity,
+    TextPartition,
     Token,
     TokenizerConfig,
     ToolCallError,
     User,
 )
 from ...event import TOOL_TYPES, Event, EventStats, EventType
-from ...memory.partitioner.text import TextPartition
 from ...memory.permanent import PermanentMemoryPartition
 from ...utils import _j, _lf, to_json
 


### PR DESCRIPTION
### Motivation

- Continue the work to satisfy mypy strictness in the `avalan.cli` package by tightening types and runtime contracts so the module can be removed from the mypy overrides that ignore errors.  
- Make the CLI codebase safer and more explicit about optional values and callable shapes used by themes, tokenizers, downloads and memory commands.

### Description

- Refined the `Theme` typing surface in `src/avalan/cli/theme/__init__.py`, introducing `TypeAlias` helpers, concrete collection types, safer defaults, a typed styler builder, and corrected abstract method signatures to better reflect actual runtime usage.  
- Fixed tokenizer command function `tokenize` in `src/avalan/cli/commands/tokenizer.py` so return paths and types are explicit and used a `cast` for the saved-tokenizer rendering callable.  
- Simplified `tqdm_rich_progress.reset` in `src/avalan/cli/download.py` to always call `Progress.reset` with the task id to avoid a mypy call-arg ambiguity.  
- Improved memory command typing in `src/avalan/cli/commands/memory.py` by importing `TextPartition` from `entities`, predeclaring `partitions` across branches, typing `sort_key`, and asserting partition presence before stacking embeddings.  
- Updated `fancy` theme imports to reference `TextPartition` from `entities` to address attribute-export issues.

### Testing

- Ran formatting and lint fixes with `ruff` and `black` (files reformatted). — succeeded.  
- Ran `ruff --fix` to apply automatic checks/fixes — succeeded.  
- Ran targeted `mypy` checks against the changed CLI files (`src/avalan/cli/commands/tokenizer.py`, `src/avalan/cli/theme/__init__.py`, `src/avalan/cli/download.py`, `src/avalan/cli/commands/memory.py`) — no issues found for those files.  
- Ran full test suite with `poetry run pytest --verbose -s` — all tests passed (1576 passed, 11 skipped).  
- Ran `poetry run mypy src/avalan/cli` to measure progress: the total mypy errors for the whole `avalan.cli` tree are reduced but not fully resolved (173 errors remain across 4 files), so the module is not yet removed from mypy overrides.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda902061083238efc5bd52e9873e2)