### PR TITLE
Harden mypy checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ lint:
 	poetry run ruff format --preview src/ tests/
 	poetry run black --preview --enable-unstable-feature=string_processing src/ tests/
 	poetry run ruff check --fix src/ tests/
+	poetry run mypy
 
 test:
 	poetry sync $(TEST_EXTRAS) --with test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ enable = true
 [tool.mypy]
 files = ["src/avalan"]
 plugins = ["pydantic.mypy"]
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_ignores = true
@@ -211,13 +212,22 @@ warn_redundant_casts = true
 warn_unused_configs = true
 show_error_codes = true
 show_column_numbers = true
+show_error_context = true
+show_error_code_links = true
 pretty = true
+exclude_gitignore = true
+local_partial_types = true
 check_untyped_defs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
-python_version = "3.11"
 disable_error_code = ["override"]
+enable_error_code = ["ignore-without-code"]
+
+[tool.pydantic-mypy]
+init_typed = true
+init_forbid_extra = true
+warn_required_dynamic_aliases = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -244,12 +254,10 @@ module = [
   "mlx_lm.*",
   "numpy",
   "ollama",
-  "ollama.*",
   "pgvector.*",
   "psutil",
   "pypdf",
   "RestrictedPython",
-  "RestrictedPython.*",
   "rich",
   "rich.*",
   "sympy",
@@ -267,7 +275,6 @@ module = [
   "transformers.*",
   "uvicorn",
   "vllm",
-  "vllm.*",
 ]
 ignore_missing_imports = true
 

--- a/src/avalan/server/a2a/router.py
+++ b/src/avalan/server/a2a/router.py
@@ -36,7 +36,7 @@ try:
     HAS_A2A = True
 except ImportError:
     HAS_A2A = False
-    a2a_types = None  # type: ignore
+    a2a_types = None  # type: ignore[assignment]
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse

--- a/src/avalan/server/routers/chat.py
+++ b/src/avalan/server/routers/chat.py
@@ -95,7 +95,7 @@ async def create_chat_completion(
     choices = [
         ChatCompletionChoice(
             index=i,
-            message=ChatMessage(role=str(MessageRole.ASSISTANT), content=text),
+            message=ChatMessage(role=MessageRole.ASSISTANT, content=text),
             finish_reason="stop",
         )
         for i in range(request.n or 1)

--- a/src/avalan/server/routers/mcp.py
+++ b/src/avalan/server/routers/mcp.py
@@ -1,5 +1,6 @@
 from ...agent.orchestrator import Orchestrator
 from ...entities import (
+    MessageRole,
     ReasoningToken,
     Token,
     TokenDetail,
@@ -402,7 +403,11 @@ def _build_chat_request(
     model_id = _default_model_id(orchestrator)
     return ChatCompletionRequest(
         model=model_id,
-        messages=[ChatMessage(role="user", content=tool_request.input_string)],
+        messages=[
+            ChatMessage(
+                role=MessageRole.USER, content=tool_request.input_string
+            )
+        ],
         stream=True,
     )
 
@@ -981,10 +986,12 @@ async def _tool_event_notifications(
             yield _resource_notification(resource)
             existing_resources = tool_summary.setdefault("resources", [])
             if isinstance(existing_resources, list):
-                existing_resources.append({
-                    "uri": resource.uri,
-                    "name": name,
-                })
+                existing_resources.append(
+                    {
+                        "uri": resource.uri,
+                        "name": name,
+                    }
+                )
 
     yield payload
 

--- a/src/avalan/tool/browser.py
+++ b/src/avalan/tool/browser.py
@@ -40,12 +40,12 @@ try:
 except ImportError:
     HAS_BROWSER_DEPENDENCIES = False
     IndexFlatL2 = None
-    MarkItDown = None  # type: ignore
-    vstack = None  # type: ignore
-    Browser = None  # type: ignore
-    Page = None  # type: ignore
-    PlaywrightContextManager = None  # type: ignore
-    async_playwright = None  # type: ignore
+    MarkItDown = None  # type: ignore[assignment, misc]
+    vstack = None  # type: ignore[assignment]
+    Browser = None  # type: ignore[assignment, misc]
+    Page = None  # type: ignore[assignment, misc]
+    PlaywrightContextManager = None  # type: ignore[assignment, misc]
+    async_playwright = None  # type: ignore[assignment]
 
 
 @final


### PR DESCRIPTION
### Motivation
- Improve static typing guarantees by enabling stricter mypy diagnostics and pydantic mypy plugin settings. 
- Make type-checking part of the standard lint workflow so regressions are caught early. 
- Fix a few code-sites that failed under stricter checking (import fallbacks and chat message role typing). 

### Description
- Tightened mypy configuration in `pyproject.toml` by adding `python_version`, `show_error_context`, `show_error_code_links`, `exclude_gitignore`, `local_partial_types`, and a `[tool.pydantic-mypy]` section (`init_typed`, `init_forbid_extra`, `warn_required_dynamic_aliases`).
- Adjusted error-code settings: enabled `ignore-without-code` explicitly and kept `override` disabled to remain compatible with the codebase.
- Added `poetry run mypy` to the `lint` Makefile target so `make lint` runs types checks.
- Replaced bare `# type: ignore` comments in import-fallback blocks with explicit ignores (e.g. `# type: ignore[assignment, misc]`) in `src/avalan/tool/browser.py` and `src/avalan/server/a2a/router.py` to satisfy `ignore-without-code` policy.
- Fixed typed usage of chat roles by using the `MessageRole` enum in `src/avalan/server/routers/chat.py` and `src/avalan/server/routers/mcp.py` instead of passing raw `str` values.

### Testing
- Ran `make lint` which executes formatting (`ruff`/`black`), lint fixes, and mypy; the target completed successfully.
- Ran `poetry run mypy` which reported `Success: no issues found in 153 source files`.
- Ran the full test suite with `poetry run pytest --verbose -s` which completed with `1579 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e342db79c48323a3827ebf2333c69a)