### PR TITLE
Fix strict mypy issues in model modules

### DIFF
--- a/src/avalan/model/audio/classification.py
+++ b/src/avalan/model/audio/classification.py
@@ -2,7 +2,7 @@ from ...model.audio import BaseAudioModel
 from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import inference_mode
@@ -14,21 +14,29 @@ from transformers import (
 
 
 class AudioClassificationModel(BaseAudioModel):
-    _extractor: AutoFeatureExtractor
+    _extractor: Any
 
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._extractor = AutoFeatureExtractor.from_pretrained(self._model_id)
-        model = AutoModelForAudioClassification.from_pretrained(
-            self._model_id,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
-            ),
-            subfolder=self._settings.subfolder or "",
-        ).to(self._device)
+        self._extractor = cast(
+            Any,
+            cast(Any, AutoFeatureExtractor).from_pretrained(self._model_id),
+        )
+        model = cast(
+            PreTrainedModel,
+            cast(Any, AutoModelForAudioClassification)
+            .from_pretrained(
+                self._model_id,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
+                subfolder=self._settings.subfolder or "",
+            )
+            .to(self._device),
+        )
 
         return model
 

--- a/src/avalan/model/audio/generation.py
+++ b/src/avalan/model/audio/generation.py
@@ -2,7 +2,7 @@ from ...model.audio import BaseAudioModel
 from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import from_numpy, inference_mode
