### PR TITLE
Add tests for CLI CUDA/transformers helpers and JSON schema utilities

### DIFF
--- a/tests/cli/main_cuda_transformers_utils_test.py
+++ b/tests/cli/main_cuda_transformers_utils_test.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from avalan.cli import __main__ as cli_main
+
+
+class CudaAndTransformerUtilityTestCase(TestCase):
+    def test_cuda_helpers_when_torch_missing(self) -> None:
+        with patch("avalan.cli.__main__._module_exists", return_value=False):
+            self.assertFalse(cli_main._is_cuda_available())
+            self.assertEqual(cli_main._cuda_device_count(), 1)
+            cli_main._set_cuda_device(0)
+
+    def test_cuda_helpers_when_torch_available(self) -> None:
+        cuda_module = SimpleNamespace(
+            is_available=lambda: True,
+            device_count=lambda: 3,
+            set_device=MagicMock(),
+        )
+        with patch("avalan.cli.__main__._module_exists", return_value=True), patch(
+            "avalan.cli.__main__.import_module", return_value=cuda_module
+        ):
+            self.assertTrue(cli_main.is_available())
+            self.assertEqual(cli_main.device_count(), 3)
+            cli_main.set_device(2)
+
+        cuda_module.set_device.assert_called_once_with(2)
+
+    def test_destroy_process_group_paths(self) -> None:
+        with patch("avalan.cli.__main__._module_exists", return_value=False):
+            cli_main.destroy_process_group()
+
+        dist_module = SimpleNamespace(destroy_process_group=MagicMock())
+        with patch("avalan.cli.__main__._module_exists", return_value=True), patch(
+            "avalan.cli.__main__.import_module", return_value=dist_module
+        ):
+            cli_main.destroy_process_group()
+
+        dist_module.destroy_process_group.assert_called_once_with()
+
+    def test_transformers_utils_and_flash_attention_helpers(self) -> None:
+        with patch("avalan.cli.__main__._module_exists", return_value=False):
+            self.assertIsNone(cli_main._transformers_utils_module())
+            self.assertFalse(cli_main.is_flash_attn_2_available())
+            self.assertFalse(cli_main.is_torch_flex_attn_available())
+
+        transformers_utils = SimpleNamespace(is_flash_attn_2_available=lambda: True)
+        with patch("avalan.cli.__main__._module_exists", return_value=True), patch(
+            "avalan.cli.__main__.import_module", return_value=transformers_utils
+        ):
+            self.assertIs(cli_main._transformers_utils_module(), transformers_utils)
+            self.assertTrue(cli_main.is_flash_attn_2_available())
+            self.assertFalse(cli_main.is_torch_flex_attn_available())

--- a/tests/tool/json_schema_additional_test.py
+++ b/tests/tool/json_schema_additional_test.py
@@ -1,0 +1,40 @@
+from typing import Literal
+from unittest import TestCase
+from unittest.mock import patch
+
+from avalan.tool.json_schema import _literal_schema, _parse_docstring_sections, get_json_schema
+
+
+class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
+    def test_parse_docstring_sections_with_none_and_empty(self) -> None:
+        self.assertEqual(_parse_docstring_sections(None), {})
+        self.assertEqual(_parse_docstring_sections(""), {})
+
+    def test_literal_schema_without_values_or_mixed_types(self) -> None:
+        with patch("avalan.tool.json_schema.get_args", return_value=()):
+            self.assertEqual(_literal_schema(Literal["value"]), {"type": "object"})
+
+        mixed_literal = _literal_schema(Literal["x", 1])
+        self.assertEqual(mixed_literal, {"type": "object"})
+
+    def test_get_json_schema_maps_unhandled_types_to_object(self) -> None:
+        def transform(
+            payload: dict[str, int],
+            items: tuple[str, ...],
+            note: object,
+        ) -> list[str | int]:
+            """Transform data.
+
+            Args:
+                payload: Payload mapping.
+                items: Collection of items.
+                note: Generic note.
+            """
+            return [*items]
+
+        schema = get_json_schema(transform)
+        properties = schema["function"]["parameters"]["properties"]
+        self.assertEqual(properties["payload"]["type"], "object")
+        self.assertEqual(properties["items"]["type"], "array")
+        self.assertEqual(properties["note"]["type"], "object")
+        self.assertEqual(schema["function"]["return"]["type"], "array")


### PR DESCRIPTION
### Motivation
- Close coverage gaps by exercising helper branches in the CLI related to CUDA/transformers and by covering edge cases in the JSON schema utilities.
- Ensure `_literal_schema`, docstring parsing and type-mapping behavior in `get_json_schema` are validated for mixed/empty literal and complex typing cases.

### Description
- Add `tests/cli/main_cuda_transformers_utils_test.py` to exercise `_is_cuda_available`, `_cuda_device_count`, `_set_cuda_device`, `destroy_process_group`, `_transformers_utils_module`, `is_flash_attn_2_available`, and `is_torch_flex_attn_available` with both dependency-present and dependency-missing paths.
- Add `tests/tool/json_schema_additional_test.py` to cover `_parse_docstring_sections` for `None`/empty docstrings, `_literal_schema` for empty/mixed literals (via `get_args` patch), and `get_json_schema` mapping for `dict`, `tuple`, `object`, and union return types.
- Adjust the expected behavior in the new JSON schema test to match the current implementation that maps the example function return to `array`.

### Testing
- Ran `poetry run pytest tests/tool/json_schema_additional_test.py tests/cli/main_cuda_transformers_utils_test.py -q` and the tests passed.
- Ran the full test suite with `poetry run pytest --verbose -s` and all tests completed successfully (suite passed).
- Ran coverage with `make test-coverage` and the command completed successfully producing the coverage report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8027ac6a48323af2a52f006d6f3da)