### PR TITLE
Add streaming call to Quickstart Python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ async def main() -> None:
         response = await model("Give me two facts about Leo Messi.")
         print(response)
 
+        async for token in await model(
+            "Give me two more facts about Leo Messi.",
+            stream=True,
+        ):
+            print(token, end="", flush=True)
+
 asyncio.run(main())
 ```
 


### PR DESCRIPTION
### Motivation
- Demonstrate how to consume streamed tokens from a `TextGenerationModel` in the Quickstart Python SDK snippet so users can see both non-streaming and streaming usage.

### Description
- Update the `README.md` Quickstart Python SDK example to add an additional `async for token in await model(..., stream=True):` loop that prints tokens incrementally alongside the existing non-streaming call.

### Testing
- Ran `make lint`, which failed in this environment due to pre-existing mypy/import issues unrelated to this README-only change (missing optional `matplotlib` stubs and redundant-cast warnings). 
- Ran `poetry run pytest --verbose -s`, which executed the suite but reported 4 failures in graph tool tests caused by missing optional graph dependencies in the environment while the rest of the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26c26dcc88323ae10535d05ea382d)