### PR TITLE
Add agent tests to achieve 100% coverage for src/avalan/agent

### DIFF
--- a/tests/agent/engine_agent_test.py
+++ b/tests/agent/engine_agent_test.py
@@ -258,6 +258,21 @@ class EngineAgentRunTestCase(IsolatedAsyncioTestCase):
         ].operation.generation_settings
         self.assertEqual(used_settings.top_p, 0.5)
 
+    async def test_run_with_list_of_strings_converts_to_user_messages(self):
+        agent, _, memory, manager = self._make_agent()
+        context = self._make_context("unused")
+
+        await agent._run(context, ["hello", "world"])
+
+        self.assertEqual(len(memory.recent_messages), 2)
+        first = memory.recent_messages[0].message
+        second = memory.recent_messages[1].message
+        self.assertEqual(first.role, MessageRole.USER)
+        self.assertEqual(first.content, "hello")
+        self.assertEqual(second.role, MessageRole.USER)
+        self.assertEqual(second.content, "world")
+        manager.assert_awaited_once()
+
 
 class EngineAgentCallTestCase(IsolatedAsyncioTestCase):
     def setUp(self):

--- a/tests/agent/orchestrator_test.py
+++ b/tests/agent/orchestrator_test.py
@@ -149,6 +149,65 @@ class OrchestratorCallTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, "done")
 
 
+class OrchestratorInputTokenCountTestCase(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        engine_uri = EngineUri(
+            host=None,
+            port=None,
+            user=None,
+            password=None,
+            vendor=None,
+            model_id="m",
+            params={},
+        )
+        environment = EngineEnvironment(
+            engine_uri=engine_uri, settings=TransformerEngineSettings()
+        )
+        operation = AgentOperation(
+            specification=Specification(role=None, goal=None),
+            environment=environment,
+        )
+        memory = MagicMock(spec=MemoryManager)
+        memory.participant_id = uuid4()
+        self.orchestrator = Orchestrator(
+            MagicMock(),
+            MagicMock(spec=ModelManager),
+            memory,
+            MagicMock(spec=ToolManager),
+            MagicMock(spec=EventManager),
+            [operation],
+        )
+
+    def test_input_token_count_without_engine_agent(self):
+        self.assertIsNone(self.orchestrator.input_token_count)
+
+    def test_input_token_count_runs_callable_without_running_loop(self):
+        engine_agent = MagicMock()
+        engine_agent.input_token_count = AsyncMock(return_value=11)
+        engine_agent.output = None
+        self.orchestrator._last_engine_agent = engine_agent
+
+        self.assertEqual(self.orchestrator.input_token_count, 11)
+
+    async def test_input_token_count_returns_output_count_inside_loop(self):
+        engine_agent = MagicMock()
+        engine_agent.input_token_count = AsyncMock(return_value=5)
+        engine_agent.output = MagicMock(input_token_count=7)
+        self.orchestrator._last_engine_agent = engine_agent
+
+        self.assertEqual(self.orchestrator.input_token_count, 7)
+
+    async def test_input_token_count_returns_none_inside_loop_without_output(
+        self,
+    ):
+        engine_agent = MagicMock()
+        engine_agent.input_token_count = AsyncMock(return_value=5)
+        engine_agent.output = None
+        self.orchestrator._last_engine_agent = engine_agent
+
+        self.assertIsNone(self.orchestrator.input_token_count)
+
+
 class OrchestratorAenterTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_aenter_loads_engine_and_agent(self):
         env = EngineEnvironment(


### PR DESCRIPTION
### Motivation
- Close remaining uncovered branches in the agent module by testing list-to-message normalization and all `input_token_count` code paths. 
- Ensure `EngineAgent._run` handles `list[str]` inputs correctly and `Orchestrator.input_token_count` behaves across sync/async contexts.

### Description
- Added `test_run_with_list_of_strings_converts_to_user_messages` to `tests/agent/engine_agent_test.py` which passes `list[str]` to `EngineAgent._run` and asserts the strings are converted to `Message` objects with `MessageRole.USER` and forwarded to the model call. 
- Added `OrchestratorInputTokenCountTestCase` to `tests/agent/orchestrator_test.py` with tests for: no engine agent set, a callable token counter executed outside a running loop, a callable counter while inside a running loop returning an output count, and a callable counter inside a running loop without output. 
- Minor test import/structure cleanups to keep the new tests consistent with existing test patterns.

### Testing
- Ran `poetry run pytest tests/agent/engine_agent_test.py tests/agent/orchestrator_test.py -q` and observed `30 passed`.
- Ran the full test suite with `poetry run pytest --verbose -s` and observed `1606 passed, 11 skipped`.
- Checked agent coverage with `poetry run pytest tests/agent --cov=src/avalan/agent --cov-report=term-missing -q` which reports `100%` coverage for `src/avalan/agent`.
- Ran `make lint` which completed formatting and ruff checks, but `mypy` failed in this environment due to a missing `pydantic` mypy plugin dependency (environment-specific; linters otherwise passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65395f0608323a4c4968f7da08641)