### PR TITLE
Add model coverage tests

### DIFF
--- a/tests/model/hubs/huggingface_test.py
+++ b/tests/model/hubs/huggingface_test.py
@@ -238,6 +238,29 @@ class HuggingfaceHubTestCase(TestCase):
         m.assert_called_once_with(info)
         self.assertEqual(models, ["x"])
 
+    def test_models_with_multi_task_and_none_inputs(self):
+        self.hf_instance.list_models.return_value = []
+        list(
+            self.hub.models(
+                filter=None,
+                name=None,
+                search=None,
+                library=None,
+                language=None,
+                task=["a", "b"],
+                tags=None,
+            )
+        )
+        self.hf_instance.list_models.assert_called_once_with(
+            filter=["a", "b"],
+            search=None,
+            author=None,
+            gated=None,
+            pipeline_tag=None,
+            limit=None,
+            full=True,
+        )
+
     def test_login(self):
         self.hub.login()
         self.mock_login.assert_called_once_with("token")

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -255,6 +255,33 @@ class MlxLmModelAdditionalTestCase(IsolatedAsyncioTestCase):
             chunks.append(c)
         self.assertEqual(chunks, ["a", "b"])
 
+    def test_input_ids_from_inputs_validation(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "include input_ids"
+        ):
+            self.mod.MlxLmModel._input_ids_from_inputs({})
+        with self.assertRaisesRegex(
+            ValueError, "mapping or tensor"
+        ):
+            self.mod.MlxLmModel._input_ids_from_inputs("bad")
+
+    def test_first_prompt_sequence_fallbacks(self) -> None:
+        class BadShape:
+            shape = [2, 1]
+
+            def __getitem__(self, _):
+                raise TypeError("bad index")
+
+        bad_shape = BadShape()
+        self.assertIs(
+            self.mod.MlxLmModel._first_prompt_sequence(bad_shape), bad_shape
+        )
+        self.assertEqual(
+            self.mod.MlxLmModel._first_prompt_sequence([[1], [2]]), [1]
+        )
+        self.assertEqual(self.mod.MlxLmModel._first_prompt_sequence([1]), [1])
+        self.assertEqual(self.mod.MlxLmModel._first_prompt_sequence("x"), "x")
+
     def test_string_output(self) -> None:
         model = self.mod.MlxLmModel(
             "id",
@@ -414,3 +441,51 @@ class MlxLmCoverageGapTestCase(IsolatedAsyncioTestCase):
                 GenerationSettings(),
                 False,
             )
+
+
+class MlxImportGuardTestCase(IsolatedAsyncioTestCase):
+    async def test_import_guard_behaviors(self) -> None:
+        mod = importlib.import_module("avalan.model.nlp.text.mlxlm")
+        mod._mlx_lm_import_is_safe.cache_clear()
+        with patch.object(mod, "find_spec", return_value=None):
+            self.assertFalse(mod._mlx_lm_import_is_safe())
+        mod._mlx_lm_import_is_safe.cache_clear()
+        self.assertIn("mlx-lm", mod._mlx_unavailable_message())
+
+        with patch.object(mod, "find_spec", side_effect=ValueError("bad")):
+            self.assertFalse(mod._mlx_lm_import_is_safe())
+        mod._mlx_lm_import_is_safe.cache_clear()
+
+        with patch.object(mod, "find_spec", return_value=True), patch.object(
+            mod, "run", return_value=MagicMock(returncode=1)
+        ):
+            self.assertFalse(mod._mlx_lm_import_is_safe())
+        mod._mlx_lm_import_is_safe.cache_clear()
+
+        with patch.object(mod, "_mlx_lm_import_is_safe", return_value=False):
+            with self.assertRaises(ModuleNotFoundError):
+                mod._require_mlx_lm()
+            with self.assertRaises(ModuleNotFoundError):
+                mod.make_sampler()
+
+    async def test_first_prompt_sequence_remaining_paths(self) -> None:
+        mod = importlib.import_module("avalan.model.nlp.text.mlxlm")
+
+        class OneDimensional:
+            shape = (2,)
+
+        one_dimensional = OneDimensional()
+        self.assertIs(
+            mod.MlxLmModel._first_prompt_sequence(one_dimensional),
+            one_dimensional,
+        )
+
+        class KeyErrorIndex:
+            def __getitem__(self, _):
+                raise KeyError("k")
+
+        key_error_index = KeyErrorIndex()
+        self.assertIs(
+            mod.MlxLmModel._first_prompt_sequence(key_error_index),
+            key_error_index,
+        )

