### PR TITLE
Fix mypy issues and typing in avalan.cli (agent & model commands)

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -2124,7 +2124,7 @@ class CLI:
         ):
             with console.status(
                 theme.logging_in(hub.domain),
-                spinner=(theme.get_spinner("connecting")),
+                spinner=(theme.get_spinner("connecting") or "dots"),
                 refresh_per_second=self._REFRESH_RATE,
             ):
                 hub.login()

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -8,15 +8,18 @@ from ...cli.commands.model import token_generation
 from ...cli.theme import Theme
 from ...entities import (
     Backend,
+    EngineMessageScored,
     GenerationCacheStrategy,
     OrchestratorSettings,
     PermanentMemoryStoreSettings,
     ToolCall,
     ToolFormat,
 )
-from ...event import EventStats
+from ...event import Event, EventStats
 from ...model.hubs.huggingface import HuggingfaceHub
+from ...model.nlp.text.generation import TextGenerationModel
 from ...model.nlp.text.vendor import TextGenerationVendorModel
+from ...model.response.text import TextGenerationResponse
 from ...server import agents_server
 from ...tool.browser import BrowserToolSettings
 from ...tool.context import ToolSettingsContext
@@ -27,7 +30,7 @@ from contextlib import AsyncExitStack
 from dataclasses import fields
 from logging import Logger
 from os.path import dirname, getmtime, join
-from typing import Iterable, Mapping
+from typing import Any, Iterable, Mapping, cast, overload
 from uuid import UUID, uuid4
 
 from jinja2 import Environment, FileSystemLoader
@@ -192,9 +195,9 @@ def _tool_settings_from_mapping(
     mapping: Mapping[str, object] | Namespace,
     *,
     prefix: str | None = None,
-    settings_cls: type,
+    settings_cls: type[BrowserToolSettings] | type[DatabaseToolSettings],
     open_files: bool = True,
-) -> object:
+) -> BrowserToolSettings | DatabaseToolSettings | None:
     """Return tool settings from a mapping using dataclass ``settings_cls``."""
     values: dict[str, object] = {}
     for field in fields(settings_cls):
@@ -224,16 +227,40 @@ def _tool_settings_from_mapping(
     if not values:
         return None
 
-    return settings_cls(**values)
+    settings = cast(
+        BrowserToolSettings | DatabaseToolSettings,
+        cast(Any, settings_cls)(**values),
+    )
+    return settings
+
+
+@overload
+def get_tool_settings(
+    args: Namespace,
+    *,
+    prefix: str,
+    settings_cls: type[BrowserToolSettings],
+    open_files: bool = True,
+) -> BrowserToolSettings | None: ...
+
+
+@overload
+def get_tool_settings(
+    args: Namespace,
+    *,
+    prefix: str,
+    settings_cls: type[DatabaseToolSettings],
+    open_files: bool = True,
+) -> DatabaseToolSettings | None: ...
 
 
 def get_tool_settings(
     args: Namespace,
     *,
     prefix: str,
-    settings_cls: type,
+    settings_cls: type[BrowserToolSettings] | type[DatabaseToolSettings],
     open_files: bool = True,
-) -> object:
+) -> BrowserToolSettings | DatabaseToolSettings | None:
     return _tool_settings_from_mapping(
         args, prefix=prefix, settings_cls=settings_cls, open_files=open_files
     )
@@ -286,7 +313,7 @@ async def agent_message_search(
         )
         with console.status(
             _("Loading agent..."),
-            spinner=theme.get_spinner("agent_loading"),
+            spinner=theme.get_spinner("agent_loading") or "dots",
             refresh_per_second=refresh_per_second,
         ):
             if specs_path:
@@ -331,7 +358,8 @@ async def agent_message_search(
                 )
             orchestrator = await stack.enter_async_context(orchestrator)
 
