### PR TITLE
Increase coverage for cli, deploy, and flow packages

### DIFF
--- a/tests/cli/download_test.py
+++ b/tests/cli/download_test.py
@@ -71,3 +71,36 @@ class DownloadTestCase(TestCase):
             calls["task_kwargs"],
             {"total": 10.0, "completed": 0},
         )
+
+    def test_tqdm_rich_progress_allows_unknown_total(self):
+        calls: dict[str, object] = {}
+
+        class DummyProgress:
+            def __init__(self, *_progress_columns, **_kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return None
+
+            def add_task(self, _description: str, **kwargs) -> int:
+                calls["task_kwargs"] = kwargs
+                return 1
+
+            def update(self, *_args, **_kwargs):
+                return None
+
+            def reset(self, *_args, **_kwargs):
+                return None
+
+        with patch.object(download, "Progress", DummyProgress):
+            prog = download.tqdm_rich_progress(
+                total=None,
+                disable=False,
+                progress=("col",),
+            )
+            prog.close()
+
+        self.assertEqual(calls["task_kwargs"], {"total": None, "completed": 0})

--- a/tests/cli/input_test.py
+++ b/tests/cli/input_test.py
@@ -1,3 +1,4 @@
+from io import UnsupportedOperation
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
@@ -101,6 +102,12 @@ class CliConfirmHasInputTestCase(TestCase):
 
     def test_has_input_false(self):
         with patch("avalan.cli.select", return_value=([], [], [])):
+            self.assertFalse(has_input(MagicMock()))
+
+    def test_has_input_unsupported_operation(self):
+        with patch(
+            "avalan.cli.select", side_effect=UnsupportedOperation("not tty")
+        ):
             self.assertFalse(has_input(MagicMock()))
 
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -4811,6 +4811,71 @@ class CliModelInternalTestCase(IsolatedAsyncioTestCase):
         self.assertTrue(stop_signal.is_set())
         slp.assert_called()
 
+    async def test_token_stream_supports_awaitable_theme_tokens(self):
+        async def token_gen():
+            yield model_cmds.Token(id=1, token="A")
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                return token_gen()
+
+        async def fake_frames():
+            yield (None, "frame")
+
+        async def awaitable_frames(*_args, **_kwargs):
+            return fake_frames()
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=1,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=1.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+        )
+
+        console = MagicMock()
+        console.width = 80
+        stop_signal = asyncio.Event()
+        group = SimpleNamespace(renderables=[None])
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=awaitable_frames)
+        lm = SimpleNamespace(
+            model_id="m", tokenizer_config=None, input_token_count=lambda _: 1
+        )
+
+        await model_cmds._token_stream(
+            live=MagicMock(),
+            group=group,
+            tokens_group_index=0,
+            args=args,
+            console=console,
+            theme=theme,
+            logger=MagicMock(),
+            orchestrator=None,
+            event_stats=None,
+            lm=lm,
+            input_string="hi",
+            response=Resp(),
+            display_tokens=1,
+            dtokens_pick=0,
+            refresh_per_second=2,
+            stop_signal=stop_signal,
+            tool_events_limit=None,
+            with_stats=True,
+        )
+
+        self.assertTrue(stop_signal.is_set())
+
 
 class CliRecordOptionTestCase(IsolatedAsyncioTestCase):
     async def test_token_generation_record_enables_screen(self):

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -428,6 +428,51 @@ class FancyThemeTestCase(IsolatedAsyncioTestCase):
         pad = self.theme.saved_tokenizer_files("/d", 2)
         self.assertIn("2 tokenizer files", pad.renderable)
 
