### PR TITLE
Split GraphToolSettings into lightweight graph_settings module

### DIFF
--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -29,8 +29,8 @@ from ..tool.database.toolset import DatabaseToolSet
 from ..tool.graph import (
     HAS_GRAPH_DEPENDENCIES,
     GraphToolSet,
-    GraphToolSettings,
 )
+from ..tool.graph_settings import GraphToolSettings
 from ..tool.manager import ToolManager
 from ..tool.math import MathToolSet
 from ..tool.memory import MemoryToolSet

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -49,7 +49,7 @@ from ..model.manager import ModelManager
 from ..model.transformer import TransformerModel
 from ..tool.browser import BrowserToolSettings
 from ..tool.database.settings import DatabaseToolSettings
-from ..tool.graph import GraphToolSettings
+from ..tool.graph_settings import GraphToolSettings
 from ..utils import logger_replace
 
 import gettext

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -24,7 +24,7 @@ from ...server import agents_server
 from ...tool.browser import BrowserToolSettings
 from ...tool.context import ToolSettingsContext
 from ...tool.database.settings import DatabaseToolSettings
-from ...tool.graph import GraphToolSettings
+from ...tool.graph_settings import GraphToolSettings
 
 from argparse import Namespace
 from contextlib import AsyncExitStack

--- a/src/avalan/tool/context.py
+++ b/src/avalan/tool/context.py
@@ -1,6 +1,6 @@
 from .browser import BrowserToolSettings
 from .database import DatabaseToolSettings
-from .graph import GraphToolSettings
+from .graph_settings import GraphToolSettings
 
 from dataclasses import dataclass
 from typing import final

--- a/src/avalan/tool/graph.py
+++ b/src/avalan/tool/graph.py
@@ -1,16 +1,16 @@
 from ..compat import override
 from ..entities import ToolCallContext
 from . import Tool, ToolSet
+from .graph_settings import GraphToolSettings
 
 from base64 import b64encode
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
 from io import BytesIO
 from math import isfinite
 from os import environ
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Any, Literal, final
+from typing import Any, Literal
 
 environ.setdefault("MPLCONFIGDIR", f"{gettempdir()}/avalan-matplotlib")
 environ.setdefault("XDG_CACHE_HOME", f"{gettempdir()}/avalan-cache")
@@ -37,15 +37,6 @@ GRAPH_MIME_TYPES: dict[GraphOutputFormat, str] = {
     "svg": "image/svg+xml",
     "pdf": "application/pdf",
 }
-
-
-@final
-@dataclass(frozen=True, kw_only=True, slots=True)
-class GraphToolSettings(dict[str, object]):
-    file: str | None = None
-
-    def __post_init__(self) -> None:
-        self["file"] = self.file
 
 
 class GraphRenderer:

--- a/src/avalan/tool/graph_settings.py
+++ b/src/avalan/tool/graph_settings.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import final
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
+class GraphToolSettings(dict[str, object]):
+    """Store configuration settings for graph tools.
+
+    This class is separated from the main graph module to allow importing
+    settings without importing matplotlib or running graph backend setup.
+    """
+
+    file: str | None = None
+
+    def __post_init__(self) -> None:
+        self["file"] = self.file

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -18,7 +18,7 @@ from avalan.model.hubs.huggingface import HuggingfaceHub
 from avalan.tool.browser import BrowserToolSettings
 from avalan.tool.context import ToolSettingsContext
 from avalan.tool.database import DatabaseToolSettings
-from avalan.tool.graph import GraphToolSettings
+from avalan.tool.graph_settings import GraphToolSettings
 
 
 class LoaderPropertyTestCase(IsolatedAsyncioTestCase):

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -44,7 +44,7 @@ from avalan.model.response.text import TextGenerationResponse
 from avalan.tool.browser import BrowserToolSettings
 from avalan.tool.context import ToolSettingsContext
 from avalan.tool.database import DatabaseToolSettings
