### PR TITLE
Fix typing in text modality loaders

### DIFF
--- a/src/avalan/model/modalities/text.py
+++ b/src/avalan/model/modalities/text.py
@@ -26,7 +26,7 @@ from contextlib import AsyncExitStack
 from functools import lru_cache
 from importlib.util import find_spec
 from logging import Logger
-from typing import Any
+from typing import Any, cast
 
 
 def _stopping_criteria(
@@ -62,11 +62,7 @@ class TextGenerationModality:
         logger: Logger,
         exit_stack: AsyncExitStack,
     ) -> TextGenerationModel:
-        model_load_args = dict(
-            model_id=engine_uri.model_id,
-            settings=engine_settings,
-            logger=logger,
-        )
+        assert engine_uri.model_id is not None
         if engine_uri.is_local:
             match engine_settings.backend:
                 case Backend.MLXLM:
@@ -78,77 +74,154 @@ class TextGenerationModality:
                         )
                         raise ModuleNotFoundError(msg)
 
-                    return mlx_loader(**model_load_args)
+                    return mlx_loader(
+                        model_id=engine_uri.model_id,
+                        settings=engine_settings,
+                        logger=logger,
+                    )
                 case Backend.VLLM:
-                    from ..nlp.text.vllm import VllmModel as Loader
+                    from ..nlp.text.vllm import VllmModel
 
-                    return Loader(**model_load_args)
+                    return VllmModel(
+                        model_id=engine_uri.model_id,
+                        settings=engine_settings,
+                        logger=logger,
+                    )
                 case _:
-                    return TextGenerationModel(**model_load_args)
+                    return TextGenerationModel(
+                        model_id=engine_uri.model_id,
+                        settings=engine_settings,
+                        logger=logger,
+                    )
         match engine_uri.vendor:
             case "anthropic":
                 from ..nlp.text.vendor.anthropic import (
-                    AnthropicModel as Loader,
+                    AnthropicModel,
                 )
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return AnthropicModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
 
             case "openai":
-                from ..nlp.text.vendor.openai import OpenAIModel as Loader
+                from ..nlp.text.vendor.openai import OpenAIModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return OpenAIModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "bedrock":
-                from ..nlp.text.vendor.bedrock import BedrockModel as Loader
+                from ..nlp.text.vendor.bedrock import BedrockModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return BedrockModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "openrouter":
                 from ..nlp.text.vendor.openrouter import (
-                    OpenRouterModel as Loader,
+                    OpenRouterModel,
                 )
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return OpenRouterModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "anyscale":
-                from ..nlp.text.vendor.anyscale import AnyScaleModel as Loader
+                from ..nlp.text.vendor.anyscale import AnyScaleModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return AnyScaleModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "together":
-                from ..nlp.text.vendor.together import TogetherModel as Loader
+                from ..nlp.text.vendor.together import TogetherModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return TogetherModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "deepseek":
-                from ..nlp.text.vendor.deepseek import DeepSeekModel as Loader
+                from ..nlp.text.vendor.deepseek import DeepSeekModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return DeepSeekModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "deepinfra":
                 from ..nlp.text.vendor.deepinfra import (
-                    DeepInfraModel as Loader,
+                    DeepInfraModel,
                 )
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return DeepInfraModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "groq":
-                from ..nlp.text.vendor.groq import GroqModel as Loader
+                from ..nlp.text.vendor.groq import GroqModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return GroqModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "ollama":
-                from ..nlp.text.vendor.ollama import OllamaModel as Loader
+                from ..nlp.text.vendor.ollama import OllamaModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return OllamaModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "huggingface":
                 from ..nlp.text.vendor.huggingface import (
-                    HuggingfaceModel as Loader,
+                    HuggingfaceModel,
                 )
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return HuggingfaceModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "hyperbolic":
                 from ..nlp.text.vendor.hyperbolic import (
-                    HyperbolicModel as Loader,
+                    HyperbolicModel,
                 )
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return HyperbolicModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
             case "litellm":
-                from ..nlp.text.vendor.litellm import LiteLLMModel as Loader
+                from ..nlp.text.vendor.litellm import LiteLLMModel
 
