### PR TITLE
Add engine module lookup coverage test

### DIFF
--- a/tests/model/engine_more_coverage_test.py
+++ b/tests/model/engine_more_coverage_test.py
@@ -45,6 +45,13 @@ class WeightAndDeviceTestCase(TestCase):
         ):
             self.assertEqual(Engine.get_default_device(), "cpu")
 
+    def test_has_module_handles_module_not_found(self) -> None:
+        with patch(
+            "avalan.model.engine.find_spec",
+            side_effect=ModuleNotFoundError("missing parent package"),
+        ):
+            self.assertFalse(Engine._has_module("mlx.nn"))
+
 
 class UsesTokenizerPropertyTestCase(TestCase):
     def test_default_property(self) -> None:


### PR DESCRIPTION
### Motivation
- Cover the previously untested exception branch in `Engine._has_module` where `importlib.util.find_spec` can raise `ModuleNotFoundError`, ensuring the model engine module lookup behaviour is exercised.

### Description
- Add `test_has_module_handles_module_not_found` to `tests/model/engine_more_coverage_test.py` to patch `avalan.model.engine.find_spec` raising `ModuleNotFoundError` and assert `Engine._has_module(...)` returns `False`.

### Testing
- Ran `make lint` which completed successfully, and ran `poetry run pytest --verbose -s tests/model/engine_more_coverage_test.py` (11 passed), `poetry run pytest --cov=src/avalan/model --cov-report=json tests/model` (473 passed, 2 skipped; coverage JSON shows model files covered), and the full test suite via `poetry run pytest --verbose -s` (1662 passed, 11 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ca59fec483238584ca253da93bea)