### PR TITLE
Fix PR Discord hook title escaping

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -20,12 +20,19 @@ jobs:
           curl -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
       - name: Notify Discord on pull request
         if: github.event_name == 'pull_request'
+        env:
+          PR_ACTION: ${{ github.event.action }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_ACTOR: ${{ github.actor }}
         run: |
-          action="${{ github.event.action }}"
-          title="${{ github.event.pull_request.title }}"
-          number="${{ github.event.pull_request.number }}"
-          url="${{ github.event.pull_request.html_url }}"
-          message="Pull request #$number $action: *$title* by **${{ github.actor }}**. <$url>"
+          action="$PR_ACTION"
+          title="$PR_TITLE"
+          number="$PR_NUMBER"
+          url="$PR_URL"
+          actor="$PR_ACTOR"
+          message="Pull request #$number $action: *$title* by **$actor**. <$url>"
           payload=$(jq -n --arg msg "$message" '{"content": $msg}')
           curl -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
       - name: Notify Discord on release


### PR DESCRIPTION
### Motivation
- Prevent shell substitution when PR titles contain characters like backticks (e.g. `HubClient`) that caused the Discord webhook step to fail with errors like `HubClient: command not found` and `local: can only be used in a function`.

### Description
- Pass GitHub event values through step-level environment variables (`PR_TITLE`, `PR_ACTION`, `PR_NUMBER`, `PR_URL`, `PR_ACTOR`) and read them inside the script in ` .github/workflows/discord.yml`, preserving the outgoing message format.

### Testing
- Ran the full test suite with `poetry run pytest --verbose -s` and received `1871 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79cb7be6483238644503679d40194)