### PR TITLE
Lazy-load torchaudio in BaseAudioModel to avoid requiring audio deps on import

### DIFF
--- a/src/avalan/model/audio/__init__.py
+++ b/src/avalan/model/audio/__init__.py
@@ -7,8 +7,6 @@ from typing import Any, Literal, cast
 from numpy import ndarray
 from PIL import Image
 from torch import Tensor
-from torchaudio import load
-from torchaudio.functional import resample
 from transformers import (
     PreTrainedTokenizer,
     PreTrainedTokenizerFast,
@@ -35,6 +33,9 @@ class BaseAudioModel(Engine, ABC):
         raise TokenizerNotSupportedException()
 
     def _resample_mono(self, audio_source: str, sampling_rate: int) -> Tensor:
+        from torchaudio import load
+        from torchaudio.functional import resample
+
         wave, wave_sampling_rate = load(audio_source)
 
         if wave.shape[0] > 1:
@@ -54,6 +55,9 @@ class BaseAudioModel(Engine, ABC):
     def _resample(
         self, audio_source: str, sampling_rate: int
     ) -> ndarray[Any, Any]:
+        from torchaudio import load
+        from torchaudio.functional import resample
+
         wave, wave_sampling_rate = load(audio_source)
         if wave_sampling_rate != sampling_rate:
             wave = resample(wave, wave_sampling_rate, sampling_rate)

--- a/tests/model/audio/base_audio_model_test.py
+++ b/tests/model/audio/base_audio_model_test.py
@@ -43,11 +43,9 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
         mean.numpy.return_value = "audio"
         audio_wave.mean.return_value = mean
         with (
+            patch("torchaudio.load", return_value=(audio_wave, 8000)) as load_patch,
             patch(
-                "avalan.model.audio.load", return_value=(audio_wave, 8000)
-            ) as load_patch,
-            patch(
-                "avalan.model.audio.resample", return_value=audio_wave
+                "torchaudio.functional.resample", return_value=audio_wave
             ) as resample_patch,
         ):
             result = model._resample("a.wav", 16000)
@@ -68,10 +66,8 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
         mean.numpy.return_value = "audio"
         audio_wave.mean.return_value = mean
         with (
-            patch(
-                "avalan.model.audio.load", return_value=(audio_wave, 16000)
-            ) as load_patch,
-            patch("avalan.model.audio.resample") as resample_patch,
+            patch("torchaudio.load", return_value=(audio_wave, 16000)) as load_patch,
+            patch("torchaudio.functional.resample") as resample_patch,
         ):
             result = model._resample("a.wav", 16000)
         self.assertEqual(result, "audio")
@@ -100,11 +96,9 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
         resampled.squeeze.return_value = "wave"
 
         with (
+            patch("torchaudio.load", return_value=(audio_wave, 8000)) as load_patch,
             patch(
-                "avalan.model.audio.load", return_value=(audio_wave, 8000)
-            ) as load_patch,
-            patch(
-                "avalan.model.audio.resample", return_value=resampled
+                "torchaudio.functional.resample", return_value=resampled
             ) as resample_patch,
         ):
             result = model._resample_mono("a.wav", 16000)
@@ -130,10 +124,8 @@ class BaseAudioModelTestCase(IsolatedAsyncioTestCase):
         audio_wave.squeeze.return_value = "wave"
 
         with (
-            patch(
-                "avalan.model.audio.load", return_value=(audio_wave, 16000)
-            ) as load_patch,
-            patch("avalan.model.audio.resample") as resample_patch,
+            patch("torchaudio.load", return_value=(audio_wave, 16000)) as load_patch,
+            patch("torchaudio.functional.resample") as resample_patch,
         ):
             result = model._resample_mono("a.wav", 16000)
 


### PR DESCRIPTION
### Motivation
- Prevent importing `avalan.model.audio` from forcing audio runtime dependencies to be installed, so vendor-only workflows (installed with `agent,server,tool,vendors` extras) can import the library without audio packages present.

### Description
- Move `torchaudio` imports from module scope into method scope inside `BaseAudioModel._resample_mono` and `BaseAudioModel._resample` so `torchaudio` is only required when audio functionality is actually used.
- Update tests in `tests/model/audio/base_audio_model_test.py` to patch `torchaudio.load` and `torchaudio.functional.resample` directly to match the lazy-import behavior.
- No API surface changes; behavior is unchanged when audio is used at runtime.

### Testing
- Ran `poetry run ruff check src/avalan/model/audio/__init__.py` with no issues.
- Ran `poetry run mypy src/avalan/model/audio/__init__.py` with no issues.
- Ran full test suite with `poetry run pytest --verbose -s` resulting in `1867 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60624be208323a91cb6dee3d7430a)