### PR TITLE
Fix more mypy issues in avalan.model

### DIFF
--- a/src/avalan/model/__init__.py
+++ b/src/avalan/model/__init__.py
@@ -8,7 +8,7 @@ from .call import ModelCallContext as ModelCallContext
 from .response.text import TextGenerationResponse
 from .vendor import TextGenerationVendorStream
 
-from typing import AsyncGenerator, Callable, Generator
+from typing import Any, AsyncGenerator, Callable, Generator
 
 from numpy.typing import NDArray
 
@@ -24,7 +24,7 @@ EngineResponse = (
     | list[ImageEntity]
     | list[str]
     | dict[str, str]
-    | NDArray[object]
+    | NDArray[Any]
     | str
 )
 

--- a/src/avalan/model/modalities/registry.py
+++ b/src/avalan/model/modalities/registry.py
@@ -17,7 +17,9 @@ from collections.abc import Callable
 from contextlib import AsyncExitStack
 from inspect import isclass
 from logging import Logger
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar, cast
+
+HandlerType = TypeVar("HandlerType")
 
 
 class ModalityHandler(Protocol):
@@ -51,11 +53,14 @@ class ModalityRegistry:
     @classmethod
     def register(
         cls, modality: Modality
-    ) -> Callable[[ModalityHandler | type], ModalityHandler]:
-        def decorator(handler: ModalityHandler | type) -> ModalityHandler:
-            cls._handlers[modality] = (
-                handler() if isclass(handler) else handler
-            )
+    ) -> Callable[[HandlerType], HandlerType]:
+        def decorator(handler: HandlerType) -> HandlerType:
+            if isclass(handler):
+                class_handler = cast(type[ModalityHandler], handler)
+                resolved_handler = class_handler()
+            else:
+                resolved_handler = cast(ModalityHandler, handler)
+            cls._handlers[modality] = resolved_handler
             return handler
 
         return decorator
@@ -134,7 +139,7 @@ class ModalityRegistry:
                 generation_settings=settings,
                 input=input_string,
                 modality=modality,
