### PR TITLE
Tighten typing in CLI download progress wrapper

### DIFF
--- a/src/avalan/cli/download.py
+++ b/src/avalan/cli/download.py
@@ -1,8 +1,8 @@
-from typing import Any
-
 from rich.console import RenderableType
 from rich.progress import Progress
-from tqdm.std import tqdm as std_tqdm
+from tqdm.std import tqdm
+
+std_tqdm = tqdm
 
 
 def create_live_tqdm_class(
@@ -21,8 +21,8 @@ def create_live_tqdm_class(
     https://github.com/tqdm/tqdm/blob/master/tqdm/rich.py """
 
 
-class tqdm_rich_progress(std_tqdm):  # type: ignore[misc]
-    def __init__(self, *args: object, **kwargs: Any) -> None:
+class tqdm_rich_progress(tqdm):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         sanitized_kwargs = {**kwargs}
         sanitized_kwargs.pop("progress", None)
         sanitized_kwargs.pop("options", None)
@@ -39,7 +39,7 @@ class tqdm_rich_progress(std_tqdm):  # type: ignore[misc]
         assert raw_progress_options is None or isinstance(
             raw_progress_options, dict
         )
-        progress_options: dict[str, Any] = {
+        progress_options: dict[str, object] = {
             "transient": not self.leave,
             **(raw_progress_options or {}),
         }


### PR DESCRIPTION
### Motivation

- Continue removing mypy suppressions in `avalan.cli` so the module can be removed from the mypy overrides, starting with the download progress wrapper.
- Replace a `# type: ignore` workaround and overly permissive `Any` usage with stricter, explicit types to improve type-checker confidence.

### Description

- Subclass `tqdm` directly in `src/avalan/cli/download.py` instead of using a `# type: ignore` on the previous base class to allow proper type checking. 
- Replace `Any` kwargs with `object` for constructor parameters and internal kwargs to narrow types. 
- Change `progress_options` typing from `dict[str, Any]` to `dict[str, object]` for stronger typing. 
- Add a `std_tqdm` alias to preserve compatibility with existing tests and monkeypatch points.

### Testing

- Ran formatting and linting commands: `poetry run ruff format`, `poetry run black`, and `poetry run ruff check --fix`, which completed successfully. 
- Ran targeted unit tests `poetry run pytest --verbose -s tests/cli/download_test.py tests/utils_test.py`, which passed (10 passed). 
- Attempted full test run and `mypy` checks in this environment; the full `pytest` collection and some `mypy` invocations did not complete reliably here, so full mypy strictness for `avalan.cli` could not be confirmed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1dbe85d08323b02db7ef84fb7c38)