### PR TITLE
Always run dependency installation in CI workflow (remove cache-only conditional)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,6 @@ jobs:
 
       - name: Install dependencies
         id: install-deps
-        if: env.IGNORE_VENV_CACHE == 'true' || steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: >
           poetry install --no-interaction
           --extras agent


### PR DESCRIPTION
### Motivation

- Ensure the CI job always installs project dependencies (including test extras) even when a cached virtualenv is present so test runs do not encounter missing packages when the cache is hit.

### Description

- Removed the `if:` conditional that gated the `Install dependencies` step in `.github/workflows/test.yml`, so `poetry install --no-interaction --extras ... --with test` always runs in the workflow.
- Preserved the existing `Load cached venv`, optional dependency installation, and the Python 3.12-specific `mlx-lm` installation steps.

### Testing

- No automated tests were executed as part of this patch; the CI workflow defines running unit tests via `poetry run pytest --cov=src/ --cov-report=xml` and uploading coverage with `coverallsapp/github-action@v2`, which will run on the next workflow invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b03d86088323bea66eca1bd7f8cd)