### PR TITLE
Fix additional mypy typing issues in avalan.cli model flow

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -1942,23 +1942,26 @@ class CLI:
         """Return ``True`` if the command needs hub authentication."""
         command = args.command
         if command == "model" and (args.model_command or "display") == "run":
+            assert isinstance(args.model, str)
             engine_uri = ModelManager.parse_uri(args.model)
-            return engine_uri.is_local
+            return bool(engine_uri.is_local)
         if command == "agent" and (
             (args.agent_command or "run") in {"run", "serve", "proxy"}
         ):
             engine = getattr(args, "engine_uri", None)
             if engine:
+                assert isinstance(engine, str)
                 engine_uri = ModelManager.parse_uri(engine)
-                return engine_uri.is_local
+                return bool(engine_uri.is_local)
             specs = getattr(args, "specifications_file", None)
             if specs:
                 with open(specs, "rb") as file:
                     config = toml_load(file)
                 engine_uri_str = config.get("engine", {}).get("uri")
                 if engine_uri_str:
+                    assert isinstance(engine_uri_str, str)
                     engine_uri = ModelManager.parse_uri(engine_uri_str)
-                    return engine_uri.is_local
+                    return bool(engine_uri.is_local)
         return True
 
     async def __call__(self) -> None:

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -35,6 +35,7 @@ from asyncio import (
 )
 from dataclasses import replace
 from datetime import datetime, timezone
+from functools import partial
 from logging import Logger
 from time import perf_counter
 
@@ -59,7 +60,7 @@ def model_display(
     theme: Theme,
     hub: HuggingfaceHub,
     logger: Logger,
-    *vargs,
+    *vargs: object,
     modality: Modality | None = None,
     load: bool | None = None,
     model: SentenceTransformerModel | TextGenerationModel | None = None,
@@ -326,8 +327,11 @@ async def model_search(
         ]
 
     # Tasks to check model access
+    def _model_access_check(model_id: str) -> tuple[str, bool]:
+        return model_id, hub.can_access(model_id)
+
     tasks = [
-        create_task(to_thread(lambda id=model.id: (id, hub.can_access(id))))
+        create_task(to_thread(partial(_model_access_check, model.id)))
         for model in models
     ]
 
@@ -394,7 +398,7 @@ async def token_generation(
     tool_events_limit: int | None,
     with_stats: bool = True,
     live_container: dict[str, Live | None] | None = None,
-):
+) -> None:
     # If no statistics needed, return as early as possible
     if not with_stats:
         async for token in response:
@@ -577,7 +581,7 @@ async def _token_stream(
     start_thinking = (
         args.start_thinking if hasattr(args, "start_thinking") else False
     )
-    tokens = []
+    tokens: list[Token] = []
     answer_text_tokens: list[str] = []
     thinking_text_tokens: list[str] = []
     tool_text_tokens: list[str] = []


### PR DESCRIPTION
## Summary
- Tighten typing in `avalan.cli.commands.model` by annotating `*vargs` as `object`, adding `-> None` to `token_generation`, and declaring `tokens` as `list[Token]` for clearer static analysis.
- Replace the inline `lambda` used for model access checks with a typed helper `def _model_access_check(model_id: str) -> tuple[str, bool]` and use `functools.partial` when scheduling `to_thread` tasks to avoid invocation/argument mismatch in test stubs.
- Improve type-safety in the CLI entrypoint `CLI._needs_hf_token` by asserting argument types with `assert isinstance(...)` before parsing engine URIs and returning `bool(...)` explicitly to satisfy strict mypy checks.
- Added the necessary `from functools import partial` import and applied formatting/linting fixes.

## Testing
- Ran focused mypy on the modified files with `python -m mypy --config-file /tmp/mypy_cli_focus.ini src/avalan/cli/commands/model.py src/avalan/cli/__main__.py`, which reported `Success: no issues found in 2 source files`.
- Ran targeted tests with `poetry run pytest --verbose -s tests/cli/model_search_additional_test.py tests/cli/model_test.py -k "model_search"`, which resulted in `6 passed, 67 deselected`.
- Ran the full test suite with `poetry run pytest --verbose -s`, which completed with `1577 passed, 11 skipped`.
- Ran the linter/formatter via `make lint` (calls `ruff`/`black`) and confirmed `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de317bd3bc83239b24cf3be12056bd)