### PR TITLE
Tighten typing in model stream and vendor

### DIFF
--- a/src/avalan/model/stream.py
+++ b/src/avalan/model/stream.py
@@ -37,7 +37,7 @@ class TextGenerationSingleStream(TextGenerationStream):
         return self._content
 
     def __call__(
-        self, *args, **kwargs
+        self, *args: Any, **kwargs: Any
     ) -> AsyncIterator[str | Token | TokenDetail]:
         self._consumed = False
         return self

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -13,7 +13,7 @@ from .stream import TextGenerationStream
 
 from abc import ABC
 from json import JSONDecodeError, dumps, loads
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator, AsyncIterator, cast
 
 
 class TextGenerationVendor(ABC):
@@ -43,14 +43,14 @@ class TextGenerationVendor(ABC):
         messages: list[Message],
         exclude_roles: list[TemplateMessageRole] | None = None,
     ) -> list[TemplateMessage]:
-        def _block(c: MessageContent) -> dict:
+        def _block(c: MessageContent) -> dict[str, Any]:
             if isinstance(c, MessageContentImage):
                 return {"type": "image_url", "image_url": c.image_url}
             return {"type": "text", "text": c.text}
 
         def _wrap(
-            content: str | MessageContent | list[MessageContent],
-        ) -> str | list[dict]:
+            content: str | MessageContent | list[MessageContent] | None,
+        ) -> str | list[dict[str, Any]]:
             if isinstance(content, str):
                 return content
 
@@ -70,7 +70,12 @@ class TextGenerationVendor(ABC):
             if exclude_roles and msg.role in exclude_roles:
                 continue
 
-            out.append({"role": str(msg.role), "content": _wrap(msg.content)})
+            out.append(
+                {
+                    "role": cast(TemplateMessageRole, str(msg.role)),
+                    "content": _wrap(msg.content),
+                }
+            )
 
         return out
 
@@ -86,17 +91,21 @@ class TextGenerationVendor(ABC):
     def build_tool_call_token(
         call_id: str | None,
         tool_name: str | None,
-        arguments: str | dict | None,
+        arguments: str | dict[str, Any] | None,
     ) -> ToolCallToken:
         name = TextGenerationVendor.decode_tool_name(tool_name or "")
         if isinstance(arguments, str):
             try:
-                args: dict = loads(arguments)
+                args = cast(dict[str, Any], loads(arguments))
             except JSONDecodeError:
                 args = {}
         else:
             args = arguments or {}
-        call = ToolCall(id=call_id, name=name, arguments=args)
+        call = ToolCall(
+            id=cast(str, call_id),
+            name=name,
+            arguments=cast(dict[str, str | int | float | bool | None], args),
+        )
         token_json = dumps({"name": name, "arguments": args})
         return ToolCallToken(
             token=f"<tool_call>{token_json}</tool_call>", call=call
@@ -104,14 +113,18 @@ class TextGenerationVendor(ABC):
 
 
 class TextGenerationVendorStream(TextGenerationStream):
-    _generator: AsyncGenerator
+    _generator: AsyncGenerator[str | ToolCallToken, None]
 
-    def __init__(self, generator: AsyncGenerator):
+    def __init__(
+        self, generator: AsyncGenerator[str | ToolCallToken, None]
+    ) -> None:
         self._generator = generator
 
-    def __call__(self, *args, **kwargs):
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncIterator[str | ToolCallToken]:
         return self.__aiter__()
 
-    def __aiter__(self):
+    def __aiter__(self) -> AsyncIterator[str | ToolCallToken]:
         assert self._generator
         return self


### PR DESCRIPTION
### Motivation
- Reduce mypy noise in the `avalan.model` area by tightening annotations in low-level stream and vendor helpers so subsequent mypy work can focus on remaining issues. 
- Make generator and wrapper helpers more explicit about the shapes they produce to avoid ambiguous `Any`/untyped paths during static checking.

### Description
- Added explicit parameter typing `*args: Any, **kwargs: Any` to `TextGenerationSingleStream.__call__` in `src/avalan/model/stream.py` to satisfy untyped-args checks. 
- Strengthened `_template_messages` helpers in `src/avalan/model/vendor.py` by adding concrete types for block/wrap results, and casting roles/content to the `TemplateMessage` shape. 
- Tightened `build_tool_call_token` signatures to `arguments: str | dict[str, Any] | None`, added `cast` usage for JSON-parsing paths, and constructed `ToolCall` with explicit casts for the `id` and `arguments` fields. 
- Typed `TextGenerationVendorStream` generator/iterator signatures as `AsyncGenerator[str | ToolCallToken, None]` and `AsyncIterator[str | ToolCallToken]` and added explicit return/type annotations to its methods.

### Testing
- Ran formatting and lint fixes with `poetry run ruff format`, `poetry run black`, and `poetry run ruff check --fix`, which completed successfully. 
- Ran targeted unit tests with `poetry run pytest --verbose -s tests/model/vendor_tool_call_token_test.py tests/model/vendor_additional_test.py tests/model/text_generation_single_stream_test.py`, and all tests passed (`6 passed`). 
- Ran the full test suite with `poetry run pytest --verbose -s`, and the run completed successfully (`1577 passed, 11 skipped`). 
- Ran `mypy`/static checks for the modified files during the change; the tightened typing removed several local mypy complaints, but `avalan.model` is not yet fully strict-clean and remains in the mypy overrides for a further incremental pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8fc3f2a883238486c72394db54a6)