### PR TITLE
Update README install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,6 @@ Avalan is a Python SDK and CLI for building and running AI workflows and agents 
   observability.
 - 🌐 **Open serving surfaces** for OpenAI-compatible APIs, MCP, and A2A.
 
-# 🚀 Start Here
-
-- [Install](#install)
-- [Quickstart](#quickstart)
-- [Models](#models)
-- [Agents](#agents)
-- [docs/examples](docs/examples/README.md)
-- [docs/CLI.md](docs/CLI.md)
-- [docs/ai_uri.md](docs/ai_uri.md)
-
 # 🗂️ Table of Contents
 
 - 📦 [Install](#install)
@@ -55,21 +45,22 @@ Avalan is a Python SDK and CLI for building and running AI workflows and agents 
 ## 📦 Install
 
 Avalan supports Python 3.11 and 3.12. Install the smallest profile that fits
-your workflow; the examples later in this README may require additional extras.
+your workflow.
 
-### 🐍 Pip (recommended)
+### 🍺 Homebrew (macOS)
 
-Hosted APIs plus tool-enabled or served agents:
+```sh
+brew install avalan-ai/avalan/avalan
+```
+
+> [!TIP]
+> This package installs the same extras profile as
+> `avalan[agent,server,tool,vendors]`.
+
+### 🐍 Pip
 
 ```sh
 python3 -m pip install -U "avalan[agent,server,tool,vendors]"
-```
-
-Broader local development setup with the capabilities used throughout this
-README:
-
-```sh
-python3 -m pip install -U "avalan[agent,audio,memory,server,tool,translation,vendors,vision]"
 ```
 
 Add hardware-specific extras when needed:
@@ -81,17 +72,10 @@ Add hardware-specific extras when needed:
 
 For the leanest install, omit the extras list entirely.
 
-### 🍺 Homebrew (macOS)
-
-```sh
-brew tap avalan-ai/avalan
-brew install avalan
-```
-
 ### 🛠️ From Source with Poetry
 
 ```sh
-poetry install --all-extras --with test
+poetry install --extras "agent server tool vendors" --with test
 ```
 
 > [!TIP]


### PR DESCRIPTION
### Motivation
- Simplify and clarify installation guidance by prioritizing Homebrew and aligning package extras across install methods.
- Reduce duplication and remove the redundant `Start Here` section to shorten the flow from Highlights to the Table of Contents.
- Ensure the Homebrew, pip, and Poetry examples present a consistent extras profile for common use cases.

### Description
- Removed the `Start Here` section from `README.md` so the document transitions directly from Highlights to the Table of Contents.
- Reordered the `Install` section to show Homebrew first, then pip, then Poetry.
- Replaced the two-step Homebrew flow with the single command `brew install avalan-ai/avalan/avalan` and added a tip noting it installs the same extras as `avalan[agent,server,tool,vendors]`.
- Updated the pip example to `python3 -m pip install -U "avalan[agent,server,tool,vendors]"` and changed the Poetry command to `poetry install --extras "agent server tool vendors" --with test`, removing the broader pip example.

### Testing
- Ran `git status --short` to confirm working tree state and the command completed successfully.
- Inspected changes with `git diff -- README.md` and confirmed the expected diff output.
- Verified the updated section content with `nl -ba README.md | sed -n '20,110p'` and confirmed the new ordering and examples were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6555eb788323953f2dbc7e45e60b)