-from avalan.tool.graph import GraphToolSettings
+from avalan.tool.graph_settings import GraphToolSettings
 from avalan.tool.manager import ToolManager, ToolManagerSettings
 from avalan.tool.parser import ToolCallParser
 

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -165,6 +165,22 @@ class CliModelTestCase(TestCase):
         ):
             model_cmds._text_generation_input("Summarize", [str(missing)])
 
+    def test_text_generation_input_without_files_returns_input(self) -> None:
+        self.assertEqual(
+            model_cmds._text_generation_input("Hello", None), "Hello"
+        )
+        self.assertIsNone(model_cmds._text_generation_input(None, []))
+
+    def test_supports_optional_stdin_only_for_encoder_decoder(self) -> None:
+        self.assertTrue(
+            model_cmds._supports_optional_stdin(
+                Modality.VISION_ENCODER_DECODER
+            )
+        )
+        self.assertFalse(
+            model_cmds._supports_optional_stdin(Modality.TEXT_GENERATION)
+        )
+
     def test_model_install_secret_creates_secret(self):
         args = Namespace(skip_display_reasoning_time=False, model="m")
         engine_uri = SimpleNamespace(
@@ -227,6 +243,30 @@ class CliModelTestCase(TestCase):
             local_dir_use_symlinks=True,
         )
 
