### PR TITLE
Tighten mypy typing in ModelManager and remove model/tool mypy ignore override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,13 +220,6 @@ python_version = "3.11"
 
 [[tool.mypy.overrides]]
 module = [
-  "avalan.model.*",
-  "avalan.tool.*",
-]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = [
   "a2a",
   "aioboto3",
   "anyio",

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -43,11 +43,20 @@ from .modalities import ModalityRegistry
 
 import asyncio
 from argparse import Namespace
-from contextlib import AsyncExitStack, ContextDecorator
+from contextlib import AsyncExitStack
 from logging import Logger
 from os import environ
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, TypeAlias, get_args
+from types import TracebackType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Mapping,
+    TypeAlias,
+    cast,
+    get_args,
+)
 from urllib.parse import parse_qsl, urlparse
 
 if TYPE_CHECKING:
@@ -79,7 +88,7 @@ ModelType: TypeAlias = (
 )
 
 
-class ModelManager(ContextDecorator):
+class ModelManager:
     _hub: HuggingfaceHub
     _stack: AsyncExitStack
     _logger: Logger
@@ -100,15 +109,15 @@ class ModelManager(ContextDecorator):
         self._event_manager = event_manager
         self._pending_exit_task = None
 
-    def __enter__(self):
+    def __enter__(self) -> "ModelManager":
         return self
 
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
-        traceback: Any | None,
-    ):
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -124,17 +133,19 @@ class ModelManager(ContextDecorator):
         self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
-        traceback: Any | None,
+        traceback: TracebackType | None,
     ) -> bool:
         if self._pending_exit_task is not None:
             await self._pending_exit_task
             self._pending_exit_task = None
-        return await self._stack.__aexit__(exc_type, exc_value, traceback)
+        return bool(
+            await self._stack.__aexit__(exc_type, exc_value, traceback)
+        )
 
     async def __call__(
         self,
         model_task: ModelCall,
-    ):
+    ) -> object:
         modality = model_task.operation.modality
 
         self._logger.info("ModelManager call process started for %s", modality)
@@ -199,10 +210,10 @@ class ModelManager(ContextDecorator):
     def get_engine_settings(
         self,
         engine_uri: EngineUri,
-        settings: dict | None = None,
+        settings: Mapping[str, object] | None = None,
         modality: Modality | None = None,
     ) -> TransformerEngineSettings:
-        engine_settings_args = settings or {}
+        engine_settings_args: dict[str, Any] = dict(settings or {})
 
         if modality != Modality.EMBEDDING and not engine_uri.is_local:
             token = None
@@ -226,7 +237,7 @@ class ModelManager(ContextDecorator):
         self,
         engine_uri: EngineUri,
         modality: Modality = Modality.TEXT_GENERATION,
-        *args,
+        *args: object,
         attention: AttentionImplementation | None = None,
         base_url: str | None = None,
         device: str | None = None,
@@ -251,7 +262,9 @@ class ModelManager(ContextDecorator):
         weight_type: WeightType = "auto",
     ) -> ModelType:
         if "backend" in engine_uri.params:
-            backend = Backend(engine_uri.params["backend"])
+            backend_param = engine_uri.params["backend"]
+            assert isinstance(backend_param, str)
+            backend = Backend(backend_param)
         engine_settings_args = dict(
             base_url=base_url,
             cache_dir=self._hub.cache_dir,
@@ -299,6 +312,7 @@ class ModelManager(ContextDecorator):
         if modality is Modality.EMBEDDING:
             from ..model.nlp.sentence import SentenceTransformerModel
 
+            assert engine_uri.model_id is not None
             model = SentenceTransformerModel(
                 model_id=engine_uri.model_id,
                 settings=engine_settings,
@@ -355,7 +369,7 @@ class ModelManager(ContextDecorator):
             else ""
         ) + (parsed.path[1:] if path_prefixed else parsed.path)
         engine_uri = EngineUri(
-            vendor=vendor,
+            vendor=cast(Vendor | None, vendor),
             host=hostname if use_host else None,
             port=(parsed.port or None) if use_host else None,
             user=parsed.username or None,


### PR DESCRIPTION
### Motivation
- Remove the broad mypy `ignore_errors` override that hid errors for `avalan.model.*` and `avalan.tool.*` and begin bringing `avalan.model` into compliance with strict mypy settings.  
- Fix type problems in the model manager that prevented the `avalan.model` package from being checked cleanly under `--strict` mypy rules.

### Description
- Deleted the `[[tool.mypy.overrides]]` block that set `ignore_errors = true` for `avalan.model.*` and `avalan.tool.*` in `pyproject.toml`, so these packages are no longer blanket-ignored by mypy.  
- Updated `src/avalan/model/manager.py` to strengthen type annotations and eliminate mypy failures; changes include removing `ContextDecorator` inheritance, adding explicit context manager return/argument types (`__enter__`, `__exit__`, `__aenter__`, `__aexit__`), using `TracebackType` and `Literal[False]` where appropriate, and annotating `__call__` return type.  
- Tightened mapping/dict typing for engine settings to `Mapping[str, object]` and converted to a `dict[str, Any]` for construction, added `*args: object`, asserted backend parameter types before constructing `Backend`, cast vendor to the `Vendor` type, and asserted `model_id` presence for embedding model loads.  

### Testing
- Ran `poetry run mypy src/avalan/model/manager.py` which succeeded with no issues.  
- Ran `poetry run mypy src/avalan/model` which still reports remaining strict mypy errors in other files (the manager is fixed but the broader `avalan.model` package requires further incremental fixes).  
- Ran `make lint` (ruff/black) which passed and auto-formatted files.  
- Ran full test suite `poetry run pytest --verbose -s` which passed: `1578 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe3e0dfa0832387cf22ca29f9f2f0)