### PR TITLE
Fix interrupt cleanup and MLX streaming behavior

### DIFF
--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -421,13 +421,11 @@ class CLI:
                 "If specified, no welcome screen and only model output is "
                 "displayed in model run (sets "
             )
-            + ", ".join(
-                [
-                    "--disable-loading-progress-bar",
-                    "--skip-hub-access-check",
-                    "--skip-special-tokens",
-                ]
-            )
+            + ", ".join([
+                "--disable-loading-progress-bar",
+                "--skip-hub-access-check",
+                "--skip-special-tokens",
+            ])
             + " automatically)",
         )
         global_parser.add_argument(
@@ -2223,22 +2221,24 @@ class CLI:
 
         hub = HuggingfaceHub(access_token, args.cache_dir, self._logger)
 
-        with _direct_keyboard_interrupts():
-            try:
-                await self._main(args, theme, console, hub)
-            except (
-                CancelledError,
-                KeyboardInterrupt,
-                CommandAbortException,
-            ):
-                self._print_bye(console, theme, quiet=args.quiet)
-                raise
-        if args.parallel and "LOCAL_RANK" in environ:
-            try:
-                destroy_process_group()
-            except AssertionError:
-                # Process group might be dead already
-                pass
+        try:
+            with _direct_keyboard_interrupts():
+                try:
+                    await self._main(args, theme, console, hub)
+                except (
+                    CancelledError,
+                    KeyboardInterrupt,
+                    CommandAbortException,
+                ):
+                    self._print_bye(console, theme, quiet=args.quiet)
+                    raise
+        finally:
+            if args.parallel and "LOCAL_RANK" in environ:
+                try:
+                    destroy_process_group()
+                except AssertionError:
+                    # Process group might be dead already
+                    pass
 
     def _print_bye(
         self,

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -302,11 +302,6 @@ class Engine(ABC):
                 "Restored transformers logging level to %s",
                 self._transformers_logging_level,
             )
-        interrupted_exit = exc_type is not None and issubclass(
-            exc_type, (asyncio.CancelledError, KeyboardInterrupt)
-        )
-        if interrupted_exit:
-            return False
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -565,7 +560,9 @@ class Engine(ABC):
         return (
             "cuda"
             if cuda.is_available()
-            else "mps" if mps.is_available() else "cpu"
+            else "mps"
+            if mps.is_available()
+            else "cpu"
         )
 
     @staticmethod

--- a/src/avalan/model/manager.py
+++ b/src/avalan/model/manager.py
@@ -96,11 +96,6 @@ class ModelManager:
     _event_manager: EventManager | None
     _pending_exit_task: asyncio.Task[None] | None
 
-    _INTERRUPTED_EXIT_EXCEPTIONS = (
-        asyncio.CancelledError,
-        KeyboardInterrupt,
-    )
-
     def __init__(
         self,
         hub: HuggingfaceHub,
@@ -123,12 +118,6 @@ class ModelManager:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> Literal[False]:
-        interrupted_exit = exc_type is not None and issubclass(
-            exc_type, self._INTERRUPTED_EXIT_EXCEPTIONS
-        )
-        if interrupted_exit:
-            return False
-
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -146,17 +135,9 @@ class ModelManager:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool:
-        interrupted_exit = exc_type is not None and issubclass(
-            exc_type, self._INTERRUPTED_EXIT_EXCEPTIONS
-        )
         if self._pending_exit_task is not None:
-            if interrupted_exit:
-                self._pending_exit_task.cancel()
-            else:
-                await self._pending_exit_task
+            await self._pending_exit_task
             self._pending_exit_task = None
-        if interrupted_exit:
-            return False
         return bool(
             await self._stack.__aexit__(exc_type, exc_value, traceback)
         )

--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -10,8 +10,9 @@ from ....tool.manager import ToolManager
 from ...vendor import TextGenerationVendorStream
 from .generation import TextGenerationModel
 
-from asyncio import Queue, create_task, get_running_loop, to_thread
+from asyncio import get_running_loop
 from collections.abc import Callable, Iterator, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, replace
 from functools import lru_cache
 from importlib import import_module
@@ -84,6 +85,7 @@ class MlxLmStream(TextGenerationVendorStream):
         generator: Iterator[object] | Callable[[], Iterator[object]],
     ) -> None:
         self._closed = False
+        self._executor = ThreadPoolExecutor(max_workers=1)
         if isinstance(generator, Iterator):
             self._iterator: Iterator[object] | None = generator
             self._iterator_factory: Callable[[], Iterator[object]] | None = (
@@ -114,7 +116,10 @@ class MlxLmStream(TextGenerationVendorStream):
 
     def close(self) -> None:
         """Mark the stream as closed."""
+        if self._closed:
+            return
         self._closed = True
+        self._executor.shutdown(wait=False, cancel_futures=True)
 
     def _next_chunk(self) -> object:
         if self._iterator is None:
@@ -127,24 +132,18 @@ class MlxLmStream(TextGenerationVendorStream):
         if self._closed:
             return self._SENTINEL
 
-        queue: Queue[object] = Queue(maxsize=1)
         loop = get_running_loop()
-
-        def _pull_chunk() -> None:
-            try:
-                chunk = self._next_chunk()
-            except Exception as exc:
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
-                return
-            loop.call_soon_threadsafe(queue.put_nowait, chunk)
-
         try:
-            pull_task = create_task(to_thread(_pull_chunk))
-            chunk = await queue.get()
-            await pull_task
+            chunk = await loop.run_in_executor(
+                self._executor, self._next_chunk
+            )
         except Exception:
             self.close()
             raise
+
+        if isinstance(chunk, BaseException):
+            self.close()
+            raise chunk
         if chunk is self._SENTINEL:
             self.close()
         return chunk

--- a/src/avalan/model/nlp/text/mlxlm.py
+++ b/src/avalan/model/nlp/text/mlxlm.py
@@ -10,6 +10,7 @@ from ....tool.manager import ToolManager
 from ...vendor import TextGenerationVendorStream
 from .generation import TextGenerationModel
 
+from asyncio import Queue, create_task, get_running_loop, to_thread
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import asdict, replace
 from functools import lru_cache
@@ -74,7 +75,7 @@ def make_sampler(*args: Any, **kwargs: Any) -> Any:
 
 
 class MlxLmStream(TextGenerationVendorStream):
-    """Wrap a synchronous MLX token generator on the consumer thread."""
+    """Bridge synchronous MLX generation from a dedicated worker thread."""
 
     _SENTINEL = object()
 
@@ -92,9 +93,9 @@ class MlxLmStream(TextGenerationVendorStream):
             self._iterator = None
             self._iterator_factory = generator
 
-        async def _generator() -> (
-            AsyncGenerator[Token | TokenDetail | str, None]
-        ):
+        async def _generator() -> AsyncGenerator[
+            Token | TokenDetail | str, None
+        ]:
             while True:
                 item = await self._next_raw()
                 if item is self._SENTINEL:
@@ -125,8 +126,22 @@ class MlxLmStream(TextGenerationVendorStream):
     async def _next_raw(self) -> object:
         if self._closed:
             return self._SENTINEL
+
+        queue: Queue[object] = Queue(maxsize=1)
+        loop = get_running_loop()
+
+        def _pull_chunk() -> None:
+            try:
+                chunk = self._next_chunk()
+            except Exception as exc:
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+                return
+            loop.call_soon_threadsafe(queue.put_nowait, chunk)
+
         try:
-            chunk = self._next_chunk()
+            pull_task = create_task(to_thread(_pull_chunk))
+            chunk = await queue.get()
+            await pull_task
         except Exception:
             self.close()
             raise

--- a/tests/model/engine_more_coverage_test.py
+++ b/tests/model/engine_more_coverage_test.py
@@ -131,7 +131,7 @@ class ContextAsyncExitTestCase(IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         engine._exit_stack.aclose.assert_awaited_once()
 
-    async def test_exit_with_running_loop_skips_close_on_interrupt(
+    async def test_exit_with_running_loop_closes_on_interrupt(
         self,
     ) -> None:
         engine = MinimalEngine(
@@ -143,8 +143,7 @@ class ContextAsyncExitTestCase(IsolatedAsyncioTestCase):
         engine.__exit__(KeyboardInterrupt, KeyboardInterrupt(), None)
         await asyncio.sleep(0)
 
-        engine._exit_stack.aclose.assert_not_awaited()
-        self.assertIsNone(engine._pending_exit_task)
+        engine._exit_stack.aclose.assert_awaited_once()
 
 
 class MlxLoadTestCase(TestCase):

--- a/tests/model/model_manager_extra_test.py
+++ b/tests/model/model_manager_extra_test.py
@@ -258,7 +258,7 @@ class ModelManagerEventDispatchTestCase(IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         manager._stack.aclose.assert_awaited_once()
 
-    async def test_exit_with_running_loop_skips_close_on_interrupt(self):
+    async def test_exit_with_running_loop_closes_on_interrupt(self):
         hub = MagicMock(spec=HuggingfaceHub)
         logger = MagicMock(spec=Logger)
         manager = ModelManager(hub, logger)
@@ -267,10 +267,9 @@ class ModelManagerEventDispatchTestCase(IsolatedAsyncioTestCase):
         manager.__exit__(KeyboardInterrupt, KeyboardInterrupt(), None)
         await asyncio.sleep(0)
 
-        manager._stack.aclose.assert_not_awaited()
-        self.assertIsNone(manager._pending_exit_task)
+        manager._stack.aclose.assert_awaited_once()
 
-    async def test_aexit_cancels_pending_close_on_interrupt(self):
+    async def test_aexit_awaits_pending_close_on_interrupt(self):
         hub = MagicMock(spec=HuggingfaceHub)
         logger = MagicMock(spec=Logger)
         manager = ModelManager(hub, logger)
@@ -283,5 +282,5 @@ class ModelManagerEventDispatchTestCase(IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
 
         self.assertFalse(result)
-        self.assertTrue(pending.cancelled())
+        self.assertFalse(pending.cancelled())
         self.assertIsNone(manager._pending_exit_task)

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -113,6 +113,38 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
 
         del sys.modules["avalan.model"].TextGenerationModel
 
+    async def test_stream_propagates_generation_error(self) -> None:
+        stub = types.ModuleType("mlx_lm")
+        stub.generate = MagicMock()
+        stub.load = MagicMock()
+        stub.stream_generate = MagicMock()
+        sampler_mod = types.ModuleType("mlx_lm.sample_utils")
+        sampler_mod.make_sampler = MagicMock()
+        from avalan.model.nlp.text import generation as gen_mod
+
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
+
+        class BrokenIterator:
+            def __iter__(self) -> "BrokenIterator":
+                return self
+
+            def __next__(self) -> str:
+                raise ValueError("bad generation")
+
+        with patch.dict(
+            sys.modules,
+            {"mlx_lm": stub, "mlx_lm.sample_utils": sampler_mod},
+        ):
+            from avalan.model.nlp.text.mlxlm import MlxLmStream
+
+            stream = MlxLmStream(lambda: BrokenIterator())
+            with self.assertRaisesRegex(ValueError, "bad generation"):
+                await stream.__anext__()
+
+        del sys.modules["avalan.model"].TextGenerationModel
+
 
 class MlxLmModelTestCase(IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:

--- a/tests/model/nlp/mlxlm_extra_test.py
+++ b/tests/model/nlp/mlxlm_extra_test.py
@@ -23,9 +23,9 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
         sampler_mod.make_sampler = MagicMock()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
         with patch.dict(
             sys.modules,
             {"mlx_lm": stub, "mlx_lm.sample_utils": sampler_mod},
@@ -39,7 +39,7 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
                 await stream.__anext__()
         del sys.modules["avalan.model"].TextGenerationModel
 
-    async def test_stream_factory_stays_on_consumer_thread(self) -> None:
+    async def test_stream_factory_stays_on_worker_thread(self) -> None:
         stub = types.ModuleType("mlx_lm")
         stub.generate = MagicMock()
         stub.load = MagicMock()
@@ -48,12 +48,11 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
         sampler_mod.make_sampler = MagicMock()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
         owner_threads: list[int] = []
         next_threads: list[int] = []
-        consumer_thread = get_ident()
 
         class ThreadBoundIterator:
             def __init__(self) -> None:
@@ -85,7 +84,7 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
 
         del sys.modules["avalan.model"].TextGenerationModel
         self.assertTrue(owner_threads)
-        self.assertEqual(owner_threads, [consumer_thread])
+        self.assertEqual(len(set(owner_threads)), 1)
         self.assertEqual(set(next_threads), set(owner_threads))
 
     async def test_stream_close_short_circuits_iteration(self) -> None:
@@ -97,9 +96,9 @@ class MlxLmStreamTestCase(IsolatedAsyncioTestCase):
         sampler_mod.make_sampler = MagicMock()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
 
         with patch.dict(
             sys.modules,
@@ -130,9 +129,9 @@ class MlxLmModelTestCase(IsolatedAsyncioTestCase):
         self.patch.start()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
         importlib.reload(
             importlib.import_module("avalan.model.nlp.text.mlxlm")
         )
@@ -270,9 +269,9 @@ class MlxLmModelAdditionalTestCase(IsolatedAsyncioTestCase):
         self.patch.start()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
         importlib.reload(
             importlib.import_module("avalan.model.nlp.text.mlxlm")
         )
@@ -318,12 +317,10 @@ class MlxLmModelAdditionalTestCase(IsolatedAsyncioTestCase):
         model._model = "m"
         model._tokenizer = MagicMock()
         model._tokenizer.decode.return_value = "p"
-        self.stub.stream_generate.side_effect = lambda *a, **kw: iter(
-            [
-                MagicMock(text="a"),
-                MagicMock(text="b"),
-            ]
-        )
+        self.stub.stream_generate.side_effect = lambda *a, **kw: iter([
+            MagicMock(text="a"),
+            MagicMock(text="b"),
+        ])
         chunks = []
         async for c in model._stream_generator(
             {"input_ids": [[1]]}, GenerationSettings(), False
@@ -437,9 +434,9 @@ class MlxLmCoverageGapTestCase(IsolatedAsyncioTestCase):
         self.patch.start()
         from avalan.model.nlp.text import generation as gen_mod
 
-        sys.modules["avalan.model"].TextGenerationModel = (
-            gen_mod.TextGenerationModel
-        )
+        sys.modules[
+            "avalan.model"
+        ].TextGenerationModel = gen_mod.TextGenerationModel
         importlib.reload(
             importlib.import_module("avalan.model.nlp.text.mlxlm")
         )
@@ -452,12 +449,10 @@ class MlxLmCoverageGapTestCase(IsolatedAsyncioTestCase):
 
     async def test_stream_handles_token_and_text_chunks(self) -> None:
         stream = self.mod.MlxLmStream(
-            iter(
-                [
-                    self.mod.Token(token="tok"),
-                    types.SimpleNamespace(text="txt"),
-                ]
-            )
+            iter([
+                self.mod.Token(token="tok"),
+                types.SimpleNamespace(text="txt"),
+            ])
         )
 
         self.assertEqual(await stream.__anext__(), "tok")
@@ -482,12 +477,10 @@ class MlxLmCoverageGapTestCase(IsolatedAsyncioTestCase):
         model._model = "m"
         model._tokenizer = MagicMock()
         model._tokenizer.decode.return_value = "p"
-        self.stub.stream_generate.side_effect = lambda *a, **kw: iter(
-            [
-                self.mod.Token(token="z"),
-                types.SimpleNamespace(text="y"),
-            ]
-        )
+        self.stub.stream_generate.side_effect = lambda *a, **kw: iter([
+            self.mod.Token(token="z"),
+            types.SimpleNamespace(text="y"),
+        ])
         chunks = []
         async for chunk in model._stream_generator(
             {"input_ids": [[1]]}, GenerationSettings(), False


### PR DESCRIPTION
### Motivation
- Ensure distributed teardown always runs for `--parallel` local-rank CLI runs even when `_main` exits via cancellation/interrupt/abort. 
- Prevent MLX synchronous token generation from blocking the asyncio event loop and delaying cancellation, UI refresh, and stop-signal handling. 
- Avoid skipping AsyncExitStack cleanup on interrupted exits which can leak resources managed by `ModelManager` / `Engine` in non-CLI contexts.

### Description
- Move CLI shutdown logic into a `try/finally` so `destroy_process_group()` is attempted regardless of `CancelledError`, `KeyboardInterrupt`, or `CommandAbortException` raised from `_main` (`src/avalan/cli/__main__.py`).
- Rework `MlxLmStream` to advance the MLX iterator on a dedicated worker thread and bridge tokens back via an `asyncio.Queue` (using `to_thread` + `create_task`), preventing the event loop from being blocked while preserving iterator thread-affinity (`src/avalan/model/nlp/text/mlxlm.py`).
- Restore bounded/awaited cleanup for `ModelManager` and `Engine` by removing early-return/cancel paths that previously skipped `AsyncExitStack` closure, so pending close tasks are awaited rather than canceled or skipped (`src/avalan/model/manager.py`, `src/avalan/model/engine.py`).
- Update tests to reflect the corrected interrupt/cleanup semantics and MLX threading behavior (`tests/model/nlp/mlxlm_extra_test.py`, `tests/model/engine_more_coverage_test.py`, `tests/model/model_manager_extra_test.py`).

### Testing
- Ran formatting and static checks with `poetry run ruff format` / `poetry run ruff check` and `mypy`, all checks passed. 
- Executed targeted test suites with `poetry run pytest -q` (including `tests/model/engine_more_coverage_test.py`, `tests/model/model_manager_extra_test.py`, `tests/model/nlp/mlxlm_extra_test.py`, `tests/cli/main_test.py`) and a full test run with `poetry run pytest --verbose -s`; final results: all tests passed (`1840 passed, 11 skipped` in the full run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bbdccb6c83238ec091b73fcdba2a)