### PR TITLE
Complete modalities TOC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,25 @@ task you need:
 * 🎧 [**Audio**](#audio): Turn audio into text or produce speech for accessibility and media.
   - 🦻 [Audio classification](#audio-classification): Label an audio based on sentiment.
   - 🗣️ [Speech recognition](#speech-recognition): Convert spoken audio to text.
+  - 🔊 [Text to speech](#text-to-speech): Synthesize natural speech from text.
+  - 🎵 [Audio generation](#audio-generation): Generate or continue audio from prompts.
+* 📝 [**Text**](#text): Understand, transform, and generate text across core NLP tasks.
+  - ❓ [Question answering](#question-answering): Extract precise answers from context.
+  - 🏷️ [Sequence classification](#sequence-classification): Classify text into labels.
+  - 🔁 [Sequence to sequence](#sequence-to-sequence): Rewrite or transform text-to-text.
+  - ✍️ [Text generation](#text-generation): Produce completions and long-form responses.
+  - 🧩 [Token classification](#token-classification): Label entities and token-level tags.
+  - 🌍 [Translation](#translation): Translate text between languages.
+* 👁️ [**Vision**](#vision): Analyze images and create visual outputs from prompts.
+  - 🖼️ [Encoder decoder](#encoder-decoder): Caption images with encoder-decoder models.
+  - 🧪 [Image classification](#image-classification): Predict image classes and scores.
+  - 📝 [Image to text](#image-to-text): Describe image content in natural language.
+  - 💬 [Image text to text](#image-text-to-text): Answer questions grounded in images.
+  - 🎯 [Object detection](#object-detection): Detect and localize objects.
+  - 🧱 [Semantic segmentation](#semantic-segmentation): Label each pixel by class.
+  - 🕺 [Text to animation](#text-to-animation): Create animated clips from prompts.
+  - 🎨 [Text to image](#text-to-image): Generate images from text prompts.
+  - 🎬 [Text to video](#text-to-video): Generate short videos from prompts.
 
 ### Audio
 


### PR DESCRIPTION
### Motivation
- Fill out the incomplete Modalities mini-TOC so readers can quickly navigate to all Audio, Text, and Vision examples using the existing emoji + concise-description style.

### Description
- Update `README.md` Modalities section to add missing Audio entries (`Text to speech`, `Audio generation`), Text entries (`Question answering`, `Sequence classification`, `Sequence to sequence`, `Text generation`, `Token classification`, `Translation`), and Vision entries (`Encoder decoder`, `Image classification`, `Image to text`, `Image text to text`, `Object detection`, `Semantic segmentation`, `Text to animation`, `Text to image`, `Text to video`) while preserving the emoji-first concise descriptions.

### Testing
- Ran `make lint`, which formatted files but ultimately failed at `poetry run mypy` due to a missing plugin error: `Error importing plugin "pydantic.mypy": No module named 'pydantic'`.
- Ran `poetry run pytest --verbose -s`, which passed with `1601 passed, 11 skipped`.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b86ecb4c8323af46e28b2de4d84c)