@@ -15,21 +15,29 @@ from transformers import (
 
 
 class AudioGenerationModel(BaseAudioModel):
-    _processor: AutoProcessor
+    _processor: Any
 
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoProcessor.from_pretrained(self._model_id)
-        model = MusicgenForConditionalGeneration.from_pretrained(
-            self._model_id,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
-            ),
-            subfolder=self._settings.subfolder or "",
-        ).to(self._device)
+        self._processor = cast(
+            Any,
+            cast(Any, AutoProcessor).from_pretrained(self._model_id),
+        )
+        model = cast(
+            PreTrainedModel,
+            cast(Any, MusicgenForConditionalGeneration)
+            .from_pretrained(
+                self._model_id,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
+                subfolder=self._settings.subfolder or "",
+            )
+            .to(self._device),
+        )
         return model
 
     async def __call__(

--- a/src/avalan/model/audio/speech.py
+++ b/src/avalan/model/audio/speech.py
@@ -2,7 +2,7 @@ from ...model.audio import BaseAudioModel
 from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import inference_mode
@@ -14,25 +14,31 @@ from transformers import (
 
 
 class TextToSpeechModel(BaseAudioModel):
-    _processor: AutoProcessor
+    _processor: Any
 
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoProcessor.from_pretrained(
-            self._model_id,
-            trust_remote_code=self._settings.trust_remote_code,
-            subfolder=self._settings.tokenizer_subfolder or "",
-        )
-        model = DiaForConditionalGeneration.from_pretrained(
-            self._model_id,
-            trust_remote_code=self._settings.trust_remote_code,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        self._processor = cast(
+            Any,
+            cast(Any, AutoProcessor).from_pretrained(
+                self._model_id,
+                trust_remote_code=self._settings.trust_remote_code,
+                subfolder=self._settings.tokenizer_subfolder or "",
             ),
-            subfolder=self._settings.subfolder or "",
+        )
+        model = cast(
+            PreTrainedModel,
+            cast(Any, DiaForConditionalGeneration).from_pretrained(
+                self._model_id,
+                trust_remote_code=self._settings.trust_remote_code,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
+                subfolder=self._settings.subfolder or "",
+            ),
         )
         return model
 

--- a/src/avalan/model/audio/speech_recognition.py
+++ b/src/avalan/model/audio/speech_recognition.py
@@ -2,7 +2,7 @@ from ...model.audio import BaseAudioModel
 from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
@@ -14,30 +14,37 @@ from transformers import (
 
 
 class SpeechRecognitionModel(BaseAudioModel):
-    _processor: AutoProcessor
+    _processor: Any
 
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoProcessor.from_pretrained(
-            self._model_id,
-            trust_remote_code=self._settings.trust_remote_code,
-            # default behavior in transformers v4.48
-            use_fast=True,
-            subfolder=self._settings.tokenizer_subfolder or "",
-        )
-        model = AutoModelForCTC.from_pretrained(
-            self._model_id,
-            trust_remote_code=self._settings.trust_remote_code,
-            pad_token_id=self._processor.tokenizer.pad_token_id,
-            ctc_loss_reduction="mean",
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        self._processor = cast(
+            Any,
+            cast(Any, AutoProcessor).from_pretrained(
+                self._model_id,
+                trust_remote_code=self._settings.trust_remote_code,
+                # default behavior in transformers v4.48
+                use_fast=True,
+                subfolder=self._settings.tokenizer_subfolder or "",
             ),
-            ignore_mismatched_sizes=True,
-            subfolder=self._settings.subfolder or "",
+        )
+        assert self._model_id
+        model = cast(
+            PreTrainedModel,
+            cast(Any, AutoModelForCTC).from_pretrained(
+                self._model_id,
+                trust_remote_code=self._settings.trust_remote_code,
+                pad_token_id=self._processor.tokenizer.pad_token_id,
+                ctc_loss_reduction="mean",
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
+                ignore_mismatched_sizes=True,
+                subfolder=self._settings.subfolder or "",
+            ),
         )
         return model
 
@@ -58,4 +65,4 @@ class SpeechRecognitionModel(BaseAudioModel):
             logits = self._model(inputs.input_values).logits
         predicted_ids = argmax(logits, dim=-1)
         transcription = self._processor.batch_decode(predicted_ids)[0]
-        return transcription
+        return cast(str, transcription)

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -24,7 +24,7 @@ from dataclasses import asdict, replace
 from importlib.util import find_spec
 from logging import Logger, getLogger
 from threading import Thread
-from typing import AsyncGenerator, Literal, cast
+from typing import Any, AsyncGenerator, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import Tensor, log_softmax, softmax, topk
@@ -87,11 +87,14 @@ class TextGenerationModel(BaseNLPModel):
             from transformers import BitsAndBytesConfig
 
             quantization = settings.quantization
-            bnb_config = BitsAndBytesConfig(
-                load_in_4bit=quantization.load_in_4bit,
-                bnb_4bit_quant_type=quantization.bnb_4bit_quant_type,
-                bnb_4bit_use_double_quant=quantization.bnb_4bit_use_double_quant,
-                bnb_4bit_compute_dtype=quantization.bnb_4bit_compute_dtype,
+            bnb_config = cast(
+                object,
+                cast(Any, BitsAndBytesConfig)(
+                    load_in_4bit=quantization.load_in_4bit,
+                    bnb_4bit_quant_type=quantization.bnb_4bit_quant_type,
+                    bnb_4bit_use_double_quant=quantization.bnb_4bit_use_double_quant,
+                    bnb_4bit_compute_dtype=quantization.bnb_4bit_compute_dtype,
+                ),
             )
         else:
             bnb_config = None
@@ -121,7 +124,10 @@ class TextGenerationModel(BaseNLPModel):
         if model_args["quantization_config"] is None:
             model_args.pop("quantization_config", None)
 
-        model = loader.from_pretrained(self._model_id, **model_args)
+        model = cast(
+            PreTrainedModel,
+            cast(Any, loader).from_pretrained(self._model_id, **model_args),
+        )
         return model
 
     async def __call__(
@@ -261,8 +267,12 @@ class TextGenerationModel(BaseNLPModel):
         assert isinstance(inputs, dict)
         input_length = inputs["input_ids"].shape[1]
         outputs = self._generate_output(inputs, settings, stopping_criterias)
-        return self._tokenizer.decode(
-            outputs[0][input_length:], skip_special_tokens=skip_special_tokens
+        return cast(
+            str,
+            self._tokenizer.decode(
+                outputs[0][input_length:],
+                skip_special_tokens=skip_special_tokens,
+            ),
         )
 
     async def _token_generator(
@@ -501,7 +511,7 @@ class TextGenerationModel(BaseNLPModel):
         if hasattr(self._model, "device"):
             _l(f"Translating inputs to {self._model.device}")
             inputs = inputs.to(self._model.device)
-        return inputs
+        return cast(dict[str, Tensor] | BatchEncoding | Tensor, inputs)
 
     def _messages(
         self,

--- a/src/avalan/model/nlp/text/vendor/anthropic.py
+++ b/src/avalan/model/nlp/text/vendor/anthropic.py
@@ -39,7 +39,10 @@ class AnthropicStream(TextGenerationVendorStream):
                         cb is not None
                         and getattr(cb, "type", None) == "tool_use"
                     ):
-                        tool_blocks[event.index] = {
+                        index = cast(int | None, getattr(event, "index", None))
+                        if index is None:
+                            continue
+                        tool_blocks[index] = {
                             "id": getattr(cb, "id", None),
                             "name": getattr(cb, "name", None),
                             "args_fragments": [],
@@ -57,8 +60,11 @@ class AnthropicStream(TextGenerationVendorStream):
                         hasattr(delta, "partial_json")
                         and delta.partial_json is not None
                     ):
+                        index = cast(int | None, getattr(event, "index", None))
+                        if index is None:
+                            continue
                         tb = tool_blocks.setdefault(
-                            event.index,
+                            index,
                             {"id": None, "name": None, "args_fragments": []},
                         )
                         tb["args_fragments"].append(delta.partial_json)
@@ -88,8 +94,9 @@ class AnthropicStream(TextGenerationVendorStream):
                             )
                             yield token
 
-                        if event.index in tool_blocks:
-                            del tool_blocks[event.index]
+                        index = cast(int | None, getattr(event, "index", None))
+                        if index is not None and index in tool_blocks:
+                            del tool_blocks[index]
 
                     continue
 
@@ -148,7 +155,9 @@ class AnthropicClient(TextGenerationVendor):
 
         response = await self._client.messages.create(**kwargs)
         content = self._non_stream_response_content(response)
-        return TextGenerationSingleStream(content)
+        return cast(
+            TextGenerationVendorStream, TextGenerationSingleStream(content)
+        )
 
     def _template_messages(
         self,
@@ -162,8 +171,9 @@ class AnthropicClient(TextGenerationVendor):
             and (message.tool_call_result or message.tool_call_error)
         ]
         do_exclude_roles = [*(exclude_roles or []), "tool"]
-        template_messages = super()._template_messages(
-            messages, do_exclude_roles
+        template_messages = cast(
+            list[dict[str, Any]],
+            super()._template_messages(messages, do_exclude_roles),
         )
         last_message = next(
             (
@@ -203,7 +213,7 @@ class AnthropicClient(TextGenerationVendor):
         for result in tool_results:
             if result is None:
                 continue
-            content = {
+            content: dict[str, Any] = {
                 "type": "tool_result",
                 "tool_use_id": result.call.id,
                 "content": to_json(
@@ -214,10 +224,10 @@ class AnthropicClient(TextGenerationVendor):
             }
             if isinstance(result, ToolCallError):
                 content["is_error"] = True
-            result_message: TemplateMessage = TemplateMessage(
-                role="user",
-                content=[cast(Any, content)],
-            )
+            result_message: dict[str, Any] = {
+                "role": "user",
+                "content": [content],
+            }
             if last_message_index is not None:
                 template_messages.insert(
                     last_message_index + 1, result_message
@@ -231,7 +241,7 @@ class AnthropicClient(TextGenerationVendor):
         ):
             template_messages.pop()
 
-        return template_messages
+        return cast(list[TemplateMessage], template_messages)
 
     @staticmethod
     def _tool_schemas(tool: ToolManager) -> list[dict[str, Any]] | None:

--- a/src/avalan/model/vision/classification.py
+++ b/src/avalan/model/vision/classification.py
@@ -3,7 +3,7 @@ from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from PIL import Image
@@ -20,17 +20,24 @@ class ImageClassificationModel(BaseVisionModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoImageProcessor.from_pretrained(
-            self._model_id,
-            # default behavior in transformers v4.48
-            use_fast=True,
+        self._processor = cast(
+            Any,
+            cast(Any, AutoImageProcessor).from_pretrained(
+                self._model_id,
+                # default behavior in transformers v4.48
+                use_fast=True,
+            ),
         )
-        model = AutoModelForImageClassification.from_pretrained(
-            self._model_id,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        assert self._model_id
+        model = cast(
+            PreTrainedModel,
+            cast(Any, AutoModelForImageClassification).from_pretrained(
+                self._model_id,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
             ),
         )
         return model

--- a/src/avalan/model/vision/decoder.py
+++ b/src/avalan/model/vision/decoder.py
@@ -3,7 +3,7 @@ from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from ...model.vision.text import ImageToTextModel
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from PIL import Image
@@ -21,16 +21,22 @@ class VisionEncoderDecoderModel(ImageToTextModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoImageProcessor.from_pretrained(
-            self._model_id,
-            use_fast=True,
+        self._processor = cast(
+            Any,
+            cast(Any, AutoImageProcessor).from_pretrained(
+                self._model_id,
+                use_fast=True,
+            ),
         )
-        model = VisionEncoderDecoderModelImpl.from_pretrained(
-            self._model_id,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        model = cast(
+            PreTrainedModel,
+            cast(Any, VisionEncoderDecoderModelImpl).from_pretrained(
+                self._model_id,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
             ),
         )
         return model
@@ -78,4 +84,4 @@ class VisionEncoderDecoderModel(ImageToTextModel):
         output = self._tokenizer.batch_decode(
             outputs.sequences, skip_special_tokens=skip_special_tokens
         )[0]
-        return output
+        return cast(str, output)

--- a/src/avalan/model/vision/detection.py
+++ b/src/avalan/model/vision/detection.py
@@ -5,7 +5,7 @@ from ...model.vision import BaseVisionModel
 from ...model.vision.classification import ImageClassificationModel
 
 from logging import Logger, getLogger
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from PIL import Image
@@ -31,19 +31,26 @@ class ObjectDetectionModel(ImageClassificationModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoImageProcessor.from_pretrained(
-            self._model_id,
-            revision=self._revision,
-            # default behavior in transformers v4.48
-            use_fast=True,
+        self._processor = cast(
+            Any,
+            cast(Any, AutoImageProcessor).from_pretrained(
+                self._model_id,
+                revision=self._revision,
+                # default behavior in transformers v4.48
+                use_fast=True,
+            ),
         )
-        model = AutoModelForObjectDetection.from_pretrained(
-            self._model_id,
-            revision=self._revision,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        assert self._model_id
+        model = cast(
+            PreTrainedModel,
+            cast(Any, AutoModelForObjectDetection).from_pretrained(
+                self._model_id,
+                revision=self._revision,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
             ),
         )
         return model

--- a/src/avalan/model/vision/diffusion/animation.py
+++ b/src/avalan/model/vision/diffusion/animation.py
@@ -5,7 +5,9 @@ from ....model.vision import BaseVisionModel
 
 from dataclasses import replace
 from logging import Logger, getLogger
+from typing import Any, cast
 
+import diffusers.utils as diffusers_utils
 from diffusers import (
     AnimateDiffPipeline,
     DiffusionPipeline,
@@ -13,11 +15,12 @@ from diffusers import (
     MotionAdapter,
 )
 from diffusers.schedulers.scheduling_utils import SchedulerMixin
-from diffusers.utils import export_to_gif
 from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
 from torch import inference_mode
 from transformers import PreTrainedModel
+
+export_to_gif = cast(Any, diffusers_utils).export_to_gif
 
 
 class TextToAnimationModel(BaseVisionModel):
@@ -40,18 +43,24 @@ class TextToAnimationModel(BaseVisionModel):
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         dtype = Engine.weight(self._settings.weight_type)
-        adapter = MotionAdapter().to(self._device, dtype)
+        assert self._model_id and self._settings.checkpoint
+        adapter = cast(Any, MotionAdapter)().to(self._device, dtype)
         adapter.load_state_dict(
             load_file(
                 hf_hub_download(self._model_id, self._settings.checkpoint),
                 device=self._device,
             )
         )
-        pipe = AnimateDiffPipeline.from_pretrained(
-            self._settings.base_model_id,
-            motion_adapter=adapter,
-            torch_dtype=dtype,
-        ).to(self._device)
+        pipe = cast(
+            DiffusionPipeline,
+            cast(Any, AnimateDiffPipeline)
+            .from_pretrained(
+                self._settings.base_model_id,
+                motion_adapter=adapter,
+                torch_dtype=dtype,
+            )
+            .to(self._device),
+        )
 
         return pipe
 
@@ -60,10 +69,10 @@ class TextToAnimationModel(BaseVisionModel):
         input: Input,
         path: str,
         *,
-        beta_schedule: BetaSchedule = "linear",
+        beta_schedule: BetaSchedule = cast(BetaSchedule, "linear"),
         guidance_scale: float = 1.0,
         steps: int = 4,
-        timestep_spacing: TimestepSpacing = "trailing",
+        timestep_spacing: TimestepSpacing = cast(TimestepSpacing, "trailing"),
     ) -> str:
         assert steps and steps in [
             1,
@@ -73,10 +82,13 @@ class TextToAnimationModel(BaseVisionModel):
         ], f"Invalid number of steps: {steps}, can only be 1, 2, 4, or 8"
         scheduler_settings = (timestep_spacing, beta_schedule)
         if scheduler_settings not in self._schedulers:
-            scheduler = EulerDiscreteScheduler.from_config(
-                self._model.scheduler.config,
-                timestep_spacing=timestep_spacing,
-                beta_schedule=beta_schedule,
+            scheduler = cast(
+                SchedulerMixin,
+                cast(Any, EulerDiscreteScheduler).from_config(
+                    self._model.scheduler.config,
+                    timestep_spacing=timestep_spacing,
+                    beta_schedule=beta_schedule,
+                ),
             )
             self._schedulers[scheduler_settings] = scheduler
         else:

--- a/src/avalan/model/vision/diffusion/image.py
+++ b/src/avalan/model/vision/diffusion/image.py
@@ -10,7 +10,7 @@ from ....model.vision import BaseVisionModel
 
 from dataclasses import replace
 from logging import Logger, getLogger
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from torch import inference_mode
@@ -37,23 +37,29 @@ class TextToImageModel(BaseVisionModel):
         dtype = Engine.weight(self._settings.weight_type)
         dtype_variant = self._settings.weight_type
 
-        base = DiffusionPipeline.from_pretrained(
-            self._model_id,
-            torch_dtype=dtype,
-            variant=dtype_variant,
-            use_safetensors=True,
+        base = cast(
+            DiffusionPipeline,
+            cast(Any, DiffusionPipeline).from_pretrained(
+                self._model_id,
+                torch_dtype=dtype,
+                variant=dtype_variant,
+                use_safetensors=True,
+            ),
         )
-        base.to(self._device)
+        cast(Any, base).to(self._device)
 
-        refiner = DiffusionPipeline.from_pretrained(
-            self._settings.refiner_model_id,
-            text_encoder_2=base.text_encoder_2,
-            vae=base.vae,
-            torch_dtype=dtype,
-            use_safetensors=True,
-            variant=dtype_variant,
+        refiner = cast(
+            DiffusionPipeline,
+            cast(Any, DiffusionPipeline).from_pretrained(
+                self._settings.refiner_model_id,
+                text_encoder_2=cast(Any, base).text_encoder_2,
+                vae=cast(Any, base).vae,
+                torch_dtype=dtype,
+                use_safetensors=True,
+                variant=dtype_variant,
+            ),
         )
-        refiner.to(self._device)
+        cast(Any, refiner).to(self._device)
 
         self._base = base
 
@@ -81,7 +87,7 @@ class TextToImageModel(BaseVisionModel):
         )
 
         with inference_mode():
-            image = self._base(
+            image = cast(Any, self._base)(
                 prompt=input if isinstance(input, str) else str(input),
                 num_inference_steps=n_steps,
                 denoising_end=high_noise_frac,

--- a/src/avalan/model/vision/segmentation.py
+++ b/src/avalan/model/vision/segmentation.py
@@ -2,7 +2,7 @@ from ...model.engine import Engine
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from diffusers import DiffusionPipeline
 from PIL import Image
@@ -18,17 +18,24 @@ class SemanticSegmentationModel(BaseVisionModel):
     def _load_model(
         self,
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
-        self._processor = AutoImageProcessor.from_pretrained(
-            self._model_id,
-            # default behavior in transformers v4.48
-            use_fast=True,
+        self._processor = cast(
+            Any,
+            cast(Any, AutoImageProcessor).from_pretrained(
+                self._model_id,
+                # default behavior in transformers v4.48
+                use_fast=True,
+            ),
         )
-        model = AutoModelForSemanticSegmentation.from_pretrained(
-            self._model_id,
-            device_map=self._device,
-            tp_plan=Engine._get_tp_plan(self._settings.parallel),
-            distributed_config=Engine._get_distributed_config(
-                self._settings.distributed_config
+        assert self._model_id
+        model = cast(
+            PreTrainedModel,
+            cast(Any, AutoModelForSemanticSegmentation).from_pretrained(
+                self._model_id,
+                device_map=self._device,
+                tp_plan=Engine._get_tp_plan(self._settings.parallel),
+                distributed_config=Engine._get_distributed_config(
+                    self._settings.distributed_config
+                ),
             ),
         )
         model.eval()

--- a/src/avalan/model/vision/text.py
+++ b/src/avalan/model/vision/text.py
@@ -30,7 +30,7 @@ class ImageToTextModel(TransformerModel):
     ) -> Any:
         self._processor = cast(
             Any,
-            AutoImageProcessor.from_pretrained(
+            cast(Any, AutoImageProcessor).from_pretrained(
                 self._model_id,
                 # default behavior in transformers v4.48
                 use_fast=True,
@@ -38,7 +38,7 @@ class ImageToTextModel(TransformerModel):
         )
         model = cast(
             Any,
-            AutoModelForVision2Seq.from_pretrained(
+            cast(Any, AutoModelForVision2Seq).from_pretrained(
                 self._model_id,
                 device_map=self._device,
                 tp_plan=Engine._get_tp_plan(self._settings.parallel),
@@ -78,7 +78,7 @@ class ImageToTextModel(TransformerModel):
         output = self._tokenizer.decode(
             output_ids[0], skip_special_tokens=skip_special_tokens
         )
-        return output
+        return cast(str, output)
 
 
 class ImageTextToTextModel(ImageToTextModel):
@@ -97,7 +97,7 @@ class ImageTextToTextModel(ImageToTextModel):
 
         self._processor = cast(
             Any,
-            AutoProcessor.from_pretrained(
+            cast(Any, AutoProcessor).from_pretrained(
                 self._model_id,
                 use_fast=True,
             ),
@@ -106,7 +106,7 @@ class ImageTextToTextModel(ImageToTextModel):
         loader = self._loaders[self._settings.loader_class]
         model = cast(
             Any,
-            loader.from_pretrained(
+            cast(Any, loader).from_pretrained(
                 self._model_id,
                 torch_dtype=Engine.weight(self._settings.weight_type),
                 device_map=self._device,
@@ -196,4 +196,7 @@ class ImageTextToTextModel(ImageToTextModel):
             skip_special_tokens=skip_special_tokens,
             clean_up_tokenization_spaces=False,
         )
-        return output_text[0] if isinstance(output_text, list) else output_text
+        return cast(
+            str,
+            output_text[0] if isinstance(output_text, list) else output_text,
+        )


### PR DESCRIPTION
### Motivation
- Remove application code from `[[tool.mypy.overrides]]` workarounds by fixing strict mypy errors in the app code instead of ignoring them. 
- Address `no-untyped-call`, `no-any-return`, `attr-defined` and related strict-mode errors caused by untyped third-party APIs while preserving runtime behavior. 
- Avoid changing business logic; add safe runtime checks/casts and narrow typing where needed to satisfy mypy. 

### Description
- Added targeted `cast(...)`/`Any` wrappers and `assert` checks around untyped third-party API calls (primarily `transformers` and `diffusers`) and tightened return typings to avoid `Any` leaks. 
- Adjusted diffusion/animation glue to import and bind `export_to_gif` safely and fixed scheduler default literal typing and scheduler creation casts. 
- Updated NLP generation code to cast loader/quantization config and ensure tokenizer/model decode/input return types are typed; also cast returned inputs in `_tokenize_input`. 
- Fixed Anthropic vendor stream/template handling by safely casting event indices, normalizing template message typing, and casting non-stream single responses to vendor stream types. 

Files with notable changes include `src/avalan/model/vision/*`, `src/avalan/model/vision/diffusion/*`, `src/avalan/model/audio/*`, `src/avalan/model/nlp/text/generation.py`, and `src/avalan/model/nlp/text/vendor/anthropic.py` where untyped external calls were wrapped with casts and small runtime assertions were added. 

### Testing
- Ran `make lint` and automatic format/lint checks which completed successfully. 
- Ran `poetry run mypy src/avalan` which returned `Success: no issues found in 153 source files` with no mypy errors remaining in app code. 
- Ran full test suite with `poetry run pytest --verbose -s` which completed successfully with `1579 passed, 11 skipped`. 
- Ran focused animation tests with `poetry run pytest tests/model/vision/animation_test.py` which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33cfaee3483239dd81c37f97f0167)