+    def test_saved_tokenizer_files_with_total_only(self):
+        pad = self.theme.saved_tokenizer_files(1)
+        self.assertIn("1 tokenizer file", pad.renderable)
+
+    def test_events_log_tool_branches(self):
+        tool_call = SimpleNamespace(
+            id=UUID(int=2), name="calc", arguments={"x": 1}
+        )
+        tool_result = SimpleNamespace(call=tool_call, result={"ok": True})
+        events = [
+            Event(
+                type=EventType.TOOL_EXECUTE,
+                payload={"call": tool_call},
+            ),
+            Event(
+                type=EventType.TOOL_MODEL_RUN,
+                payload={"model_id": "react", "messages": ["a", "b"]},
+            ),
+            Event(
+                type=EventType.TOOL_MODEL_RESPONSE,
+                payload={"model_id": "react"},
+            ),
+            Event(
+                type=EventType.TOOL_PROCESS,
+                payload=[SimpleNamespace(name="weather")],
+            ),
+            Event(
+                type=EventType.TOOL_RESULT,
+                payload={"result": tool_result},
+                elapsed=0.01,
+            ),
+        ]
+
+        log = self.theme._events_log(
+            events,
+            events_limit=None,
+            include_tokens=False,
+            include_tool_detect=False,
+            include_tools=True,
+            include_non_tools=False,
+        )
+
+        assert log is not None
+        self.assertEqual(len(log), 5)
+
     def test_search_message_matches(self):
         msg = EngineMessageScored(
             agent_id=UUID(int=0),

--- a/tests/cli/tokenizer_test.py
+++ b/tests/cli/tokenizer_test.py
@@ -214,3 +214,28 @@ class CliTokenizerTestCase(IsolatedAsyncioTestCase):
             self.console.print.call_args_list,
             [call("cfg_panel"), call("tokens_panel")],
         )
+
+    async def test_tokenize_input_empty_returns_none(self):
+        args = Namespace(**vars(self.args))
+
+        dummy_model = MagicMock()
+        dummy_model.__enter__.return_value = dummy_model
+        dummy_model.__exit__.return_value = False
+        dummy_model.tokenizer_config = SimpleNamespace(
+            tokens=["x"], special_tokens=["y"]
+        )
+
+        with (
+            patch.object(
+                self.tokenizer_mod,
+                "TextGenerationModel",
+                return_value=dummy_model,
+            ),
+            patch.object(self.tokenizer_mod, "get_input", return_value=""),
+        ):
+            result = await self.tokenizer_mod.tokenize(
+                args, self.console, self.theme, self.hub, self.logger
+            )
+
+        self.assertIsNone(result)
+        self.theme.tokenizer_tokens.assert_not_called()

--- a/tests/deploy/aws_test.py
+++ b/tests/deploy/aws_test.py
@@ -252,6 +252,31 @@ class AwsTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(db, "db")
         self.aws._rds.create_db_instance.assert_not_called()
 
