### PR TITLE
Add coverage tests for secrets and server modules

### DIFF
--- a/tests/secrets/keyring_module_test.py
+++ b/tests/secrets/keyring_module_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase, main
 from unittest.mock import MagicMock, patch
 
+from avalan.secrets import keyring as keyring_module
 from avalan.secrets.keyring import KeyringSecrets
 
 
@@ -19,6 +20,15 @@ class KeyringModuleTest(TestCase):
         ring.set_password.assert_called_once_with("avalan", "k", "v")
 
         sec.delete("k")
+        ring.delete_password.assert_called_once_with("avalan", "k")
+
+    def test_delete_without_password_delete_error_guard(self) -> None:
+        ring = MagicMock()
+        secrets = KeyringSecrets(ring)
+
+        with patch.object(keyring_module, "_password_delete_error", None):
+            secrets.delete("k")
+
         ring.delete_password.assert_called_once_with("avalan", "k")
 
 

--- a/tests/server/a2a_router_unit_extra_test.py
+++ b/tests/server/a2a_router_unit_extra_test.py
@@ -55,6 +55,7 @@ from avalan.server.a2a.router import (
     _skill_tags,
     _state_for_item,
     _status_to_state,
+    _STREAM_RESPONSE_ID_UNSET,
     _task_metadata,
     _task_metadata_from_overview,
     _timestamp_to_iso,
@@ -584,6 +585,16 @@ async def _run_event_converter_fallbacks() -> None:
         "data": {"message": {}},
     }
     assert await converter.convert(message_event) == message_event
+    assert await converter._response_id() is None
+
+    converter._cached_response_id = _STREAM_RESPONSE_ID_UNSET
+
+    async def _overview_with_unset(task_id: str) -> dict[str, object]:
+        assert task_id == "convert-fallback"
+        return {"metadata": {"jsonrpc_id": _STREAM_RESPONSE_ID_UNSET}}
+
+    store.get_task_overview = _overview_with_unset  # type: ignore[assignment]
+    assert await converter._response_id() is None
 
 
 def test_message_and_artifact_result_branches() -> None:

--- a/tests/server/mcp_router_test.py
+++ b/tests/server/mcp_router_test.py
@@ -1008,6 +1008,31 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
         self.assertFalse(tool_summaries)
         self.assertFalse(resources)
 
+    async def test_tool_event_notifications_ignores_non_string_call_id(
+        self,
+    ) -> None:
+        tool_summaries: dict[str, dict[str, Any]] = {}
+        resources: dict[str, mcp_router.MCPResource] = {}
+        store = mcp_router.MCPResourceStore()
+        event = Event(type=EventType.TOOL_PROCESS, payload=None)
+
+        with patch.object(
+            mcp_router, "_tool_call_event_item", return_value={"id": 1}
+        ):
+            items = []
+            async for item in mcp_router._tool_event_notifications(
+                event=event,
+                tool_summaries=tool_summaries,
+                resources=resources,
+                resource_store=store,
+                base_path="/base",
+            ):
+                items.append(item)
+
+        self.assertFalse(items)
+        self.assertFalse(tool_summaries)
+        self.assertFalse(resources)
+
     async def test_tool_event_notifications_append_existing_resource(
         self,
     ) -> None:

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -207,6 +207,23 @@ class ResponsesUtilsTestCase(TestCase):
         result_payload = loads(delta["result"])
         self.assertEqual(result_payload["payload"], {"status": "ok"})
 
+    def test_tool_call_event_item_supports_indexed_mapping_payload(
+        self,
+    ) -> None:
+        call = ToolCall(id="c6", name="calc", arguments={"n": 1})
+
+        class IndexedPayload(dict[int, ToolCall]):
+            pass
+
+        event = Event(
+            type=EventType.TOOL_PROCESS,
+            payload=IndexedPayload({0: call}),
+        )
+
+        item = _tool_call_event_item(event)
+        self.assertEqual(item["id"], "c6")
+        self.assertEqual(item["name"], "calc")
+
     def test_sse_formats_event_and_data(self) -> None:
         result = sse_message(to_json({"a": 1}), event="test.event")
         self.assertEqual(result, 'event: test.event\ndata: {"a": 1}\n\n')


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for `src/avalan/secrets` and `src/avalan/server` to exercise edge branches and reach full coverage.
- Ensure code paths that depend on optional dependencies or unusual payload shapes are validated by tests.

### Description
- Added a test in `tests/secrets/keyring_module_test.py` to exercise `KeyringSecrets.delete()` when the `_password_delete_error` guard is absent and assert `delete_password` is still called.
- Extended A2A converter fallback tests in `tests/server/a2a_router_unit_extra_test.py` to cover the `_response_id()` code path that uses the `_STREAM_RESPONSE_ID_UNSET` sentinel by stubbing `get_task_overview()`.
- Added an async test in `tests/server/mcp_router_test.py` to verify `_tool_event_notifications()` no-ops when `_tool_call_event_item()` returns a non-string `id`.
- Added a responses utils test in `tests/server/responses_utils_test.py` to validate `_tool_call_event_item()` handles an indexed-mapping payload type (mapping with integer keys) the same as list/dict payloads.

### Testing
- Ran the new focused test set with `poetry run pytest tests/secrets/keyring_module_test.py tests/server/a2a_router_unit_extra_test.py tests/server/mcp_router_test.py tests/server/responses_utils_test.py -q` and all tests passed.
- Ran full test and coverage checks with `poetry run pytest --cov=src/avalan/secrets --cov=src/avalan/server --cov-report=term-missing -q` which reported 100% coverage for both `src/avalan/secrets` and `src/avalan/server`.
- Ran linting and type checks with `make lint` and `poetry run mypy` and resolved formatting; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68e355b0c832384797cce680f4c3d)