-            assert orchestrator.engine_agent and orchestrator.engine.model_id
+            assert orchestrator.engine_agent
+            assert orchestrator.engine and orchestrator.engine.model_id
 
             can_access = args.skip_hub_access_check or hub.can_access(
                 orchestrator.engine.model_id
@@ -367,7 +395,9 @@ async def agent_message_search(
             )
             console.print(
                 theme.search_message_matches(
-                    participant_id, orchestrator, messages
+                    participant_id,
+                    orchestrator,
+                    cast(list[EngineMessageScored], messages),
                 )
             )
 
@@ -411,7 +441,8 @@ async def agent_run(
             console, call, tty_path=tty_path, live=live_container["live"]
         )
 
-    async def _event_listener(event):
+    async def _event_listener(event: object) -> None:
+        assert isinstance(event, Event)
         nonlocal event_stats
         event_stats.total_triggers += 1
         if event.type not in event_stats.triggers:
@@ -494,13 +525,17 @@ async def agent_run(
             (
                 "yes, with session #"
                 + str(orchestrator.memory.permanent_message.session_id)
-                if orchestrator.memory.has_permanent_message
+                if (
+                    orchestrator.memory.has_permanent_message
+                    and orchestrator.memory.permanent_message is not None
+                )
                 else "no"
             ),
         )
 
         if not args.quiet:
-            assert orchestrator.engine_agent and orchestrator.engine.model_id
+            assert orchestrator.engine_agent
+            assert orchestrator.engine and orchestrator.engine.model_id
 
             is_local = not isinstance(
                 orchestrator.engine, TextGenerationVendorModel
@@ -533,14 +568,17 @@ async def agent_run(
         if (
             load_recent_messages
             and orchestrator.memory.has_recent_message
-            and not orchestrator.memory.recent_message.is_empty
             and not args.quiet
         ):
+            recent_message = orchestrator.memory.recent_message
+            assert recent_message is not None
+            if recent_message.is_empty:
+                return orchestrator
             console.print(
                 theme.recent_messages(
                     participant_id,
                     orchestrator,
-                    orchestrator.memory.recent_message.data,
+                    recent_message.data,
                 )
             )
 
@@ -549,7 +587,7 @@ async def agent_run(
     async with AsyncExitStack() as stack:
         with console.status(
             _("Loading agent..."),
-            spinner=theme.get_spinner("agent_loading"),
+            spinner=theme.get_spinner("agent_loading") or "dots",
             refresh_per_second=refresh_per_second,
         ):
             orchestrator = await _init_orchestrator()
@@ -574,6 +612,7 @@ async def agent_run(
                 + str(orchestrator.memory.recent_message.size)
                 if orchestrator.memory
                 and orchestrator.memory.has_recent_message
+                and orchestrator.memory.recent_message is not None
                 else "0" + " messages"
             )
             input_string = get_input(
@@ -603,6 +642,9 @@ async def agent_run(
                 return
 
             assert isinstance(output, OrchestratorResponse)
+            assert orchestrator.engine is not None
+            text_output = cast(TextGenerationResponse, output)
+            text_engine = cast(TextGenerationModel, orchestrator.engine)
 
             await token_generation(
                 args=args,
@@ -611,10 +653,10 @@ async def agent_run(
                 logger=logger,
                 orchestrator=orchestrator,
                 event_stats=event_stats,
-                lm=orchestrator.engine,
+                lm=text_engine,
                 input_string=input_string,
                 refresh_per_second=refresh_per_second,
-                response=output,
+                response=text_output,
                 dtokens_pick=dtokens_pick,
                 display_tokens=display_tokens,
                 tool_events_limit=args.display_tools_events,

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -38,12 +38,13 @@ from datetime import datetime, timezone
 from functools import partial
 from logging import Logger
 from time import perf_counter
-from typing import AsyncGenerator, Awaitable, Literal, cast
+from typing import Any, AsyncGenerator, Awaitable, cast
 
 from rich.console import Console, Group, RenderableType
 from rich.live import Live
 from rich.padding import Padding
 from rich.prompt import Prompt
+from rich.spinner import Spinner
 
 _HAS_INPUT = has_input
 
@@ -611,7 +612,7 @@ async def _token_stream(
     ttft: float | None = None
     ttnt: float | None = None
     last_current_dtoken: Token | None = None
-    tool_running_spinner: Literal["tool_running"] | None = None
+    tool_running_spinner: Spinner | None = None
 
     if start_thinking and response.can_think and not response.is_thinking:
         response.set_thinking(start_thinking)
@@ -670,7 +671,18 @@ async def _token_stream(
                 if str(getattr(c, "id", "")) not in completed_call_ids
             ]
             if tool_calling_names:
-                tool_running_spinner = "tool_running"
+                tool_running_spinner = Spinner(
+                    theme.get_spinner("tool_running") or "dots",
+                    text="[cyan]"
+                    + theme._n(
+                        "Running tool {tool_names}...",
+                        "Running tools {tool_names}...",
+                        len(tool_calling_names),
+                    ).format(tool_names=", ".join(tool_calling_names))
+                    + "[/cyan]",
+                    style="cyan",
+                    speed=1.0,
+                )
 
         elapsed = perf_counter() - start
         total_tokens += 1
@@ -741,7 +753,7 @@ async def _token_stream(
             tool_events,
             tool_event_calls,
             tool_event_results,
-            tool_running_spinner,
+            cast(Any, tool_running_spinner),
             ttft,
             ttnt,
             ttsr,

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -38,12 +38,12 @@ from datetime import datetime, timezone
 from functools import partial
 from logging import Logger
 from time import perf_counter
+from typing import AsyncGenerator, Awaitable, Literal, cast
 
 from rich.console import Console, Group, RenderableType
 from rich.live import Live
 from rich.padding import Padding
 from rich.prompt import Prompt
-from rich.spinner import Spinner
 
 _HAS_INPUT = has_input
 
@@ -163,8 +163,7 @@ async def model_run(
     with ModelManager(hub, logger) as manager:
         engine_uri = manager.parse_uri(args.model)
         model_settings = get_model_settings(args, hub, logger, engine_uri)
-        modality = model_settings["modality"]
-        assert modality
+        modality = cast(Modality, model_settings["modality"])
 
         if not args.quiet:
             if engine_uri.is_local:
@@ -258,10 +257,15 @@ async def model_run(
                     orchestrator=None,
                     event_stats=None,
                     lm=model,
-                    input_string=operation.input,
+                    input_string=cast(str, operation.input),
                     refresh_per_second=refresh_per_second,
                     response=output,
-                    dtokens_pick=operation.parameters["text"].pick_tokens,
+                    dtokens_pick=(
+                        operation.parameters["text"].pick_tokens or 0
+                        if operation.parameters
+                        and operation.parameters["text"]
+                        else 0
+                    ),
                     display_tokens=args.display_tokens or 0,
                     with_stats=not args.quiet,
                     tool_events_limit=args.display_tools_events,
@@ -307,7 +311,7 @@ async def model_search(
     # Fetch matching models
     with console.status(
         _("Loading models..."),
-        spinner=theme.get_spinner("downloading"),
+        spinner=theme.get_spinner("downloading") or "dots",
         refresh_per_second=refresh_per_second,
     ):
         models = [
@@ -603,10 +607,11 @@ async def _token_stream(
             else lm.input_token_count(input_string)
         )
     )
+    assert lm.model_id is not None
     ttft: float | None = None
     ttnt: float | None = None
     last_current_dtoken: Token | None = None
-    tool_running_spinner: Spinner | None = None
+    tool_running_spinner: Literal["tool_running"] | None = None
 
     if start_thinking and response.can_think and not response.is_thinking:
         response.set_thinking(start_thinking)
@@ -626,13 +631,14 @@ async def _token_stream(
                 answer_text_tokens = []
                 tool_text_tokens = []
                 thinking_text_tokens = []
+                assert event.payload is not None
                 inner_response = event.payload["response"]
                 assert isinstance(inner_response, TextGenerationResponse)
                 if inner_response.input_token_count:
                     input_token_count = inner_response.input_token_count
             elif event.type == EventType.TOOL_RESULT:
                 tool_event_results.append(event)
-                if "call" in event.payload:
+                if event.payload and "call" in event.payload:
                     completed_call_ids.add(event.payload["call"].id)
             else:
                 tool_event_calls.append(event)
@@ -658,28 +664,13 @@ async def _token_stream(
         tool_running_spinner = None
         if tool_event_calls or tool_event_results:
             tool_calling_names = [
-                c.name
+                str(getattr(c, "name", ""))
                 for e in tool_event_calls
-                for c in e.payload
-                if c.id not in completed_call_ids
+                for c in cast(list[object], e.payload or [])
+                if str(getattr(c, "id", "")) not in completed_call_ids
             ]
-
-            tool_running_spinner = (
-                Spinner(
-                    theme.get_spinner("tool_running"),
-                    text="[cyan]"
-                    + theme._n(
-                        "Running tool {tool_names}...",
-                        "Running tools {tool_names}...",
-                        len(tool_calling_names),
-                    ).format(tool_names=", ".join(tool_calling_names))
-                    + "[/cyan]",
-                    style="cyan",
-                    speed=1.0,
-                )
-                if tool_calling_names
-                else None
-            )
+            if tool_calling_names:
+                tool_running_spinner = "tool_running"
 
         elapsed = perf_counter() - start
         total_tokens += 1
@@ -704,7 +695,7 @@ async def _token_stream(
         )
         answer_height = getattr(args, "display_answer_height", 12)
 
-        token_frames_promise = theme.tokens(
+        token_frames_result = theme.tokens(
             lm.model_id,
             lm.tokenizer_config.tokens if lm.tokenizer_config else None,
             (
@@ -718,12 +709,17 @@ async def _token_stream(
             # Which tokens to mark as interesting
             lambda dtoken: (
                 (
-                    dtoken.probability < args.display_probabilities_maximum
+                    dtoken.probability is not None
+                    and dtoken.probability < args.display_probabilities_maximum
                     or len(
                         [
                             t
-                            for t in dtoken.tokens
+                            for t in cast(
+                                list[Token],
+                                getattr(dtoken, "tokens", []) or [],
+                            )
                             if t.id != dtoken.id
+                            and t.probability is not None
                             and t.probability
                             >= args.display_probabilities_sample_minimum
                         ]
@@ -734,13 +730,13 @@ async def _token_stream(
                 and args.display_probabilities
                 and args.display_probabilities_maximum > 0
                 and args.display_probabilities_maximum > 0
-                else None
+                else False
             ),
             thinking_text_tokens,
             tool_text_tokens,
             answer_text_tokens,
             tokens or None,
-            input_token_count,
+            input_token_count or 0,
             total_tokens,
             tool_events,
             tool_event_calls,
@@ -760,8 +756,24 @@ async def _token_stream(
             start_thinking=start_thinking,
         )
 
+        token_frames_stream: AsyncGenerator[
+            tuple[Token | None, RenderableType], None
+        ]
+        if isinstance(token_frames_result, Awaitable):
+            token_frames_stream = await cast(
+                Awaitable[
+                    AsyncGenerator[tuple[Token | None, RenderableType], None]
+                ],
+                token_frames_result,
+            )
+        else:
+            token_frames_stream = cast(
+                AsyncGenerator[tuple[Token | None, RenderableType], None],
+                token_frames_result,
+            )
+
         token_frame_list = [
-            token_frame async for token_frame in token_frames_promise
+            token_frame async for token_frame in token_frames_stream
         ]
 
         token_frames = [token_frame_list[0]]


### PR DESCRIPTION
### Motivation
- Remove mypy errors in the CLI command modules and tighten typing so the `avalan.cli` package can be promoted toward strict checking. 
- Make token rendering and tool-event handling in the model/agent code robust to both awaitable and direct async-generator providers. 

### Description
- Added a safe spinner fallback (`or "dots"`) in status displays to ensure `console.status(..., spinner=...)` always gets a valid value in `src/avalan/cli/__main__.py` and command modules. 
- Improved typing for tool settings in `src/avalan/cli/commands/agent.py` by adding a typed `_tool_settings_from_mapping`, `get_tool_settings` overloads, and precise return annotations for `BrowserToolSettings` and `DatabaseToolSettings`. 
- Hardened agent runtime paths by narrowing/casting orchestrator engine and response values before passing them to token rendering, and added null-safety checks for recent/permanent memory access. 
- Enhanced token rendering flow in `src/avalan/cli/commands/model.py` by supporting both awaitable-returning and direct async-generator theme token providers, handling spinner signaling for running tools, and fixing several conditional/None checks and casts. 
- Minor refactors and ruff/black formatting fixes applied to the modified files. 

### Testing
- Ran formatting and linting with `make lint` (ruff/black run); formatting changes applied and ruff checks passed. 
- Ran mypy on the modified CLI files with `poetry run mypy src/avalan/cli/__main__.py src/avalan/cli/commands/agent.py src/avalan/cli/commands/model.py` and it reported no issues. 
- Executed focused pytest runs for failing/relevant tests (examples listed in the rollout), which passed: `tests/cli/model_test.py::CliToolCallTokenTestCase::test_tool_call_token_tracked`, `tests/cli/token_stream_start_thinking_test.py::TokenStreamStartThinkingTestCase::test_start_thinking`, `tests/cli/agent_test.py::CliAgentRunTestCase::test_run_with_text_response`, and `tests/cli/agent_reasoning_tag_test.py::CliAgentReasoningTagTestCase::test_channel_tag`. 
- Ran the full test suite with `poetry run pytest --verbose -s` and all tests passed (`1577 passed, 11 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de52f9f74883239a965831517ab247)