-                return Loader(**model_load_args, exit_stack=exit_stack)
+                return LiteLLMModel(
+                    model_id=engine_uri.model_id,
+                    settings=engine_settings,
+                    logger=logger,
+                    exit_stack=exit_stack,
+                )
         raise NotImplementedError()
 
     def get_operation_from_arguments(
@@ -159,7 +232,7 @@ class TextGenerationModality:
     ) -> Operation:
         parameters = OperationParameters(
             text=OperationTextParameters(
-                manual_sampling=args.display_tokens or 0,
+                manual_sampling=cast(bool | None, args.display_tokens or 0),
                 pick_tokens=(
                     10
                     if args.display_tokens and args.display_tokens > 0
@@ -226,6 +299,7 @@ class TextQuestionAnsweringModality:
         _ = exit_stack
         if not engine_uri.is_local:
             raise NotImplementedError()
+        assert engine_uri.model_id is not None
         return QuestionAnsweringModel(
             model_id=engine_uri.model_id,
             settings=engine_settings,
@@ -286,6 +360,7 @@ class TextSequenceClassificationModality:
         _ = exit_stack
         if not engine_uri.is_local:
             raise NotImplementedError()
+        assert engine_uri.model_id is not None
         return SequenceClassificationModel(
             model_id=engine_uri.model_id,
             settings=engine_settings,
@@ -302,7 +377,7 @@ class TextSequenceClassificationModality:
             generation_settings=settings,
             input=input_string,
             modality=Modality.TEXT_SEQUENCE_CLASSIFICATION,
-            parameters=None,
+            parameters=cast(OperationParameters, None),
             requires_input=True,
         )
 
@@ -329,6 +404,7 @@ class TextSequenceToSequenceModality:
         _ = exit_stack
         if not engine_uri.is_local:
             raise NotImplementedError()
+        assert engine_uri.model_id is not None
         return SequenceToSequenceModel(
             model_id=engine_uri.model_id,
             settings=engine_settings,
@@ -382,6 +458,7 @@ class TextTokenClassificationModality:
         _ = exit_stack
         if not engine_uri.is_local:
             raise NotImplementedError()
+        assert engine_uri.model_id is not None
         return TokenClassificationModel(
             model_id=engine_uri.model_id,
             settings=engine_settings,
@@ -437,6 +514,7 @@ class TextTranslationModality:
         _ = exit_stack
         if not engine_uri.is_local:
             raise NotImplementedError()
+        assert engine_uri.model_id is not None
         return TranslationModel(
             model_id=engine_uri.model_id,
             settings=engine_settings,

--- a/src/avalan/model/nlp/text/vendor/ollama.py
+++ b/src/avalan/model/nlp/text/vendor/ollama.py
@@ -11,6 +11,7 @@ from .....tool.manager import ToolManager
 from ....vendor import TextGenerationVendor, TextGenerationVendorStream
 from . import TextGenerationVendorModel
 
+from contextlib import AsyncExitStack
 from dataclasses import replace
 from logging import Logger, getLogger
 from typing import AsyncIterator
@@ -77,7 +78,9 @@ class OllamaModel(TextGenerationVendorModel):
         model_id: str,
         settings: TransformerEngineSettings | None = None,
         logger: Logger = getLogger(__name__),
+        exit_stack: AsyncExitStack | None = None,
     ) -> None:
+        _ = exit_stack
         settings = settings or TransformerEngineSettings()
         settings = replace(settings, enable_eval=False)
         TextGenerationModel.__init__(self, model_id, settings, logger)


### PR DESCRIPTION
### Motivation
- Continue removing mypy exceptions for `avalan.model` by fixing typing issues in the text modality loader and related vendor constructor call sites so the module can eventually be removed from the mypy overrides. 
- Address mismatches caused by using loose `**dict` expansions and transient loader aliases which prevented strict typing and caused failing tests/type assertions under strict mypy. 

### Description
- Add `assert engine_uri.model_id is not None` and replace the generic `**model_load_args` expansions with explicit keyword arguments when constructing loaders in `TextGenerationModality.load_engine`. 
- Replace reused `Loader` aliases with direct class names to avoid import/typing confusion and pass the explicit `model_id`, `settings`, and `logger` to each loader. 
- Use `cast` to preserve runtime behavior while satisfying mypy for `manual_sampling` (`cast(bool | None, args.display_tokens or 0)`) and for returning `None` for `Operation.parameters` where appropriate (`cast(OperationParameters, None)`). 
- Add an optional `exit_stack: AsyncExitStack | None = None` parameter to `OllamaModel.__init__` (and ignore it) so vendor loader signatures match the calls from `TextGenerationModality`, and update the modality to pass `exit_stack` to `OllamaModel`. 

### Testing
- Ran `poetry run mypy src/avalan/model/modalities/text.py` which reported `Success: no issues found in 1 source file`. 
- Ran targeted pytest subsets: `tests/model/text_generation_modality_vendors_test.py`, `tests/model/modalities_additional_test.py`, and `tests/model/modality_load_engine_nonlocal_test.py`, which all passed (31 tests). 
- Ran `tests/model/model_manager_operation_test.py` and `tests/model/text_modalities_full_test.py`, which passed (31 tests). 
- Ran the full test suite via `poetry run pytest --verbose -s` which completed successfully (1578 passed, 11 skipped). 
- Ran `make lint` which completed with fixes and no remaining ruff/black issues. 

Note: `avalan.model` as a whole still reports remaining mypy errors across many files; this PR completes a focused cleanup for the text modality loader and associated vendor initialization to make further mypy progress possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfeb5127d883239de3f0ab54df2f1f)