-                parameters=None,
+                parameters=cast(Any, None),
                 requires_input=False,
             )
         return handler.get_operation_from_arguments(

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -8,7 +8,7 @@ from ....tool.parser import ToolCallParser
 
 from io import StringIO
 from time import perf_counter
-from typing import Any, Iterable
+from typing import Any, Iterable, cast
 
 
 class ToolCallResponseParser:
@@ -90,7 +90,9 @@ class ToolCallResponseParser:
             return result
 
         event = Event(
-            type=EventType.TOOL_PROCESS, payload=calls, started=perf_counter()
+            type=EventType.TOOL_PROCESS,
+            payload=cast(dict[str, Any], calls),
+            started=perf_counter(),
         )
 
         self._buffer = StringIO()

--- a/src/avalan/model/response/text.py
+++ b/src/avalan/model/response/text.py
@@ -16,6 +16,7 @@ from logging import Logger
 from queue import Queue
 from re import DOTALL, Pattern, compile
 from typing import (
+    Any,
     AsyncGenerator,
     AsyncIterator,
     Awaitable,
@@ -27,7 +28,7 @@ OutputFunction = Callable[..., OutputGenerator | str]
 
 
 class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
-    _json_patterns: list[Pattern] = [
+    _json_patterns: list[Pattern[str]] = [
         # Markdown code fence with explicit json tag
         compile(r"```json\s*(\{.*?\})\s*```", DOTALL),
         # Any markdown code fence possibly with a language specifier
@@ -38,7 +39,7 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
     _output_fn: OutputFunction
     _input_token_count: int = 0
     _output_token_count: int = 0
-    _output: OutputGenerator | None = None
+    _output: AsyncIterator[Token | TokenDetail | str] | None = None
     _buffer: StringIO = StringIO()
     _on_consumed: Callable[[], Awaitable[None] | None] | None = None
     _consumed: bool = False
@@ -50,13 +51,13 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
     def __init__(
         self,
         output_fn: OutputFunction,
-        *args,
+        *args: Any,
         logger: Logger,
         use_async_generator: bool,
         generation_settings: GenerationSettings | None = None,
         bos_token: str | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         self._args = args
         self._kwargs = kwargs
         self._output_fn = output_fn
@@ -94,9 +95,13 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
 
         result = self._output_fn(*self._args, **self._kwargs)
         if isinstance(result, TextGenerationSingleStream):
-            result = result.content
-
-        if isinstance(result, (Token, TokenDetail)):
+            result_content: str | Token | TokenDetail = result.content
+            text = (
+                result_content.token
+                if isinstance(result_content, (Token, TokenDetail))
+                else str(result_content)
+            )
+        elif isinstance(result, (Token, TokenDetail)):
             text = result.token
         else:
             text = str(result)
@@ -125,7 +130,9 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
 
     @property
     def is_thinking(self) -> bool:
-        return self.can_think and self._reasoning_parser.is_thinking
+        return bool(
+            self._reasoning_parser and self._reasoning_parser.is_thinking
+        )
 
     def set_thinking(self, thinking: bool) -> None:
         if self._reasoning_parser:
@@ -140,9 +147,13 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
             if iscoroutine(result):
                 await result
 
-    def __aiter__(self):
+    def __aiter__(self) -> AsyncIterator[Token | TokenDetail | str]:
         # Create a fresh async generator each time we start iterating
-        self._output = self._output_fn(*self._args, **self._kwargs)
+        output = self._output_fn(*self._args, **self._kwargs)
+        if isinstance(output, str):
+            self._output = TextGenerationSingleStream(output)
+        else:
+            self._output = output
         return self
 
     async def __anext__(self) -> Token | TokenDetail | str:
@@ -157,9 +168,11 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
                 token = await self._output.__anext__()
             except StopAsyncIteration:
                 if self._reasoning_parser:
+                    parser_queue = self._parser_queue
+                    assert parser_queue is not None
                     for it in await self._reasoning_parser.flush():
-                        self._parser_queue.put(it)
-                    if not self._parser_queue.empty():
+                        parser_queue.put(it)
+                    if not parser_queue.empty():
                         continue
                 await self._trigger_consumed()
                 raise
@@ -181,12 +194,15 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
                 raise StopAsyncIteration
 
             for it in items:
+                parsed: Token | TokenDetail | str
                 if isinstance(it, ReasoningToken):
                     token_id = (
                         token.id
                         if isinstance(token, (Token, TokenDetail))
                         else it.id
                     )
+                    if token_id is None:
+                        token_id = -1
                     parsed = ReasoningToken(
                         token=it.token, id=token_id, probability=it.probability
                     )
@@ -207,11 +223,15 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
                     parsed = Token(id=token.id, token=str(it))
                 else:
                     parsed = it
-                self._parser_queue.put(parsed)
+                parser_queue = self._parser_queue
+                assert parser_queue is not None
+                parser_queue.put(parsed)
 
-            if not self._parser_queue.empty():
+            parser_queue = self._parser_queue
+            assert parser_queue is not None
+            if not parser_queue.empty():
                 self._output_token_count += 1
-                return self._parser_queue.get()
+                return parser_queue.get()
 
     def __str__(self) -> str:
         if not self._use_async_generator:
@@ -230,9 +250,11 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
         # Ensure buffer is filled, wether we were already iterating or not
         if not self._output:
             self.__aiter__()
+        assert self._output is not None
 
         async for token in self._output:
-            self._buffer.write(token)
+            token_text = token if isinstance(token, str) else token.token
+            self._buffer.write(token_text)
             self._output_token_count += 1
 
         await self._trigger_consumed()
@@ -252,7 +274,7 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
                     continue
         raise InvalidJsonResponseException(text)
 
-    async def to(self, entity_class: type) -> any:
+    async def to(self, entity_class: type[Any]) -> Any:
         json = await self.to_json()
         data = loads(json)
         return entity_class(**data)

--- a/src/avalan/model/response/text.py
+++ b/src/avalan/model/response/text.py
@@ -151,10 +151,14 @@ class TextGenerationResponse(AsyncIterator[Token | TokenDetail | str]):
         # Create a fresh async generator each time we start iterating
         output = self._output_fn(*self._args, **self._kwargs)
         if isinstance(output, str):
-            self._output = TextGenerationSingleStream(output)
+            self._output = self._string_output_generator(output)
         else:
             self._output = output
         return self
+
+    @staticmethod
+    async def _string_output_generator(text: str) -> OutputGenerator:
+        yield text
 
     async def __anext__(self) -> Token | TokenDetail | str:
         assert self._output

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -4,11 +4,17 @@ from ..entities import (
     MessageContent,
     MessageContentImage,
     MessageContentText,
+    Token,
+    TokenDetail,
     ToolCall,
     ToolCallToken,
 )
 from ..tool.manager import ToolManager
-from .message import TemplateMessage, TemplateMessageRole
+from .message import (
+    TemplateMessage,
+    TemplateMessageContent,
+    TemplateMessageRole,
+)
 from .stream import TextGenerationStream
 
 from abc import ABC
@@ -29,14 +35,16 @@ class TextGenerationVendor(ABC):
         raise NotImplementedError()
 
     def _system_prompt(self, messages: list[Message]) -> str | None:
-        return next(
-            (
-                message.content
-                for message in messages
-                if message.role == "system"
-            ),
-            None,
-        )
+        for message in messages:
+            if message.role != "system":
+                continue
+            content = message.content
+            if isinstance(content, str):
+                return content
+            if isinstance(content, MessageContentText):
+                return content.text
+            return None
+        return None
 
     def _template_messages(
         self,
@@ -73,7 +81,12 @@ class TextGenerationVendor(ABC):
             out.append(
                 {
                     "role": cast(TemplateMessageRole, str(msg.role)),
-                    "content": _wrap(msg.content),
+                    "content": cast(
+                        str
+                        | TemplateMessageContent
+                        | list[TemplateMessageContent],
+                        _wrap(msg.content),
+                    ),
                 }
             )
 
@@ -122,9 +135,12 @@ class TextGenerationVendorStream(TextGenerationStream):
 
     def __call__(
         self, *args: Any, **kwargs: Any
-    ) -> AsyncIterator[str | ToolCallToken]:
+    ) -> AsyncIterator[Token | TokenDetail | str]:
         return self.__aiter__()
 
-    def __aiter__(self) -> AsyncIterator[str | ToolCallToken]:
+    def __aiter__(self) -> AsyncIterator[Token | TokenDetail | str]:
         assert self._generator
         return self
+
+    async def __anext__(self) -> str | ToolCallToken:
+        return await self._generator.__anext__()

--- a/tests/model/text_generation_response_non_stream_test.py
+++ b/tests/model/text_generation_response_non_stream_test.py
@@ -69,3 +69,19 @@ class TextGenerationResponseNonStreamTestCase(IsolatedAsyncioTestCase):
         response._prefetched_text = "cached"
         response._ensure_non_stream_prefetched()
         self.assertIn("TextGenerationResponse", str(response))
+
+    async def test_streaming_string_output_is_not_replayed_in_to_str(
+        self,
+    ) -> None:
+        settings = GenerationSettings()
+        response = TextGenerationResponse(
+            lambda **_: "hi",
+            logger=getLogger("response-stream-string"),
+            generation_settings=settings,
+            settings=settings,
+            use_async_generator=True,
+        )
+        response.__aiter__()
+        first = await response.__anext__()
+        self.assertEqual(first, "hi")
+        self.assertEqual(await response.to_str(), "hi")


### PR DESCRIPTION
### Motivation
- Remove a class of mypy errors in the `avalan.model` package so we can progressively remove `avalan.model.*` from the mypy overrides; address problems around async iteration, typed regex/generics, and handler registration typing.

### Description
- Tightened `TextGenerationResponse` typing and control flow in `src/avalan/model/response/text.py` by typing regex patterns, annotating variadic ctor args, handling `TextGenerationSingleStream` results, asserting parser-queue presence, and normalizing token/text writes.
- Improved vendor stream and message handling in `src/avalan/model/vendor.py` by making `_system_prompt` and `_template_messages` explicit about content types, adding proper casts, and providing an `__anext__` implementation for vendor streams.
- Fixed decorator/registration typing in `src/avalan/model/modalities/registry.py` so decorated handlers preserve their original return type while storing typed handler instances, and preserved the `parameters=None` fallback with a safe cast.
- Restored runtime `Event` payload behavior while satisfying mypy by casting the payload in `src/avalan/model/response/parsers/tool.py` to the expected type.
- Relaxed the numpy generic in `src/avalan/model/__init__.py` from `NDArray[object]` to `NDArray[Any]` to satisfy numpy typing constraints.

### Testing
- Ran `make lint` and autoformatters (black/ruff); formatting and ruff checks passed.
- Ran the full test suite with `poetry run pytest --verbose -s`; result: all tests passed (`1577 passed, 11 skipped`).
- Ran targeted mypy checks for modified files with `poetry run mypy --config-file /tmp/pyproject_mypy.toml src/avalan/model/response/text.py src/avalan/model/vendor.py src/avalan/model/modalities/registry.py src/avalan/model/response/parsers/tool.py src/avalan/model/__init__.py`; result: no issues.
- Note: a full-module mypy run over `src/avalan/model` still reports remaining strict errors in other files (notably `engine.py` and `transformer.py`); this change reduces the surface but does not yet allow removing `avalan.model.*` from the mypy overrides entirely.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbac7cd3483238318540f8f148973)