### PR TITLE
Configure git identity in release workflow to fix tagging failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,12 @@ jobs:
           echo "If auto-merge is unavailable, merge that PR manually, then start a NEW workflow_dispatch run from the updated branch."
           echo "Do not use GitHub's Re-run jobs on this run, because it keeps the original commit SHA."
 
+      - name: Configure git identity for tagging
+        if: steps.version_state.outputs.version_changed == 'false'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Create and push tag
         if: steps.version_state.outputs.version_changed == 'false'
         env:


### PR DESCRIPTION
### Motivation
- Fix the `git tag -a` failure on GitHub Actions caused by a missing committer identity (error: "fatal: empty ident name") when running the publish path for an already-bumped version.

### Description
- Add a `Configure git identity for tagging` step to `.github/workflows/release.yml` (runs when `steps.version_state.outputs.version_changed == 'false'`) that runs `git config --local user.name "github-actions[bot]"` and `git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"` before running `git tag -a`.

### Testing
- Ran `poetry run pytest --verbose -s`, which passed: `1880 passed, 11 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a3d1bbcc83239038d2f4960fa7ab)