### PR TITLE
Add SDK helper for file-based model input

### DIFF
--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -7,10 +7,6 @@ from ...entities import (
     GenerationSettings,  # noqa: F401
     Input,
     Message,
-    MessageContent,
-    MessageContentFile,
-    MessageContentText,
-    MessageRole,
     Modality,
     Model,
     ReasoningToken,
@@ -21,6 +17,7 @@ from ...event import TOOL_TYPES, Event, EventStats, EventType
 from ...model.call import ModelCall, ModelCallContext
 from ...model.criteria import KeywordStoppingCriteria  # noqa: F401
 from ...model.hubs.huggingface import HuggingfaceHub
+from ...model.input import text_generation_input_from_files
 from ...model.manager import ModelManager
 from ...model.nlp.sentence import SentenceTransformerModel
 from ...model.nlp.text.generation import TextGenerationModel
@@ -39,13 +36,10 @@ from asyncio import (
     sleep,
     to_thread,
 )
-from base64 import b64encode
 from dataclasses import replace
 from datetime import datetime, timezone
 from functools import partial
 from logging import Logger
-from mimetypes import guess_type
-from pathlib import Path
 from time import perf_counter
 from typing import Any, AsyncGenerator, Awaitable, cast
 
@@ -67,29 +61,7 @@ def _supports_optional_stdin(modality: Modality) -> bool:
 def _text_generation_input(
     input_string: str | None, file_paths: list[str] | None
 ) -> Message | str | None:
-    if not file_paths:
-        return input_string
-
-    content: list[MessageContent] = []
-    if input_string:
-        content.append(MessageContentText(type="text", text=input_string))
-
-    for file_path in file_paths:
-        path = Path(file_path)
-        assert path.is_file(), f"Input file not found: {file_path}"
-        mime_type = guess_type(path.name)[0] or "application/octet-stream"
-        content.append(
-            MessageContentFile(
-                type="file",
-                file={
-                    "file_data": b64encode(path.read_bytes()).decode("ascii"),
-                    "filename": path.name,
-                    "mime_type": mime_type,
-                },
-            )
-        )
-
-    return Message(role=MessageRole.USER, content=content)
+    return text_generation_input_from_files(input_string, file_paths)
 
 
 def model_display(

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -17,7 +17,7 @@ from ...event import TOOL_TYPES, Event, EventStats, EventType
 from ...model.call import ModelCall, ModelCallContext
 from ...model.criteria import KeywordStoppingCriteria  # noqa: F401
 from ...model.hubs.huggingface import HuggingfaceHub
-from ...model.input import text_generation_input_from_files
+from ...model.input import input_files
 from ...model.manager import ModelManager
 from ...model.nlp.sentence import SentenceTransformerModel
 from ...model.nlp.text.generation import TextGenerationModel
@@ -61,7 +61,7 @@ def _supports_optional_stdin(modality: Modality) -> bool:
 def _text_generation_input(
     input_string: str | None, file_paths: list[str] | None
 ) -> Message | str | None:
-    return text_generation_input_from_files(input_string, file_paths)
+    return input_files(input_string, file_paths)
 
 
 def model_display(

--- a/src/avalan/model/__init__.py
+++ b/src/avalan/model/__init__.py
@@ -5,9 +5,7 @@ from ..entities import (
 )
 from .call import ModelCall as ModelCall
 from .call import ModelCallContext as ModelCallContext
-from .input import (
-    text_generation_input_from_files as text_generation_input_from_files,
-)
+from .input import input_files as input_files
 from .response.text import TextGenerationResponse
 from .vendor import TextGenerationVendorStream
 

--- a/src/avalan/model/__init__.py
+++ b/src/avalan/model/__init__.py
@@ -5,6 +5,9 @@ from ..entities import (
 )
 from .call import ModelCall as ModelCall
 from .call import ModelCallContext as ModelCallContext
+from .input import (
+    text_generation_input_from_files as text_generation_input_from_files,
+)
 from .response.text import TextGenerationResponse
 from .vendor import TextGenerationVendorStream
 

--- a/src/avalan/model/input.py
+++ b/src/avalan/model/input.py
@@ -11,7 +11,7 @@ from mimetypes import guess_type
 from pathlib import Path
 
 
-def text_generation_input_from_files(
+def input_files(
     input_text: str | None, file_paths: list[str] | None
 ) -> Message | str | None:
     """Build text-generation input from text and local file paths."""

--- a/src/avalan/model/input.py
+++ b/src/avalan/model/input.py
@@ -1,0 +1,40 @@
+from ..entities import (
+    Message,
+    MessageContent,
+    MessageContentFile,
+    MessageContentText,
+    MessageRole,
+)
+
+from base64 import b64encode
+from mimetypes import guess_type
+from pathlib import Path
+
+
+def text_generation_input_from_files(
+    input_text: str | None, file_paths: list[str] | None
+) -> Message | str | None:
+    """Build text-generation input from text and local file paths."""
+    if not file_paths:
+        return input_text
+
+    content: list[MessageContent] = []
+    if input_text:
+        content.append(MessageContentText(type="text", text=input_text))
+
+    for file_path in file_paths:
+        path = Path(file_path)
+        assert path.is_file(), f"Input file not found: {file_path}"
+        mime_type = guess_type(path.name)[0] or "application/octet-stream"
+        content.append(
+            MessageContentFile(
+                type="file",
+                file={
+                    "file_data": b64encode(path.read_bytes()).decode("ascii"),
+                    "filename": path.name,
+                    "mime_type": mime_type,
+                },
+            )
+        )
+
+    return Message(role=MessageRole.USER, content=content)

--- a/tests/model/model_input_test.py
+++ b/tests/model/model_input_test.py
@@ -1,0 +1,72 @@
+from base64 import b64encode
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from avalan.entities import (
+    Message,
+    MessageContentFile,
+    MessageContentText,
+    MessageRole,
+)
+from avalan.model import text_generation_input_from_files
+
+
+def test_text_generation_input_from_files_with_text_and_file() -> None:
+    with NamedTemporaryFile(suffix=".pdf") as tmp:
+        tmp.write(b"%PDF-1.7")
+        tmp.flush()
+
+        result = text_generation_input_from_files("Summarize", [tmp.name])
+
+    assert isinstance(result, Message)
+    assert result.role == MessageRole.USER
+    assert isinstance(result.content, list)
+    assert result.content[0] == MessageContentText(
+        type="text", text="Summarize"
+    )
+    assert result.content[1] == MessageContentFile(
+        type="file",
+        file={
+            "file_data": b64encode(b"%PDF-1.7").decode("ascii"),
+            "filename": Path(tmp.name).name,
+            "mime_type": "application/pdf",
+        },
+    )
+
+
+def test_text_generation_input_from_files_without_text() -> None:
+    with NamedTemporaryFile(suffix=".md") as tmp:
+        tmp.write(b"content")
+        tmp.flush()
+
+        result = text_generation_input_from_files(None, [tmp.name])
+
+    assert isinstance(result, Message)
+    assert isinstance(result.content, list)
+    assert result.content == [
+        MessageContentFile(
+            type="file",
+            file={
+                "file_data": b64encode(b"content").decode("ascii"),
+                "filename": Path(tmp.name).name,
+                "mime_type": "text/markdown",
+            },
+        )
+    ]
+
+
+def test_text_generation_input_from_files_missing_file() -> None:
+    missing = Path("tests/__missing_sdk_input__.pdf").resolve()
+    assert not missing.exists()
+
+    try:
+        text_generation_input_from_files("Summarize", [str(missing)])
+    except AssertionError as exc:
+        assert str(exc) == f"Input file not found: {missing}"
+    else:
+        raise AssertionError("Expected missing file assertion")
+
+
+def test_text_generation_input_from_files_without_paths() -> None:
+    assert text_generation_input_from_files("Hello", None) == "Hello"
+    assert text_generation_input_from_files(None, []) is None

--- a/tests/model/model_input_test.py
+++ b/tests/model/model_input_test.py
@@ -8,15 +8,15 @@ from avalan.entities import (
     MessageContentText,
     MessageRole,
 )
-from avalan.model import text_generation_input_from_files
+from avalan.model import input_files
 
 
-def test_text_generation_input_from_files_with_text_and_file() -> None:
+def test_input_files_with_text_and_file() -> None:
     with NamedTemporaryFile(suffix=".pdf") as tmp:
         tmp.write(b"%PDF-1.7")
         tmp.flush()
 
-        result = text_generation_input_from_files("Summarize", [tmp.name])
+        result = input_files("Summarize", [tmp.name])
 
     assert isinstance(result, Message)
     assert result.role == MessageRole.USER
@@ -34,12 +34,12 @@ def test_text_generation_input_from_files_with_text_and_file() -> None:
     )
 
 
-def test_text_generation_input_from_files_without_text() -> None:
+def test_input_files_without_text() -> None:
     with NamedTemporaryFile(suffix=".md") as tmp:
         tmp.write(b"content")
         tmp.flush()
 
-        result = text_generation_input_from_files(None, [tmp.name])
+        result = input_files(None, [tmp.name])
 
     assert isinstance(result, Message)
     assert isinstance(result.content, list)
@@ -55,18 +55,18 @@ def test_text_generation_input_from_files_without_text() -> None:
     ]
 
 
-def test_text_generation_input_from_files_missing_file() -> None:
+def test_input_files_missing_file() -> None:
     missing = Path("tests/__missing_sdk_input__.pdf").resolve()
     assert not missing.exists()
 
     try:
-        text_generation_input_from_files("Summarize", [str(missing)])
+        input_files("Summarize", [str(missing)])
     except AssertionError as exc:
         assert str(exc) == f"Input file not found: {missing}"
     else:
         raise AssertionError("Expected missing file assertion")
 
 
-def test_text_generation_input_from_files_without_paths() -> None:
-    assert text_generation_input_from_files("Hello", None) == "Hello"
-    assert text_generation_input_from_files(None, []) is None
+def test_input_files_without_paths() -> None:
+    assert input_files("Hello", None) == "Hello"
+    assert input_files(None, []) is None


### PR DESCRIPTION
### Motivation
- Improve SDK ergonomics for sending local files to text-generation models by avoiding manual message construction and enabling consistent behavior across CLI and SDK paths.

### Description
- Add `text_generation_input_from_files` in `src/avalan/model/input.py` to build a `Message` from optional prompt text and local file paths, performing existence checks, MIME inference, and base64 encoding.
- Export the helper from `src/avalan/model/__init__.py` so SDK users can import `avalan.model.text_generation_input_from_files` directly.
- Refactor the CLI `model run` input handling in `src/avalan/cli/commands/model.py` to reuse the new helper for `--input-file` behavior.
- Add unit tests in `tests/model/model_input_test.py` covering text+file, file-only, no-files passthrough, and missing-file error paths.

### Testing
- Ran `make lint` and automatic formatters and type checks completed without errors.
- Ran `poetry run pytest --verbose -s` with the full test suite and observed all tests passing (1811 passed, 11 skipped) after adding the new tests.
- Ran the repository coverage target which produced a coverage report and completed successfully, with the new tests exercising the added code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f358c6e640832392d3598a0361e509)