### PR TITLE
Improve release workflow handoff for repeated versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
-          CURRENT_VERSION="$(awk -F" '/^version = / {print $2; exit}' pyproject.toml)"
+          CURRENT_VERSION="$(awk -F'"' '/^version = / {print $2; exit}' pyproject.toml)"
           if [ -z "$CURRENT_VERSION" ]; then
             echo "Could not determine current project version from pyproject.toml."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate release input
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version '$VERSION'. Use semantic version format X.Y.Z."
+            exit 1
+          fi
+
+      - name: Determine whether version bump is required
+        id: version_state
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          CURRENT_VERSION="$(awk -F" '/^version = / {print $2; exit}' pyproject.toml)"
+          if [ -z "$CURRENT_VERSION" ]; then
+            echo "Could not determine current project version from pyproject.toml."
+            exit 1
+          fi
+
+          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+            echo "pyproject.toml already at version $VERSION; continuing with publish flow."
+          else
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
+            echo "pyproject.toml at version $CURRENT_VERSION; bump PR required for $VERSION."
+          fi
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -36,37 +64,22 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Validate release input
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-        run: |
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version '$VERSION'. Use semantic version format X.Y.Z."
-            exit 1
-          fi
-
       - name: Install dependencies
+        if: steps.version_state.outputs.version_changed == 'true'
         run: poetry sync --all-extras --with test --no-interaction
 
       - name: Run tests
+        if: steps.version_state.outputs.version_changed == 'true'
         run: poetry run pytest --verbose -s
 
       - name: Bump version
-        id: bump
+        if: steps.version_state.outputs.version_changed == 'true'
         env:
           VERSION: ${{ github.event.inputs.version }}
-        run: |
-          CURRENT_VERSION="$(poetry version --short)"
-          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
-            poetry version "$VERSION"
-            echo "version_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "version_changed=false" >> "$GITHUB_OUTPUT"
-            echo "pyproject.toml already at version $VERSION; no version bump needed."
-          fi
+        run: poetry version "$VERSION"
 
       - name: Create signed version bump pull request
-        if: steps.bump.outputs.version_changed == 'true'
+        if: steps.version_state.outputs.version_changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
@@ -80,15 +93,21 @@ jobs:
 
             Merge this pull request, then rerun the release workflow for v${{ github.event.inputs.version }}.
 
+      - name: Enable auto-merge for version bump pull request
+        if: steps.version_state.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash
+
       - name: Stop release after creating version bump pull request
-        if: steps.bump.outputs.version_changed == 'true'
+        if: steps.version_state.outputs.version_changed == 'true'
         run: |
           echo "Created or updated signed PR #${{ steps.cpr.outputs.pull-request-number }} for version bump."
-          echo "Merge that PR, then start a NEW workflow_dispatch run from the updated branch."
+          echo "If auto-merge is unavailable, merge that PR manually, then start a NEW workflow_dispatch run from the updated branch."
           echo "Do not use GitHub's Re-run jobs on this run, because it keeps the original commit SHA."
 
       - name: Create and push tag
-        if: steps.bump.outputs.version_changed == 'false'
+        if: steps.version_state.outputs.version_changed == 'false'
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
@@ -100,15 +119,15 @@ jobs:
           git push origin "v$VERSION"
 
       - name: Build package
-        if: steps.bump.outputs.version_changed == 'false'
+        if: steps.version_state.outputs.version_changed == 'false'
         run: poetry build --clean
 
       - name: Publish package to PyPI
-        if: steps.bump.outputs.version_changed == 'false'
+        if: steps.version_state.outputs.version_changed == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub release
-        if: steps.bump.outputs.version_changed == 'false'
+        if: steps.version_state.outputs.version_changed == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
### Motivation
- The release workflow retrigger for the same version was re-running the bump path and required manual PR acceptance and repeated heavy setup steps.
- Avoid unnecessary dependency installation and test execution during a publish-only run and reduce manual PR merging when repository settings permit.

### Description
- Add a `Determine whether version bump is required` step that compares `pyproject.toml` to the input `version` and sets `steps.version_state.outputs.version_changed` accordingly.
- Gate dependency installation, test execution, and bump/PR creation on `version_changed == 'true'` while gating tag/build/publish/release steps on `version_changed == 'false'` so publish-only runs skip the bump phase.
- Simplify the bump step to run `poetry version "$VERSION"` when a bump is required and continue to create a signed version-bump pull request using `peter-evans/create-pull-request@v7`.
- Attempt to enable auto-merge for the generated bump PR via `gh pr merge --auto --squash` and update messaging to indicate manual merge is needed if auto-merge is unavailable.

### Testing
- Ran the full test suite with `poetry run pytest --verbose -s` and observed success: `1880 passed, 11 skipped`.
- No workflow run was executed in this change; behavior verified by local test execution only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89e60aa3c8323960ca3a19c4b09dd)