+    async def test_create_rds_if_missing_handles_client_error_not_found(self):
+        self.aws._rds.exceptions = MagicMock(DBInstanceNotFoundFault=None)
+        self.aws._rds.describe_db_instances = AsyncMock(
+            side_effect=DummyClientError(
+                {"Error": {"Code": "DBInstanceNotFound"}}, "describe"
+            )
+        )
+        self.aws._rds.create_db_instance = AsyncMock()
+        waiter = MagicMock()
+        waiter.wait = AsyncMock()
+        self.aws._rds.get_waiter = AsyncMock(return_value=waiter)
+
+        db = await self.aws.create_rds_if_missing("db", "cls", "sg", 10)
+
+        self.assertEqual(db, "db")
+        self.aws._rds.create_db_instance.assert_awaited_once()
+
+    async def test_create_rds_if_missing_reraises_unknown_error(self):
+        self.aws._rds.exceptions = MagicMock(DBInstanceNotFoundFault=None)
+        err = DummyClientError({"Error": {"Code": "AccessDenied"}}, "describe")
+        self.aws._rds.describe_db_instances = AsyncMock(side_effect=err)
+
+        with self.assertRaises(DummyClientError):
+            await self.aws.create_rds_if_missing("db", "cls", "sg", 10)
+
     async def test_create_instance_if_missing(self):
         self.aws._ec2.describe_instances = AsyncMock(
             return_value={

--- a/tests/flow/flow_extra_test.py
+++ b/tests/flow/flow_extra_test.py
@@ -47,6 +47,55 @@ invalid
         result = flow.execute()
         self.assertEqual(result, {"B": 2, "C": 2})
 
+    def test_execute_detects_reachable_cycle(self) -> None:
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=lambda _: 2))
+        flow.add_node(Node("C", func=lambda _: 3))
+        flow.add_connection("A", "B")
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        with self.assertRaises(ValueError) as context:
+            flow.execute()
+
+        self.assertIn("cycle", str(context.exception))
+
+    def test_resolve_start_nodes_with_unknown_node_inputs(self) -> None:
+        flow = Flow()
+        flow.add_node(Node("A"))
+
+        with self.assertRaises(KeyError):
+            flow.execute(initial_node=Node("B"))
+
+        with self.assertRaises(KeyError):
+            flow.execute(initial_node="B")
+
+    def test_execute_with_existing_node_instance(self) -> None:
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda inputs: inputs.get("__init__", 0)))
+
+        result = flow.execute(initial_node=Node("A"), initial_data=7)
+
+        self.assertEqual(result, 7)
+
+    def test_detect_cycle_nodes_handles_previously_visited_branch(
+        self,
+    ) -> None:
+        flow = Flow()
+        flow.add_node(Node("A"))
+        flow.add_node(Node("B"))
+        flow.add_node(Node("C"))
+        flow.add_node(Node("D"))
+        flow.add_connection("A", "B")
+        flow.add_connection("A", "C")
+        flow.add_connection("B", "D")
+        flow.add_connection("C", "D")
+
+        cycle_nodes = flow._detect_cycle_nodes([flow.nodes["A"]])
+
+        self.assertEqual(cycle_nodes, set())
+
 
 class ConnectionReprTestCase(unittest.TestCase):
     def test_repr(self) -> None:


### PR DESCRIPTION
### Motivation
- Reach full test coverage for `src/avalan/cli`, `src/avalan/deploy`, and `src/avalan/flow` and exercise uncovered edge branches. 
- Add focused unit tests to validate error handling and alternative control-flow paths in CLI, AWS deploy, and Flow logic.

### Description
- Added tests for CLI input handling including `has_input` when `select()` raises `UnsupportedOperation` and tokenizer interactive input returning `None` when empty. 
- Added download progress tests for `tqdm_rich_progress` covering the `total=None` branch and progress/task option construction. 
- Extended Fancy theme tests to cover integer-only `saved_tokenizer_files()` usage and `_events_log()` branches for `TOOL_EXECUTE`, `TOOL_MODEL_RUN`, `TOOL_MODEL_RESPONSE`, `TOOL_PROCESS`, and `TOOL_RESULT`. 
- Added model token-stream test for `theme.tokens` returning an awaitable, and AWS deploy tests for RDS creation error handling (missing instance versus unexpected `ClientError`); added Flow tests for reachable-cycle detection, unknown start-node resolution, existing `Node` start execution, and previously-visited DFS branch behavior.

### Testing
- Ran linting with `make lint` (ruff/black/mypy) and it completed successfully. 
- Ran focused pytest on modified tests with `poetry run pytest tests/cli/input_test.py tests/cli/download_test.py tests/cli/tokenizer_test.py tests/cli/theme_fancy_test.py tests/cli/model_test.py tests/deploy/aws_test.py tests/flow/flow_extra_test.py -q` and observed `173 passed`. 
- Ran coverage for the targeted packages with `poetry run pytest --cov=src/avalan/cli --cov=src/avalan/deploy --cov=src/avalan/flow --cov-report=term-missing -q` and verified 100% coverage for those packages. 
- Ran the full test suite with `poetry run pytest --verbose -s` and observed `1618 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e659dacc348323a1030326e48b2992)