### PR TITLE
Fix release workflow for signed commit repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,14 +80,15 @@ jobs:
 
             Merge this pull request, then rerun the release workflow for v${{ github.event.inputs.version }}.
 
-      - name: Stop after creating version bump pull request
+      - name: Stop release after creating version bump pull request
         if: steps.bump.outputs.version_changed == 'true'
         run: |
-          echo "Created signed PR #${{ steps.cpr.outputs.pull-request-number }} for version bump."
-          echo "Merge the PR and rerun this workflow to continue the release."
-          exit 1
+          echo "Created or updated signed PR #${{ steps.cpr.outputs.pull-request-number }} for version bump."
+          echo "Merge that PR, then start a NEW workflow_dispatch run from the updated branch."
+          echo "Do not use GitHub's Re-run jobs on this run, because it keeps the original commit SHA."
 
       - name: Create and push tag
+        if: steps.bump.outputs.version_changed == 'false'
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
@@ -99,12 +100,15 @@ jobs:
           git push origin "v$VERSION"
 
       - name: Build package
+        if: steps.bump.outputs.version_changed == 'false'
         run: poetry build --clean
 
       - name: Publish package to PyPI
+        if: steps.bump.outputs.version_changed == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub release
+        if: steps.bump.outputs.version_changed == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -50,22 +51,41 @@ jobs:
       - name: Run tests
         run: poetry run pytest --verbose -s
 
-      - name: Bump version and create release commit
+      - name: Bump version
+        id: bump
         env:
           VERSION: ${{ github.event.inputs.version }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           CURRENT_VERSION="$(poetry version --short)"
           if [ "$CURRENT_VERSION" != "$VERSION" ]; then
             poetry version "$VERSION"
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add pyproject.toml
-            git commit -m "Bump version to v$VERSION"
-            git push origin "HEAD:${GITHUB_REF_NAME}"
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "pyproject.toml already at version $VERSION; no version commit created."
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+            echo "pyproject.toml already at version $VERSION; no version bump needed."
           fi
+
+      - name: Create signed version bump pull request
+        if: steps.bump.outputs.version_changed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
+          branch: workflow/release-version-bump-v${{ github.event.inputs.version }}
+          title: Bump version to v${{ github.event.inputs.version }}
+          commit-message: Bump version to v${{ github.event.inputs.version }}
+          body: |
+            Automated signed version bump created by the release workflow.
+
+            Merge this pull request, then rerun the release workflow for v${{ github.event.inputs.version }}.
+
+      - name: Stop after creating version bump pull request
+        if: steps.bump.outputs.version_changed == 'true'
+        run: |
+          echo "Created signed PR #${{ steps.cpr.outputs.pull-request-number }} for version bump."
+          echo "Merge the PR and rerun this workflow to continue the release."
+          exit 1
 
       - name: Create and push tag
         env:


### PR DESCRIPTION
## Summary
- Update `.github/workflows/release.yml` to avoid making unsigned `git commit`/`git push` during the release.
- Add `pull-requests: write` permission and replace the direct bump-and-push with a two-step flow that detects a version change and creates a signed version-bump PR using `peter-evans/create-pull-request@v7` with `sign-commits: true` and branch `workflow/release-version-bump-v${{ github.event.inputs.version }}`.
- Emit a `version_changed` output from the bump step via `GITHUB_OUTPUT` and add a stop step that exits when a signed bump PR is created, instructing maintainers to merge the PR and rerun the workflow.
- Remove the inline `git config`/`git add`/`git commit`/`git push` steps that would fail branch protection requiring signed commits.

## Testing
- Ran the full test suite with `poetry run pytest --verbose -s` and the run completed successfully with `1880 passed, 11 skipped, 7 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f810f8eae88323bbc290cd8cfc185e)