### PR TITLE
Tighten typing in avalan.model stream and criteria helpers

### DIFF
--- a/src/avalan/model/__init__.py
+++ b/src/avalan/model/__init__.py
@@ -10,7 +10,7 @@ from .vendor import TextGenerationVendorStream
 
 from typing import AsyncGenerator, Callable, Generator
 
-from numpy import ndarray
+from numpy.typing import NDArray
 
 OutputGenerator = AsyncGenerator[Token | TokenDetail | str, None]
 OutputFunction = Callable[..., OutputGenerator | str]
@@ -24,7 +24,7 @@ EngineResponse = (
     | list[ImageEntity]
     | list[str]
     | dict[str, str]
-    | ndarray
+    | NDArray[object]
     | str
 )
 

--- a/src/avalan/model/criteria.py
+++ b/src/avalan/model/criteria.py
@@ -1,23 +1,31 @@
 from io import StringIO
 from re import Pattern, compile, escape
+from typing import Any, Protocol
 
-from transformers import AutoTokenizer
-from transformers.generation import StoppingCriteria
+from transformers.generation.stopping_criteria import StoppingCriteria
+
+
+class TokenDecoder(Protocol):
+    """Define the tokenizer contract required by keyword stopping criteria."""
+
+    def decode(
+        self, token_ids: int | list[int], skip_special_tokens: bool = False
+    ) -> str: ...
 
 
 class KeywordStoppingCriteria(StoppingCriteria):
     _buffer: StringIO
-    _tokenizer: AutoTokenizer
-    _pattern: Pattern
+    _tokenizer: TokenDecoder
+    _pattern: Pattern[str]
     _keywords: list[str]
     _keyword_count: int
 
     def __init__(
         self,
         keywords: list[str],
-        tokenizer: AutoTokenizer,
+        tokenizer: TokenDecoder,
         all_must_be_present: bool = False,
-    ):
+    ) -> None:
         assert keywords
         escaped_keywords = [escape(k) for k in keywords]
         self._pattern = compile(
@@ -30,7 +38,7 @@ class KeywordStoppingCriteria(StoppingCriteria):
         self._keywords = keywords
         self._keyword_count = len(keywords)
 
-    def __call__(self, input_ids, scores, **kwargs):
+    def __call__(self, input_ids: Any, scores: Any, **kwargs: Any) -> bool:
         token_id = input_ids[0][-1]
         token = self._tokenizer.decode(token_id, skip_special_tokens=False)
         self._buffer.write(token)

--- a/src/avalan/model/stream.py
+++ b/src/avalan/model/stream.py
@@ -4,24 +4,23 @@ from ..entities import (
 )
 
 from abc import ABC, abstractmethod
-from typing import (
-    AsyncGenerator,
-    AsyncIterator,
-)
+from typing import Any, AsyncGenerator, AsyncIterator
 
 
 class TextGenerationStream(AsyncIterator[Token | TokenDetail | str], ABC):
-    _generator: AsyncGenerator | None = None
+    _generator: AsyncGenerator[Token | TokenDetail | str, None] | None = None
 
     @abstractmethod
-    def __call__(self, *args, **kwargs):
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncIterator[Token | TokenDetail | str]:
         raise NotImplementedError()
 
     @abstractmethod
     async def __anext__(self) -> Token | TokenDetail | str:
         raise NotImplementedError()
 
-    def __aiter__(self):
+    def __aiter__(self) -> AsyncIterator[Token | TokenDetail | str]:
         assert self._generator
         return self
 
@@ -30,7 +29,7 @@ class TextGenerationSingleStream(TextGenerationStream):
     _content: str | Token | TokenDetail
     _consumed: bool = False
 
-    def __init__(self, content: str):
+    def __init__(self, content: str | Token | TokenDetail) -> None:
         self._content = content
 
     @property


### PR DESCRIPTION
### Motivation
- Improve static typing in the `avalan.model` package to reduce mypy strict-mode issues and make the stream/criteria helpers safer to use. 
- Provide explicit, narrow contracts for tokenizer and streaming APIs so downstream code can rely on stable types.

### Description
- Add a `TokenDecoder` `Protocol` and use it for `KeywordStoppingCriteria` tokenizer typing in `src/avalan/model/criteria.py`.
- Import `StoppingCriteria` from `transformers.generation.stopping_criteria` and add explicit type annotations for the regex pattern, constructor return, and `__call__` signature in `KeywordStoppingCriteria`.
- Tighten async iterator/generator types in `TextGenerationStream` and `TextGenerationSingleStream` and add explicit argument/return typing in `src/avalan/model/stream.py`.
- Replace unparameterized `ndarray` with `NDArray[object]` in `EngineResponse` in `src/avalan/model/__init__.py`.

### Testing
- Ran targeted tests with `poetry run pytest --verbose -s tests/model/criteria_test.py tests/model/text_generation_single_stream_test.py tests/model/model_init_test.py` and they passed.
- Ran the full test suite with `poetry run pytest --verbose -s` and it passed (`1577 passed, 11 skipped`).
- Ran lint/format checks with `make lint` / `ruff` / `black` and `ruff check` for the updated files and they passed.
- Ran `mypy` on `src/avalan/model` (after temporarily removing the `avalan.model.*` ignore override to measure progress) and observed the error count decrease slightly (from ~714 to ~709 errors), indicating incremental progress but not yet fully mypy-clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df66c02e0083238e590c2ae2606e1c)