### PR TITLE
Fix test assertion for model loading kwarg (expect dtype instead of torch_dtype)

### DIFF
--- a/tests/model/nlp/text_test.py
+++ b/tests/model/nlp/text_test.py
@@ -119,7 +119,7 @@ class TextGenerationModelTestCase(TestCase):
                     attn_implementation=None,
                     output_hidden_states=False,
                     trust_remote_code=False,
-                    torch_dtype="auto",
+                    dtype="auto",
                     state_dict=None,
                     local_files_only=False,
                     low_cpu_mem_usage=True,


### PR DESCRIPTION
### Motivation
- The unit test expected the legacy `torch_dtype` keyword but the implementation uses `dtype`, causing a mock assertion failure.

### Description
- Update `tests/model/nlp/text_test.py` to assert `dtype="auto"` instead of `torch_dtype="auto"` for `AutoModelForCausalLM.from_pretrained`.

### Testing
- Ran `poetry run pytest -q tests/model/nlp/text_test.py::TextGenerationModelTestCase::test_instantiation_with_load_model_and_tokenizer`, which passed.
- Ran the full suite with `poetry run pytest --verbose -s`, which completed successfully (`1840 passed, 11 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b052e6588323920baf3112d2dced)