+    def test_model_install_secret_no_override_when_declined(self):
+        args = Namespace(skip_display_reasoning_time=False, model="m")
+        engine_uri = SimpleNamespace(
+            vendor="openai", password="pw", user="secret"
+        )
+        secrets = MagicMock()
+        secrets.read.return_value = "tok"
+        with (
+            patch.object(
+                model_cmds.ModelManager, "parse_uri", return_value=engine_uri
+            ),
+            patch.object(model_cmds, "KeyringSecrets", return_value=secrets),
+            patch.object(model_cmds, "cache_download") as cache_download,
+            patch.object(model_cmds, "confirm", return_value=False),
+            patch.object(model_cmds.Prompt, "ask") as ask,
+        ):
+            model_cmds.model_install(args, self.console, self.theme, self.hub)
+
+        ask.assert_not_called()
+        secrets.write.assert_not_called()
+        cache_download.assert_called_once_with(
+            args, self.console, self.theme, self.hub
+        )
+
     def test_model_uninstall_secret(self):
         args = Namespace(skip_display_reasoning_time=False, model="m")
         engine_uri = SimpleNamespace(
@@ -248,6 +288,26 @@ class CliModelTestCase(TestCase):
 
         ks.assert_called_once_with()
         secrets.delete.assert_called_once_with("pw")
+        cache_delete.assert_called_once_with(
+            args, self.console, self.theme, self.hub, is_full_deletion=True
+        )
+
+    def test_model_uninstall_without_secret_skips_keyring(self):
+        args = Namespace(skip_display_reasoning_time=False, model="m")
+        engine_uri = SimpleNamespace(vendor=None, password=None, user=None)
+
+        with (
+            patch.object(
+                model_cmds.ModelManager, "parse_uri", return_value=engine_uri
+            ),
+            patch.object(model_cmds, "KeyringSecrets") as keyring_secrets,
+            patch.object(model_cmds, "cache_delete") as cache_delete,
+        ):
+            model_cmds.model_uninstall(
+                args, self.console, self.theme, self.hub
+            )
+
+        keyring_secrets.assert_not_called()
         cache_delete.assert_called_once_with(
             args, self.console, self.theme, self.hub, is_full_deletion=True
         )
@@ -591,13 +651,11 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
         captured: list[dict[str, float | int | None]] = []
 
         async def fake_tokens(*p, **kw):
-            captured.append(
-                {
-                    "total_tokens": p[12],
-                    "ttft": p[17],
-                    "ttnt": p[18],
-                }
-            )
+            captured.append({
+                "total_tokens": p[12],
+                "ttft": p[17],
+                "ttnt": p[18],
+            })
             yield (None, "frame")
 
         theme = MagicMock()
@@ -672,17 +730,15 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
         captured: list[dict[str, object]] = []
 
         async def fake_tokens(*p, **kw):
-            captured.append(
-                {
-                    "tool_text_tokens": list(p[8]),
-                    "tokens": list(p[10]) if p[10] else None,
-                    "input_token_count": p[11],
-                    "total_tokens": p[12],
-                    "ttft": p[17],
-                    "ttnt": p[18],
-                    "tool_token_count": kw["tool_token_count"],
-                }
-            )
+            captured.append({
+                "tool_text_tokens": list(p[8]),
+                "tokens": list(p[10]) if p[10] else None,
+                "input_token_count": p[11],
+                "total_tokens": p[12],
+                "ttft": p[17],
+                "ttnt": p[18],
+                "tool_token_count": kw["tool_token_count"],
+            })
             yield (None, "frame")
 
         theme = MagicMock()
@@ -1283,17 +1339,15 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
         call_args: list[dict] = []
 
         async def fake_tokens(*p, **kw):
-            call_args.append(
-                {
-                    "text_tokens": list(p[7]) + list(p[9]),
-                    "tokens": list(p[10]) if p[10] else None,
-                    "tool_events": list(p[13]),
-                    "tool_event_calls": list(p[14]),
-                    "tool_event_results": list(p[15]),
-                    "spinner": p[16],
-                    "input_token_count": p[11],
-                }
-            )
+            call_args.append({
+                "text_tokens": list(p[7]) + list(p[9]),
+                "tokens": list(p[10]) if p[10] else None,
+                "tool_events": list(p[13]),
+                "tool_event_calls": list(p[14]),
+                "tool_event_results": list(p[15]),
+                "spinner": p[16],
+                "input_token_count": p[11],
+            })
             yield (None, "frame")
 
         theme = MagicMock()
@@ -6183,9 +6237,9 @@ class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):
             tokens.append(t)
 
         self.assertEqual(
-            len(
-                [t for t in tokens if isinstance(t, model_cmds.ReasoningToken)]
-            ),
+            len([
+                t for t in tokens if isinstance(t, model_cmds.ReasoningToken)
+            ]),
             4,
         )
         self.assertEqual(

--- a/tests/tool/graph_settings_test.py
+++ b/tests/tool/graph_settings_test.py
@@ -1,0 +1,8 @@
+from avalan.tool.graph_settings import GraphToolSettings
+
+
+def test_graph_tool_settings_dict_mapping() -> None:
+    settings = GraphToolSettings(file="/tmp/chart.png")
+
+    assert settings.file == "/tmp/chart.png"
+    assert settings["file"] == "/tmp/chart.png"


### PR DESCRIPTION
### Motivation
- Importing `GraphToolSettings` from the main `graph` module caused top-level `matplotlib` initialization for callers that only need settings, adding unnecessary startup cost; the database tool already avoids this by using a separate `database/settings.py` module.

### Description
- Add a new lightweight module `src/avalan/tool/graph_settings.py` that defines `GraphToolSettings` as a frozen dataclass mapping to a dict and documents why it is separated from the heavy graph module.
- Remove the `GraphToolSettings` definition from `src/avalan/tool/graph.py` and import it from `..tool.graph_settings` instead, leaving actual matplotlib/backend initialization confined to `graph.py`.
- Update settings-only import sites to use `graph_settings` (`src/avalan/tool/context.py`, `src/avalan/cli/__main__.py`, `src/avalan/cli/commands/agent.py`, `src/avalan/agent/loader.py`, and tests) while keeping `GraphToolSet` imports where the full graph implementation is required.
- Add `tests/tool/graph_settings_test.py` to assert the `file` attribute and dict mapping behavior of the new settings class.

### Testing
- Run `make lint` (which runs `ruff` and `black`) and static checks, and they passed with formatting applied and no ruff errors.
- Run the full test suite with `poetry run pytest --verbose -s` and it succeeded: `1773 passed, 11 skipped, 7 warnings`.
- Run targeted tests with `poetry run pytest --verbose -s tests/tool/graph_settings_test.py tests/agent/loader_test.py tests/cli/agent_test.py` and they succeeded: `92 passed, 1 skipped, 6 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2275465b48323acc303415671124c)