### PR TITLE
Add optional stdin modality coverage test

### DIFF
--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -188,6 +188,11 @@ class CliModelTestCase(TestCase):
         self.assertFalse(
             model_cmds._supports_optional_stdin(Modality.TEXT_GENERATION)
         )
+        self.assertFalse(
+            model_cmds._supports_optional_stdin(
+                Modality.VISION_IMAGE_CLASSIFICATION
+            )
+        )
 
     def test_model_install_secret_creates_secret(self):
         args = Namespace(skip_display_reasoning_time=False, model="m")


### PR DESCRIPTION
### Motivation
- Ensure `_supports_optional_stdin` branch coverage includes a negative case for a non-encoder-decoder modality to keep `src/avalan/cli/commands/model.py` fully covered.

### Description
- Add a single assertion in `tests/cli/model_test.py` to verify `model_cmds._supports_optional_stdin(Modality.VISION_IMAGE_CLASSIFICATION)` returns `False`.

### Testing
- Ran `poetry run pytest --verbose -s` and `poetry run pytest tests/cli/model_test.py --cov=src/avalan/cli/commands --cov-report=term-missing -q`, both completed successfully and the targeted `model.py` is covered at 100% in the coverage output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bb6d9e548323b829d9442835c649)