### PR TITLE
Fix mypy types in CLI download progress

### DIFF
--- a/src/avalan/cli/download.py
+++ b/src/avalan/cli/download.py
@@ -1,8 +1,48 @@
-from rich.console import RenderableType
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypedDict, cast
+
+from rich.console import Console, RenderableType
 from rich.progress import Progress
 from tqdm.std import tqdm
 
 std_tqdm = tqdm
+
+
+class _ProgressOptions(TypedDict, total=False):
+    auto_refresh: bool
+    console: Console | None
+    expand: bool
+    get_time: Callable[[], float] | None
+    redirect_stderr: bool
+    redirect_stdout: bool
+    refresh_per_second: float
+    speed_estimate_period: float
+    transient: bool
+
+
+class _TaskOptions(TypedDict, total=False):
+    completed: int
+    total: float | None
+    visible: bool
+
+
+if TYPE_CHECKING:
+
+    class _TqdmBase:
+        disable: bool
+        leave: bool
+        desc: str | None
+        n: float
+        format_dict: dict[str, object]
+
+        def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+        def close(self) -> None: ...
+
+        def reset(self, total: int | float | None = None) -> None: ...
+
+else:
+    _TqdmBase = tqdm
 
 
 def create_live_tqdm_class(
@@ -21,7 +61,7 @@ def create_live_tqdm_class(
     https://github.com/tqdm/tqdm/blob/master/tqdm/rich.py """
 
 
-class tqdm_rich_progress(tqdm):
+class tqdm_rich_progress(_TqdmBase):
     def __init__(self, *args: object, **kwargs: object) -> None:
         sanitized_kwargs = {**kwargs}
         sanitized_kwargs.pop("progress", None)
@@ -39,15 +79,25 @@ class tqdm_rich_progress(tqdm):
         assert raw_progress_options is None or isinstance(
             raw_progress_options, dict
         )
-        progress_options: dict[str, object] = {
-            "transient": not self.leave,
-            **(raw_progress_options or {}),
-        }
+        progress_options: _ProgressOptions = {"transient": not self.leave}
+        if raw_progress_options:
+            progress_options.update(
+                cast(_ProgressOptions, raw_progress_options)
+            )
 
         self._progress = Progress(*progress, **progress_options)
         self._progress.__enter__()
+        task_options: _TaskOptions = {}
+        task_total = self.format_dict.get("total")
+        if task_total is None:
+            task_options["total"] = None
+        elif isinstance(task_total, (int, float)):
+            task_options["total"] = float(task_total)
+        task_completed = self.format_dict.get("n")
+        if isinstance(task_completed, (int, float)):
+            task_options["completed"] = int(task_completed)
         self._task_id = self._progress.add_task(
-            self.desc or "", **self.format_dict
+            self.desc or "", **task_options
         )
 
     def close(self) -> None:

--- a/tests/cli/download_test.py
+++ b/tests/cli/download_test.py
@@ -25,3 +25,49 @@ class DownloadTestCase(TestCase):
         prog.clear()
         prog.reset(1)
         prog.close()
+
+    def test_tqdm_rich_progress_builds_progress_and_task_options(self):
+        calls: dict[str, object] = {}
+
+        class DummyProgress:
+            def __init__(self, *progress_columns, **kwargs):
+                calls["progress_columns"] = progress_columns
+                calls["progress_kwargs"] = kwargs
+
+            def __enter__(self):
+                calls["entered"] = True
+                return self
+
+            def __exit__(self, *_):
+                calls["exited"] = True
+
+            def add_task(self, description: str, **kwargs) -> int:
+                calls["description"] = description
+                calls["task_kwargs"] = kwargs
+                return 1
+
+            def update(self, *_args, **_kwargs):
+                return None
+
+            def reset(self, *_args, **_kwargs):
+                return None
+
+        with patch.object(download, "Progress", DummyProgress):
+            prog = download.tqdm_rich_progress(
+                total=10,
+                disable=False,
+                progress=("col",),
+                options={"expand": True},
+            )
+            prog.close()
+
+        self.assertEqual(calls["progress_columns"], ("col",))
+        self.assertEqual(
+            calls["progress_kwargs"],
+            {"transient": False, "expand": True},
+        )
+        self.assertEqual(calls["description"], "")
+        self.assertEqual(
+            calls["task_kwargs"],
+            {"total": 10.0, "completed": 0},
+        )


### PR DESCRIPTION
### Motivation

- Make the `avalan.cli` download progress code satisfy mypy strict typing rules so the module can be cleaned of unchecked/ignored errors, starting with the `download` submodule.

### Description

- Add typed option maps ` _ProgressOptions` and `_TaskOptions` to restrict and document kwargs forwarded to `rich.progress.Progress` and task creation. 
- Introduce a `TYPE_CHECKING` `_TqdmBase` stub and subclass it instead of the `Any`-typed `tqdm` to avoid static-analysis subclassing issues.
- Validate and cast `options` coming from `format_dict` and build a typed `task_options` dict (converting totals/completed to numeric types) instead of forwarding an untyped `format_dict` directly to `add_task`.
- Add unit tests `tests/cli/download_test.py::DownloadTestCase::test_tqdm_rich_progress_builds_progress_and_task_options` to assert progress/task option construction and update existing tests accordingly.

### Testing

- `poetry run mypy src/avalan/cli/download.py --show-error-codes` succeeded for the modified file.
- `poetry run mypy src/avalan/cli/theme/fancy.py --show-error-codes` was run and still reports existing strict typing issues (not addressed in this PR).
- `poetry run pytest tests/cli/download_test.py -q` passed (3 tests, all green).
- Full test run `poetry run pytest --verbose -s` completed successfully (1577 passed, 11 skipped) after the changes, and formatting/linting (`ruff`/`black`) checks were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de27e8eb34832395ad6caf836c05b6)