### PR TITLE
Fix release workflow branch push target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Bump version and create release commit
         env:
           VERSION: ${{ github.event.inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           CURRENT_VERSION="$(poetry version --short)"
           if [ "$CURRENT_VERSION" != "$VERSION" ]; then
@@ -61,7 +62,7 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add pyproject.toml
             git commit -m "Bump version to v$VERSION"
-            git push origin HEAD:main
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           else
             echo "pyproject.toml already at version $VERSION; no version commit created."
           fi


### PR DESCRIPTION
### Motivation
- The release workflow failed when triggered from non-`main` branches because the version bump commit was pushed to a hardcoded `main` branch instead of the branch that initiated the workflow.

### Description
- Update `.github/workflows/release.yml` to expose `GITHUB_REF_NAME` in the bump step and use `github.ref_name` as the push target so the version bump commit is pushed back to the triggering branch instead of `main`.

### Testing
- No automated tests were run locally for this workflow-only change; the repository CI will execute the normal test step (`poetry run pytest --verbose -s`) when the release workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80cb76c548323991ae8bace13b330)