--- a/tests/model/nlp/vendor_anthropic_test.py
+++ b/tests/model/nlp/vendor_anthropic_test.py
@@ -848,3 +848,12 @@ def test_non_stream_response_content_ignores_non_list_content(anthropic_mod):
     response = {"content": "not-a-list"}
 
     assert mod.AnthropicClient._non_stream_response_content(response) == ""
+
+
+def test_content_blocks_variants(anthropic_mod):
+    mod, _ = anthropic_mod
+    assert mod.AnthropicClient._content_blocks([{"a": 1}, "x"]) == [{"a": 1}]
+    assert mod.AnthropicClient._content_blocks(
+        "v", empty_when_none=True
+    ) == []
+    assert mod.AnthropicClient._content_blocks(None) == []

--- a/tests/model/text_generation_response_full_test.py
+++ b/tests/model/text_generation_response_full_test.py
@@ -16,6 +16,45 @@ async def _gen():
 
 
 class TextGenerationResponseFullCoverageTestCase(IsolatedAsyncioTestCase):
+    async def test_count_input_tokens_fallback_paths(self):
+        class NoLen:
+            def __len__(self):
+                raise TypeError("no len")
+
+        self.assertEqual(TextGenerationResponse._count_input_tokens(None), 0)
+        self.assertEqual(
+            TextGenerationResponse._count_input_tokens({"input_ids": None}), 0
+        )
+        self.assertEqual(
+            TextGenerationResponse._count_input_tokens(NoLen()),
+            0,
+        )
+
+    async def test_first_input_sequence_edge_paths(self):
+        class BadShape:
+            shape = object()
+
+            def __getitem__(self, _):
+                raise TypeError("bad index")
+
+        self.assertEqual(
+            TextGenerationResponse._first_input_sequence([]),
+            [],
+        )
+        bad_shape = BadShape()
+        self.assertIs(
+            TextGenerationResponse._first_input_sequence(bad_shape), bad_shape
+        )
+
+        class OneDimensional:
+            shape = (3,)
+
+        one_dimensional = OneDimensional()
+        self.assertIs(
+            TextGenerationResponse._first_input_sequence(one_dimensional),
+            one_dimensional,
+        )
+
     async def test_parser_queue_precedence(self):
         settings = GenerationSettings()
         resp = TextGenerationResponse(


### PR DESCRIPTION
### Motivation
- Eliminate coverage gaps in `src/avalan/model` by exercising edge branches and error paths in MLX-LM integration, Anthropic vendor handling, Hugging Face hub filtering, and TextGenerationResponse token/sequence helpers.

### Description
- Added a Hugging Face hub test to cover multi-task filtering and the path where `pipeline_tag` is not used (`tests/model/hubs/huggingface_test.py`).
- Expanded MLX-LM tests to validate the import-safety guard, `make_sampler`/`_require_mlx_lm` error paths, and additional `_first_prompt_sequence` edge cases (`tests/model/nlp/mlxlm_extra_test.py`).
- Added Anthropic vendor tests covering `_content_blocks` variants including list filtering, `empty_when_none=True`, and `None` input (`tests/model/nlp/vendor_anthropic_test.py`).
- Added TextGenerationResponse edge-case tests for `_count_input_tokens` and `_first_input_sequence` fallback paths (`tests/model/text_generation_response_full_test.py`).

### Testing
- Ran the full test suite with `poetry run pytest --verbose -s`, which completed successfully (all tests passed in the local environment).
- Ran focused model tests with coverage using `poetry run pytest --cov=src/avalan/model --cov-report=term-missing tests/model`, which completed successfully and reports 100% coverage for `src/avalan/model`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c030b09083239c2c49e35d1ab91e)