### PR TITLE
Delegate DS4 integration helpers to pyds4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
       matrix:
         python: ['3.11', '3.12']
         target:
-          - name: linux-cpu
+          - name: linux-cuda
             os: ubuntu-latest
-            backend: cpu
+            backend: cuda
           - name: macos-metal
             os: macos-15
             backend: metal
@@ -75,6 +75,7 @@ jobs:
         run: |
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
+          poetry config installer.only-binary pyds4
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Install DS4 bridge dependencies
-        run: poetry sync --extras ds4 --with test --no-interaction
+        run: poetry sync --extras "ds4 tool" --with test --no-interaction
 
       - name: Run DS4 bridge tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,23 @@ permissions:
 
 jobs:
   test:
+    name: test (${{ matrix.target.name }}, Python ${{ matrix.python }})
     env:
       IGNORE_VENV_CACHE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ignore_venv_cache == 'true' }}
+      PYDS4_BACKEND: ${{ matrix.target.backend }}
     strategy:
       fail-fast: false
       matrix:
         python: ['3.11', '3.12']
+        target:
+          - name: linux-cpu
+            os: ubuntu-latest
+            backend: cpu
+          - name: macos-metal
+            os: macos-15
+            backend: metal
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target.os }}
 
     steps:
       - name: Check out repository
@@ -70,18 +79,40 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-v12-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          key: venv-v13-${{ runner.os }}-${{ matrix.target.name }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
           restore-keys: |
-            venv-v12-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
+            venv-v13-${{ runner.os }}-${{ matrix.target.name }}-${{ steps.setup-python.outputs.python-version }}-
 
       - name: Install dependencies
         run: poetry sync --all-extras --with test --no-interaction
 
+      - name: Verify pyds4 backend
+        run: |
+          poetry run python - <<'PY'
+          import os
+
+          import pyds4
+
+          expected = os.environ["PYDS4_BACKEND"]
+          capabilities = pyds4.capabilities()
+          actual = getattr(pyds4, "__ds4_native_backend__", None)
+          if not actual:
+              actual = getattr(capabilities, "backend", None)
+          if hasattr(actual, "value"):
+              actual = actual.value
+          if str(actual).lower() != expected:
+              raise SystemExit(
+                  f"pyds4 backend {actual!r} does not match {expected!r}"
+              )
+          print(f"pyds4 backend: {actual}")
+          PY
+
       - name: Install Linux MLX runtime
+        if: matrix.target.os == 'ubuntu-latest'
         run: poetry run pip install "mlx[cpu]==0.28.0"
 
       - name: Install MLX-LM runtime (Python 3.12 only)
-        if: matrix.python == '3.12'
+        if: matrix.python == '3.12' && matrix.target.os == 'ubuntu-latest'
         run: poetry run pip install "mlx-lm==0.26.3"
 
       - name: Run tests with coverage analysis
@@ -94,64 +125,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           format: cobertura
           file: coverage.xml
-          flag-name: unit-tests-${{ matrix.python }}
+          flag-name: unit-tests-${{ matrix.target.name }}-${{ matrix.python }}
           parallel: true
           fail-on-error: true
-
-  ds4-bridge:
-    name: DS4 bridge (${{ matrix.target.name }}, Python ${{ matrix.python }})
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ['3.11', '3.12']
-        target:
-          - name: linux-cpu
-            os: ubuntu-latest
-            backend: cpu
-          - name: macos-metal
-            os: macos-15
-            backend: metal
-
-    runs-on: ${{ matrix.target.os }}
-
-    env:
-      PYDS4_BACKEND: ${{ matrix.target.backend }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 2.3.3
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          virtualenvs-path: .venv
-          installer-parallel: true
-
-      - name: Configure Poetry
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-
-      - name: Install DS4 bridge dependencies
-        run: poetry sync --extras "ds4 tool" --with test --no-interaction
-
-      - name: Run DS4 bridge tests
-        run: |
-          poetry run pytest \
-            tests/model/ds4_binding_packaging_test.py::test_import_compatible_binding_accepts_installed_local_pyds4 \
-            tests/model/ds4_model_test.py::test_ds4_generation_stream_accepts_real_pyds4_score_types \
-            tests/tool/dsml_test.py \
-            --verbose
 
   finish:
     if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,61 @@ jobs:
           parallel: true
           fail-on-error: true
 
+  ds4-bridge:
+    name: DS4 bridge (${{ matrix.target.name }}, Python ${{ matrix.python }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12']
+        target:
+          - name: linux-cpu
+            os: ubuntu-latest
+            backend: cpu
+          - name: macos-metal
+            os: macos-15
+            backend: metal
+
+    runs-on: ${{ matrix.target.os }}
+
+    env:
+      PYDS4_BACKEND: ${{ matrix.target.backend }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 2.3.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
+
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+
+      - name: Install DS4 bridge dependencies
+        run: poetry sync --extras ds4 --with test --no-interaction
+
+      - name: Run DS4 bridge tests
+        run: |
+          poetry run pytest \
+            tests/model/ds4_binding_packaging_test.py::test_import_compatible_binding_accepts_installed_local_pyds4 \
+            tests/model/ds4_model_test.py::test_ds4_generation_stream_accepts_real_pyds4_score_types \
+            tests/tool/dsml_test.py \
+            --verbose
+
   finish:
     if: ${{ always() }}
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.11', '3.12']
+        python: ['3.11', '3.12', '3.13', '3.14']
         target:
           - name: linux-cuda
             os: ubuntu-latest
@@ -113,11 +113,11 @@ jobs:
 
       - name: Install Linux MLX runtime
         if: matrix.target.os == 'ubuntu-latest'
-        run: poetry run pip install "mlx[cpu]==0.28.0"
+        run: poetry run pip install "mlx[cpu]==0.31.2"
 
-      - name: Install MLX-LM runtime (Python 3.12 only)
-        if: matrix.python == '3.12' && matrix.target.os == 'ubuntu-latest'
-        run: poetry run pip install "mlx-lm==0.26.3"
+      - name: Install Linux MLX-LM runtime
+        if: matrix.target.os == 'ubuntu-latest'
+        run: poetry run pip install "mlx-lm[cpu]==0.31.3"
 
       - name: Run tests with coverage analysis
         run: make test coverage no-install
@@ -143,3 +143,60 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  wheel:
+    name: wheel (${{ matrix.target.name }}, Python ${{ matrix.python }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12', '3.13', '3.14']
+        target:
+          - name: linux-cuda
+            os: ubuntu-latest
+            backend: cuda
+          - name: macos-metal
+            os: macos-15
+            backend: metal
+
+    runs-on: ${{ matrix.target.os }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python }} + Poetry cache
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Load cached Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.local
+          key: poetry-v13-${{ runner.os }}-2.3.3
+
+      - name: Add Poetry to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          version: 2.3.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
+
+      - name: Build wheel
+        run: poetry build --format wheel --clean
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: avalan-wheel-${{ matrix.target.name }}-${{ matrix.python }}
+          path: dist/*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.11', '3.12', '3.13', '3.14']
+        python: ['3.11', '3.12', '3.13']
         target:
           - name: linux-cuda
             os: ubuntu-latest
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.11', '3.12', '3.13', '3.14']
+        python: ['3.11', '3.12', '3.13']
         target:
           - name: linux-cuda
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-v12-2.3.3
+          key: poetry-v13-${{ runner.os }}-2.3.3
+
+      - name: Add Poetry to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ The example below uses a local 8B LLM, enables recent memory, and loads a calcul
 echo "What is (4 + 6) and then that result times 5, divided by 2?" \
   | avalan agent run \
       --engine-uri "NousResearch/Hermes-3-Llama-3.1-8B" \
+      --backend mlx \
       --tool "math.calculator" \
       --memory-recent \
       --run-max-new-tokens 8192 \

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Avalan is a Python SDK and CLI for building and running AI workflows and agents 
 
 ## 📦 Install
 
-Avalan supports Python 3.11 and 3.12. Install the smallest profile that fits
-your workflow.
+Avalan supports Python 3.11 through 3.14, except Python 3.14.1 due to
+upstream PyTorch wheel metadata. Install the smallest profile that fits your
+workflow.
 
 ### 🍺 Homebrew (macOS)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ Avalan is a Python SDK and CLI for building and running AI workflows and agents 
 
 ## 📦 Install
 
-Avalan supports Python 3.11 through 3.14, except Python 3.14.1 due to
-upstream PyTorch wheel metadata. Install the smallest profile that fits your
-workflow.
+Avalan supports Python 3.11 through 3.13. Install the smallest profile that
+fits your workflow.
+
+> [!NOTE]
+> Python 3.14 support is currently held back by upstream package support:
+> `faiss-cpu` does not publish Python 3.14 Linux/macOS wheels yet, and
+> `cuda-tile` still declares `<3.14`. Recheck those packages before
+> re-enabling Python 3.14 CI targets.
 
 ### 🍺 Homebrew (macOS)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,7 +30,7 @@ Start a new poetry project, specify the python version, and add avalan with
 
 ```bash
 mkdir avalan-test/ && cd avalan-test/
-poetry init --no-interaction --python=">=3.12,<3.14"
+poetry init --no-interaction --python=">=3.11,!=3.14.1,<3.15"
 poetry add "avalan[all]" --no-cache
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,7 +30,7 @@ Start a new poetry project, specify the python version, and add avalan with
 
 ```bash
 mkdir avalan-test/ && cd avalan-test/
-poetry init --no-interaction --python=">=3.11,!=3.14.1,<3.15"
+poetry init --no-interaction --python=">=3.11,<3.14"
 poetry add "avalan[all]" --no-cache
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -134,7 +134,7 @@ description = "Happy Eyeballs for asyncio"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
     {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
@@ -147,7 +147,7 @@ description = "Async http client/server framework (asyncio)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b"},
     {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5"},
@@ -323,7 +323,7 @@ description = "aiosignal: a list of registered asynchronous callbacks"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
     {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
@@ -340,7 +340,7 @@ description = "Document parameters, class attributes, return types, and variable
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
     {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
@@ -357,7 +357,7 @@ files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"}
+markers = {main = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""}
 
 [[package]]
 name = "anthropic"
@@ -366,7 +366,7 @@ description = "The official Python library for the anthropic API"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "anthropic-0.71.1-py3-none-any.whl", hash = "sha256:6ca6c579f0899a445faeeed9c0eb97aa4bdb751196262f9ccc96edfc0bb12679"},
     {file = "anthropic-0.71.1.tar.gz", hash = "sha256:a77d156d3e7d318b84681b59823b2dee48a8ac508a3e54e49f0ab0d074e4b0da"},
@@ -588,7 +588,7 @@ description = "Classes Without Boilerplate"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"},
     {file = "attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"},
@@ -882,7 +882,7 @@ description = "Extensible memoizing collections and decorators"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6"},
     {file = "cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32"},
@@ -969,7 +969,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "implementation_name == \"pypy\" and platform_system == \"Linux\" and platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") or implementation_name == \"pypy\" and platform_system == \"Linux\" and platform_python_implementation != \"PyPy\" and (extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\") or implementation_name == \"pypy\" and platform_system == \"Linux\" and (extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") or platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") or platform_python_implementation != \"PyPy\" and (extra == \"memory\" or extra == \"audio\") or extra == \"audio\""
+markers = "platform_system == \"Linux\" and extra == \"secrets\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" or platform_system == \"Linux\" and extra == \"memory\" and platform_python_implementation != \"PyPy\" or platform_system == \"Linux\" and extra == \"audio\" or platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\") and implementation_name == \"pypy\" or (platform_python_implementation != \"PyPy\" or extra == \"audio\") and platform_system != \"Linux\" and (sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\") and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\")"
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -1067,7 +1067,7 @@ description = "The Real First Universal Charset Detector. Open, modern and activ
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vendors\" or extra == \"vision\""
 files = [
     {file = "charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72"},
     {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe"},
@@ -1590,41 +1590,12 @@ all = ["cuda-bindings[all] (>=13.2.0,<13.3.0)"]
 
 [[package]]
 name = "cuda-tile"
-version = "1.0.0"
-description = "CUDA Tile Compiler"
-optional = true
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version >= \"3.14\" and (extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
-files = [
-    {file = "cuda_tile-1.0.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:2ddad07570074c38a4b41c257a47a5f0679561234964f074498b649d66b2372f"},
-    {file = "cuda_tile-1.0.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1a24cc9762553a6997e4cc13388e430e963b3a01647aab7da8ca8bb8827b7e0b"},
-    {file = "cuda_tile-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:6164fdf072d3c5cf2fa9bc61b7e9c38234facb7a0eda2b92094131afa6cb664f"},
-    {file = "cuda_tile-1.0.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5303302a0415a67c9479ac18b3c112e707ca3ff6f4c4e3bddc08266852065bd9"},
-    {file = "cuda_tile-1.0.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:3cf9763f45c467bb41d0933fb4b2b5181aede4ea8db1f098d6ade5d8c368a713"},
-    {file = "cuda_tile-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e58e3ae013bee6ce6a75b842ff2e244f4c156337adc582c510a7990e2f90bea"},
-    {file = "cuda_tile-1.0.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:200972cab54583d19be6514330f39e34109a0af0733a4e9dd88ef96a24231411"},
-    {file = "cuda_tile-1.0.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:72474601fdfe32d2f05257b22d4c00d0502fc13f96593304d54e883af2463e2b"},
-    {file = "cuda_tile-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:8003cdf688463c8076b38fefa9c28045ab328180691cf909de4eaf1d45e71c44"},
-    {file = "cuda_tile-1.0.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:f14eb291ea573ff9959666348f1a2e80b7bae266619ad340d4ff95d6066af0a4"},
-    {file = "cuda_tile-1.0.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:d42f5e989a3f393fbd4f05bcd87bb76efaa6ed8ca36877c1d9a4b49d1d1f3756"},
-    {file = "cuda_tile-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae190de78bfae2401f7e6eda68c439eb367112ebdb52e2bf6898d4657e411f31"},
-]
-
-[package.dependencies]
-typing-extensions = "*"
-
-[package.extras]
-test = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "cuda-tile"
 version = "1.3.0"
 description = "CUDA Tile Compiler"
 optional = true
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
-markers = "python_version <= \"3.13\" and (extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
     {file = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:c55616c648f06f84808648a521c67f2d7c790574d6b53ddf8c3bfbc995d36d45"},
     {file = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:8c71c2fd9b96c054c126a218f9927c8c8dde72441a532464551b865b416d452a"},
@@ -1824,7 +1795,7 @@ description = "Distro - an OS platform information API"
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
@@ -1859,7 +1830,7 @@ description = "Parse Python docstrings in reST, Google and Numpydoc format"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
     {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
@@ -2007,7 +1978,7 @@ description = "FastAPI framework, high performance, easy to learn, fast to code,
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"},
     {file = "fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f"},
@@ -2410,7 +2381,7 @@ description = "A list-like structure which implements collections.abc.MutableSeq
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011"},
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565"},
@@ -2696,7 +2667,7 @@ description = "Common protobufs used in Google APIs"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8"},
     {file = "googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257"},
@@ -2887,7 +2858,7 @@ description = "Fast transfer of large files with the Hugging Face Hub."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and (extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"mlx\" or extra == \"apple\") and platform_machine == \"arm64\" or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"aarch64\")"
+markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"mlx\" or extra == \"apple\") or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144"},
     {file = "hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f"},
@@ -3032,7 +3003,7 @@ description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "httpx_sse-0.4.2-py3-none-any.whl", hash = "sha256:a9fa4afacb293fa50ef9bacb6cae8287ba5fd1f4b1c2d10a35bb981c41da31ab"},
     {file = "httpx_sse-0.4.2.tar.gz", hash = "sha256:5bb6a2771a51e6c7a5f5c645e40b8a5f57d8de708f46cb5f3868043c3c18124e"},
@@ -3288,7 +3259,7 @@ description = "Read metadata from Python packages"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(python_version == \"3.11\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\") and (platform_system == \"Linux\" or python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") or python_version == \"3.11\" and (extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\") or extra == \"vendors\" or extra == \"vision\" or python_version == \"3.11\" and platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\")"
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
@@ -3438,7 +3409,7 @@ description = "Fast iterable JSON parser."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "jiter-0.11.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3893ce831e1c0094a83eeaf56c635a167d6fa8cc14393cc14298fd6fdc2a2449"},
     {file = "jiter-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:25c625b9b61b5a8725267fdf867ef2e51b429687f6a4eef211f4612e95607179"},
@@ -3527,7 +3498,7 @@ description = "JSON Matching Expressions"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\") or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\""
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
@@ -3553,7 +3524,7 @@ description = "An implementation of JSON Schema validation for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63"},
     {file = "jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85"},
@@ -3576,7 +3547,7 @@ description = "The JSON Schema meta-schemas and vocabularies, exposed as a Regis
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -4280,7 +4251,7 @@ description = "Model Context Protocol SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "mcp-1.12.3-py3-none-any.whl", hash = "sha256:5483345bf39033b858920a5b6348a303acacf45b23936972160ff152107b850e"},
     {file = "mcp-1.12.3.tar.gz", hash = "sha256:ab2e05f5e5c13e1dc90a4a9ef23ac500a6121362a564447855ef0ab643a99fed"},
@@ -4337,16 +4308,10 @@ numpy = [
 ]
 opencv-python-headless = {version = ">=4.0.0", optional = true, markers = "extra == \"opencv\""}
 pillow = ">=10.3.0"
-pydantic = [
-    {version = ">=2.7,<3.0", markers = "python_version <= \"3.13\""},
-    {version = ">=2.12,<3.0", markers = "python_version >= \"3.14\""},
-]
+pydantic = {version = ">=2.7,<3.0", markers = "python_version <= \"3.13\""}
 pydantic-extra-types = {version = ">=2.10.5", extras = ["pycountry"]}
 requests = ">=2.0.0"
-tiktoken = [
-    {version = ">=0.7.0", markers = "python_version <= \"3.13\""},
-    {version = ">=0.12.0", markers = "python_version >= \"3.14\""},
-]
+tiktoken = {version = ">=0.7.0", markers = "python_version <= \"3.13\""}
 typing-extensions = ">=4.11.0"
 
 [package.extras]
@@ -4553,7 +4518,7 @@ description = "Python library for arbitrary-precision floating-point arithmetic"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\")"
+markers = "platform_system == \"Linux\" and (extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -4626,7 +4591,7 @@ description = "multidict implementation"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "multidict-6.7.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9f474ad5acda359c8758c8accc22032c6abe6dc87a8be2440d097785e27a9349"},
     {file = "multidict-6.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a9db5a870f780220e931d0002bbfd88fb53aceb6293251e2c839415c1b20e"},
@@ -4863,7 +4828,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") or extra == \"local\" or extra == \"vision\""
 files = [
     {file = "networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec"},
     {file = "networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037"},
@@ -5372,7 +5337,7 @@ description = "The official Python library for the openai API"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107"},
     {file = "openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9"},
@@ -5535,7 +5500,6 @@ googleapis-common-protos = ">=1.57,<2.0"
 grpcio = [
     {version = ">=1.63.2,<2.0.0", markers = "python_version < \"3.13\""},
     {version = ">=1.66.2,<2.0.0", markers = "python_version == \"3.13\""},
-    {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
 ]
 opentelemetry-api = ">=1.15,<2.0"
 opentelemetry-exporter-otlp-proto-common = "1.41.1"
@@ -5991,7 +5955,7 @@ files = [
     {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
     {file = "pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vision\" or extra == \"tool\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"tool\" or extra == \"vendors\" or extra == \"vision\")"}
+markers = {main = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vision\" or extra == \"tool\" or extra == \"vendors\") or extra == \"tool\" or extra == \"vendors\" or extra == \"vision\""}
 
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
@@ -6098,7 +6062,7 @@ description = "Accelerated property cache"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db"},
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8"},
@@ -6271,7 +6235,7 @@ description = "Cross-platform lib for process and system monitoring."
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and (platform_system == \"Linux\" or extra == \"local\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") or extra == \"local\""
 files = [
     {file = "psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13"},
     {file = "psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5"},
@@ -6688,7 +6652,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name != \"PyPy\" and (implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") and (platform_system == \"Linux\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\") and (implementation_name == \"pypy\" or sys_platform == \"linux\" or extra == \"audio\" or extra == \"memory\") and (implementation_name == \"pypy\" or extra == \"audio\" or extra == \"memory\" or extra == \"secrets\") and (platform_python_implementation != \"PyPy\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") and (sys_platform == \"linux\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\") and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\")"
+markers = "implementation_name != \"PyPy\" and (implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") and (implementation_name == \"pypy\" or sys_platform == \"linux\" or extra == \"audio\" or extra == \"memory\") and (implementation_name == \"pypy\" or extra == \"audio\" or extra == \"memory\" or extra == \"secrets\") and (platform_python_implementation != \"PyPy\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") and (sys_platform == \"linux\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\") and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\")"
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
@@ -6705,7 +6669,7 @@ files = [
     {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
     {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"}
+markers = {main = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""}
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
@@ -6848,7 +6812,7 @@ files = [
     {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
     {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"}
+markers = {main = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""}
 
 [package.dependencies]
 typing-extensions = ">=4.14.1"
@@ -6887,7 +6851,7 @@ description = "Settings management using Pydantic"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c"},
     {file = "pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180"},
@@ -6923,7 +6887,7 @@ files = [
     {file = "pyds4-1.1.0-cp314-cp314-manylinux_2_38_x86_64.whl", hash = "sha256:6cc6f1d5990c6b7a799cbe1b8f397dd007fc1a6ff55be569a7eb3f77c3db2c16"},
     {file = "pyds4-1.1.0.tar.gz", hash = "sha256:f7efd564e1b647ef5efedac8e457841e34dc0d82b4e5d110b4fccbd963df03eb"},
 ]
-markers = {main = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")", test = "(platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")"}
+markers = {main = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")", test = "platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\""}
 
 [package.extras]
 dev = ["black (>=25.1.0)", "mypy (>=1.20.0)", "pybind11 (>=2.12)", "ruff (>=0.11.11)"]
@@ -7099,7 +7063,7 @@ description = "Read key-value pairs from a .env file and set them as environment
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"memory\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"memory\" or extra == \"vendors\") or extra == \"memory\" or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
     {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
@@ -7131,7 +7095,7 @@ description = "A streaming multipart parser for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
     {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
@@ -7471,7 +7435,7 @@ description = "JSON Referencing + Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -7614,7 +7578,7 @@ description = "Python HTTP for Humans."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") or extra == \"memory\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vendors\" or extra == \"vision\""
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -7827,7 +7791,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""
 files = [
     {file = "rpds_py-0.27.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:68afeec26d42ab3b47e541b272166a0b4400313946871cba3ed3a4fc0cab1cef"},
     {file = "rpds_py-0.27.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74e5b2f7bb6fa38b1b10546d27acbacf2a022a8b5543efb06cfebc72a59c85be"},
@@ -8283,7 +8247,7 @@ description = "Unsupervised text tokenizer and detokenizer."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"translation\") or extra == \"translation\" and platform_system != \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"translation\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"translation\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"translation\")"
 files = [
     {file = "sentencepiece-0.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e10fa50bdbaa5e2445dbd387979980d391760faf0ec99a09bd7780ff37eaec44"},
     {file = "sentencepiece-0.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f27ae6deea72efdb6f361750c92f6c21fd0ad087445082770cc34015213c526"},
@@ -8534,7 +8498,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") or extra == \"local\" or extra == \"vision\""
 files = [
     {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
     {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
@@ -8573,7 +8537,7 @@ files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
-markers = {main = "extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or (extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or extra == \"vllm\" or extra == \"nvidia\") and python_version >= \"3.12\" and platform_system == \"Linux\""}
+markers = {main = "(extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or extra == \"vllm\" or extra == \"nvidia\") and (extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or python_version >= \"3.12\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\")"}
 
 [[package]]
 name = "sniffio"
@@ -8745,7 +8709,7 @@ description = "SSE plugin for Starlette"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "sse_starlette-3.0.2-py3-none-any.whl", hash = "sha256:16b7cbfddbcd4eaca11f7b586f3b8a080f1afe952c15813455b162edea619e5a"},
     {file = "sse_starlette-3.0.2.tar.gz", hash = "sha256:ccd60b5765ebb3584d0de2d7a6e4f745672581de4f5005ab31c3a25d10b52b3a"},
@@ -8767,7 +8731,7 @@ description = "The little ASGI library that shines."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74"},
     {file = "starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933"},
@@ -8803,7 +8767,7 @@ description = "Computer algebra system (CAS) in Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\")"
+markers = "platform_system == \"Linux\" and (extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -8868,7 +8832,7 @@ description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"translation\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\") or extra == \"translation\" or extra == \"vendors\""
 files = [
     {file = "tiktoken-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:47b1df8d73390a24f94980c75158cdd5c56d256f16d55f30cb49c230caba9ba4"},
     {file = "tiktoken-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d40c6c5aab171dcd6eb8455bc567bde404bb9def60cdb8c1299cc782b242bb9"},
@@ -8975,7 +8939,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\") or (extra == \"local\" or extra == \"vendors\") and platform_system != \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"local\" or extra == \"vendors\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"local\" or extra == \"vendors\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\")"
 files = [
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c"},
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001"},
@@ -9054,7 +9018,7 @@ description = "Tensors and Dynamic neural networks in Python with strong GPU acc
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") or extra == \"local\" or extra == \"vision\""
 files = [
     {file = "torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e"},
     {file = "torch-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4cf8687f4aec3900f748d553483ef40e0ac38411c3c48d0a86a438f6d7a99b18"},
@@ -9153,7 +9117,7 @@ description = "An audio package for PyTorch"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"audio\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") or extra == \"audio\""
 files = [
     {file = "torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ebb59c694909eccb5d61b7cc199d297692012c43286e36d92983aa7bad7586d"},
     {file = "torchaudio-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:be7ad472acb16d16e98c005f0219b0db06a47dfe8f7b4d177062e1638f871e3b"},
@@ -9192,7 +9156,7 @@ description = "image and video datasets and models for torch deep learning"
 optional = true
 python-versions = "!=3.14.1,>=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vision\") or extra == \"vision\""
 files = [
     {file = "torchvision-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a06d4772a8e13e772906ed736cc53ec6639e5e60554f8e5fa6ca165aabebc464"},
     {file = "torchvision-0.26.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2adfbe438473236191ff077a4a9a0c767436879c89628aa97137e959b0c11a94"},
@@ -9263,7 +9227,7 @@ description = "Transformers: the model-definition framework for state-of-the-art
 optional = true
 python-versions = ">=3.10.0"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\") or extra == \"local\" and platform_system != \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"local\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"local\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\")"
 files = [
     {file = "transformers-5.7.0-py3-none-any.whl", hash = "sha256:869660cd8fc92badc041f5551bf755a42f4b9558c93341bf3fa3eeed7065079c"},
     {file = "transformers-5.7.0.tar.gz", hash = "sha256:a9d35cf39804e3456c1f9bc1a79ad5ffa878640a61f51f66f71c97f4b4e2ce10"},
@@ -9445,7 +9409,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"quantization\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"memory\" or extra == \"tool\") or (extra == \"vendors\" or extra == \"server\" or extra == \"local\" or extra == \"vision\" or extra == \"memory\" or extra == \"tool\") and platform_system != \"Linux\""}
+markers = {main = "(python_version <= \"3.12\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"quantization\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\") and platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"quantization\" or extra == \"memory\" or extra == \"tool\") or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"memory\" or extra == \"tool\") or (extra == \"vendors\" or extra == \"server\" or extra == \"local\" or extra == \"vision\" or extra == \"memory\" or extra == \"tool\") and platform_system != \"Linux\""}
 
 [[package]]
 name = "typing-inspection"
@@ -9458,7 +9422,7 @@ files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"server\" or extra == \"vendors\")"}
+markers = {main = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"vendors\") or extra == \"server\" or extra == \"vendors\""}
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
@@ -9483,7 +9447,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"server\" or extra == \"tool\" or extra == \"vision\") or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"server\" or extra == \"tool\" or extra == \"translation\" or extra == \"vision\""
 files = [
     {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
     {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
@@ -9502,7 +9466,7 @@ description = "The lightning-fast ASGI server."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") or extra == \"server\""
 files = [
     {file = "uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a"},
     {file = "uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"},
@@ -9801,7 +9765,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
@@ -10048,7 +10012,7 @@ description = "Yet another URL library"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") or extra == \"vendors\""
 files = [
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7bd6683587567e5a49ee6e336e0612bec8329be1b7d4c8af5687dcdeb67ee1e"},
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cdac20da754f3a723cceea5b3448e1a2074866406adeb4ef35b469d089adb8f"},
@@ -10229,7 +10193,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(python_version == \"3.11\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\") and (platform_system == \"Linux\" or python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") or python_version == \"3.11\" and (extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\") or extra == \"vendors\" or extra == \"vision\" or python_version == \"3.11\" and platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\")"
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
@@ -10263,5 +10227,5 @@ vllm = ["vllm"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11,!=3.14.1,<3.15"
-content-hash = "e720883a7c26c7fe2fcedb09652e46e8d65142c5acbcf6cf7b34d9212d38c187"
+python-versions = ">=3.11,<3.14"
+content-hash = "04cf66f58e84efbc0c83a60794443ac6890856ad0cc5420a9cba66187bdbde62"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5994,15 +5994,17 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pyds4"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python bindings for the DS4 native inference engine"
 optional = false
 python-versions = ">=3.11"
 groups = ["main", "test"]
 files = [
-    {file = "pyds4-1.0.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:42928d6c2a00242201d27076cd686818de699d330afe514c627bcd51d523f650"},
-    {file = "pyds4-1.0.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:ec5d90e934d60fcb02f52bc1567bf9eb832c71283f5d13c4b1c1c644e6d562b6"},
-    {file = "pyds4-1.0.0.tar.gz", hash = "sha256:cf83f97d281b9e5faf5c33ab51d228e1644eeaf24773d9d88d9e1a505ba1a4b3"},
+    {file = "pyds4-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4ddc03be73e79789bfa53544a2eeb9df01db465762eb989c1732a541e65245dd"},
+    {file = "pyds4-1.0.1-cp311-cp311-manylinux_2_38_x86_64.whl", hash = "sha256:a62f63fc756657feac9009d94b2145a31a2eb08f4731b2422c066dfe4360cc77"},
+    {file = "pyds4-1.0.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:02681c5236074a09cdbcdc1a64b531df3a72f30d5bf8691479161f23461408ec"},
+    {file = "pyds4-1.0.1-cp312-cp312-manylinux_2_38_x86_64.whl", hash = "sha256:668179ebf5f973b4fa053a3bb5a7da315542e5af0341f1b5ea3efa5f78a3a949"},
+    {file = "pyds4-1.0.1.tar.gz", hash = "sha256:a6a487cba41f8b0c730f4a4a7e98ce45e85c0ea133e58b2249deb0580d2a94d3"},
 ]
 markers = {main = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")", test = "(platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")"}
 
@@ -9190,4 +9192,4 @@ vllm = ["vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "d3be021bad6349adef60863dc5c9606b5cbe8a8831b92d9185d66b50fe38893f"
+content-hash = "3d74a726e4c19e14b6c4afb6682adafadf138045087bd3659e43a296526ee639"

--- a/poetry.lock
+++ b/poetry.lock
@@ -142,133 +142,133 @@ files = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.0"
+version = "3.13.5"
 description = "Async http client/server framework (asyncio)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
 files = [
-    {file = "aiohttp-3.13.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca69ec38adf5cadcc21d0b25e2144f6a25b7db7bea7e730bac25075bc305eff0"},
-    {file = "aiohttp-3.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:240f99f88a9a6beb53ebadac79a2e3417247aa756202ed234b1dbae13d248092"},
-    {file = "aiohttp-3.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a4676b978a9711531e7cea499d4cdc0794c617a1c0579310ab46c9fdf5877702"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48fcdd5bc771cbbab8ccc9588b8b6447f6a30f9fe00898b1a5107098e00d6793"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:eeea0cdd2f687e210c8f605f322d7b0300ba55145014a5dbe98bd4be6fff1f6c"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b3f01d5aeb632adaaf39c5e93f040a550464a768d54c514050c635adcbb9d0"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a4dc0b83e25267f42ef065ea57653de4365b56d7bc4e4cfc94fabe56998f8ee6"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:72714919ed9b90f030f761c20670e529c4af96c31bd000917dd0c9afd1afb731"},
-    {file = "aiohttp-3.13.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:564be41e85318403fdb176e9e5b3e852d528392f42f2c1d1efcbeeed481126d7"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:84912962071087286333f70569362e10793f73f45c48854e6859df11001eb2d3"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:90b570f1a146181c3d6ae8f755de66227ded49d30d050479b5ae07710f7894c5"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:2d71ca30257ce756e37a6078b1dff2d9475fee13609ad831eac9a6531bea903b"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:cd45eb70eca63f41bb156b7dffbe1a7760153b69892d923bdb79a74099e2ed90"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:5ae3a19949a27982c7425a7a5a963c1268fdbabf0be15ab59448cbcf0f992519"},
-    {file = "aiohttp-3.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ea6df292013c9f050cbf3f93eee9953d6e5acd9e64a0bf4ca16404bfd7aa9bcc"},
-    {file = "aiohttp-3.13.0-cp310-cp310-win32.whl", hash = "sha256:3b64f22fbb6dcd5663de5ef2d847a5638646ef99112503e6f7704bdecb0d1c4d"},
-    {file = "aiohttp-3.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:f8d877aa60d80715b2afc565f0f1aea66565824c229a2d065b31670e09fed6d7"},
-    {file = "aiohttp-3.13.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:99eb94e97a42367fef5fc11e28cb2362809d3e70837f6e60557816c7106e2e20"},
-    {file = "aiohttp-3.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4696665b2713021c6eba3e2b882a86013763b442577fe5d2056a42111e732eca"},
-    {file = "aiohttp-3.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3e6a38366f7f0d0f6ed7a1198055150c52fda552b107dad4785c0852ad7685d1"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aab715b1a0c37f7f11f9f1f579c6fbaa51ef569e47e3c0a4644fba46077a9409"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7972c82bed87d7bd8e374b60a6b6e816d75ba4f7c2627c2d14eed216e62738e1"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca8313cb852af788c78d5afdea24c40172cbfff8b35e58b407467732fde20390"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c333a2385d2a6298265f4b3e960590f787311b87f6b5e6e21bb8375914ef504"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc6d5fc5edbfb8041d9607f6a417997fa4d02de78284d386bea7ab767b5ea4f3"},
-    {file = "aiohttp-3.13.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7ddedba3d0043349edc79df3dc2da49c72b06d59a45a42c1c8d987e6b8d175b8"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:23ca762140159417a6bbc959ca1927f6949711851e56f2181ddfe8d63512b5ad"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:bfe824d6707a5dc3c5676685f624bc0c63c40d79dc0239a7fd6c034b98c25ebe"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3c11fa5dd2ef773a8a5a6daa40243d83b450915992eab021789498dc87acc114"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:00fdfe370cffede3163ba9d3f190b32c0cfc8c774f6f67395683d7b0e48cdb8a"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6475e42ef92717a678bfbf50885a682bb360a6f9c8819fb1a388d98198fdcb80"},
-    {file = "aiohttp-3.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:77da5305a410910218b99f2a963092f4277d8a9c1f429c1ff1b026d1826bd0b6"},
-    {file = "aiohttp-3.13.0-cp311-cp311-win32.whl", hash = "sha256:2f9d9ea547618d907f2ee6670c9a951f059c5994e4b6de8dcf7d9747b420c820"},
-    {file = "aiohttp-3.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0f19f7798996d4458c669bd770504f710014926e9970f4729cf55853ae200469"},
-    {file = "aiohttp-3.13.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1c272a9a18a5ecc48a7101882230046b83023bb2a662050ecb9bfcb28d9ab53a"},
-    {file = "aiohttp-3.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:97891a23d7fd4e1afe9c2f4473e04595e4acb18e4733b910b6577b74e7e21985"},
-    {file = "aiohttp-3.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:475bd56492ce5f4cffe32b5533c6533ee0c406d1d0e6924879f83adcf51da0ae"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c32ada0abb4bc94c30be2b681c42f058ab104d048da6f0148280a51ce98add8c"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4af1f8877ca46ecdd0bc0d4a6b66d4b2bddc84a79e2e8366bc0d5308e76bceb8"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e04ab827ec4f775817736b20cdc8350f40327f9b598dec4e18c9ffdcbea88a93"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a6d9487b9471ec36b0faedf52228cd732e89be0a2bbd649af890b5e2ce422353"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e66c57416352f36bf98f6641ddadd47c93740a22af7150d3e9a1ef6e983f9a8"},
-    {file = "aiohttp-3.13.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:469167d5372f5bb3aedff4fc53035d593884fff2617a75317740e885acd48b04"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a9f3546b503975a69b547c9fd1582cad10ede1ce6f3e313a2f547c73a3d7814f"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6b4174fcec98601f0cfdf308ee29a6ae53c55f14359e848dab4e94009112ee7d"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a533873a7a4ec2270fb362ee5a0d3b98752e4e1dc9042b257cd54545a96bd8ed"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ce887c5e54411d607ee0959cac15bb31d506d86a9bcaddf0b7e9d63325a7a802"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:d871f6a30d43e32fc9252dc7b9febe1a042b3ff3908aa83868d7cf7c9579a59b"},
-    {file = "aiohttp-3.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:222c828243b4789d79a706a876910f656fad4381661691220ba57b2ab4547865"},
-    {file = "aiohttp-3.13.0-cp312-cp312-win32.whl", hash = "sha256:682d2e434ff2f1108314ff7f056ce44e457f12dbed0249b24e106e385cf154b9"},
-    {file = "aiohttp-3.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:0a2be20eb23888df130214b91c262a90e2de1553d6fb7de9e9010cec994c0ff2"},
-    {file = "aiohttp-3.13.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:00243e51f16f6ec0fb021659d4af92f675f3cf9f9b39efd142aa3ad641d8d1e6"},
-    {file = "aiohttp-3.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:059978d2fddc462e9211362cbc8446747ecd930537fa559d3d25c256f032ff54"},
-    {file = "aiohttp-3.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:564b36512a7da3b386143c611867e3f7cfb249300a1bf60889bd9985da67ab77"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4aa995b9156ae499393d949a456a7ab0b994a8241a96db73a3b73c7a090eff6a"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55ca0e95a3905f62f00900255ed807c580775174252999286f283e646d675a49"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:49ce7525853a981fc35d380aa2353536a01a9ec1b30979ea4e35966316cace7e"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2117be9883501eaf95503bd313eb4c7a23d567edd44014ba15835a1e9ec6d852"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d169c47e40c911f728439da853b6fd06da83761012e6e76f11cb62cddae7282b"},
-    {file = "aiohttp-3.13.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:703ad3f742fc81e543638a7bebddd35acadaa0004a5e00535e795f4b6f2c25ca"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5bf635c3476f4119b940cc8d94ad454cbe0c377e61b4527f0192aabeac1e9370"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cfe6285ef99e7ee51cef20609be2bc1dd0e8446462b71c9db8bb296ba632810a"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:34d8af6391c5f2e69749d7f037b614b8c5c42093c251f336bdbfa4b03c57d6c4"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:12f5d820fadc5848d4559ea838aef733cf37ed2a1103bba148ac2f5547c14c29"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:0f1338b61ea66f4757a0544ed8a02ccbf60e38d9cfb3225888888dd4475ebb96"},
-    {file = "aiohttp-3.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:582770f82513419512da096e8df21ca44f86a2e56e25dc93c5ab4df0fe065bf0"},
-    {file = "aiohttp-3.13.0-cp313-cp313-win32.whl", hash = "sha256:3194b8cab8dbc882f37c13ef1262e0a3d62064fa97533d3aa124771f7bf1ecee"},
-    {file = "aiohttp-3.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:7897298b3eedc790257fef8a6ec582ca04e9dbe568ba4a9a890913b925b8ea21"},
-    {file = "aiohttp-3.13.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c417f8c2e1137775569297c584a8a7144e5d1237789eae56af4faf1894a0b861"},
-    {file = "aiohttp-3.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f84b53326abf8e56ebc28a35cebf4a0f396a13a76300f500ab11fe0573bf0b52"},
-    {file = "aiohttp-3.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:990a53b9d6a30b2878789e490758e568b12b4a7fb2527d0c89deb9650b0e5813"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c811612711e01b901e18964b3e5dec0d35525150f5f3f85d0aee2935f059910a"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ee433e594d7948e760b5c2a78cc06ac219df33b0848793cf9513d486a9f90a52"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:19bb08e56f57c215e9572cd65cb6f8097804412c54081d933997ddde3e5ac579"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f27b7488144eb5dd9151cf839b195edd1569629d90ace4c5b6b18e4e75d1e63a"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d812838c109757a11354a161c95708ae4199c4fd4d82b90959b20914c1d097f6"},
-    {file = "aiohttp-3.13.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c20db99da682f9180fa5195c90b80b159632fb611e8dbccdd99ba0be0970620"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cf8b0870047900eb1f17f453b4b3953b8ffbf203ef56c2f346780ff930a4d430"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b8a5557d5af3f4e3add52a58c4cf2b8e6e59fc56b261768866f5337872d596d"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:052bcdd80c1c54b8a18a9ea0cd5e36f473dc8e38d51b804cea34841f677a9971"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:76484ba17b2832776581b7ab466d094e48eba74cb65a60aea20154dae485e8bd"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:62d8a0adcdaf62ee56bfb37737153251ac8e4b27845b3ca065862fb01d99e247"},
-    {file = "aiohttp-3.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5004d727499ecb95f7c9147dd0bfc5b5670f71d355f0bd26d7af2d3af8e07d2f"},
-    {file = "aiohttp-3.13.0-cp314-cp314-win32.whl", hash = "sha256:a1c20c26af48aea984f63f96e5d7af7567c32cb527e33b60a0ef0a6313cf8b03"},
-    {file = "aiohttp-3.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:56f7d230ec66e799fbfd8350e9544f8a45a4353f1cf40c1fea74c1780f555b8f"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:2fd35177dc483ae702f07b86c782f4f4b100a8ce4e7c5778cea016979023d9fd"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:4df1984c8804ed336089e88ac81a9417b1fd0db7c6f867c50a9264488797e778"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e68c0076052dd911a81d3acc4ef2911cc4ef65bf7cadbfbc8ae762da24da858f"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc95c49853cd29613e4fe4ff96d73068ff89b89d61e53988442e127e8da8e7ba"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3b3bdc89413117b40cc39baae08fd09cbdeb839d421c4e7dce6a34f6b54b3ac1"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e77a729df23be2116acc4e9de2767d8e92445fbca68886dd991dc912f473755"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e88ab34826d6eeb6c67e6e92400b9ec653faf5092a35f07465f44c9f1c429f82"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:019dbef24fe28ce2301419dd63a2b97250d9760ca63ee2976c2da2e3f182f82e"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2c4aeaedd20771b7b4bcdf0ae791904445df6d856c02fc51d809d12d17cffdc7"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b3a8e6a2058a0240cfde542b641d0e78b594311bc1a710cbcb2e1841417d5cb3"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8e38d55ca36c15f36d814ea414ecb2401d860de177c49f84a327a25b3ee752b"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a921edbe971aade1bf45bcbb3494e30ba6863a5c78f28be992c42de980fd9108"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:474cade59a447cb4019c0dce9f0434bf835fb558ea932f62c686fe07fe6db6a1"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:99a303ad960747c33b65b1cb65d01a62ac73fa39b72f08a2e1efa832529b01ed"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bb34001fc1f05f6b323e02c278090c07a47645caae3aa77ed7ed8a3ce6abcce9"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-win32.whl", hash = "sha256:dea698b64235d053def7d2f08af9302a69fcd760d1c7bd9988fd5d3b6157e657"},
-    {file = "aiohttp-3.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1f164699a060c0b3616459d13c1464a981fddf36f892f0a5027cbd45121fb14b"},
-    {file = "aiohttp-3.13.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fcc425fb6fd2a00c6d91c85d084c6b75a61bc8bc12159d08e17c5711df6c5ba4"},
-    {file = "aiohttp-3.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7c2c4c9ce834801651f81d6760d0a51035b8b239f58f298de25162fcf6f8bb64"},
-    {file = "aiohttp-3.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f91e8f9053a07177868e813656ec57599cd2a63238844393cd01bd69c2e40147"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df46d9a3d78ec19b495b1107bf26e4fcf97c900279901f4f4819ac5bb2a02a4c"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3b1eb9871cbe43b6ca6fac3544682971539d8a1d229e6babe43446279679609d"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:62a3cddf8d9a2eae1f79585fa81d32e13d0c509bb9e7ad47d33c83b45a944df7"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0f735e680c323ee7e9ef8e2ea26425c7dbc2ede0086fa83ce9d7ccab8a089f26"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a51839f778b0e283b43cd82bb17f1835ee2cc1bf1101765e90ae886e53e751c"},
-    {file = "aiohttp-3.13.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac90cfab65bc281d6752f22db5fa90419e33220af4b4fa53b51f5948f414c0e7"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:62fd54f3e6f17976962ba67f911d62723c760a69d54f5d7b74c3ceb1a4e9ef8d"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:cf2b60b65df05b6b2fa0d887f2189991a0dbf44a0dd18359001dc8fcdb7f1163"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:1ccedfe280e804d9a9d7fe8b8c4309d28e364b77f40309c86596baa754af50b1"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:ea01ffbe23df53ece0c8732d1585b3d6079bb8c9ee14f3745daf000051415a31"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:19ba8625fa69523627b67f7e9901b587a4952470f68814d79cdc5bc460e9b885"},
-    {file = "aiohttp-3.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4b14bfae90598d331b5061fd15a7c290ea0c15b34aeb1cf620464bb5ec02a602"},
-    {file = "aiohttp-3.13.0-cp39-cp39-win32.whl", hash = "sha256:cf7a4b976da219e726d0043fc94ae8169c0dba1d3a059b3c1e2c964bafc5a77d"},
-    {file = "aiohttp-3.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b9697d15231aeaed4786f090c9c8bc3ab5f0e0a6da1e76c135a310def271020"},
-    {file = "aiohttp-3.13.0.tar.gz", hash = "sha256:378dbc57dd8cf341ce243f13fa1fa5394d68e2e02c15cd5f28eae35a70ec7f67"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f546a4dc1e6a5edbb9fd1fd6ad18134550e096a5a43f4ad74acfbd834fc6670"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c86969d012e51b8e415a8c6ce96f7857d6a87d6207303ab02d5d11ef0cad2274"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b6f6cd1560c5fa427e3b6074bb24d2c64e225afbb7165008903bd42e4e33e28a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:636bc362f0c5bbc7372bc3ae49737f9e3030dbce469f0f422c8f38079780363d"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a7cbeb06d1070f1d14895eeeed4dac5913b22d7b456f2eb969f11f4b3993796"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca9ef7517fd7874a1a08970ae88f497bf5c984610caa0bf40bd7e8450852b95"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:019a67772e034a0e6b9b17c13d0a8fe56ad9fb150fc724b7f3ffd3724288d9e5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f34ecee82858e41dd217734f0c41a532bd066bcaab636ad830f03a30b2a96f2a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4eac02d9af4813ee289cd63a361576da36dba57f5a1ab36377bc2600db0cbb73"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4beac52e9fe46d6abf98b0176a88154b742e878fdf209d2248e99fcdf73cd297"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c180f480207a9b2475f2b8d8bd7204e47aec952d084b2a2be58a782ffcf96074"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2837fb92951564d6339cedae4a7231692aa9f73cbc4fb2e04263b96844e03b4e"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d9010032a0b9710f58012a1e9c222528763d860ba2ee1422c03473eab47703e7"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win32.whl", hash = "sha256:7c4b6668b2b2b9027f209ddf647f2a4407784b5d88b8be4efcc72036f365baf9"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:cd3db5927bf9167d5a6157ddb2f036f6b6b0ad001ac82355d43e97a4bde76d76"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:347542f0ea3f95b2a955ee6656461fa1c776e401ac50ebce055a6c38454a0adf"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:178c7b5e62b454c2bc790786e6058c3cc968613b4419251b478c153a4aec32b1"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af545c2cffdb0967a96b6249e6f5f7b0d92cdfd267f9d5238d5b9ca63e8edb10"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:206b7b3ef96e4ce211754f0cd003feb28b7d81f0ad26b8d077a5d5161436067f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ee5e86776273de1795947d17bddd6bb19e0365fd2af4289c0d2c5454b6b1d36b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95d14ca7abefde230f7639ec136ade282655431fd5db03c343b19dda72dd1643"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:912d4b6af530ddb1338a66229dac3a25ff11d4448be3ec3d6340583995f56031"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e999f0c88a458c836d5fb521814e92ed2172c649200336a6df514987c1488258"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39380e12bd1f2fdab4285b6e055ad48efbaed5c836433b142ed4f5b9be71036a"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9efcc0f11d850cefcafdd9275b9576ad3bfb539bed96807663b32ad99c4d4b88"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:147b4f501d0292077f29d5268c16bb7c864a1f054d7001c4c1812c0421ea1ed0"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d147004fede1b12f6013a6dbb2a26a986a671a03c6ea740ddc76500e5f1c399f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9277145d36a01653863899c665243871434694bcc3431922c3b35c978061bdb8"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4e704c52438f66fdd89588346183d898bb42167cf88f8b7ff1c0f9fc957c348f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a8a4d3427e8de1312ddf309cc482186466c79895b3a139fed3259fc01dfa9a5b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win32.whl", hash = "sha256:6f497a6876aa4b1a102b04996ce4c1170c7040d83faa9387dd921c16e30d5c83"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win_amd64.whl", hash = "sha256:cb979826071c0986a5f08333a36104153478ce6018c58cba7f9caddaf63d5d67"},
+    {file = "aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1"},
 ]
 
 [package.dependencies]
@@ -281,7 +281,7 @@ propcache = ">=0.2.0"
 yarl = ">=1.17.0,<2.0"
 
 [package.extras]
-speedups = ["Brotli ; platform_python_implementation == \"CPython\"", "aiodns (>=3.3.0)", "brotlicffi ; platform_python_implementation != \"CPython\"", "zstandard ; platform_python_implementation == \"CPython\" and python_version < \"3.14\""]
+speedups = ["Brotli (>=1.2) ; platform_python_implementation == \"CPython\"", "aiodns (>=3.3.0)", "backports.zstd ; platform_python_implementation == \"CPython\" and python_version < \"3.14\"", "brotlicffi (>=1.2) ; platform_python_implementation != \"CPython\""]
 
 [[package]]
 name = "aioitertools"
@@ -334,6 +334,19 @@ frozenlist = ">=1.1.0"
 typing-extensions = {version = ">=4.2", markers = "python_version < \"3.13\""}
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -348,20 +361,21 @@ markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"serve
 
 [[package]]
 name = "anthropic"
-version = "0.61.0"
+version = "0.71.1"
 description = "The official Python library for the anthropic API"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"vendors\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
 files = [
-    {file = "anthropic-0.61.0-py3-none-any.whl", hash = "sha256:798c8e6cc61e6315143c3f5847d2f220c45f1e69f433436872a237413ca58803"},
-    {file = "anthropic-0.61.0.tar.gz", hash = "sha256:af4b3b8f3bc4626cca6af2d412e301974da1747179341ad9e271bdf5cbd2f008"},
+    {file = "anthropic-0.71.1-py3-none-any.whl", hash = "sha256:6ca6c579f0899a445faeeed9c0eb97aa4bdb751196262f9ccc96edfc0bb12679"},
+    {file = "anthropic-0.71.1.tar.gz", hash = "sha256:a77d156d3e7d318b84681b59823b2dee48a8ac508a3e54e49f0ab0d074e4b0da"},
 ]
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
 distro = ">=1.7.0,<2"
+docstring-parser = ">=0.15,<1"
 httpx = ">=0.25.0,<1"
 jiter = ">=0.4.0,<1"
 pydantic = ">=1.9.0,<3"
@@ -369,7 +383,7 @@ sniffio = "*"
 typing-extensions = ">=4.10,<5"
 
 [package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.8)"]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
 bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
 vertex = ["google-auth[requests] (>=2,<3)"]
 
@@ -393,6 +407,60 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.31.0)"]
+
+[[package]]
+name = "apache-tvm-ffi"
+version = "0.1.9"
+description = "tvm ffi"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d911cbbc83bf12a0d9ec03e5315ff1bb92d95702fe912cd7a050393274382e71"},
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1c8dd4018420c0d14bace688594710909ce198056ff8ac2ad1cd462b30fe1bdd"},
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f6bc8846d570b8ce38692fc91b530b44cd6ae092c805a844da23970e81b12c0"},
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3ec9149f207a7af3ea3531cad7a0b0d04ded06df4f51a547479d5eb489428dd"},
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eefcd17f61bf503ff0f4ad429e03ef6c241c7d13682f58281d883218b854c9bd"},
+    {file = "apache_tvm_ffi-0.1.9-cp310-cp310-win_amd64.whl", hash = "sha256:dd58da01331826fbe6c064d6f0c9bbc2d62883b78df8d15baa8ea21d37507e4d"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:932d94e29595a47109f0ef6e0b4209a934451582954ea8b426e758d6b3e307e3"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c0449fc3802987c3652bea266ffda2934a6f69c80bba791a3f55b91040656a18"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f16d73a82a9e68a439b7d233d48b1b929be17fe92df4bbf1ee2274e573144a3"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01ebb1308b2666c206aa9a4015eb48f03a5d98ea2e9cfb002bd5e2ca0b9c7ef3"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21365abd2a2a1a6d3b4e6e4f048309651125becfa795440c3607f3cc27d30ac7"},
+    {file = "apache_tvm_ffi-0.1.9-cp311-cp311-win_amd64.whl", hash = "sha256:9ee710a9fba3d9ff9747870bbd7e2175eb8d5b9c791f17fd645f35f6dab3f8aa"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:49e52350b0470654847de752e65603b604a4d3323e7e9f5e8a982f44acc4c143"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d503029e66c43b1a1cb1a42a1e9bb428c8a28dcbdec31c28e705472ca648a3a"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28241371934ea8af10d5067087ba1229ebddded7b2c02d33a258ec2a96df8c46"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87cacce81df55685fc6a76e1e3c5db1200e85e87bf5974b692c59d131b7bc622"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f45eb43499acac45ff6c93564f0ff2d3ca27b69656d540fd56ce59d51c0b4c65"},
+    {file = "apache_tvm_ffi-0.1.9-cp312-abi3-win_amd64.whl", hash = "sha256:d1dcf4c041d5ec05e3da1d545800c33cdbb95c113baa7705085ff79fa262752b"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c3349f72ddb8ce206472d0380a729f213017a2180707096f8d57114b81097dd1"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d1f4d2b7ec7b1213632e9a104e9330bfc3dec48decffa62114c33aa188c9f43a"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4f01d16ba53fe118e363f7257253f07003797e4abe6fc9567f23b6a930dbff2"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c0581dd6bfbce7b017ef85cfda08bbe38891cc4b3afbcfaa8bc2d383728e426"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dfa14be2a49347791ef21222a8225ce7f99bfec17104a676cb4f1bf3a107088"},
+    {file = "apache_tvm_ffi-0.1.9-cp314-cp314t-win_amd64.whl", hash = "sha256:a42d7ca27dce83efbdce7ec970fe3e773a69c31d928730ee5d9badb1229d106c"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0e326ff3ccea0f9b03a7270ab5203ebed9c4cbfc55b6c2a77610bc2fe98ee7b7"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6845535b79e089743befe1e67c6cf8687a8aa548c23ab3e73228e2c656d0b007"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e0fc70020d5ae953c04ae279272df7647eaf16fc988c9c5783aa550102942d1d"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1401693fc2bd4504878e19c4e87910c46029954f63890a48cc80dfc21f8db31e"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ba2b01f7eb2d9bd7e243d48c74fd93387b236fa8ccae27ba14bc01f423e4ce3"},
+    {file = "apache_tvm_ffi-0.1.9-cp38-cp38-win_amd64.whl", hash = "sha256:076ae2b4bb1dbc5bd3ad8cb5699460fb87c06c0d320659b75a2d651f3f090525"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:707edfb9c1a50534a14527b341fbd496a6c0f9f3b209e51faafc81fd2aab2923"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b4133c7c8f31ce7dd0fa8278f17bc9c8e72efd8aee0be4e12312330eb4639236"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:429be745bc6a9301cb48f16f97c3f07723e959cf7094b9d571a07a66284ae244"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44e7967fa0c6493b6f81756688409bc465af620b1731e4940f0ad70d0e8a7ce6"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:71fe51ca8993baed194d0506b91e6266e6abde5550d65dfff2324f569ee7f37d"},
+    {file = "apache_tvm_ffi-0.1.9-cp39-cp39-win_amd64.whl", hash = "sha256:7445d767c8561adfe81c4697e1781269f8e84e001b86e153f916e3c77210d55e"},
+    {file = "apache_tvm_ffi-0.1.9.tar.gz", hash = "sha256:d2d402587e8906de0a07f4746aa78f3d452c7efe3625d4bb39ac2ad693bce530"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.5"
+
+[package.extras]
+cpp = ["ninja"]
 
 [[package]]
 name = "ast-serialize"
@@ -901,7 +969,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"memory\" or extra == \"secrets\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"memory\" or sys_platform == \"linux\") and (platform_python_implementation != \"PyPy\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") and (platform_system == \"Linux\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\")"
+markers = "implementation_name == \"pypy\" and platform_system == \"Linux\" and platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") or implementation_name == \"pypy\" and platform_system == \"Linux\" and platform_python_implementation != \"PyPy\" and (extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\") or implementation_name == \"pypy\" and platform_system == \"Linux\" and (extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") or platform_python_implementation != \"PyPy\" and sys_platform == \"linux\" and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") or platform_python_implementation != \"PyPy\" and (extra == \"memory\" or extra == \"audio\") or extra == \"audio\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -1145,25 +1213,26 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "compressed-tensors"
-version = "0.10.2"
+version = "0.15.0.1"
 description = "Library for utilization of compressed safetensors of neural network models"
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "compressed_tensors-0.10.2-py3-none-any.whl", hash = "sha256:e1b4d9bc2006e3fd3a938e59085f318fdb280c5af64688a4792bf1bc263e579d"},
-    {file = "compressed_tensors-0.10.2.tar.gz", hash = "sha256:6de13ac535d7ffdd8890fad3d229444c33076170acaa8fab6bab8ecfa96c1d8f"},
+    {file = "compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9"},
+    {file = "compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99"},
 ]
 
 [package.dependencies]
+loguru = "*"
 pydantic = ">=2.0"
 torch = ">=1.7.0"
-transformers = "*"
+transformers = ">=4.45.0"
 
 [package.extras]
 accelerate = ["accelerate"]
-dev = ["black (==22.12.0)", "flake8 (>=3.8.3)", "isort (==5.8.0)", "nbconvert (>=7.16.3)", "pytest (>=6.0.0)", "wheel (>=0.36.2)"]
+dev = ["accelerate", "black (==22.12.0)", "flake8 (>=3.8.3)", "isort (==5.8.0)", "nbconvert (>=7.16.3)", "pytest (>=6.0.0)", "wheel (>=0.36.2)"]
 
 [[package]]
 name = "contourpy"
@@ -1454,38 +1523,181 @@ test = ["certifi (>=2024)", "cryptography-vectors (==46.0.2)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "cupy-cuda12x"
-version = "13.6.0"
-description = "CuPy: NumPy & SciPy for GPU"
+name = "cuda-bindings"
+version = "13.2.0"
+description = "Python bindings for CUDA"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and sys_platform != \"darwin\" and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:9e37f60f27ff9625dfdccc4688a09852707ec613e32ea9404f425dd22a386d14"},
-    {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e78409ea72f5ac7d6b6f3d33d99426a94005254fa57e10617f430f9fd7c3a0a1"},
-    {file = "cupy_cuda12x-13.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f33c9c975782ef7a42c79b6b4fb3d5b043498f9b947126d792592372b432d393"},
-    {file = "cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c790d012fd4d86872b9c89af9f5f15d91c30b8e3a4aa4dd04c2610f45f06ac44"},
-    {file = "cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:77ba6745a130d880c962e687e4e146ebbb9014f290b0a80dbc4e4634eb5c3b48"},
-    {file = "cupy_cuda12x-13.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:a20b7acdc583643a623c8d8e3efbe0db616fbcf5916e9c99eedf73859b6133af"},
-    {file = "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:a6970ceefe40f9acbede41d7fe17416bd277b1bd2093adcde457b23b578c5a59"},
-    {file = "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:79b0cacb5e8b190ef409f9e03f06ac8de1b021b0c0dda47674d446f5557e0eb1"},
-    {file = "cupy_cuda12x-13.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca06fede7b8b83ca9ad80062544ef2e5bb8d4762d1c4fc3ac8349376de9c8a5e"},
-    {file = "cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e5426ae3b1b9cf59927481e457a89e3f0b50a35b114a8034ec9110e7a833434c"},
-    {file = "cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:52d9e7f83d920da7d81ec2e791c2c2c747fdaa1d7b811971b34865ce6371e98a"},
-    {file = "cupy_cuda12x-13.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:297b4268f839de67ef7865c2202d3f5a0fb8d20bd43360bc51b6e60cb4406447"},
-    {file = "cupy_cuda12x-13.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6ccd2fc75b0e0e24493531b8f8d8f978efecddb45f8479a48890c40d3805eb87"},
-    {file = "cupy_cuda12x-13.6.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:771f3135861b68199c18b49345210180d4fcdce4681b51c28224db389c4aac5d"},
-    {file = "cupy_cuda12x-13.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4d2dfd9bb4705d446f542739a3616b4c9eea98d674fce247402cc9bcec89a1e4"},
+    {file = "cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556"},
+    {file = "cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6f3682ec3c4769326aafc67c2ba669d97d688d0b7e63e659d36d2f8b72f32d6"},
+    {file = "cuda_bindings-13.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:845025438a1b9e20718b9fb42add3e0eb72e85458bcab3eeb80bfd8f0a9dab33"},
+    {file = "cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d"},
+    {file = "cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1"},
+    {file = "cuda_bindings-13.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:debb51b211d246f8326f6b6e982506a5d0d9906672c91bc478b66addc7ecc60a"},
+    {file = "cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788"},
+    {file = "cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955"},
+    {file = "cuda_bindings-13.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:45815daeb595bf3b405c52671a2542b1f8e9329f3b029494acbfcc74aeaa1f2d"},
+    {file = "cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0"},
+    {file = "cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d"},
+    {file = "cuda_bindings-13.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:8cebe3ce4aeeca5af9c490e175f76c4b569bbf4a35a62294b777bc77bf7ac4d8"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd658bb5c0e55b7b3e5dd0ed509c6addb298c665db26a9bfba35e1e626000ba2"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b"},
+    {file = "cuda_bindings-13.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6ccf14e0c1def3b7200100aafff3a9f7e210ecb6e409329e92dcf6cd2c00d5c7"},
 ]
 
 [package.dependencies]
-fastrlock = ">=0.5"
-numpy = ">=1.22,<2.6"
+cuda-pathfinder = ">=1.1,<2.0"
 
 [package.extras]
-all = ["Cython (>=3)", "optuna (>=2.0)", "scipy (>=1.7,<1.17)"]
-test = ["hypothesis (>=6.37.2,<6.55.0)", "mpmath", "packaging", "pytest (>=7.2)"]
+all = ["cuda-toolkit[cufile] (==13.*) ; sys_platform == \"linux\"", "cuda-toolkit[nvfatbin,nvjitlink,nvrtc,nvvm] (==13.*)"]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.4"
+description = "Pathfinder for CUDA components"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
+files = [
+    {file = "cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7"},
+]
+
+[[package]]
+name = "cuda-python"
+version = "13.2.0"
+description = "CUDA Python: Performance meets Productivity"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "cuda_python-13.2.0-py3-none-any.whl", hash = "sha256:2f092b0ec13a860115fa595411889ee939ad203450ea4f91e9461b174ea7b084"},
+]
+
+[package.dependencies]
+cuda-bindings = ">=13.2.0,<13.3.0"
+cuda-pathfinder = ">=1.1,<2.0"
+
+[package.extras]
+all = ["cuda-bindings[all] (>=13.2.0,<13.3.0)"]
+
+[[package]]
+name = "cuda-tile"
+version = "1.0.0"
+description = "CUDA Tile Compiler"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.14\" and (extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "cuda_tile-1.0.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:2ddad07570074c38a4b41c257a47a5f0679561234964f074498b649d66b2372f"},
+    {file = "cuda_tile-1.0.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1a24cc9762553a6997e4cc13388e430e963b3a01647aab7da8ca8bb8827b7e0b"},
+    {file = "cuda_tile-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:6164fdf072d3c5cf2fa9bc61b7e9c38234facb7a0eda2b92094131afa6cb664f"},
+    {file = "cuda_tile-1.0.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5303302a0415a67c9479ac18b3c112e707ca3ff6f4c4e3bddc08266852065bd9"},
+    {file = "cuda_tile-1.0.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:3cf9763f45c467bb41d0933fb4b2b5181aede4ea8db1f098d6ade5d8c368a713"},
+    {file = "cuda_tile-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e58e3ae013bee6ce6a75b842ff2e244f4c156337adc582c510a7990e2f90bea"},
+    {file = "cuda_tile-1.0.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:200972cab54583d19be6514330f39e34109a0af0733a4e9dd88ef96a24231411"},
+    {file = "cuda_tile-1.0.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:72474601fdfe32d2f05257b22d4c00d0502fc13f96593304d54e883af2463e2b"},
+    {file = "cuda_tile-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:8003cdf688463c8076b38fefa9c28045ab328180691cf909de4eaf1d45e71c44"},
+    {file = "cuda_tile-1.0.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:f14eb291ea573ff9959666348f1a2e80b7bae266619ad340d4ff95d6066af0a4"},
+    {file = "cuda_tile-1.0.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:d42f5e989a3f393fbd4f05bcd87bb76efaa6ed8ca36877c1d9a4b49d1d1f3756"},
+    {file = "cuda_tile-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae190de78bfae2401f7e6eda68c439eb367112ebdb52e2bf6898d4657e411f31"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "cuda-tile"
+version = "1.3.0"
+description = "CUDA Tile Compiler"
+optional = true
+python-versions = "<3.14,>=3.10"
+groups = ["main"]
+markers = "python_version <= \"3.13\" and (extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:c55616c648f06f84808648a521c67f2d7c790574d6b53ddf8c3bfbc995d36d45"},
+    {file = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:8c71c2fd9b96c054c126a218f9927c8c8dde72441a532464551b865b416d452a"},
+    {file = "cuda_tile-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:339769f95b3a5453b7f416da6d1285f24d0daf3a700a895b68dee3fa6fc93e8f"},
+    {file = "cuda_tile-1.3.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:59d9843fa723ceb4d680ec246e12e3ded857266e4c2bf5c5d21e530d6d765060"},
+    {file = "cuda_tile-1.3.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:2888d6b89fae053a53ca7bb703c508a5cf90671d266934573c5b6c25978022c4"},
+    {file = "cuda_tile-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:791b363251fbc64db4402d92153ba3d14bc0aaa4d218cea66562af02a7a76bd9"},
+    {file = "cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:375316b64c51ee7cfadb2f170a30c1547bc41eb39f1e233a6556713857d2e81f"},
+    {file = "cuda_tile-1.3.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:e4865acbff1172aaee304bf9c550586088d8b4545a384423597a590899386709"},
+    {file = "cuda_tile-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:93e20ed31e46e5bf704fb31d13e1c08338d2177838798876f7ee9ec4384b75ba"},
+    {file = "cuda_tile-1.3.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:8a9bd4dae193cddf438f55d617b6f25b4b0b0fcf4ac4acde7d2695898e396c30"},
+    {file = "cuda_tile-1.3.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:a44a81e255fdb7bf8e1f7511fe3a019e6045024574509ea8548e0f71f25f8473"},
+    {file = "cuda_tile-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:efcb93c25563fe23d6aa083c22893fd703122eaf684b0d36874982d28a6dad0b"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+tileiras = ["nvidia-cuda-nvcc (>=13.2,<13.3)", "nvidia-cuda-tileiras (>=13.2,<13.3)", "nvidia-nvvm (>=13.2,<13.3)"]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+description = "CUDA Toolkit meta-package"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
+files = [
+    {file = "cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb"},
+]
+
+[package.dependencies]
+nvidia-cublas = {version = "==13.1.0.3.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cublas\""}
+nvidia-cuda-cupti = {version = "==13.0.85.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cupti\""}
+nvidia-cuda-nvrtc = {version = "==13.0.88.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"nvrtc\""}
+nvidia-cuda-runtime = {version = "==13.0.96.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cudart\""}
+nvidia-cufft = {version = "==12.0.0.61.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cufft\""}
+nvidia-cufile = {version = "==1.15.1.6.*", optional = true, markers = "sys_platform == \"linux\" and extra == \"cufile\""}
+nvidia-curand = {version = "==10.4.0.35.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"curand\""}
+nvidia-cusolver = {version = "==12.0.4.66.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cusolver\""}
+nvidia-cusparse = {version = "==12.6.3.3.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"cusparse\""}
+nvidia-nvjitlink = {version = "==13.0.88.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"nvjitlink\""}
+nvidia-nvtx = {version = "==13.0.85.*", optional = true, markers = "(sys_platform == \"linux\" or sys_platform == \"win32\") and extra == \"nvtx\""}
+
+[package.extras]
+all = ["nvidia-cublas (==13.1.0.3.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-cccl (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-crt (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-culibos (==13.0.85.*) ; sys_platform == \"linux\"", "nvidia-cuda-cupti (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-cuxxfilt (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-nvcc (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-nvrtc (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-opencl (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-profiler-api (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-runtime (==13.0.96.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cuda-sanitizer-api (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cufft (==12.0.0.61.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cufile (==1.15.1.6.*) ; sys_platform == \"linux\"", "nvidia-curand (==10.4.0.35.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cusolver (==12.0.4.66.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-cusparse (==12.6.3.3.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-npp (==13.0.1.2.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvfatbin (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvjitlink (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvjpeg (==13.0.1.86.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvml-dev (==13.0.87.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvptxcompiler (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvtx (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\"", "nvidia-nvvm (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cccl = ["nvidia-cuda-cccl (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+crt = ["nvidia-cuda-crt (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cublas = ["nvidia-cublas (==13.1.0.3.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cudart = ["nvidia-cuda-runtime (==13.0.96.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cufft = ["nvidia-cufft (==12.0.0.61.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cufile = ["nvidia-cufile (==1.15.1.6.*) ; sys_platform == \"linux\""]
+culibos = ["nvidia-cuda-culibos (==13.0.85.*) ; sys_platform == \"linux\""]
+cupti = ["nvidia-cuda-cupti (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+curand = ["nvidia-curand (==10.4.0.35.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cusolver = ["nvidia-cusolver (==12.0.4.66.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cusparse = ["nvidia-cusparse (==12.6.3.3.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+cuxxfilt = ["nvidia-cuda-cuxxfilt (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+npp = ["nvidia-npp (==13.0.1.2.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvcc = ["nvidia-cuda-nvcc (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvfatbin = ["nvidia-nvfatbin (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvjitlink = ["nvidia-nvjitlink (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvjpeg = ["nvidia-nvjpeg (==13.0.1.86.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvml = ["nvidia-nvml-dev (==13.0.87.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvptxcompiler = ["nvidia-nvptxcompiler (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvrtc = ["nvidia-cuda-nvrtc (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvtx = ["nvidia-nvtx (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+nvvm = ["nvidia-nvvm (==13.0.88.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+opencl = ["nvidia-cuda-opencl (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+profiler = ["nvidia-cuda-profiler-api (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
+sanitizer = ["nvidia-cuda-sanitizer-api (==13.0.85.*) ; sys_platform == \"linux\" or sys_platform == \"win32\""]
 
 [[package]]
 name = "cycler"
@@ -1519,15 +1731,15 @@ files = [
 
 [[package]]
 name = "depyf"
-version = "0.19.0"
+version = "0.20.0"
 description = "Decompile python functions, from bytecode to source code!"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "depyf-0.19.0-py3-none-any.whl", hash = "sha256:040b35fc0997d49df024b7d094f2a7836f91e9ed02f49982dd37e70aa3285ad5"},
-    {file = "depyf-0.19.0.tar.gz", hash = "sha256:afed0916b32d141cc90fa6220df01885eda442ca43b297d5050eeb90b4a5cb44"},
+    {file = "depyf-0.20.0-py3-none-any.whl", hash = "sha256:d31effad4261cebecb58955d832e448ace88f432328f95f82fd99c30fd9308d4"},
+    {file = "depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98"},
 ]
 
 [package.dependencies]
@@ -1639,6 +1851,24 @@ doq = ["aioquic (>=1.2.0)"]
 idna = ["idna (>=3.10)"]
 trio = ["trio (>=0.30)"]
 wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+files = [
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "einops"
@@ -1772,32 +2002,37 @@ packaging = "*"
 
 [[package]]
 name = "fastapi"
-version = "0.116.1"
+version = "0.136.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
-    {file = "fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565"},
-    {file = "fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143"},
+    {file = "fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"},
+    {file = "fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f"},
 ]
 
 [package.dependencies]
+annotated-doc = ">=0.0.2"
 email-validator = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
 fastapi-cli = {version = ">=0.0.8", extras = ["standard"], optional = true, markers = "extra == \"standard\""}
-httpx = {version = ">=0.23.0", optional = true, markers = "extra == \"standard\""}
+fastar = {version = ">=0.9.0", optional = true, markers = "extra == \"standard\""}
+httpx = {version = ">=0.23.0,<1.0.0", optional = true, markers = "extra == \"standard\""}
 jinja2 = {version = ">=3.1.5", optional = true, markers = "extra == \"standard\""}
-pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+pydantic = ">=2.9.0"
+pydantic-extra-types = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
+pydantic-settings = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
 python-multipart = {version = ">=0.0.18", optional = true, markers = "extra == \"standard\""}
-starlette = ">=0.40.0,<0.48.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
+typing-inspection = ">=0.4.2"
 uvicorn = {version = ">=0.12.0", extras = ["standard"], optional = true, markers = "extra == \"standard\""}
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
-standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "fastapi-cli"
@@ -1848,84 +2083,180 @@ uvicorn = {version = ">=0.15.0", extras = ["standard"]}
 standard = ["uvicorn[standard] (>=0.15.0)"]
 
 [[package]]
-name = "fastrlock"
-version = "0.8.3"
-description = "Fast, re-entrant optimistic lock implemented in Cython"
+name = "fastar"
+version = "0.11.0"
+description = "High-level bindings for the Rust tar crate"
 optional = true
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and sys_platform != \"darwin\" and platform_system == \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bbbe31cb60ec32672969651bf68333680dacaebe1a1ec7952b8f5e6e23a70aa5"},
-    {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:45055702fe9bff719cdc62caa849aa7dbe9e3968306025f639ec62ef03c65e88"},
-    {file = "fastrlock-0.8.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac4fcc9b43160f7f64b49bd7ecfd129faf0793c1c8c6f0f56788c3bacae7f54a"},
-    {file = "fastrlock-0.8.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d3ebb29de71bf9e330c2769c34a6b5e69d560126f02994e6c09635a2784f6de3"},
-    {file = "fastrlock-0.8.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cc5fa9166e05409f64a804d5b6d01af670979cdb12cd2594f555cb33cdc155bd"},
-    {file = "fastrlock-0.8.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7a77ebb0a24535ef4f167da2c5ee35d9be1e96ae192137e9dc3ff75b8dfc08a5"},
-    {file = "fastrlock-0.8.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:d51f7fb0db8dab341b7f03a39a3031678cf4a98b18533b176c533c122bfce47d"},
-    {file = "fastrlock-0.8.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:767ec79b7f6ed9b9a00eb9ff62f2a51f56fdb221c5092ab2dadec34a9ccbfc6e"},
-    {file = "fastrlock-0.8.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d6a77b3f396f7d41094ef09606f65ae57feeb713f4285e8e417f4021617ca62"},
-    {file = "fastrlock-0.8.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:92577ff82ef4a94c5667d6d2841f017820932bc59f31ffd83e4a2c56c1738f90"},
-    {file = "fastrlock-0.8.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3df8514086e16bb7c66169156a8066dc152f3be892c7817e85bf09a27fa2ada2"},
-    {file = "fastrlock-0.8.3-cp310-cp310-win_amd64.whl", hash = "sha256:001fd86bcac78c79658bac496e8a17472d64d558cd2227fdc768aa77f877fe40"},
-    {file = "fastrlock-0.8.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:f68c551cf8a34b6460a3a0eba44bd7897ebfc820854e19970c52a76bf064a59f"},
-    {file = "fastrlock-0.8.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:55d42f6286b9d867370af4c27bc70d04ce2d342fe450c4a4fcce14440514e695"},
-    {file = "fastrlock-0.8.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:bbc3bf96dcbd68392366c477f78c9d5c47e5d9290cb115feea19f20a43ef6d05"},
-    {file = "fastrlock-0.8.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:77ab8a98417a1f467dafcd2226718f7ca0cf18d4b64732f838b8c2b3e4b55cb5"},
-    {file = "fastrlock-0.8.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04bb5eef8f460d13b8c0084ea5a9d3aab2c0573991c880c0a34a56bb14951d30"},
-    {file = "fastrlock-0.8.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c9d459ce344c21ff03268212a1845aa37feab634d242131bc16c2a2355d5f65"},
-    {file = "fastrlock-0.8.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:33e6fa4af4f3af3e9c747ec72d1eadc0b7ba2035456c2afb51c24d9e8a56f8fd"},
-    {file = "fastrlock-0.8.3-cp311-cp311-win_amd64.whl", hash = "sha256:5e5f1665d8e70f4c5b4a67f2db202f354abc80a321ce5a26ac1493f055e3ae2c"},
-    {file = "fastrlock-0.8.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8cb2cf04352ea8575d496f31b3b88c42c7976e8e58cdd7d1550dfba80ca039da"},
-    {file = "fastrlock-0.8.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85a49a1f1e020097d087e1963e42cea6f307897d5ebe2cb6daf4af47ffdd3eed"},
-    {file = "fastrlock-0.8.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f13ec08f1adb1aa916c384b05ecb7dbebb8df9ea81abd045f60941c6283a670"},
-    {file = "fastrlock-0.8.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0ea4e53a04980d646def0f5e4b5e8bd8c7884288464acab0b37ca0c65c482bfe"},
-    {file = "fastrlock-0.8.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38340f6635bd4ee2a4fb02a3a725759fe921f2ca846cb9ca44531ba739cc17b4"},
-    {file = "fastrlock-0.8.3-cp312-cp312-win_amd64.whl", hash = "sha256:da06d43e1625e2ffddd303edcd6d2cd068e1c486f5fd0102b3f079c44eb13e2c"},
-    {file = "fastrlock-0.8.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5264088185ca8e6bc83181dff521eee94d078c269c7d557cc8d9ed5952b7be45"},
-    {file = "fastrlock-0.8.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a98ba46b3e14927550c4baa36b752d0d2f7387b8534864a8767f83cce75c160"},
-    {file = "fastrlock-0.8.3-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dbdea6deeccea1917c6017d353987231c4e46c93d5338ca3e66d6cd88fbce259"},
-    {file = "fastrlock-0.8.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c6e5bfecbc0d72ff07e43fed81671747914d6794e0926700677ed26d894d4f4f"},
-    {file = "fastrlock-0.8.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2a83d558470c520ed21462d304e77a12639859b205759221c8144dd2896b958a"},
-    {file = "fastrlock-0.8.3-cp313-cp313-win_amd64.whl", hash = "sha256:8d1d6a28291b4ace2a66bd7b49a9ed9c762467617febdd9ab356b867ed901af8"},
-    {file = "fastrlock-0.8.3-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a0eadc772353cfa464b34c814b2a97c4f3c0ba0ed7b8e1c2e0ad3ebba84bf8e0"},
-    {file = "fastrlock-0.8.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:350f517a7d22d383f8ef76652b0609dc79de6693880a99bafc8a05c100e8c5e7"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:924abbf21eba69c1b35c04278f3ca081e8de1ef5933355756e86e05499123238"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fd6727c1e0952ba93fdc5975753781039772be6c1a3911a3afc87b53460dc0"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:9c2c24856d2adc60ab398780f7b7cd8a091e4bd0c0e3bb3e67f12bef2800f377"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2b84b2fe858e64946e54e0e918b8a0e77fc7b09ca960ae1e50a130e8fbc9af8"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:963123bafc41c9fba72e57145917a3f23086b5d631b6cda9cf858c428a606ff9"},
-    {file = "fastrlock-0.8.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:314e787532ce555a7362d3c438f0a680cd88a82c69b655e7181a4dd5e67712f5"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:494fc374afd0b6c7281c87f2ded9607c2731fc0057ec63bd3ba4451e7b7cb642"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:da53350b90a67d5431df726816b041f1f96fd558ad6e2fc64948e13be3c7c29a"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cdee8c02c20a0b17dbc52f54c48ede3bd421985e5d9cef5cd2136b14da967996"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:558b538221e9c5502bb8725a1f51157ec38467a20498212838e385807e4d1b89"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6ac082d670e195ad53ec8d0c5d2e87648f8838b0d48f7d44a6e696b8a9528e2"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d7edaf0071a6a98340fc2ec45b0ba37b7a16ed7761479aab577e41e09b3565e1"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9c4068f21fddc47393a3526ce95b180a2f4e1ac286db8d9e59e56771da50c815"},
-    {file = "fastrlock-0.8.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d7f359bb989c01a5875e8dbde9acab37b9da0943b60ef97ba9887c4598eb3009"},
-    {file = "fastrlock-0.8.3-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:239e85cbebda16f14be92468ce648d0bc25e2442a3d11818deca59a7c43a4416"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5eef1d32d7614e0ceb6db198cf53df2a5830685cccbcf141a3e116faca967384"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:80876d9e04e8e35abbdb3e1a81a56558f4d5cf90c8592e428d4d12efce048347"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24522689f4b5311afad0c8f998daec84a3dbe3a70cf821a615a763f843903030"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:de8c90c1a23fbe929d8a9628a6c1f0f1d8af6019e786354a682a26fa22ea21be"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0ceefadde046a5f6a261bfeaf25de9e0eba3ee790a9795b1fa9634111d3220e"},
-    {file = "fastrlock-0.8.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1dd7f1520f7424793c812e1a4090570f8ff312725dbaf10a925b688aef7425f1"},
-    {file = "fastrlock-0.8.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:15e13a8b01a3bbf25f1615a6ac1d6ed40ad3bcb8db134ee5ffa7360214a8bc5c"},
-    {file = "fastrlock-0.8.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fcb50e195ec981c92d0211a201704aecbd9e4f9451aea3a6f71ac5b1ec2c98cf"},
-    {file = "fastrlock-0.8.3-cp38-cp38-win_amd64.whl", hash = "sha256:3e77a3d0ca5b29695d86b7d03ea88029c0ed8905cfee658eb36052df3861855a"},
-    {file = "fastrlock-0.8.3-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:668fad1c8322badbc8543673892f80ee563f3da9113e60e256ae9ddd5b23daa4"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:40b328369005a0b32de14b699192aed32f549c2d2b27a5e1f614fb7ac4cec4e9"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:6cbfb6f7731b5a280851c93883624424068fa5b22c2f546d8ae6f1fd9311e36d"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1fced4cb0b3f1616be68092b70a56e9173713a4a943d02e90eb9c7897a7b5e07"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:387b2ac642938a20170a50f528817026c561882ea33306c5cbe750ae10d0a7c2"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a0d31840a28d66573047d2df410eb971135a2461fb952894bf51c9533cbfea5"},
-    {file = "fastrlock-0.8.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0a9dc6fa73174f974dfb22778d05a44445b611a41d5d3776b0d5daa9e50225c6"},
-    {file = "fastrlock-0.8.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9842b7722e4923fe76b08d8c58a9415a9a50d4c29b80673cffeae4874ea6626a"},
-    {file = "fastrlock-0.8.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:05029d7080c0c61a81d5fee78e842c9a1bf22552cd56129451a252655290dcef"},
-    {file = "fastrlock-0.8.3-cp39-cp39-win_amd64.whl", hash = "sha256:accd897ab2799024bb87b489c0f087d6000b89af1f184a66e996d3d96a025a3b"},
-    {file = "fastrlock-0.8.3.tar.gz", hash = "sha256:4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d"},
+    {file = "fastar-0.11.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e7c906ad371ca365591ebcb7630009923f3eceb20956814494d15591a78e9e46"},
+    {file = "fastar-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6919497b35fa5bd978d2c26ee117cf1771b90ee5073f7518e44b9bc364b57715"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:56b50206aeedd99e22b83289e6fb3ff8f7d7da4407d2419902e4716b4f90585a"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a1811a69ae81d469720df0c8af3f84f834a93b5e4f8be0e0e8bde6a52fa11f2"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10486238c55589a3947c38f9cfb88a67d8a608eb8dddc722038237d0278a41d7"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1555ef9992d368a6ec39092276990cef8d329c39a1d86ebd847eaa3b10efd472"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1f4aca0a9620b76988bbf6225cdea6678a392902444ca18bb8a51495b165a89"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75beeecac7d11a666a6c4a0b7f7e80842ae5cf523f2f890b99c78fc82b403545"},
+    {file = "fastar-0.11.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a08cdf5d16daa401c65c9c7493a18db7dc515c52155a17071ec7098bb07da9d3"},
+    {file = "fastar-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6e210375e5a7ba53586cbd6017aa417d2d2ceacbe8671682470281bd0a15e8ef"},
+    {file = "fastar-0.11.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a2988eb2604b8e15670f355425e8c800e4dcd4edfbcbfe194397f8f17b7eb19e"},
+    {file = "fastar-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:34abc857b46068fdf91d157bd0203bfd6791dc7a432d1ed180f5af6c2f5bcce9"},
+    {file = "fastar-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0d884be84e37a01053776395441fc960031974e0265801ce574efc3d05e0cdaf"},
+    {file = "fastar-0.11.0-cp310-cp310-win32.whl", hash = "sha256:c721c1ad758e3e4c2c1fd9e96911a0fa58c0a6be5668f1bcfd0b741e72c7cb63"},
+    {file = "fastar-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba4180b7c3080f55f9035fdd7d8c39fe0e1485087a68ff615bb4784a10b8106b"},
+    {file = "fastar-0.11.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b82fd6f996e65a86f67a6bd64dd22ef3e8ae2dcaed0ae3b550e71f7e1bbb1df5"},
+    {file = "fastar-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27eed386fd0558e6daa29211111bbd7b740f7c7e881197f8a00ac7c0f3cdb1d7"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a6931bebc1d8e95ddeef55732c195449e6b44ef33aa31b325505097ed3b4d6aa"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f72ce42a5e28a74fbd4d5fbf1a3ac1a1163d13cbc200cbd005fb0fabc54bd"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b83c1f61f7017d6e1498568038f8745440cfc16ca2f697ec81bac83050108f6"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db73a9b765a516e73983b25341e7b5e0189733878279e278b2295131b0e3a21e"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:625827d52eb4e8fec942e0233f125ff8010fcf6a67c0a974a8e5f4666b771e3c"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7f5fd8fa21ec0a88296a38dc5d7fc35efd3b26d46a17b8b7c73c5563925ca15"},
+    {file = "fastar-0.11.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8c15af91b8cd87ddf23ea55355ae513c1de3ab67178f26dad017c9e9c0af6096"},
+    {file = "fastar-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a112395a8b0bff251423bd1564c012f0cc058ad8b6bd8fba96f3d7fc117e44"},
+    {file = "fastar-0.11.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f2994bb8f5f8c11eb12beae1e6e77a907173c9819236b8a4c8f0573652ceccce"},
+    {file = "fastar-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dcf99e4b5973d842c7f19c776c3a83cdc0977d505edce6206438505c0456b517"},
+    {file = "fastar-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29c9c386dc0d5dda78845a8e6b1480d26ab861c1e0b68f42ae5735cb70ca07f1"},
+    {file = "fastar-0.11.0-cp311-cp311-win32.whl", hash = "sha256:030b2580fc394f2c9b7890b6735810404e9b9ed5e0344db150b945965b5482b7"},
+    {file = "fastar-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:83ab57ae067969cd0b483ac3b6dccc4b595fc77f5c820760998648d4c42822b5"},
+    {file = "fastar-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:27b1a4cee2298b704de8151d310462ee7335ed036011ca9aa6e784b30b6c73a9"},
+    {file = "fastar-0.11.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3c51f1c2cdddbd1420d2897ace7738e36c65e17f6ae84e0bfe763f8d1068bb97"},
+    {file = "fastar-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0d9d6b052baf5380baea866675dab6ccd04ec2460d12b1c46f10ce3f4ee6a820"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd2f05666d4df7e14885b5c38fefd92a785917387513d33d837ff42ec143a22f"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e6e74aba1ae77ca4aedcaf1697cd413319f4c88a5ccbe5b42c709517c5097e"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38ef77fe940bbc9b37a98bd838727f844b11731cd39358a2640ff864fb385086"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8955e61b32d6aff82c983217abf80933fd823b0e727586fc72f08043d996fd59"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:483532442cdb08fbff0169510224eae0836f2f672cea6aacb52847d90fefdc46"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef5a6071121e05d8287fc75bccb054bcbac8bb0501200a0c0a8feeace5303ea4"},
+    {file = "fastar-0.11.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:e45e598af5afe8412197d4786efd6cf29be02e7d3d4f6a3461149eae5d7e94f1"},
+    {file = "fastar-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e160919b1c47ddb8538e7e8eb4cd527281b40f0bf75110a75993838ef61f286"},
+    {file = "fastar-0.11.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4bb4dc0fc8f7a6807febcebce8a2f3626ba4955a9263d81ecc630aad83be84c0"},
+    {file = "fastar-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4ec95af56aa173f6e320e1183001bf108ba59beaf13edd1fc8200648db203588"},
+    {file = "fastar-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:136cf342735464091c39dc3708168f9fdeb9ebea40b1ead937c61afaf46143d9"},
+    {file = "fastar-0.11.0-cp312-cp312-win32.whl", hash = "sha256:35f23c11b556cc4d3704587faacbc0037f7bdf6c4525cd1d09c70bda4b1c6809"},
+    {file = "fastar-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:920bc56c3c0b8a8ca492904941d1883c1c947c858cd93343356c29122a38f44c"},
+    {file = "fastar-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:395248faf89e8a6bd5dc1fd544c8465113b627cb6d7c8b296796b60ebea33593"},
+    {file = "fastar-0.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:33f544b08b4541b678e53749b4552a44720d96761fb79c172b005b1089c443ed"},
+    {file = "fastar-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c1c792447e4a642745f347ff9847c52af39633071c57ee67ed53c157fc3506"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:881247e6b6eaea59fc6569f9b61447aa6b9fc2ee864e048b4643d69c52745805"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:863b7929845c9fec92ef6c8d59579cf46af5136655e5342f8df5cebe46cab06c"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96b4a57df12bf3211662627a3ea29d62ecb314a2434a0d0843f9fc23e47536e5"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ceef1c2c4df7b7b8ebd3f5d718bbf457b9bbdf25ce0bd07870211ec4fbd9aff4"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8e545918441910a779659d4759ad0eef349e935fbdb4668a666d3681567eb05"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28095bb8f821e85fc2764e1a55f03e5e2876dee2abe7cd0ee9420d929905d643"},
+    {file = "fastar-0.11.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0fafb95ecbe70f666a5e9b35dd63974ccdc9bb3d99ccdbd4014a823ec3e659b5"},
+    {file = "fastar-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af48fed039b94016629dcdad1c95c90c486326dd068de2b0a4df419ee09b6821"},
+    {file = "fastar-0.11.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:74cd96163f39b8638ab4e8d49708ca887959672a22871d8170d01f067319533b"},
+    {file = "fastar-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e8b993cb5613bab495ed482810bedc0986633fcb9a3b55c37ec88e0d6714f6a"},
+    {file = "fastar-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfe39d91fc28e37e06162d94afe01050220edb7df554acb5b702b5503e564816"},
+    {file = "fastar-0.11.0-cp313-cp313-win32.whl", hash = "sha256:c5f63d4d99ff4bfb37c659982ec413358bdee747005348756cc50a04d412d989"},
+    {file = "fastar-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8690ed1928d31ded3ada308e1086525fb3871f5fa81e1b69601a3f7774004583"},
+    {file = "fastar-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:d977ded9d98a0719a305e0a4d5ee811f1d3e856d853a50acb8ae833c3cd6d5d2"},
+    {file = "fastar-0.11.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:71375bd6f03c2a43eb47bd949ea38ff45434917f9cdac79675c5b9f60de4fa73"},
+    {file = "fastar-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eddfd9cab16e19ae247fe44bf992cb403ccfe27d3931d6de29a4695d95ad386c"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7c371f1d4386c699018bb64eb2fa785feacf32785559049d2bb72fe4af023f53"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cad7fa41e3e66554387481c1a09365e4638becd322904932674159d5f4046728"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf36652fa71b83761717c9899b98732498f8a2cb6327ff16bbf07f6be85c3437"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f68ff8c17833053da4841720e95edde80ce45bb994b6b7d51418dddaac70ee47"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4563ed37a12ea1cdc398af8571258d24b988bf342b7b3bf5451bd5891243280c"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cee63c9875cba3b70dc44338c560facc5d6e763047dcc4a30501f9a68cf5f890"},
+    {file = "fastar-0.11.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:bd76bfffae6d0a91f4ac4a612f721e7aec108db97dccdd120ae063cd66959f27"},
+    {file = "fastar-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f5b707501ec01c1bc0518f741f01d322e50c9adc19a451aa24f67a2316e9397"},
+    {file = "fastar-0.11.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:37c0b5a88a657839aad98b0a6c9e4ac4c2c15d6b49c44ee3935c6b08e9d3e479"},
+    {file = "fastar-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6c55f536c62a6efb180c1af0d5182948bff576bbfe6276e8e1359c9c7d2215d8"},
+    {file = "fastar-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3082eeca59e189b9039335862f4c2780c0c8871d656bfdf559db4414a105b251"},
+    {file = "fastar-0.11.0-cp314-cp314-win32.whl", hash = "sha256:b201a0a4e29f9fec2a177e13154b8725ec65ab9f83bd6415483efaa2aa18344b"},
+    {file = "fastar-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:868fddb26072a43e870a8819134b9f80ee602931be5a76e6fb873e04da343637"},
+    {file = "fastar-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:3db39c9cc42abb0c780a26b299f24dfbc8be455985e969e15336d70d7b2f833b"},
+    {file = "fastar-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:49c3299dec5e125e7ebaa27545714da9c7391777366015427e0ae62d548b442b"},
+    {file = "fastar-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3328ed1ed56d31f5198350b17dd60449b8d6b9d47abb4688bab6aef4450a165b"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd3eca3bbfec84a614bcb4143b4ad4f784d0895babc26cfc88436af88ca23c7a"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff86a967acb0d621dd24063dda090daa67bf4993b9570e97fe156de88a9006ca"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:86eaf7c0e985d93a7734168be2fb232b2a8cca53e41431c2782d7c12b12c03b1"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91f07b0b8eb67e2f177733a1f884edad7dfb9f8977ffef15927b20cb9604027d"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f85c896885eb4abf1a635d54dea22cac6ae48d04fc2ea26ae652fcf1febe1220"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:075c07095c8de4b774ba8f28b9c0a02b1a2cd254da50cbe464dd3bb2432e9158"},
+    {file = "fastar-0.11.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:07f028933820c65750baf3383b807ecce1cd9385cf00ce192b79d263ad6b856c"},
+    {file = "fastar-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:039f875efa0f01fa43c20bf4e2fc7305489c61d0ac76eda991acfba7820a0e63"},
+    {file = "fastar-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:fff12452a9a5c6814a012445f26365541cc3d99dcca61f09762e6a389f7a32ea"},
+    {file = "fastar-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2bf733e09f942b6fa876efe30a90508d1f4caef5630c00fb2a84fba355873712"},
+    {file = "fastar-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d1531fa848fdd3677d2dce0a4b436ea64d9ae38fb8babe2ddbc180dd153cb7a3"},
+    {file = "fastar-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:5744551bc67c6fc6581cbd0e34a0fd6e2cd0bd30b43e94b1c3119cf35064b162"},
+    {file = "fastar-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f4ce44e3b56c47cf38244b98d29f269b259740a580c47a2552efa5b96a5458fb"},
+    {file = "fastar-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:76c1359314355eafbc6989f20fb1ad565a3d10200117923b9da765a17e2f6f11"},
+    {file = "fastar-0.11.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:a2cbcd0dde5548a8b2fc37a24b4bd957daf168973e63ba6dd1cbc2279964631d"},
+    {file = "fastar-0.11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f7d361813a881fef5ab97945ae89ebda7f6fa5ef74ee75871047f88bb2eac471"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dac5916958156c067ee0f678b4af9a1918aeca80d3c9ac0f81a2dc7a9af0451"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:207b01117a770c0720415c19a43177cc701d458db411f0a8e1c9003138121a9d"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:096f52102b5401b2f60fdca6f417f9b2fae146c644846eda123fe42cbd392178"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:492487d8d2209b71f5f768644a30fced192acf32af287c9ee219a6331ad08097"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d20fbd0fae43453de998027b13646e3376e59077ef7e2c9fbde4e9d65a951e91"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353db755d840bb2ce4c54d3f889c4d4e17680a9c18e676ff558b45943d4af1bf"},
+    {file = "fastar-0.11.0-cp38-cp38-manylinux_2_31_riscv64.whl", hash = "sha256:0881f68bead037eb2bb0e7832ba8bb3b014c67a9fcc1a085dd81f968c611c9da"},
+    {file = "fastar-0.11.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:65b38e1a47e6f15585ecb02d7bec27d4cbf1b39d4e030a4159bfee32d275deeb"},
+    {file = "fastar-0.11.0-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:9c6157c5df39f3283cfa0f1d0c466ce2cc9375a66d8d451eab5786574a7baa55"},
+    {file = "fastar-0.11.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:a84b8d5457b9d378912fb9220548e8a816f35ec952decdc8df8bd5bdb1b28c66"},
+    {file = "fastar-0.11.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:aab189c0ff354bc246ea540187901daf8527a71e83c9a506a512e693c4bb68ad"},
+    {file = "fastar-0.11.0-cp38-cp38-win32.whl", hash = "sha256:2f3da9d75b9aa2e936d410a81eef5303f3d97356748d7079545c32a23837292f"},
+    {file = "fastar-0.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:9d0bbd6a34eedd44aa72e7cd7fd9828b4e35fe212e4524a45299288544527991"},
+    {file = "fastar-0.11.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:6ced901e08b81514d141b8820857d51be4b0cc881a58edc555fff21ce3b16d8e"},
+    {file = "fastar-0.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9277b377ac7dce7d927baf8460ac59248769cd3f5099b547b329b8ecaf2ed3ae"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cb0009f9dd263261be455f8f2a38c0814370ab4febb90adf33e6dc54740438f6"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec9de5c99c01de7be04e332a57dda9dceb98f4b2424c5bea4d4b899732483219"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:628073cfc782f383ef2fa3ce2598fff9ff344d74d7d1e8dd5cff31b7675be1e7"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50194636d86af5317f8a3b4a7cfbb45c14efe2045c7a099b6760785470a57bc9"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88f665ac38c976146fa1f87a9151e6ff3a3e7d423a52e88ab35e9d49da2f4b2f"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78ee04e4b6f94a42b889040ab310f446fc477fd0e71ec3592c1d0e5446f24737"},
+    {file = "fastar-0.11.0-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:9177d62f253b3fa2f4304ffaddab5fc3063c13e2fd481c032631437a2850f99f"},
+    {file = "fastar-0.11.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a5b4399806d77e5172b1a37a0a7954e220f84e388cdbfbf80bd1de90fed70aa4"},
+    {file = "fastar-0.11.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:e74cbb513f32a5b4499d49fb7a436713cb7a66a3498b002ec1de933650afb447"},
+    {file = "fastar-0.11.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d95530421ef5ea46d37c38509932c52a5862480515f599f5b0eb2e951d04de1b"},
+    {file = "fastar-0.11.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2ef4691d57ce8f55e4696235fa98cf86f3f00916e4571838ad2041d1334d6cb0"},
+    {file = "fastar-0.11.0-cp39-cp39-win32.whl", hash = "sha256:f3a3dc706fd59fb3566f34597656bdfdabecb563fbefdc41441a85b431fe96cf"},
+    {file = "fastar-0.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:1a08582519c2564ecb2d034f1be7a73ceb309c4891d01f4d19ce712c72420fa5"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1266d6a004f427b0d61bd6c7b544d84cc964691b2232c2f4d635a1b75f2f6d5e"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:298a827ec04ade43733f6ca960d0faec38706aa1494175869ea7ea17f5bad5d3"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8800e2387e463a0e5799416a1cbe72dd0fde7270a20e4bde684145e7878f6516"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7496def0a2befd82d429cb004ef7ca831585cc887947bd6b9abb68a5ef852b0b"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:878eaf15463eb572e3538af7ca3a8534e5e279cf8196db902d24e5725c4af86e"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0324ed1d1ef0186e1bbd843b17807d6d837d0906899d4c99378b02c5d86bdd9c"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdf9bd863205590beaf8ef6e66f315310196632180dceaf674985d01a876cac3"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59af8dbb683b24b90fb5b506de080faeab0a17a908e6c2a5d93a97260ed75d7b"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:9f3df73a3c4292cfe15696cdf59cdb6c309ab59d30b34c733be13c6e32d9a264"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa3762cbb16e41a76b61f4a6914937a71aab3a7b6c2d82ca233bc686ebaf756b"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:a8c7bc8ac74cb359bb546b199288c83236372d094b402e557c197e85527495cd"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:587cbd060a2699c5f66281081395bb4657b2b1e0eef5c206b1aabf740019d670"},
+    {file = "fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a1c56957ac82408be37a3f63594bc83e0919e8760492a4475e542f9f1828778"},
+    {file = "fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce"},
 ]
+
+[[package]]
+name = "fastsafetensors"
+version = "0.3.1"
+description = "High-performance safetensors model loader"
+optional = true
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "fastsafetensors-0.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:acc0971b006f381598d32c5f7aae3a07d9a10d87c701f26b65215083e15a4733"},
+    {file = "fastsafetensors-0.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32cf4b531b5d77de41d777106ea69036a16bdea80062646dabc93a11b4cf88ee"},
+    {file = "fastsafetensors-0.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac76f33e47959b7c31658fbbda1805df7540819828a3ce6a94eb34b4db0b1fa7"},
+    {file = "fastsafetensors-0.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c9f8d3e18969090b5d66581cb6e9f6c9057158c151ed87e9c309dead5c64442"},
+    {file = "fastsafetensors-0.3.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:348814ad027891317ad8aff90a3c62f8f704a0861d089ea33cff088980602355"},
+    {file = "fastsafetensors-0.3.1.tar.gz", hash = "sha256:b7eb039a564d77280d17e5d63b27e9963ba5158ad02d2a3c1772c62072a81a53"},
+]
+
+[package.dependencies]
+typer = ">=0.9.0"
+
+[package.extras]
+dev = ["black (==25.11.0)", "flake8 (==7.3.0)", "isort (==6.1.0)", "mypy (==1.19.1)", "pre-commit (>=3.6.0)"]
+progress = ["tqdm (>=4.66.0)"]
+test = ["pytest (>=8.1.1)", "pytest-cov (>=5.0.0)", "safetensors (>=0.4.0)", "torch (>=2.5.1)", "transformers (>=4.40.2)", "vllm (>=0.8.2)"]
+threefs = ["fastsafetensor-3fs-reader (>=0.3.3)"]
 
 [[package]]
 name = "filelock"
@@ -1934,11 +2265,56 @@ description = "A platform independent file lock."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\" or extra == \"quantization\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\") or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\") and platform_system != \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"quantization\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\") or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system != \"Linux\""
 files = [
     {file = "filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2"},
     {file = "filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4"},
 ]
+
+[[package]]
+name = "flashinfer-cubin"
+version = "0.6.8.post1"
+description = "Pre-compiled cubins for FlashInfer"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "flashinfer_cubin-0.6.8.post1-py3-none-any.whl", hash = "sha256:43636d4cd39e694a83d76a89f87fefcdf4cecb4c4f7dd22dac25ec368c1e901f"},
+]
+
+[[package]]
+name = "flashinfer-python"
+version = "0.6.8.post1"
+description = "FlashInfer: Kernel Library for LLM Serving"
+optional = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "flashinfer_python-0.6.8.post1-py3-none-any.whl", hash = "sha256:818f9b8cc2fe66c42a1f6264be4841ac8821ada703685a02cfccb2b5124a710b"},
+    {file = "flashinfer_python-0.6.8.post1.tar.gz", hash = "sha256:b18e4121baf9b93fa9a9f368ba9b981a0342895f50ab9dddc224aeb964ed346f"},
+]
+
+[package.dependencies]
+apache-tvm-ffi = ">=0.1.6,<0.1.8 || >0.1.8,<0.1.8.post0 || >0.1.8.post0,<0.2"
+click = "*"
+cuda-tile = "*"
+einops = "*"
+ninja = "*"
+numpy = "*"
+nvidia-cudnn-frontend = ">=1.13.0"
+nvidia-cutlass-dsl = ">=4.4.2"
+nvidia-ml-py = "*"
+packaging = ">=24.2"
+requests = "*"
+tabulate = "*"
+torch = "*"
+tqdm = "*"
+
+[package.extras]
+cu12 = ["nvidia-cutlass-dsl (>=4.4.2)"]
+cu13 = ["nvidia-cutlass-dsl[cu13] (>=4.4.2)"]
 
 [[package]]
 name = "flatbuffers"
@@ -2175,7 +2551,7 @@ description = "File-system specification"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\" or extra == \"quantization\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\") or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"audio\") and platform_system != \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"quantization\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\") or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system != \"Linux\""
 files = [
     {file = "fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7"},
     {file = "fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19"},
@@ -2246,7 +2622,10 @@ files = [
 [package.dependencies]
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
-proto-plus = ">=1.22.3,<2.0.0"
+proto-plus = [
+    {version = ">=1.22.3,<2.0.0"},
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 requests = ">=2.18.0,<3.0.0"
 
@@ -2317,7 +2696,7 @@ description = "Common protobufs used in Google APIs"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"server\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8"},
     {file = "googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257"},
@@ -2411,6 +2790,84 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+description = "HTTP/2-based RPC framework"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "grpcio-1.80.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:886457a7768e408cdce226ad1ca67d2958917d306523a0e21e1a2fdaa75c9c9c"},
+    {file = "grpcio-1.80.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7b641fc3f1dc647bfd80bd713addc68f6d145956f64677e56d9ebafc0bd72388"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33eb763f18f006dc7fee1e69831d38d23f5eccd15b2e0f92a13ee1d9242e5e02"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:52d143637e3872633fc7dd7c3c6a1c84e396b359f3a72e215f8bf69fd82084fc"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c51bf8ac4575af2e0678bccfb07e47321fc7acb5049b4482832c5c195e04e13a"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:50a9871536d71c4fba24ee856abc03a87764570f0c457dd8db0b4018f379fed9"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a72d84ad0514db063e21887fbacd1fd7acb4d494a564cae22227cd45c7fbf199"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7691a6788ad9196872f95716df5bc643ebba13c97140b7a5ee5c8e75d1dea81"},
+    {file = "grpcio-1.80.0-cp310-cp310-win32.whl", hash = "sha256:46c2390b59d67f84e882694d489f5b45707c657832d7934859ceb8c33f467069"},
+    {file = "grpcio-1.80.0-cp310-cp310-win_amd64.whl", hash = "sha256:dc053420fc75749c961e2a4c906398d7c15725d36ccc04ae6d16093167223b58"},
+    {file = "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a"},
+    {file = "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6"},
+    {file = "grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440"},
+    {file = "grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9"},
+    {file = "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0"},
+    {file = "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f"},
+    {file = "grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193"},
+    {file = "grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff"},
+    {file = "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad"},
+    {file = "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7"},
+    {file = "grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294"},
+    {file = "grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50"},
+    {file = "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e"},
+    {file = "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e"},
+    {file = "grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae"},
+    {file = "grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f"},
+    {file = "grpcio-1.80.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:aacdfb4ed3eb919ca997504d27e03d5dba403c85130b8ed450308590a738f7a4"},
+    {file = "grpcio-1.80.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a361c20ec1ccd3c3953d20fb6d7b4125093bdd10dff44c5e2bbb39e58917cedc"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:43168871f170d1e4ed16ae03d10cd21efa29f190e710a624cee7e5ae07da6f4f"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1b97cd29a8eda100b559b455331c487a80915b6ea6bd91cf3e89836c4ee8d957"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bac1d573dfa84ce59a5547073e28fa7326d53352adda6912e362da0b917fcef4"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4560cf0e86514595dbbd330cd65b7afad4b5c4b8c4905c041cfffa138d45e6fd"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec0a592e926071b4abad50c1495cd0d0d513324b3ff5e7267067c33ba27506e4"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:deb10a1528473c11f72a0939eed36d83e847d7cbb63e8cc5611fb7a912d38614"},
+    {file = "grpcio-1.80.0-cp39-cp39-win32.whl", hash = "sha256:627fb7312171cdc52828bd6fac8d7028ff2a64b89f1957b6f3416caa2218d141"},
+    {file = "grpcio-1.80.0-cp39-cp39-win_amd64.whl", hash = "sha256:05d55e1798756282cddd52d56c896b3e7d673e3a8798c2f1cd05ba249a3bb4de"},
+    {file = "grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12,<5.0"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.80.0)"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -2430,7 +2887,7 @@ description = "Fast transfer of large files with the Hugging Face Hub."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and platform_system == \"Linux\" and (extra == \"local\" or extra == \"vllm\" or extra == \"nvidia\") or (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and extra == \"local\""
+markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and (extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"mlx\" or extra == \"apple\") and platform_machine == \"arm64\" or (extra == \"local\" or extra == \"vendors\" or extra == \"vision\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144"},
     {file = "hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f"},
@@ -2575,7 +3032,7 @@ description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"server\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "httpx_sse-0.4.2-py3-none-any.whl", hash = "sha256:a9fa4afacb293fa50ef9bacb6cae8287ba5fd1f4b1c2d10a35bb981c41da31ab"},
     {file = "httpx_sse-0.4.2.tar.gz", hash = "sha256:5bb6a2771a51e6c7a5f5c645e40b8a5f57d8de708f46cb5f3868043c3c18124e"},
@@ -2597,7 +3054,7 @@ files = [
 [package.dependencies]
 filelock = ">=3.10.0"
 fsspec = ">=2023.5.0"
-hf-xet = {version = ">=1.4.3,<2.0.0", optional = true, markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\" or extra == \"hf-xet\""}
+hf-xet = {version = ">=1.4.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
 httpx = ">=0.23.0,<1"
 packaging = ">=20.9"
 pyyaml = ">=5.1"
@@ -2666,6 +3123,112 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "ijson"
+version = "3.5.0"
+description = "Iterative JSON parser with standard Python iterator interfaces"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "ijson-3.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ea8dcac10d86adaeead454bc25c97b68d0bda573d5fd6f86f5e21cf8f7906f88"},
+    {file = "ijson-3.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:92b0495bbb2150bbf14fc5d98fb6d76bcd1c526605a172709e602e6fedc96495"},
+    {file = "ijson-3.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7af0c4c8943be8b09a4e57bdc1da6001dae7b36526d4154fe5c8224738d0921f"},
+    {file = "ijson-3.5.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:45887d5e84ff0d2b138c926cebd9071830733968afe8d9d12080b3c178c7f918"},
+    {file = "ijson-3.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a70b575be8e57a28c80e90ed349ad3a851c3478524c70e36e07d6092ecd12c9"},
+    {file = "ijson-3.5.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2adeecd45830bfd5580ca79a584154713aabef0b9607e16249133df5d2859813"},
+    {file = "ijson-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d873e72889e7fc5962ab58909f1adff338d7c2f49e450e5b5fe844eff8155a14"},
+    {file = "ijson-3.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9a88c559456a79708592234d697645d92b599718f4cbbeaa6515f83ac63ca0ae"},
+    {file = "ijson-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cf83f58ad50dc0d39a2105cb26d4f359b38f42cef68b913170d4d47d97d97ba5"},
+    {file = "ijson-3.5.0-cp310-cp310-win32.whl", hash = "sha256:aec4580a7712a19b1f95cd41bed260fc6a31266d37ef941827772a4c199e8143"},
+    {file = "ijson-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:9a9c4c70501e23e8eb1675330686d1598eebfa14b6f0dbc8f00c2e081cc628fa"},
+    {file = "ijson-3.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5616311404b858d32740b7ad8b9a799c62165f5ecb85d0a8ed16c21665a90533"},
+    {file = "ijson-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e9733f94029dd41702d573ef64752e2556e72aea14623d6dbb7a44ca1ccf30fd"},
+    {file = "ijson-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db8398c6721b98412a4f618da8022550c8b9c5d9214040646071b5deb4d4a393"},
+    {file = "ijson-3.5.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c061314845c08163b1784b6076ea5f075372461a32e6916f4e5f211fd4130b64"},
+    {file = "ijson-3.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1111a1c5ac79119c5d6e836f900c1a53844b50a18af38311baa6bb61e2645aca"},
+    {file = "ijson-3.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e74aff8c681c24002b61b1822f9511d4c384f324f7dbc08c78538e01fdc9fcb"},
+    {file = "ijson-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:739a7229b1b0cc5f7e2785a6e7a5fc915e850d3fed9588d0e89a09f88a417253"},
+    {file = "ijson-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ef88712160360cab3ca6471a4e5418243f8b267cf1fe1620879d1b5558babc71"},
+    {file = "ijson-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ca0d1b6b5f8166a6248f4309497585fb8553b04bc8179a0260fad636cfdb798"},
+    {file = "ijson-3.5.0-cp311-cp311-win32.whl", hash = "sha256:966039cf9047c7967febf7b9a52ec6f38f5464a4c7fbb5565e0224b7376fefff"},
+    {file = "ijson-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:6bad6a1634cb7c9f3f4c7e52325283b35b565f5b6cc27d42660c6912ce883422"},
+    {file = "ijson-3.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1ebefbe149a6106cc848a3eaf536af51a9b5ccc9082de801389f152dba6ab755"},
+    {file = "ijson-3.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:19e30d9f00f82e64de689c0b8651b9cfed879c184b139d7e1ea5030cec401c21"},
+    {file = "ijson-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a04a33ee78a6f27b9b8528c1ca3c207b1df3b8b867a4cf2fcc4109986f35c227"},
+    {file = "ijson-3.5.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d48dc2984af02eb3c56edfb3f13b3f62f2f3e4fe36f058c8cfc75d93adf4fed"},
+    {file = "ijson-3.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1e73a44844d9adbca9cf2c4132cd875933e83f3d4b23881fcaf82be83644c7d"},
+    {file = "ijson-3.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7389a56b8562a19948bdf1d7bae3a2edc8c7f86fb59834dcb1c4c722818e645a"},
+    {file = "ijson-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3176f23f8ebec83f374ed0c3b4e5a0c4db7ede54c005864efebbed46da123608"},
+    {file = "ijson-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6babd88e508630c6ef86c9bebaaf13bb2fb8ec1d8f8868773a03c20253f599bc"},
+    {file = "ijson-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dc1b3836b174b6db2fa8319f1926fb5445abd195dc963368092103f8579cb8ed"},
+    {file = "ijson-3.5.0-cp312-cp312-win32.whl", hash = "sha256:6673de9395fb9893c1c79a43becd8c8fbee0a250be6ea324bfd1487bb5e9ee4c"},
+    {file = "ijson-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f4f7fabd653459dcb004175235f310435959b1bb5dfa8878578391c6cc9ad944"},
+    {file = "ijson-3.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e9cedc10e40dd6023c351ed8bfc7dcfce58204f15c321c3c1546b9c7b12562a4"},
+    {file = "ijson-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3647649f782ee06c97490b43680371186651f3f69bebe64c6083ee7615d185e5"},
+    {file = "ijson-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90e74be1dce05fce73451c62d1118671f78f47c9f6be3991c82b91063bf01fc9"},
+    {file = "ijson-3.5.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:78e9ad73e7be2dd80627504bd5cbf512348c55ce2c06e362ed7683b5220e8568"},
+    {file = "ijson-3.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9577449313cc94be89a4fe4b3e716c65f09cc19636d5a6b2861c4e80dddebd58"},
+    {file = "ijson-3.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e4c1178fb50aff5f5701a30a5152ead82a14e189ce0f6102fa1b5f10b2f54ff"},
+    {file = "ijson-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0eb402ab026ffb37a918d75af2b7260fe6cfbce13232cc83728a714dd30bd81d"},
+    {file = "ijson-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5b08ee08355f9f729612a8eb9bf69cc14f9310c3b2a487c6f1c3c65d85216ec4"},
+    {file = "ijson-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bda62b6d48442903e7bf56152108afb7f0f1293c2b9bef2f2c369defea76ab18"},
+    {file = "ijson-3.5.0-cp313-cp313-win32.whl", hash = "sha256:8d073d9b13574cfa11083cc7267c238b7a6ed563c2661e79192da4a25f09c82c"},
+    {file = "ijson-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:2419f9e32e0968a876b04d8f26aeac042abd16f582810b576936bbc4c6015069"},
+    {file = "ijson-3.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4d4b0cd676b8c842f7648c1a783448fac5cd3b98289abd83711b3e275e143524"},
+    {file = "ijson-3.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:252dec3680a48bb82d475e36b4ae1b3a9d7eb690b951bb98a76c5fe519e30188"},
+    {file = "ijson-3.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:aa1b5dca97d323931fde2501172337384c958914d81a9dac7f00f0d4bfc76bc7"},
+    {file = "ijson-3.5.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7a5ec7fd86d606094bba6f6f8f87494897102fa4584ef653f3005c51a784c320"},
+    {file = "ijson-3.5.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:009f41443e1521847701c6d87fa3923c0b1961be3c7e7de90947c8cb92ea7c44"},
+    {file = "ijson-3.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4c3651d1f9fe2839a93fdf8fd1d5ca3a54975349894249f3b1b572bcc4bd577"},
+    {file = "ijson-3.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:945b7abcfcfeae2cde17d8d900870f03536494245dda7ad4f8d056faa303256c"},
+    {file = "ijson-3.5.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0574b0a841ff97495c13e9d7260fbf3d85358b061f540c52a123db9dbbaa2ed6"},
+    {file = "ijson-3.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f969ffb2b89c5cdf686652d7fb66252bc72126fa54d416317411497276056a18"},
+    {file = "ijson-3.5.0-cp313-cp313t-win32.whl", hash = "sha256:59d3f9f46deed1332ad669518b8099920512a78bda64c1f021fcd2aff2b36693"},
+    {file = "ijson-3.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c2839fa233746d8aad3b8cd2354e441613f5df66d721d59da4a09394bd1db2b"},
+    {file = "ijson-3.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:25a5a6b2045c90bb83061df27cfa43572afa43ba9408611d7bfe237c20a731a9"},
+    {file = "ijson-3.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8976c54c0b864bc82b951bae06567566ac77ef63b90a773a69cd73aab47f4f4f"},
+    {file = "ijson-3.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:859eb2038f7f1b0664df4241957694cc35e6295992d71c98659b22c69b3cbc10"},
+    {file = "ijson-3.5.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c911aa02991c7c0d3639b6619b93a93210ff1e7f58bf7225d613abea10adc78e"},
+    {file = "ijson-3.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:903cbdc350173605220edc19796fbea9b2203c8b3951fb7335abfa8ed37afda8"},
+    {file = "ijson-3.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4549d96ded5b8efa71639b2160235415f6bdb8c83367615e2dbabcb72755c33"},
+    {file = "ijson-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6b2dcf6349e6042d83f3f8c39ce84823cf7577eba25bac5aae5e39bbbbbe9c1c"},
+    {file = "ijson-3.5.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e44af39e6f8a17e5627dcd89715d8279bf3474153ff99aae031a936e5c5572e5"},
+    {file = "ijson-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9260332304b7e7828db56d43f08fc970a3ab741bf84ff10189361ea1b60c395b"},
+    {file = "ijson-3.5.0-cp314-cp314-win32.whl", hash = "sha256:63bc8121bb422f6969ced270173a3fa692c29d4ae30c860a2309941abd81012a"},
+    {file = "ijson-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:01b6dad72b7b7df225ef970d334556dfad46c696a2c6767fb5d9ed8889728bca"},
+    {file = "ijson-3.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ea4b676ec98e374c1df400a47929859e4fa1239274339024df4716e802aa7e4"},
+    {file = "ijson-3.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:014586eec043e23c80be9a923c56c3a0920a0f1f7d17478ce7bc20ba443968ef"},
+    {file = "ijson-3.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5b8b886b0248652d437f66e7c5ac318bbdcb2c7137a7e5327a68ca00b286f5f"},
+    {file = "ijson-3.5.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:498fd46ae2349297e43acf97cdc421e711dbd7198418677259393d2acdc62d78"},
+    {file = "ijson-3.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a51b4f9b81f12793731cf226266d1de2112c3c04ba4a04117ad4e466897e05"},
+    {file = "ijson-3.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9636c710dc4ac4a281baa266a64f323b4cc165cec26836af702c44328b59a515"},
+    {file = "ijson-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f7168a39e8211107666d71b25693fd1b2bac0b33735ef744114c403c6cac21e1"},
+    {file = "ijson-3.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8696454245415bc617ab03b0dc3ae4c86987df5dc6a90bad378fe72c5409d89e"},
+    {file = "ijson-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c21bfb61f71f191565885bf1bc29e0a186292d866b4880637b833848360bdc1b"},
+    {file = "ijson-3.5.0-cp314-cp314t-win32.whl", hash = "sha256:a2619460d6795b70d0155e5bf016200ac8a63ab5397aa33588bb02b6c21759e6"},
+    {file = "ijson-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4f24b78d4ef028d17eb57ad1b16c0aed4a17bdd9badbf232dc5d9305b7e13854"},
+    {file = "ijson-3.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0ec62d397447cbe4941818c53e22b054e03250ff9cdbaea75144b11bc6db44ed"},
+    {file = "ijson-3.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75980237a16e5e36ad46fbdd33e3f3d817c187624974c48947df0a2bfa104b9e"},
+    {file = "ijson-3.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a9c321e8e1cdeac8aac698d09a90d98a049c9be8e8330c89cf2fcc517c96d51d"},
+    {file = "ijson-3.5.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:92878b130d7ad71919c70b4f50ad23ec7fbf2d09a9c675f9179d49c4be869a63"},
+    {file = "ijson-3.5.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1ab890d43656c1d12c4a8dafb7fac5a2278ed3e4408102e0971f48b6ed4583d"},
+    {file = "ijson-3.5.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a55185e8983fef0b21abc1a0bbaa11eeb2fabdc651e2167f23defa9fe4eb999b"},
+    {file = "ijson-3.5.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5a3af031e30751164c3289294f249f942535fbe7e8f35eb3ecc374247449214e"},
+    {file = "ijson-3.5.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f4c8f5ccf7230a9a94c1d836322783ed0c0ec2a151f3d53b2e0a67c89ad66970"},
+    {file = "ijson-3.5.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6e249796d2090afc1c42d2458ab0dbf0072a30ffa246b5683e3f7b9dc9b1b7f9"},
+    {file = "ijson-3.5.0-cp39-cp39-win32.whl", hash = "sha256:1b2cf2c0c79313fbc607a0d90788ffb4f4614872983af4aa85c5b92533ec4da2"},
+    {file = "ijson-3.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:d38cb03f6b7cc26d542ff710adfe98e5f6d53878461c45456c97d3668297ec0d"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d64c624da0e9d692d6eb0ff63a79656b59d76bf80773a17c5b0f835e4e8ef627"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:876f7df73b7e0d6474f9caa729b9cdbfc8e76de9075a4887dfd689e29e85c4ca"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e7dbff2c8d9027809b0cde663df44f3210da10ea377121d42896fb6ee405dd31"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4217a1edc278660679e1197c83a1a2a2d367792bfbb2a3279577f4b59b93730d"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04f0fc740311388ee745ba55a12292b722d6f52000b11acbb913982ba5fbdf87"},
+    {file = "ijson-3.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fdeee6957f92e0c114f65c55cf8fe7eabb80cfacab64eea6864060913173f66d"},
+    {file = "ijson-3.5.0.tar.gz", hash = "sha256:94688760720e3f5212731b3cb8d30267f9a045fb38fb3870254e7b9504246f31"},
+]
+
+[[package]]
 name = "imageio"
 version = "2.37.0"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
@@ -2725,7 +3288,7 @@ description = "Read metadata from Python packages"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "(python_version == \"3.11\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\") and (platform_system == \"Linux\" or python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
@@ -2856,7 +3419,7 @@ description = "A very fast and expressive template engine."
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") or (extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system != \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") or (extra == \"local\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system != \"Linux\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2964,7 +3527,7 @@ description = "JSON Matching Expressions"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\")"
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
@@ -3337,66 +3900,70 @@ utils = ["numpydoc"]
 
 [[package]]
 name = "llguidance"
-version = "0.7.30"
+version = "1.3.0"
 description = "Bindings for the Low-level Guidance (llguidance) Rust library for use within Guidance"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and (platform_machine == \"x86_64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and platform_system == \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and (platform_machine == \"x86_64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\" or platform_machine == \"ppc64le\") and platform_system == \"Linux\""
 files = [
-    {file = "llguidance-0.7.30-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c80af02c118d2b0526bcecaab389af2ed094537a069b0fc724cd2a2f2ba3990f"},
-    {file = "llguidance-0.7.30-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00a256d532911d2cf5ba4ef63e182944e767dd2402f38d63002016bc37755958"},
-    {file = "llguidance-0.7.30-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af8741c867e4bc7e42f7cdc68350c076b4edd0ca10ecefbde75f15a9f6bc25d0"},
-    {file = "llguidance-0.7.30-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4a327a30dd37d86dd6347861ac8de3521fc1dbef9475296c06744e5b40ffc54"},
-    {file = "llguidance-0.7.30-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9edc409b9decd6cffba5f5bf3b4fbd7541f95daa8cbc9510cbf96c6ab1ffc153"},
-    {file = "llguidance-0.7.30-cp39-abi3-win32.whl", hash = "sha256:a0d52b8d1b2d3b0e661e3f953ecccfa16644f302026b3067a4815c1baa2ae643"},
-    {file = "llguidance-0.7.30-cp39-abi3-win_amd64.whl", hash = "sha256:05234ecceea7c9c6ff13b9739112043173a3bcb88cae860249b20335a07b3075"},
-    {file = "llguidance-0.7.30.tar.gz", hash = "sha256:e93bf75f2b6e48afb86a5cee23038746975e1654672bf5ba0ae75f7d4d4a2248"},
+    {file = "llguidance-1.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f7685222660a762e481ac633d49cc559c64980fe2ee59c8f932a5bb5cbc0c2c2"},
+    {file = "llguidance-1.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:098030ff0687261a3f1bd54cf21fe951fc861d56d37a0671250dd36677eaf224"},
+    {file = "llguidance-1.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f6caca5d78db7f76e1fbb0fff8607b861c32d47fa3d5dee2fc49de27ee269df"},
+    {file = "llguidance-1.3.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0612bb3f034d2487b6e8f9561f02a94a6039d88273bf0c5c539a3bd3895e47d2"},
+    {file = "llguidance-1.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc17e9dd602c3879bf91664a64bf72f54c74dbfbeb24ccfab6a5fe435b12f7aa"},
+    {file = "llguidance-1.3.0-cp39-abi3-win32.whl", hash = "sha256:2f6f558485a43e273fc5c6c974a9a3ace5d5e170076db9b40e0560e41c3ff18f"},
+    {file = "llguidance-1.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:1d1cd1c8618d1a13605d3e057c978651e551c8c469b481ee4041f1d6c436002d"},
+    {file = "llguidance-1.3.0.tar.gz", hash = "sha256:861249afd51dc325646834462ea827e57a5c2b2042e108e6aae7059fdad9104d"},
 ]
 
 [[package]]
 name = "llvmlite"
-version = "0.44.0"
+version = "0.47.0"
 description = "lightweight wrapper around basic LLVM functionality"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "llvmlite-0.44.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:9fbadbfba8422123bab5535b293da1cf72f9f478a65645ecd73e781f962ca614"},
-    {file = "llvmlite-0.44.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cccf8eb28f24840f2689fb1a45f9c0f7e582dd24e088dcf96e424834af11f791"},
-    {file = "llvmlite-0.44.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7202b678cdf904823c764ee0fe2dfe38a76981f4c1e51715b4cb5abb6cf1d9e8"},
-    {file = "llvmlite-0.44.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40526fb5e313d7b96bda4cbb2c85cd5374e04d80732dd36a282d72a560bb6408"},
-    {file = "llvmlite-0.44.0-cp310-cp310-win_amd64.whl", hash = "sha256:41e3839150db4330e1b2716c0be3b5c4672525b4c9005e17c7597f835f351ce2"},
-    {file = "llvmlite-0.44.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:eed7d5f29136bda63b6d7804c279e2b72e08c952b7c5df61f45db408e0ee52f3"},
-    {file = "llvmlite-0.44.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ace564d9fa44bb91eb6e6d8e7754977783c68e90a471ea7ce913bff30bd62427"},
-    {file = "llvmlite-0.44.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5d22c3bfc842668168a786af4205ec8e3ad29fb1bc03fd11fd48460d0df64c1"},
-    {file = "llvmlite-0.44.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f01a394e9c9b7b1d4e63c327b096d10f6f0ed149ef53d38a09b3749dcf8c9610"},
-    {file = "llvmlite-0.44.0-cp311-cp311-win_amd64.whl", hash = "sha256:d8489634d43c20cd0ad71330dde1d5bc7b9966937a263ff1ec1cebb90dc50955"},
-    {file = "llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:1d671a56acf725bf1b531d5ef76b86660a5ab8ef19bb6a46064a705c6ca80aad"},
-    {file = "llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f79a728e0435493611c9f405168682bb75ffd1fbe6fc360733b850c80a026db"},
-    {file = "llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0143a5ef336da14deaa8ec26c5449ad5b6a2b564df82fcef4be040b9cacfea9"},
-    {file = "llvmlite-0.44.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d752f89e31b66db6f8da06df8b39f9b91e78c5feea1bf9e8c1fba1d1c24c065d"},
-    {file = "llvmlite-0.44.0-cp312-cp312-win_amd64.whl", hash = "sha256:eae7e2d4ca8f88f89d315b48c6b741dcb925d6a1042da694aa16ab3dd4cbd3a1"},
-    {file = "llvmlite-0.44.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:319bddd44e5f71ae2689859b7203080716448a3cd1128fb144fe5c055219d516"},
-    {file = "llvmlite-0.44.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9c58867118bad04a0bb22a2e0068c693719658105e40009ffe95c7000fcde88e"},
-    {file = "llvmlite-0.44.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46224058b13c96af1365290bdfebe9a6264ae62fb79b2b55693deed11657a8bf"},
-    {file = "llvmlite-0.44.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0097052c32bf721a4efc03bd109d335dfa57d9bffb3d4c24cc680711b8b4fc"},
-    {file = "llvmlite-0.44.0-cp313-cp313-win_amd64.whl", hash = "sha256:2fb7c4f2fb86cbae6dca3db9ab203eeea0e22d73b99bc2341cdf9de93612e930"},
-    {file = "llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4"},
+    {file = "llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063"},
+    {file = "llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea"},
+    {file = "llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8"},
+    {file = "llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327"},
+    {file = "llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077"},
+    {file = "llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7"},
+    {file = "llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40"},
+    {file = "llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e"},
+    {file = "llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca"},
+    {file = "llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453"},
+    {file = "llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc"},
 ]
 
 [[package]]
 name = "lm-format-enforcer"
-version = "0.10.12"
+version = "0.11.3"
 description = "Enforce the output format (JSON Schema, Regex etc) of a language model"
 optional = true
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "lm_format_enforcer-0.10.12-py3-none-any.whl", hash = "sha256:267c2b421c77f7cd51ac2e0e3af8db278a373704d834b49ff55f18a2c05e9800"},
-    {file = "lm_format_enforcer-0.10.12.tar.gz", hash = "sha256:130bd7ce8a6b224f25b6314ba9ae78ee4b48594db1767c74391c9182e2902a6c"},
+    {file = "lm_format_enforcer-0.11.3-py3-none-any.whl", hash = "sha256:cf586350875def1ae7a8fba84fcbbfc8371424b6c9d05c1fcba70aa233fbf06f"},
+    {file = "lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da"},
 ]
 
 [package.dependencies]
@@ -3404,6 +3971,26 @@ interegular = ">=0.3.2"
 packaging = "*"
 pydantic = ">=1.10.8"
 pyyaml = "*"
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+description = "Python logging made (stupidly) simple"
+optional = true
+python-versions = "<4.0,>=3.5"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c"},
+    {file = "loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==8.1.3) ; python_version >= \"3.11\"", "build (==1.2.2) ; python_version >= \"3.11\"", "colorama (==0.4.5) ; python_version < \"3.8\"", "colorama (==0.4.6) ; python_version >= \"3.8\"", "exceptiongroup (==1.1.3) ; python_version >= \"3.7\" and python_version < \"3.11\"", "freezegun (==1.1.0) ; python_version < \"3.8\"", "freezegun (==1.5.0) ; python_version >= \"3.8\"", "mypy (==0.910) ; python_version < \"3.6\"", "mypy (==0.971) ; python_version == \"3.6\"", "mypy (==1.13.0) ; python_version >= \"3.8\"", "mypy (==1.4.1) ; python_version == \"3.7\"", "myst-parser (==4.0.0) ; python_version >= \"3.11\"", "pre-commit (==4.0.1) ; python_version >= \"3.9\"", "pytest (==6.1.2) ; python_version < \"3.8\"", "pytest (==8.3.2) ; python_version >= \"3.8\"", "pytest-cov (==2.12.1) ; python_version < \"3.8\"", "pytest-cov (==5.0.0) ; python_version == \"3.8\"", "pytest-cov (==6.0.0) ; python_version >= \"3.9\"", "pytest-mypy-plugins (==1.9.3) ; python_version >= \"3.6\" and python_version < \"3.8\"", "pytest-mypy-plugins (==3.1.0) ; python_version >= \"3.8\"", "sphinx-rtd-theme (==3.0.2) ; python_version >= \"3.11\"", "tox (==3.27.1) ; python_version < \"3.8\"", "tox (==4.23.2) ; python_version >= \"3.8\"", "twine (==6.0.1) ; python_version >= \"3.11\""]
 
 [[package]]
 name = "magika"
@@ -3426,6 +4013,7 @@ click = ">=8.1.7"
 numpy = [
     {version = ">=1.24", markers = "python_version < \"3.12\""},
     {version = ">=1.26", markers = "python_version == \"3.12\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
 ]
 onnxruntime = {version = ">=1.17.0", markers = "python_version > \"3.9\""}
 python-dotenv = ">=1.0.1"
@@ -3512,7 +4100,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") or (extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system != \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") or (extra == \"local\" or extra == \"vision\" or extra == \"agent\" or extra == \"vendors\") and platform_system != \"Linux\""
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -3692,7 +4280,7 @@ description = "Model Context Protocol SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"server\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "mcp-1.12.3-py3-none-any.whl", hash = "sha256:5483345bf39033b858920a5b6348a303acacf45b23936972160ff152107b850e"},
     {file = "mcp-1.12.3.tar.gz", hash = "sha256:ab2e05f5e5c13e1dc90a4a9ef23ac500a6121362a564447855ef0ab643a99fed"},
@@ -3730,39 +4318,108 @@ files = [
 
 [[package]]
 name = "mistral-common"
-version = "1.8.5"
+version = "1.11.2"
 description = "Mistral-common is a library of common utilities for Mistral AI."
 optional = true
-python-versions = "<3.14,>=3.9.0"
+python-versions = "<3.15,>=3.10.0"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "mistral_common-1.8.5-py3-none-any.whl", hash = "sha256:f3cf87b61958a00485e603f3fe0530eb509d7e9b2f7178329dcd260e307eced1"},
-    {file = "mistral_common-1.8.5.tar.gz", hash = "sha256:9f6204ede9c807f09040a208a9381ae78ef93e2e5a9cd5202dc12e712a025de8"},
+    {file = "mistral_common-1.11.2-py3-none-any.whl", hash = "sha256:ebb42062cd705a0aa2bc69b4cde2b83d446ae58150b7e29322c90cb08fcfca6c"},
+    {file = "mistral_common-1.11.2.tar.gz", hash = "sha256:79f68fc2d1190f28637f40e053f919c8c2697e00b2aa679ddee562a95183f4ad"},
 ]
 
 [package.dependencies]
 jsonschema = ">=4.21.1"
-numpy = ">=1.25"
+numpy = [
+    {version = ">=1.25,<2.4", markers = "python_version <= \"3.12\""},
+    {version = ">=1.25", markers = "python_version > \"3.12\""},
+]
 opencv-python-headless = {version = ">=4.0.0", optional = true, markers = "extra == \"opencv\""}
 pillow = ">=10.3.0"
-pydantic = ">=2.7,<3.0"
+pydantic = [
+    {version = ">=2.7,<3.0", markers = "python_version <= \"3.13\""},
+    {version = ">=2.12,<3.0", markers = "python_version >= \"3.14\""},
+]
 pydantic-extra-types = {version = ">=2.10.5", extras = ["pycountry"]}
 requests = ">=2.0.0"
-soundfile = {version = ">=0.12.1", optional = true, markers = "extra == \"soundfile\""}
-soxr = {version = ">=0.5.0", optional = true, markers = "extra == \"soxr\""}
-tiktoken = ">=0.7.0"
+tiktoken = [
+    {version = ">=0.7.0", markers = "python_version <= \"3.13\""},
+    {version = ">=0.12.0", markers = "python_version >= \"3.14\""},
+]
 typing-extensions = ">=4.11.0"
 
 [package.extras]
+all = ["mistral_common[audio,guidance,hf-hub,image,opencv,sentencepiece,server]"]
 audio = ["mistral_common[soundfile]", "mistral_common[soxr]"]
-hf-hub = ["huggingface-hub (>=0.32.4)"]
+guidance = ["jinja2 (>=3.1.0)", "llguidance (>=1.3.0,<1.4.0)"]
+hf-hub = ["huggingface-hub (>=1.0)"]
 image = ["mistral_common[opencv]"]
 opencv = ["opencv-python-headless (>=4.0.0)"]
 sentencepiece = ["sentencepiece (>=0.2.0)"]
-server = ["click (>=8.1.0)", "fastapi[standard] (>=0.115.12)", "pydantic-settings (>=2.9.1)"]
+server = ["click (>=8.1.0)", "fastapi[standard] (>=0.118.3)", "pydantic-settings (>=2.9.1)", "uvloop (>=0.22.1) ; python_version >= \"3.14\""]
 soundfile = ["soundfile (>=0.12.1)"]
 soxr = ["soxr (>=0.5.0)"]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d81fdb088defa30eb37bf390bb7dde35d3a83ec112ac8e33d75ab28cc29dd8b0"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88c982aac7cb1cbe8cbb4e7f253072b1df872701fcaf48d84ffbb433b6568f24"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9b61c19040397970d18d7737375cffd83b1f36a11dd4ad19f83a016f736c3ef"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:3d277bf3637f2a62176f4575512e9ff9ef51d00e39626d9fe4a161992f355af2"},
+    {file = "ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.23.3", markers = "python_version >= \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
+]
+
+[package.extras]
+dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
 
 [[package]]
 name = "mlx"
@@ -3855,6 +4512,28 @@ files = [
 ]
 
 [[package]]
+name = "model-hosting-container-standards"
+version = "0.1.15"
+description = "Python toolkit for standardized model hosting container implementations with Amazon SageMaker integration"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "model_hosting_container_standards-0.1.15-py3-none-any.whl", hash = "sha256:849e08c4732203ee861c8c24966b4e916ea4420fa324b430f7f74a1e1fe8811a"},
+    {file = "model_hosting_container_standards-0.1.15.tar.gz", hash = "sha256:ae8dd74d3250545c14f0a7068186c7b0f0ab6563d31e7137f556b6b660c8a6a9"},
+]
+
+[package.dependencies]
+fastapi = "*"
+httpx = "*"
+jmespath = "*"
+pydantic = "*"
+setuptools = "*"
+starlette = ">=0.49.1"
+supervisor = ">=4.2.0"
+
+[[package]]
 name = "more-itertools"
 version = "10.8.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -3874,7 +4553,7 @@ description = "Python library for arbitrary-precision floating-point arithmetic"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"tool\")"
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\")"
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -3885,79 +4564,6 @@ develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
 docs = ["sphinx"]
 gmpy = ["gmpy2 (>=2.1.0a4) ; platform_python_implementation != \"PyPy\""]
 tests = ["pytest (>=4.6)"]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-description = "MessagePack serializer"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
-files = [
-    {file = "msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2"},
-    {file = "msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87"},
-    {file = "msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251"},
-    {file = "msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a"},
-    {file = "msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f"},
-    {file = "msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f"},
-    {file = "msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9"},
-    {file = "msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa"},
-    {file = "msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c"},
-    {file = "msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0"},
-    {file = "msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296"},
-    {file = "msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef"},
-    {file = "msgpack-1.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7bc8813f88417599564fafa59fd6f95be417179f76b40325b500b3c98409757c"},
-    {file = "msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e"},
-    {file = "msgpack-1.1.2-cp311-cp311-win32.whl", hash = "sha256:602b6740e95ffc55bfb078172d279de3773d7b7db1f703b2f1323566b878b90e"},
-    {file = "msgpack-1.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:d198d275222dc54244bf3327eb8cbe00307d220241d9cec4d306d49a44e85f68"},
-    {file = "msgpack-1.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:86f8136dfa5c116365a8a651a7d7484b65b13339731dd6faebb9a0242151c406"},
-    {file = "msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa"},
-    {file = "msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb"},
-    {file = "msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f"},
-    {file = "msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42"},
-    {file = "msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9"},
-    {file = "msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620"},
-    {file = "msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029"},
-    {file = "msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b"},
-    {file = "msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69"},
-    {file = "msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf"},
-    {file = "msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7"},
-    {file = "msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999"},
-    {file = "msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e"},
-    {file = "msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162"},
-    {file = "msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794"},
-    {file = "msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c"},
-    {file = "msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9"},
-    {file = "msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84"},
-    {file = "msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00"},
-    {file = "msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939"},
-    {file = "msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e"},
-    {file = "msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931"},
-    {file = "msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014"},
-    {file = "msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2"},
-    {file = "msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717"},
-    {file = "msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b"},
-    {file = "msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af"},
-    {file = "msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a"},
-    {file = "msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b"},
-    {file = "msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245"},
-    {file = "msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90"},
-    {file = "msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20"},
-    {file = "msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27"},
-    {file = "msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b"},
-    {file = "msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff"},
-    {file = "msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46"},
-    {file = "msgpack-1.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ea5405c46e690122a76531ab97a079e184c0daf491e588592d6a23d3e32af99e"},
-    {file = "msgpack-1.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9fba231af7a933400238cb357ecccf8ab5d51535ea95d94fc35b7806218ff844"},
-    {file = "msgpack-1.1.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a8f6e7d30253714751aa0b0c84ae28948e852ee7fb0524082e6716769124bc23"},
-    {file = "msgpack-1.1.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94fd7dc7d8cb0a54432f296f2246bc39474e017204ca6f4ff345941d4ed285a7"},
-    {file = "msgpack-1.1.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:350ad5353a467d9e3b126d8d1b90fe05ad081e2e1cef5753f8c345217c37e7b8"},
-    {file = "msgpack-1.1.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6bde749afe671dc44893f8d08e83bf475a1a14570d67c4bb5cec5573463c8833"},
-    {file = "msgpack-1.1.2-cp39-cp39-win32.whl", hash = "sha256:ad09b984828d6b7bb52d1d1d0c9be68ad781fa004ca39216c8a1e63c0f34ba3c"},
-    {file = "msgpack-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:67016ae8c8965124fdede9d3769528ad8284f14d635337ffa6a713a580f6c030"},
-    {file = "msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e"},
-]
 
 [[package]]
 name = "msgspec"
@@ -4257,7 +4863,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\")"
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
 files = [
     {file = "networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec"},
     {file = "networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037"},
@@ -4304,39 +4910,43 @@ files = [
 
 [[package]]
 name = "numba"
-version = "0.61.2"
+version = "0.65.0"
 description = "compiling Python code using LLVM"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "numba-0.61.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:cf9f9fc00d6eca0c23fc840817ce9f439b9f03c8f03d6246c0e7f0cb15b7162a"},
-    {file = "numba-0.61.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ea0247617edcb5dd61f6106a56255baab031acc4257bddaeddb3a1003b4ca3fd"},
-    {file = "numba-0.61.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae8c7a522c26215d5f62ebec436e3d341f7f590079245a2f1008dfd498cc1642"},
-    {file = "numba-0.61.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bd1e74609855aa43661edffca37346e4e8462f6903889917e9f41db40907daa2"},
-    {file = "numba-0.61.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae45830b129c6137294093b269ef0a22998ccc27bf7cf096ab8dcf7bca8946f9"},
-    {file = "numba-0.61.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:efd3db391df53aaa5cfbee189b6c910a5b471488749fd6606c3f33fc984c2ae2"},
-    {file = "numba-0.61.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:49c980e4171948ffebf6b9a2520ea81feed113c1f4890747ba7f59e74be84b1b"},
-    {file = "numba-0.61.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3945615cd73c2c7eba2a85ccc9c1730c21cd3958bfcf5a44302abae0fb07bb60"},
-    {file = "numba-0.61.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbfdf4eca202cebade0b7d43896978e146f39398909a42941c9303f82f403a18"},
-    {file = "numba-0.61.2-cp311-cp311-win_amd64.whl", hash = "sha256:76bcec9f46259cedf888041b9886e257ae101c6268261b19fda8cfbc52bec9d1"},
-    {file = "numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:34fba9406078bac7ab052efbf0d13939426c753ad72946baaa5bf9ae0ebb8dd2"},
-    {file = "numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ddce10009bc097b080fc96876d14c051cc0c7679e99de3e0af59014dab7dfe8"},
-    {file = "numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b1bb509d01f23d70325d3a5a0e237cbc9544dd50e50588bc581ba860c213546"},
-    {file = "numba-0.61.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:48a53a3de8f8793526cbe330f2a39fe9a6638efcbf11bd63f3d2f9757ae345cd"},
-    {file = "numba-0.61.2-cp312-cp312-win_amd64.whl", hash = "sha256:97cf4f12c728cf77c9c1d7c23707e4d8fb4632b46275f8f3397de33e5877af18"},
-    {file = "numba-0.61.2-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:3a10a8fc9afac40b1eac55717cece1b8b1ac0b946f5065c89e00bde646b5b154"},
-    {file = "numba-0.61.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d3bcada3c9afba3bed413fba45845f2fb9cd0d2b27dd58a1be90257e293d140"},
-    {file = "numba-0.61.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bdbca73ad81fa196bd53dc12e3aaf1564ae036e0c125f237c7644fe64a4928ab"},
-    {file = "numba-0.61.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5f154aaea625fb32cfbe3b80c5456d514d416fcdf79733dd69c0df3a11348e9e"},
-    {file = "numba-0.61.2-cp313-cp313-win_amd64.whl", hash = "sha256:59321215e2e0ac5fa928a8020ab00b8e57cda8a97384963ac0dfa4d4e6aa54e7"},
-    {file = "numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d"},
+    {file = "numba-0.65.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:dff9fd5fbc9a35c517359c5823ea705d9b65f01fb46e42e35a2eabe5a52c2e96"},
+    {file = "numba-0.65.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4c894c94afa5ffd627c7e3b693df10cb0d905bd5eb06de3dfc31775140cf4f89"},
+    {file = "numba-0.65.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7325b1aab88f0339057288ee32f39dc660e14f93872a6fda14fa6eb9f95b047"},
+    {file = "numba-0.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:71e72e9ca2f619df4768f9c3962bfec60191a5a26fe2b6a8c6a07532b6146169"},
+    {file = "numba-0.65.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:28e547d0b18024f19cbaf9de02fc5c145790213d9be8a2c95b43f93ec162b9e4"},
+    {file = "numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:032b0b8e879512cd424d79eed6d772a1399c6387ded184c2cf3cc22c08d750a6"},
+    {file = "numba-0.65.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af143d823624033a128b5950c0aaf9ffc2386dfe954eb757119cf0432335534c"},
+    {file = "numba-0.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:15d159578e59a39df246b83480f78d7794b0fca40153b5684d3849a99c48a0fb"},
+    {file = "numba-0.65.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b27ee4847e1bfb17e9604d100417ee7c1d10f15a6711c6213404b3da13a0b2aa"},
+    {file = "numba-0.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a52d92ffd297c10364bce60cd1fcb88f99284ab5df085f2c6bcd1cb33b529a6f"},
+    {file = "numba-0.65.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da8e371e328c06d0010c3d8b44b21858652831b85bcfba78cb22c042e22dbd8e"},
+    {file = "numba-0.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:59bb9f2bb9f1238dfd8e927ba50645c18ae769fef4f3d58ea0ea22a2683b91f5"},
+    {file = "numba-0.65.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c6334094563a456a695c812e6846288376ca02327cf246cdcc83e1bb27862367"},
+    {file = "numba-0.65.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b8a9008411615c69d083d1dcf477f75a5aa727b30beb16e139799e2be945cdfd"},
+    {file = "numba-0.65.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af96c0cba53664efcb361528b8c75e011a6556c859c7e08424c2715201c6cf7a"},
+    {file = "numba-0.65.0-cp313-cp313-win_amd64.whl", hash = "sha256:6254e73b9c929dc736a1fbd3d6f5680789709a5067cae1fa7198707385129c04"},
+    {file = "numba-0.65.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ee336b398a6fca51b1f626034de99f50cb1bd87d537a166275158a3cee744b82"},
+    {file = "numba-0.65.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05c0a9fdf75d85f57dee47b719e8d6415707b80aae45d75f63f9dc1b935c29f7"},
+    {file = "numba-0.65.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:583680e0e8faf124d362df23b4b593f3221a8996341a63d1b664c122401bec2f"},
+    {file = "numba-0.65.0-cp314-cp314-win_amd64.whl", hash = "sha256:add297d3e1c08dd884f44100152612fa41e66a51d15fdf91307f9dde31d06830"},
+    {file = "numba-0.65.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:194a243ba53a9157c8538cbb3166ec015d785a8c5d584d06cdd88bee902233c7"},
+    {file = "numba-0.65.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fa502960f7a2f3f5cb025bc7bff888a3551277b92431bfdc5ba2f11a375749"},
+    {file = "numba-0.65.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5046c63f783ca3eb6195f826a50797465e7c4ce811daa17c9bea47e310c9b964"},
+    {file = "numba-0.65.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46fd679ae4f68c7a5d5721efbd29ecee0b0f3013211591891d79b51bfdf73113"},
+    {file = "numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b"},
 ]
 
 [package.dependencies]
-llvmlite = "==0.44.*"
-numpy = ">=1.24,<2.3"
+llvmlite = "==0.47.*"
+numpy = ">=1.22,<2.5"
 
 [[package]]
 name = "numpy"
@@ -4405,225 +5015,313 @@ files = [
 markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"audio\" or extra == \"memory\" or extra == \"quantization\" or extra == \"tool\" or extra == \"vendors\" or extra == \"vision\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"audio\" or extra == \"memory\" or extra == \"tool\" or extra == \"vendors\" or extra == \"vision\") or (extra == \"vision\" or extra == \"tool\" or extra == \"memory\" or extra == \"local\" or extra == \"audio\" or extra == \"vendors\") and platform_system != \"Linux\""}
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.6.4.1"
+name = "nvidia-cublas"
+version = "13.1.0.3"
 description = "CUBLAS native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb"},
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668"},
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-win_amd64.whl", hash = "sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8"},
+    {file = "nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2"},
+    {file = "nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171"},
+    {file = "nvidia_cublas-13.1.0.3-py3-none-win_amd64.whl", hash = "sha256:2a3b94a37def342471c59fad7856caee4926809a72dd5270155d6a31b5b277be"},
 ]
 
 [[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.6.80"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
 description = "CUDA profiling tools runtime libs."
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-win_amd64.whl", hash = "sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a"},
+    {file = "nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151"},
+    {file = "nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8"},
+    {file = "nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00"},
 ]
 
 [[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.6.77"
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
 description = "NVRTC native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a"},
+    {file = "nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575"},
+    {file = "nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b"},
+    {file = "nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872"},
 ]
 
 [[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.6.77"
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
 description = "CUDA Runtime native Libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f"},
+    {file = "nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55"},
+    {file = "nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548"},
+    {file = "nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492"},
 ]
 
 [[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.5.1.17"
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
 description = "cuDNN runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def"},
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2"},
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-win_amd64.whl", hash = "sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8"},
+    {file = "nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4"},
+    {file = "nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf"},
+    {file = "nvidia_cudnn_cu13-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:40d8c375005bcb01495f8edf375230b203a411a0c05fb6dc92a3781edcb23eac"},
 ]
 
 [package.dependencies]
-nvidia-cublas-cu12 = "*"
+nvidia-cublas = "*"
 
 [[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.0.4"
+name = "nvidia-cudnn-frontend"
+version = "1.18.0"
+description = "CUDNN FrontEnd python library"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "nvidia_cudnn_frontend-1.18.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:baa6fbc8e7c55f1c78c0374ed9a890e1cf81acaca0c92d6135d18a8e3c985244"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4bcca42259e358002c8867e3624a558f66cd5dff2cc6c3aafd860ef2f41730"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp310-cp310-win_amd64.whl", hash = "sha256:06252021ef1e5a7256f1e70429a426b01792636c05cc547fe8e64c6885a9652e"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6d4d0b88d617b233a503c84980b54d840b60b2734497d1a7a071ec5293daec2"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:382ea063b92cbfd5b442cb75ff8422932d78276aecf139e46713ed1ad3d07af4"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp311-cp311-win_amd64.whl", hash = "sha256:baa509effc4d299d3f04e549d4188f88bca8a8b527f483cbd2f66bc18f13a8b1"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:310b417f2848a83d1437203fcaeea320a74fb7f28af20bf42bf5afc9c01f1c12"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c023539ca6de99234cf5102c3ec0d6af817f5396fc93028a22ba5b834a35b8a"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:e13f7dd46cdb4762dde87f181f06d1c5e15e9478bbdd547bfa74d9b11f415aae"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a6e2b7bd43705ffa4af3b187374fdd5e7d09fc228a4d65fc8b4b0a537a8e605"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0544206b02cae9da4f044ca3fe7416b99e0c8a8052285dd3e5a8fc445d34f9c"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:7eefa5f10cc003df5f3593f82f1ee6c001fc3412bdc78430c751914dfceefd7f"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b489da1b30f1d7da822b37b89cc4f68afd80e020eb57e4ab24921f8b57f6e946"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37688c81a34ac590aff9de4c34d2968bab949411af707baa327616ebd4b34ae1"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:5053b473fa74168b5fbf35934cd6187f88aa03b8447b9f2cd417332d5e5c9569"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e019ec7e693e6d38acd2c5a50b1834726bd4213ec8b5eb18d8f6f3ae83a80fb"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd9049e397e3bbb81ceeb6e384e60fea08c5c7cfa07029e7509ec98002d3064f"},
+    {file = "nvidia_cudnn_frontend-1.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:e696a29a0d3c171ac81ad4374017771cf4c17081838a2115bde4c703fa9751c6"},
+]
+
+[package.extras]
+cutedsl = ["cuda-python", "nvidia-cutlass-dsl (==4.3.5)", "torch"]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
 description = "CUFFT native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-win_amd64.whl", hash = "sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464"},
+    {file = "nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5"},
+    {file = "nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3"},
+    {file = "nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb"},
 ]
 
 [package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
+nvidia-nvjitlink = "*"
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.11.1.6"
+name = "nvidia-cufile"
+version = "1.15.1.6"
 description = "cuFile GPUDirect libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and sys_platform == \"linux\" and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159"},
-    {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db"},
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44"},
+    {file = "nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1"},
 ]
 
 [[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.7.77"
+name = "nvidia-curand"
+version = "10.4.0.35"
 description = "CURAND native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-win_amd64.whl", hash = "sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905"},
+    {file = "nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a"},
+    {file = "nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc"},
+    {file = "nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f"},
 ]
 
 [[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.1.2"
+name = "nvidia-cusolver"
+version = "12.0.4.66"
 description = "CUDA solver native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-win_amd64.whl", hash = "sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7"},
+    {file = "nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2"},
+    {file = "nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112"},
+    {file = "nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65"},
 ]
 
 [package.dependencies]
-nvidia-cublas-cu12 = "*"
-nvidia-cusparse-cu12 = "*"
-nvidia-nvjitlink-cu12 = "*"
+nvidia-cublas = "*"
+nvidia-cusparse = "*"
+nvidia-nvjitlink = "*"
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.4.2"
+name = "nvidia-cusparse"
+version = "12.6.3.3"
 description = "CUSPARSE native runtime libraries"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-win_amd64.whl", hash = "sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20"},
+    {file = "nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c"},
+    {file = "nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b"},
+    {file = "nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79"},
 ]
 
 [package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
+nvidia-nvjitlink = "*"
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.6.3"
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
 description = "NVIDIA cuSPARSELt"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1"},
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46"},
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7"},
+    {file = "nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c"},
+    {file = "nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd"},
+    {file = "nvidia_cusparselt_cu13-0.8.0-py3-none-win_amd64.whl", hash = "sha256:e80212ed7b1afc97102fbb2b5c82487aa73f6a0edfa6d26c5a152593e520bb8f"},
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.26.2"
+name = "nvidia-cutlass-dsl"
+version = "4.4.2"
+description = "NVIDIA CUTLASS Python DSL"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "nvidia_cutlass_dsl-4.4.2-py3-none-any.whl", hash = "sha256:7cfb9ef19062b055b9372c7a627004724e2755e4c8b16c3cc88807d64501a4ae"},
+]
+
+[package.dependencies]
+nvidia-cutlass-dsl-libs-base = "4.4.2"
+
+[package.extras]
+cu13 = ["nvidia-cutlass-dsl-libs-cu13 (==4.4.2)"]
+
+[[package]]
+name = "nvidia-cutlass-dsl-libs-base"
+version = "4.4.2"
+description = "NVIDIA CUTLASS Python DSL"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:06acb3acff3dcf4bf6630476efac7de94de30b988ded4fa00b647bbcec4224ff"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:916bf612fba5fbc5162e300fe18196e960dac2328c1c1360c0939d3be05c7c71"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:261832dafe7579dc83cd3816ab9ea845e3de3737d876c215f01fb4edff1f4473"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40c2352b2fcc80789a216cbeb9b2ee10c85c15de839cda8f5c1d18166b8249df"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2ec8812eeadcbb6fe20bda2e295ed9c00653f8253b78e33cf0ab65a47b829e73"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:22e37b58f7a6f2f43bba533c4df8a088012122e0b4e9a632eca23937adeafb39"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b59a052cbfb9a25747d1b6d413615456bea38d1f377da085af07c0d86a4c8b39"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8e3324a33afa7424e93beae7e54a311e80db82b9e4ed4bba2aeeda1d6c888cd9"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:af96c1170569138b3cb965202907fbf5ab95d7c1dcc210952d00cdf9ab7b859a"},
+    {file = "nvidia_cutlass_dsl_libs_base-4.4.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:95db0c8d1d56992e2f5c2dcd5b3baab0297bedc0cbcefc1e70b57acd934e7b23"},
+]
+
+[package.dependencies]
+cuda-python = ">=12.8"
+numpy = "*"
+typing-extensions = "*"
+
+[[package]]
+name = "nvidia-ml-py"
+version = "13.595.45"
+description = "Python Bindings for the NVIDIA Management Library"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376"},
+    {file = "nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079"},
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
 description = "NVIDIA Collective Communication Library (NCCL) Runtime"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522"},
-    {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6"},
+    {file = "nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643"},
+    {file = "nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42"},
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.6.85"
+name = "nvidia-nvjitlink"
+version = "13.0.88"
 description = "Nvidia JIT LTO Library"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a"},
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41"},
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-win_amd64.whl", hash = "sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c"},
+    {file = "nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b"},
+    {file = "nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c"},
+    {file = "nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f"},
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.6.77"
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+description = "NVSHMEM creates a global address space that provides efficient and scalable communication for NVIDIA GPU clusters."
+optional = true
+python-versions = ">=3"
+groups = ["main"]
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
+files = [
+    {file = "nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9"},
+    {file = "nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80"},
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
 description = "NVIDIA Tools Extension"
 optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (sys_platform == \"linux\" or sys_platform == \"win32\") and platform_system == \"Linux\""
 files = [
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f44f8d86bb7d5629988d61c8d3ae61dddb2015dee142740536bc7481b022fe4b"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0"},
+    {file = "nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4"},
+    {file = "nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6"},
+    {file = "nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519"},
 ]
 
 [[package]]
@@ -4669,32 +5367,62 @@ sympy = "*"
 
 [[package]]
 name = "openai"
-version = "1.90.0"
+version = "2.37.0"
 description = "The official Python library for the openai API"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
 files = [
-    {file = "openai-1.90.0-py3-none-any.whl", hash = "sha256:e5dcb5498ea6b42fec47546d10f1bcc05fb854219a7d953a5ba766718b212a02"},
-    {file = "openai-1.90.0.tar.gz", hash = "sha256:9771982cdd5b6631af68c6a603da72ed44cd2caf73b49f717a72b71374bc565b"},
+    {file = "openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107"},
+    {file = "openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9"},
 ]
 
 [package.dependencies]
 anyio = ">=3.5.0,<5"
 distro = ">=1.7.0,<2"
 httpx = ">=0.23.0,<1"
-jiter = ">=0.4.0,<1"
+jiter = ">=0.10.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
 tqdm = ">4"
-typing-extensions = ">=4.11,<5"
+typing-extensions = ">=4.14,<5"
 
 [package.extras]
-aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.6)"]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
 datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
 realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
+
+[[package]]
+name = "openai-harmony"
+version = "0.0.8"
+description = "OpenAI's response format for its open-weight model series gpt-oss"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "openai_harmony-0.0.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:029ec25ca74abe48fdb58eb9fdd2a8c1618581fc33ce8e5653f8a1ffbfbd9326"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4f709815924ec325b9a890e6ab2bbb0ceec8e319a4e257328eb752cf36b2efc"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5cfcfd963b50a41fc656c84d3440ca6eecdccd6c552158ce790b8f2e33dfb5a9"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a3a16972aa1cee38ea958470cd04ac9a2d5ac38fdcf77ab686611246220c158"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4d5cfa168e74d08f8ba6d58a7e49bc7daef4d58951ec69b66b0d56f4927a68d"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007d277218a50db8839e599ed78e0fffe5130f614c3f6d93ae257f282071a29"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8565d4f5a0638da1bffde29832ed63c9e695c558611053add3b2dc0b56c92dbc"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:cbaa3bda75ef0d8836e1f8cc84af62f971b1d756d740efc95c38c3e04c0bfde2"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:772922a9bd24e133950fad71eb1550836f415a88e8c77870e12d0c3bd688ddc2"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:007b0476a1f331f8130783f901f1da6f5a7057af1a4891f1b6a31dec364189b5"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-win32.whl", hash = "sha256:a9b5f893326b28d9e935ade14b4f655f5a840942473bc89b201c25f7a15af9cf"},
+    {file = "openai_harmony-0.0.8-cp38-abi3-win_amd64.whl", hash = "sha256:39d44f0d8f466bd56698e7ead708bead3141e27b9b87e3ab7d5a6d0e4a869ee5"},
+    {file = "openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf"},
+]
+
+[package.dependencies]
+pydantic = ">=2.11.7"
+
+[package.extras]
+demo = ["fastapi", "uvicorn"]
 
 [[package]]
 name = "opencv-python"
@@ -4719,75 +5447,259 @@ numpy = {version = ">=2,<2.3.0", markers = "python_version >= \"3.9\""}
 
 [[package]]
 name = "opencv-python-headless"
-version = "4.12.0.88"
+version = "4.13.0.92"
 description = "Wrapper package for OpenCV python bindings."
 optional = true
 python-versions = ">=3.6"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "opencv-python-headless-4.12.0.88.tar.gz", hash = "sha256:cfdc017ddf2e59b6c2f53bc12d74b6b0be7ded4ec59083ea70763921af2b6c09"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1e58d664809b3350c1123484dd441e1667cd7bed3086db1b9ea1b6f6cb20b50e"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:365bb2e486b50feffc2d07a405b953a8f3e8eaa63865bc650034e5c71e7a5154"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aeb4b13ecb8b4a0beb2668ea07928160ea7c2cd2d9b5ef571bbee6bafe9cc8d0"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:236c8df54a90f4d02076e6f9c1cc763d794542e886c576a6fee46ec8ff75a7a9"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-win32.whl", hash = "sha256:fde2cf5c51e4def5f2132d78e0c08f9c14783cd67356922182c6845b9af87dbd"},
-    {file = "opencv_python_headless-4.12.0.88-cp37-abi3-win_amd64.whl", hash = "sha256:86b413bdd6c6bf497832e346cd5371995de148e579b9774f8eba686dee3f5528"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b"},
+    {file = "opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6"},
 ]
 
 [package.dependencies]
-numpy = {version = ">=2,<2.3.0", markers = "python_version >= \"3.9\""}
+numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+description = "OpenTelemetry Python API"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f"},
+    {file = "opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621"},
+]
+
+[package.dependencies]
+importlib-metadata = ">=6.0,<8.8.0"
+typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.41.1"
+description = "OpenTelemetry Collector Exporters"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_exporter_otlp-1.41.1-py3-none-any.whl", hash = "sha256:db276c5a80c02b063994e80950d00ca1bfddcf6520f608335b7dc2db0c0eb9c6"},
+    {file = "opentelemetry_exporter_otlp-1.41.1.tar.gz", hash = "sha256:299a2f0541ca175df186f5ac58fd5db177ba1e9b72b0826049062f750d55b47f"},
+]
+
+[package.dependencies]
+opentelemetry-exporter-otlp-proto-grpc = "1.41.1"
+opentelemetry-exporter-otlp-proto-http = "1.41.1"
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+description = "OpenTelemetry Protobuf encoding"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9"},
+    {file = "opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb"},
+]
+
+[package.dependencies]
+opentelemetry-proto = "1.41.1"
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.1"
+description = "OpenTelemetry Collector Protobuf over gRPC Exporter"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_exporter_otlp_proto_grpc-1.41.1-py3-none-any.whl", hash = "sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94"},
+    {file = "opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b"},
+]
+
+[package.dependencies]
+googleapis-common-protos = ">=1.57,<2.0"
+grpcio = [
+    {version = ">=1.63.2,<2.0.0", markers = "python_version < \"3.13\""},
+    {version = ">=1.66.2,<2.0.0", markers = "python_version == \"3.13\""},
+    {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
+]
+opentelemetry-api = ">=1.15,<2.0"
+opentelemetry-exporter-otlp-proto-common = "1.41.1"
+opentelemetry-proto = "1.41.1"
+opentelemetry-sdk = ">=1.41.1,<1.42.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc"},
+]
+
+[package.dependencies]
+googleapis-common-protos = ">=1.52,<2.0"
+opentelemetry-api = ">=1.15,<2.0"
+opentelemetry-exporter-otlp-proto-common = "1.41.1"
+opentelemetry-proto = "1.41.1"
+opentelemetry-sdk = ">=1.41.1,<1.42.0"
+requests = ">=2.7,<3.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+description = "OpenTelemetry Python Proto"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720"},
+    {file = "opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5"},
+]
+
+[package.dependencies]
+protobuf = ">=5.0,<7.0"
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+description = "OpenTelemetry Python SDK"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d"},
+    {file = "opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.41.1"
+opentelemetry-semantic-conventions = "0.62b1"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+file-configuration = ["jsonschema (>=4.0)", "pyyaml (>=6.0)"]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+description = "OpenTelemetry Semantic Conventions"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c"},
+    {file = "opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.41.1"
+typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opentelemetry-semantic-conventions-ai"
+version = "0.5.1"
+description = "OpenTelemetry Semantic Conventions Extension for Large Language Models"
+optional = true
+python-versions = "<4,>=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "opentelemetry_semantic_conventions_ai-0.5.1-py3-none-any.whl", hash = "sha256:25aeb22bd261543b4898a73824026d96770e5351209c7d07a0b1314762b1f6e4"},
+    {file = "opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c"},
+]
+
+[package.dependencies]
+opentelemetry-sdk = ">=1.38.0,<2"
+opentelemetry-semantic-conventions = ">=0.59b0"
 
 [[package]]
 name = "outlines-core"
-version = "0.2.10"
+version = "0.2.14"
 description = "Structured Text Generation in Rust"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "outlines_core-0.2.10-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b984c932bdf2843e3d5a8e57e09830d52c4237ac394f39542c4e543378b94ffb"},
-    {file = "outlines_core-0.2.10-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:65b2dba48d0f98b0145eb50494985f026e3c10df3fde94ced40e9c2aa6ea32ca"},
-    {file = "outlines_core-0.2.10-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:ac23b028da10e6914b762f36a7096e793a0e37b6c03f19963ef7875c05b67890"},
-    {file = "outlines_core-0.2.10-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:9c5b9a3f7e658949a3dd07b8a28134277a047ed7d73f6e3b4ca8209346bbff54"},
-    {file = "outlines_core-0.2.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70d99dd37a826b4d85a5dcb39ae3b557e986c9bb1c4566bbb26f589531369a53"},
-    {file = "outlines_core-0.2.10-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:207309a1d4fcf3100e3bbdc31b4d65f2b4f5d809d600c1509e28b6dca028a892"},
-    {file = "outlines_core-0.2.10-cp310-cp310-win32.whl", hash = "sha256:534fafab18e2962b9973cae852f47476307dc217dd0708d53cbf54809d8b304e"},
-    {file = "outlines_core-0.2.10-cp310-cp310-win_amd64.whl", hash = "sha256:a29e261ab57fd992b236854fd19b46b17ad8c8b7fdc6d95a97ae83480e634cff"},
-    {file = "outlines_core-0.2.10-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c0de2c683f5ca37211a3fe1c8d8530c3d92fa0ae3297b237369517dcea4b5a77"},
-    {file = "outlines_core-0.2.10-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:434aba95e0e08ef8cb6af2008562df1ad67ab02b68e64f4e725eff00bfcceb29"},
-    {file = "outlines_core-0.2.10-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:750e2d5e0b083161208599c9c2b99c8c2b944ac82d22de91546f4b2c14c57895"},
-    {file = "outlines_core-0.2.10-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:4231fb008d6282f8c49543d6ae57b173e3ca1d77bbc4ff75472706a4a38cecbf"},
-    {file = "outlines_core-0.2.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63b9f0ef1fb61a5e18697e885b2eaa1f244d2ea021d68fdb2c9a607a769aeaa8"},
-    {file = "outlines_core-0.2.10-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7b48e4bd776d4b3083d07baa3d722654e0425780772c4217f1df49d4984041b6"},
-    {file = "outlines_core-0.2.10-cp311-cp311-win32.whl", hash = "sha256:795b19362798c408113da913a03e31a562a5faf4e2ea45ec0f44435843cc185e"},
-    {file = "outlines_core-0.2.10-cp311-cp311-win_amd64.whl", hash = "sha256:b5df420c57fc257a30cf3a6e088b174aeb84a19d516f6818f00b29b626540629"},
-    {file = "outlines_core-0.2.10-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:32615f6fe4286d80699e9e6537eecbde387bf73d87751858f7a0693947381cdc"},
-    {file = "outlines_core-0.2.10-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:db3e07c999ee17035114f20263c7200bf5bea0f643d2d026671eb5cfc2a9cf71"},
-    {file = "outlines_core-0.2.10-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e39847ab495ec9923dc1a59ccab04ef7888b5e066bc5856b5cb7fe98e9663f3d"},
-    {file = "outlines_core-0.2.10-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:f543f23b263c0b010860ab5ea760b2be566b604315e6a89499632758ca177a5d"},
-    {file = "outlines_core-0.2.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8666735ec367a06e26331e164a80a4c2936b349713ac05ab53650e2997a30891"},
-    {file = "outlines_core-0.2.10-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:faf5b43181b1d033871364e74e9d348362c6a77b1d054d7af35e09fdfcff5b16"},
-    {file = "outlines_core-0.2.10-cp312-cp312-win32.whl", hash = "sha256:b37e192de974fdbfe20332720a4a9cdda92719536dface60b48dc8eeeda24390"},
-    {file = "outlines_core-0.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:f895834da0a577120dcb8d979c12c0690fe912095413bf0070a73e9ff363b7bf"},
-    {file = "outlines_core-0.2.10-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:367277a882aefa6c32438d554e1bc7389fdcaf89a3eb4d8a25cda5f1c1efb750"},
-    {file = "outlines_core-0.2.10-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4130170e53942561941d5f212583fb9c97e33d100eaac94f4b00fb3e0c4c06cf"},
-    {file = "outlines_core-0.2.10-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:202a8682319ac2c3ece876a5910eb90b399d7db3e2e0ea9c371bca61071dc840"},
-    {file = "outlines_core-0.2.10-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:e4b2ce2b96cbe858358e71136511075678bd0e1d6d0c1641525c4dbe4c7b9270"},
-    {file = "outlines_core-0.2.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:766554bed5afb19bb09f3ad01224e67723973ecc9da3d63b78dec36e3a3bfeb9"},
-    {file = "outlines_core-0.2.10-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7a1d44ccfeb029f8a0ae973ba729b59333f56ebab3d6bb765ba1cda685ebb407"},
-    {file = "outlines_core-0.2.10-cp313-cp313-win32.whl", hash = "sha256:cd13c80be1052d735b10c84488bf081274c710744c34bf7a9b7233f69ba31537"},
-    {file = "outlines_core-0.2.10-cp313-cp313-win_amd64.whl", hash = "sha256:5b651ae12331326b820df0ae9b255d9ed6cd1b725c33c8eeca5ca8ad655d8bf6"},
-    {file = "outlines_core-0.2.10-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:e8730816d97e17c31e21c26713f22ecd1899f4635fb7eb10ba10b9de2e1f33a6"},
-    {file = "outlines_core-0.2.10-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:5400dbd98ba9cba1817527510f457655ccfd7e4293a48dacc2115e04af55ae74"},
-    {file = "outlines_core-0.2.10-cp39-cp39-macosx_15_0_arm64.whl", hash = "sha256:82c97846e36cd6d7a9605013e07e1b9a481a270ac589b0b81076afd5ba850261"},
-    {file = "outlines_core-0.2.10-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:8e5c11ad18818233ad2f579675c530873966ea155557ade9464c30a67c8aa95f"},
-    {file = "outlines_core-0.2.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1437c9b90a8faef2b480c8f0b944e8cc0b050c9a97164a7aacaa868ae08ceb1"},
-    {file = "outlines_core-0.2.10-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:91facff8856f38ac77305dfea13e1c1a9be9152a14b3891a6422028291a1ea85"},
-    {file = "outlines_core-0.2.10-cp39-cp39-win32.whl", hash = "sha256:c7210bdd63116682ce0a4f38e93b0ace0adbcd333644b2dddddb0d8db2a2a9a7"},
-    {file = "outlines_core-0.2.10-cp39-cp39-win_amd64.whl", hash = "sha256:0a9e4b192ca837a472a1bb1428397509f543db08e1aeeee30252525cec34093a"},
-    {file = "outlines_core-0.2.10.tar.gz", hash = "sha256:c9ee7be195ac18dda5acce41d8805c2fb550a4affd525414511662cfa7097dfe"},
+    {file = "outlines_core-0.2.14-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:056f656ea6e4807338963377afb50b9d936593ba3545a819f1aba56fd6e14920"},
+    {file = "outlines_core-0.2.14-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:c76f28feb6ea71b1ff4b0ba5901dc383273a32b156213dc1bc753fc634645a1e"},
+    {file = "outlines_core-0.2.14-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:e604925d6525f669253160568397df6d6c8124b2e01f1fde553e3b9f28ce9e21"},
+    {file = "outlines_core-0.2.14-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:f0e5037153b5b3abfb617f6dfdc3ff28b6fab50f0de5936ea6995f5675d23e0b"},
+    {file = "outlines_core-0.2.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e4b5b7c8e50489bea444b095692ddb5d8fb92ea6b949c4a6a3381eca9b691a7"},
+    {file = "outlines_core-0.2.14-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b582b5d2f773cff966f37d7a5680d97506792647c93fb2e522283e8a14726e9d"},
+    {file = "outlines_core-0.2.14-cp310-cp310-win32.whl", hash = "sha256:f753edd430ac27e6dcde5a614665888db72b78c666aa160c478afd1eb986fb8b"},
+    {file = "outlines_core-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:060a0174a6262bfd378763f210e374e52011776849a3a767df9863fb6839c142"},
+    {file = "outlines_core-0.2.14-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7770b5e0497e6f4548a8923299d4438d7dd61dc17c2f58acfd5df4d3101bb991"},
+    {file = "outlines_core-0.2.14-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:a2795dc2047821b229457f941a303639e0c14e4c3c5718797540a27b529a062e"},
+    {file = "outlines_core-0.2.14-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4daa22d677dc6a74c44f9266ec9e3151332dcea4250dd019ea0c75b98ae32938"},
+    {file = "outlines_core-0.2.14-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:813b28813b22025c3d079b3b8a20cf5a28c6d5ba29ec21c5b1093442aa5d4e91"},
+    {file = "outlines_core-0.2.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:615566bf8257d2bba8ac192cdfc29d1c4357f57b53672fbd622e821215e4f1bd"},
+    {file = "outlines_core-0.2.14-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:81d01cfae29de5671bc5013fd6b2008621157bec3d8be284da7da2dc0672745c"},
+    {file = "outlines_core-0.2.14-cp311-cp311-win32.whl", hash = "sha256:8a5e5f34961fe4d04c389d00f92d624c6318ab3ff00467fbf7c93324458886d9"},
+    {file = "outlines_core-0.2.14-cp311-cp311-win_amd64.whl", hash = "sha256:babf97a54662330c55a79fdcab8994f96faa6dcb71b458d4b18c4fb538f5d461"},
+    {file = "outlines_core-0.2.14-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:95e6476d9702d2fcc4e85370dbbfb6933a46c816e9c90107f6ce36eb68b5d64a"},
+    {file = "outlines_core-0.2.14-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:f04731a5e29a190e2cc9f692a1f3fb2414a645355ca7d01b83df43439c38bea8"},
+    {file = "outlines_core-0.2.14-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:0e4c69f0a8565edb56464c4c9b6c291a10805f3a96dff84182980e90ae1a5e2f"},
+    {file = "outlines_core-0.2.14-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:63f53cfd9614e754499ae86dd699f3abcecf42d6a4e58d80fd80347881d85960"},
+    {file = "outlines_core-0.2.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bb2060c240c4507f334965a8948dbeeb22007560d797f6debd92346c0b620cb"},
+    {file = "outlines_core-0.2.14-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1de34681c7e0e7e1551fc9036e4fa3c57986336c905a10536591ceb6d869c258"},
+    {file = "outlines_core-0.2.14-cp312-cp312-win32.whl", hash = "sha256:870e8e038853818cb202ccc8cde92251f300f96805bfcc3be1c883adda7b5297"},
+    {file = "outlines_core-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:87b42440478764cce1353a87d8560ef82f3b39b9d753bfe93195ea3584f369e3"},
+    {file = "outlines_core-0.2.14-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8b3e8d668188282a1f7666732bb8a01958ab134db35bb792e7442a40e55ff1e7"},
+    {file = "outlines_core-0.2.14-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:66e695b375b180725fb534d9adf298531c152ec3d881e3b9e01c82b5dd269f52"},
+    {file = "outlines_core-0.2.14-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:6bd166d3b07acef2f60d4ede44592a26d3f7d8712876bfc8e22150045def5857"},
+    {file = "outlines_core-0.2.14-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:9d45462d7548aa0e17176a691ae73447f3e6bed9658a0cd96fe72eadf7474475"},
+    {file = "outlines_core-0.2.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6453e23f01d98ec48e3a4141d7112792ce77001dfb28d91d6fd89f47009f91ef"},
+    {file = "outlines_core-0.2.14-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7deef6df74cb247f2a3a62f03438ba967456504b0555ec7029f8db834e054448"},
+    {file = "outlines_core-0.2.14-cp313-cp313-win32.whl", hash = "sha256:bb008c7ecc034bcfda0ddc10a4d1f2181a4b61ec1643ee56183dd6fa64139c9d"},
+    {file = "outlines_core-0.2.14-cp313-cp313-win_amd64.whl", hash = "sha256:eb27e92204b296a063ac58f361153be4e78c8103a96e0b1c085b22d4fc3534cf"},
+    {file = "outlines_core-0.2.14-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:69410e5b55bcbaad8c865d94bd01e7bff8a57996dcd2251b7d50dec70d7d9a63"},
+    {file = "outlines_core-0.2.14-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:adf96395759d7fdf6efeb8a67d3f36f520c1546bfd4df0752306db8c7cb7d6c5"},
+    {file = "outlines_core-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b02bb0fc21c5e23e2ff9b2d1459db2c1c3e813a7646c9d5db091c6931edb9c85"},
+    {file = "outlines_core-0.2.14-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:e75395b1cccecdf85d8d8265aba28841ddeb1e8da406f4b1e0135df5a6e9960f"},
+    {file = "outlines_core-0.2.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1776ae984574461f249fe590314a439992eb9b883f4091b8fa7fc56f29f3717"},
+    {file = "outlines_core-0.2.14-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7eba2b41dac03d6e6e8d5ea0aecbbc03dacb4c57de3b1fc944d0bafb022941f7"},
+    {file = "outlines_core-0.2.14-cp314-cp314-win32.whl", hash = "sha256:0cd8ce3ce61df44fd9c5450d9744e2280586c2a6e6e3dfefa0dab1944764b424"},
+    {file = "outlines_core-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:3e67fc23b1a3ac9562488fb50f409c171538b76f64aa5f7e25d9b0bf14770204"},
+    {file = "outlines_core-0.2.14-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:7d14c48649d5df5c488b16c67493385cf8b3fe71da14466843e294c562417f21"},
+    {file = "outlines_core-0.2.14-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:7a52a56b2b627cec2d824af063a5020bf6ab9090cf9c9b4f20dcf1407eee80fc"},
+    {file = "outlines_core-0.2.14-cp39-cp39-macosx_15_0_arm64.whl", hash = "sha256:a646a43a482aa0b4a2b286735efa476b31cecd0032024cba4bb9a5d62623ef45"},
+    {file = "outlines_core-0.2.14-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:6b149452f7387501252f46f2c81847067e0820d7bff8b2b4201084f559d2300d"},
+    {file = "outlines_core-0.2.14-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb3245cbd7a2e9800f257b45cb5a8d690abd39dbaa8371ea40132f6f1eb2e3d2"},
+    {file = "outlines_core-0.2.14-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:fd7d432817978ea474de428ed6ca5ed3195812f8cfb787b85fb5ec0a51a440d2"},
+    {file = "outlines_core-0.2.14-cp39-cp39-win32.whl", hash = "sha256:98d1929a7a0ff43332448c176b92041c2755c4843a22223d341c3b96165c2a37"},
+    {file = "outlines_core-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:5f8893cf24e4f3e5a7b246b578079ff0dff3228aa9c731bd7fb1f3f55ebee19e"},
+    {file = "outlines_core-0.2.14.tar.gz", hash = "sha256:64808deed1591ca3029ff64346ceb974cd5d780c916ea82504951fe83523039e"},
 ]
 
 [package.extras]
@@ -5333,22 +6245,23 @@ testing = ["google-api-core (>=1.31.5)"]
 
 [[package]]
 name = "protobuf"
-version = "6.32.1"
+version = "6.33.6"
 description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"memory\" or extra == \"server\" or extra == \"translation\" or extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"memory\" or extra == \"server\" or extra == \"translation\" or extra == \"mlx\" or extra == \"apple\") or (extra == \"memory\" or extra == \"server\" or extra == \"translation\") and platform_system != \"Linux\""
+markers = "(extra == \"memory\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"translation\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"memory\" or extra == \"server\" or extra == \"translation\" or extra == \"mlx\" or extra == \"apple\") or (extra == \"memory\" or extra == \"server\" or extra == \"translation\") and platform_system != \"Linux\""
 files = [
-    {file = "protobuf-6.32.1-cp310-abi3-win32.whl", hash = "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085"},
-    {file = "protobuf-6.32.1-cp310-abi3-win_amd64.whl", hash = "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1"},
-    {file = "protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281"},
-    {file = "protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4"},
-    {file = "protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710"},
-    {file = "protobuf-6.32.1-cp39-cp39-win32.whl", hash = "sha256:68ff170bac18c8178f130d1ccb94700cf72852298e016a2443bdb9502279e5f1"},
-    {file = "protobuf-6.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122"},
-    {file = "protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346"},
-    {file = "protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d"},
+    {file = "protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3"},
+    {file = "protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326"},
+    {file = "protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3"},
+    {file = "protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593"},
+    {file = "protobuf-6.33.6-cp39-cp39-win32.whl", hash = "sha256:bd56799fb262994b2c2faa1799693c95cc2e22c62f56fb43af311cae45d26f0e"},
+    {file = "protobuf-6.33.6-cp39-cp39-win_amd64.whl", hash = "sha256:f443a394af5ed23672bc6c486be138628fbe5c651ccbc536873d7da23d1868cf"},
+    {file = "protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901"},
+    {file = "protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135"},
 ]
 
 [[package]]
@@ -5775,7 +6688,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"memory\" or extra == \"secrets\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"memory\" or sys_platform == \"linux\") and (platform_python_implementation != \"PyPy\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") and implementation_name != \"PyPy\" and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") and (platform_system == \"Linux\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\")"
+markers = "implementation_name != \"PyPy\" and (implementation_name == \"pypy\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"memory\" or extra == \"audio\") and (platform_system == \"Linux\" or platform_python_implementation != \"PyPy\" or extra == \"audio\") and (platform_system == \"Linux\" or sys_platform == \"linux\" or extra == \"memory\" or extra == \"audio\") and (implementation_name == \"pypy\" or sys_platform == \"linux\" or extra == \"audio\" or extra == \"memory\") and (implementation_name == \"pypy\" or extra == \"audio\" or extra == \"memory\" or extra == \"secrets\") and (platform_python_implementation != \"PyPy\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\") and (sys_platform == \"linux\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\") and (extra == \"secrets\" or extra == \"memory\" or extra == \"audio\" or extra == \"vllm\" or extra == \"nvidia\")"
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
@@ -5974,7 +6887,7 @@ description = "Settings management using Pydantic"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"server\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c"},
     {file = "pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180"},
@@ -5994,17 +6907,21 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pyds4"
-version = "1.0.1"
+version = "1.1.0"
 description = "Python bindings for the DS4 native inference engine"
 optional = false
 python-versions = ">=3.11"
 groups = ["main", "test"]
 files = [
-    {file = "pyds4-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4ddc03be73e79789bfa53544a2eeb9df01db465762eb989c1732a541e65245dd"},
-    {file = "pyds4-1.0.1-cp311-cp311-manylinux_2_38_x86_64.whl", hash = "sha256:a62f63fc756657feac9009d94b2145a31a2eb08f4731b2422c066dfe4360cc77"},
-    {file = "pyds4-1.0.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:02681c5236074a09cdbcdc1a64b531df3a72f30d5bf8691479161f23461408ec"},
-    {file = "pyds4-1.0.1-cp312-cp312-manylinux_2_38_x86_64.whl", hash = "sha256:668179ebf5f973b4fa053a3bb5a7da315542e5af0341f1b5ea3efa5f78a3a949"},
-    {file = "pyds4-1.0.1.tar.gz", hash = "sha256:a6a487cba41f8b0c730f4a4a7e98ce45e85c0ea133e58b2249deb0580d2a94d3"},
+    {file = "pyds4-1.1.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:1f2de91ee75ddec23fabd3148b5a942929dadb259aa05c592222d213b1191517"},
+    {file = "pyds4-1.1.0-cp311-cp311-manylinux_2_38_x86_64.whl", hash = "sha256:4d24122df45617fa58413aa3e19c5a2b0ed763fa7f6e1cde80af379d1dd15bc7"},
+    {file = "pyds4-1.1.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:021e41306581f0d2fee392d8865b024840e0ab3094bebbba2e740a7116c2a2fc"},
+    {file = "pyds4-1.1.0-cp312-cp312-manylinux_2_38_x86_64.whl", hash = "sha256:e711862d943f0a640184baade953a5579dc13bf92392c788633eab3104cca1ac"},
+    {file = "pyds4-1.1.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:95b4502f895850923bd98ea2e39d49792faf187a748566e33e738e751399efac"},
+    {file = "pyds4-1.1.0-cp313-cp313-manylinux_2_38_x86_64.whl", hash = "sha256:31a309fda5d9a602e90e92192600e0b28c41e25951c802ab6dc3228cb281a5a1"},
+    {file = "pyds4-1.1.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:441d60a2fab16d674802180df18b080e75ae2b9ddcb428725031614d14d6101b"},
+    {file = "pyds4-1.1.0-cp314-cp314-manylinux_2_38_x86_64.whl", hash = "sha256:6cc6f1d5990c6b7a799cbe1b8f397dd007fc1a6ff55be569a7eb3f77c3db2c16"},
+    {file = "pyds4-1.1.0.tar.gz", hash = "sha256:f7efd564e1b647ef5efedac8e457841e34dc0d82b4e5d110b4fccbd963df03eb"},
 ]
 markers = {main = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")", test = "(platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")"}
 
@@ -6182,7 +7099,7 @@ description = "Read key-value pairs from a .env file and set them as environment
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"memory\" or extra == \"server\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"server\" or extra == \"vendors\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\" or extra == \"memory\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"server\" or extra == \"vendors\")"
 files = [
     {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
     {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
@@ -6295,7 +7212,7 @@ description = "Python for Window Extensions"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"server\" and sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -6523,69 +7440,29 @@ files = [
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
-name = "ray"
-version = "2.49.2"
-description = "Ray provides a simple, universal API for building distributed applications."
+name = "quack-kernels"
+version = "0.4.1"
+description = ""
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "ray-2.49.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:08bec467576bc030d8bd0638004e1b8e075588929349112988a4bd4928684e8c"},
-    {file = "ray-2.49.2-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3e441bf2acd7f368cf45132752066c5c3b83d88cd5f85762e703774bba4f2b6d"},
-    {file = "ray-2.49.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:eae07b3fed45f5b041a8bf9795cd26fad2464be5126efd447e4484905a29b677"},
-    {file = "ray-2.49.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:74566876af7bf4e48ea4b9b3b75b34db053d1064cc4d4b1670dc4ce78f6894af"},
-    {file = "ray-2.49.2-cp310-cp310-win_amd64.whl", hash = "sha256:e6becc2026d900ca0ba07eff12a130c9d651a91290bb24d43594842b575cc4e5"},
-    {file = "ray-2.49.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4fb9f9bf62fd5c92d22da20cd2aacb4ade1fb23033765fa9274f0a0c50bc42f6"},
-    {file = "ray-2.49.2-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:9ece957a13985f7bbf4077f4ff0204314d7e99a941f95dff2a16b453d5376dc3"},
-    {file = "ray-2.49.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:eada9dd89ccda643a3c6c2cba7016b59898432d126e10b38fed52d74165364f4"},
-    {file = "ray-2.49.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:54077dde338c5ffba349a4ab61b72352a3c3be69ea5b4f1b436d98d40b312763"},
-    {file = "ray-2.49.2-cp311-cp311-win_amd64.whl", hash = "sha256:41e11802ebbc487380e6c21dc041cb405e69fdda717a4eafdfeea294c6c3f9ca"},
-    {file = "ray-2.49.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d6d612de5c6341b776fc75edeee5b698bb4af7ee84a2ff30552b32a9e6e4a772"},
-    {file = "ray-2.49.2-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:6784e076e4418222ef8ee3b6a8bfeb867d8797803b25bcfcce3bf3bc5414bef1"},
-    {file = "ray-2.49.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:dd0d8d8641d142fafe6d83e87d3c19bd5637d21e34608d3ff69ad71ea3e2f462"},
-    {file = "ray-2.49.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:2ecaaa51f588ccdda2b61563a8be3843bf65dfaaa83a240588a307f4ebb82471"},
-    {file = "ray-2.49.2-cp312-cp312-win_amd64.whl", hash = "sha256:cba59684f031c9e778c588bc925777967e1b49bab3f00c638e4980bfdab07aec"},
-    {file = "ray-2.49.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2e2fe20fa90562e73630da9ff7932d3ed6507e73291c4d9bdf566537ae9deddf"},
-    {file = "ray-2.49.2-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:b2f4f0fed936faf688e87ffdcc9356c034513c00259a2f1a8589e345fcfbdbc0"},
-    {file = "ray-2.49.2-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:b4c7869688c518e902f7b6288edec2365ab4d28a464291e6d0a7040c7d01b5f7"},
-    {file = "ray-2.49.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:b7d8214cff86df044fec727eeeabccc3bfc9b0271d28d61ba92c09f0d127d01d"},
-    {file = "ray-2.49.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:321000d626da81f5cba56bba54c779c1b317717a369aa41377508b756fa78259"},
-    {file = "ray-2.49.2-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:e0ece2617dcedfcd4e2f4fe12dfab11375981dff9010f94298ca29ad5a330a78"},
-    {file = "ray-2.49.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df99b7aafbfbe122befebfdca78facb297273260a1026752ff43af613b237939"},
-    {file = "ray-2.49.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:057e2e1408790d11d8931c46ed0ca6a0c125bc129811ea1c8a833ee945c36e13"},
-    {file = "ray-2.49.2-cp39-cp39-win_amd64.whl", hash = "sha256:0cee0a693a312cf5a5acc28d0a8b9e2c677ab4f755981d6ae76e6d9e25f99811"},
+    {file = "quack_kernels-0.4.1-py3-none-any.whl", hash = "sha256:c1c8df2935bf5156ec47d2c5384ac08b411fd0ee702d80ae916dbf6d6f5ae813"},
+    {file = "quack_kernels-0.4.1.tar.gz", hash = "sha256:9d7d6ba412bc0c8a9b1331c52a73db76280adb9dc2f2750df4851ddabef1466b"},
 ]
 
 [package.dependencies]
-click = ">=7.0"
-cupy-cuda12x = {version = "*", optional = true, markers = "sys_platform != \"darwin\" and extra == \"cgraph\""}
-filelock = "*"
-jsonschema = "*"
-msgpack = ">=1.0.0,<2.0.0"
-packaging = "*"
-protobuf = ">=3.20.3"
-pyyaml = "*"
-requests = "*"
+apache-tvm-ffi = ">=0.1.6,<0.2"
+einops = "*"
+nvidia-cutlass-dsl = ">=4.4.2"
+torch = "*"
+torch-c-dlpack-ext = "*"
 
 [package.extras]
-adag = ["cupy-cuda12x ; sys_platform != \"darwin\""]
-air = ["aiohttp (>=3.7)", "aiohttp_cors", "colorful", "fastapi", "fsspec", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "numpy (>=1.20)", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "pandas", "pandas (>=1.3)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pyarrow (>=9.0.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "starlette", "tensorboardX (>=1.9)", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-all = ["aiohttp (>=3.7)", "aiohttp_cors", "celery", "colorful", "cupy-cuda12x ; sys_platform != \"darwin\"", "dm_tree", "fastapi", "fsspec", "grpcio", "grpcio (!=1.56.0) ; sys_platform == \"darwin\"", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "gymnasium (==1.1.1)", "lz4", "memray ; sys_platform != \"win32\"", "numpy (>=1.20)", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "ormsgpack (==1.7.0)", "pandas", "pandas (>=1.3)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pyOpenSSL", "pyarrow (>=9.0.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "pyyaml", "requests", "scipy", "smart_open", "starlette", "tensorboardX (>=1.9)", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-all-cpp = ["aiohttp (>=3.7)", "aiohttp_cors", "celery", "colorful", "cupy-cuda12x ; sys_platform != \"darwin\"", "dm_tree", "fastapi", "fsspec", "grpcio", "grpcio (!=1.56.0) ; sys_platform == \"darwin\"", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "gymnasium (==1.1.1)", "lz4", "memray ; sys_platform != \"win32\"", "numpy (>=1.20)", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "ormsgpack (==1.7.0)", "pandas", "pandas (>=1.3)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pyOpenSSL", "pyarrow (>=9.0.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "pyyaml", "ray-cpp (==2.49.2)", "requests", "scipy", "smart_open", "starlette", "tensorboardX (>=1.9)", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-cgraph = ["cupy-cuda12x ; sys_platform != \"darwin\""]
-client = ["grpcio", "grpcio (!=1.56.0) ; sys_platform == \"darwin\""]
-cpp = ["ray-cpp (==2.49.2)"]
-data = ["fsspec", "numpy (>=1.20)", "pandas (>=1.3)", "pyarrow (>=9.0.0)"]
-default = ["aiohttp (>=3.7)", "aiohttp_cors", "colorful", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "virtualenv (>=20.0.24,!=20.21.1)"]
-llm = ["aiohttp (>=3.7)", "aiohttp_cors", "async-timeout ; python_version < \"3.11\"", "colorful", "fastapi", "fsspec", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "hf_transfer", "jsonref (>=1.1.0)", "jsonschema", "ninja", "numpy (>=1.20)", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "pandas (>=1.3)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pyarrow (>=9.0.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "starlette", "typer", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "vllm (>=0.10.0)", "watchfiles"]
-observability = ["memray ; sys_platform != \"win32\""]
-rllib = ["dm_tree", "fsspec", "gymnasium (==1.1.1)", "lz4", "ormsgpack (==1.7.0)", "pandas", "pyarrow (>=9.0.0)", "pyyaml", "requests", "scipy", "tensorboardX (>=1.9)"]
-serve = ["aiohttp (>=3.7)", "aiohttp_cors", "colorful", "fastapi", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "starlette", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-serve-async-inference = ["aiohttp (>=3.7)", "aiohttp_cors", "celery", "colorful", "fastapi", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "starlette", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-serve-grpc = ["aiohttp (>=3.7)", "aiohttp_cors", "colorful", "fastapi", "grpcio (>=1.32.0) ; python_version < \"3.10\"", "grpcio (>=1.42.0) ; python_version >= \"3.10\"", "opencensus", "opentelemetry-exporter-prometheus", "opentelemetry-proto", "opentelemetry-sdk (>=1.30.0)", "prometheus_client (>=0.7.1)", "py-spy (>=0.2.0) ; python_version < \"3.12\"", "py-spy (>=0.4.0) ; python_version >= \"3.12\"", "pyOpenSSL", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "smart_open", "starlette", "uvicorn[standard]", "virtualenv (>=20.0.24,!=20.21.1)", "watchfiles"]
-train = ["fsspec", "pandas", "pyarrow (>=9.0.0)", "pydantic (<2.0.dev0 || >=2.5.dev0,<3)", "requests", "tensorboardX (>=1.9)"]
-tune = ["fsspec", "pandas", "pyarrow (>=9.0.0)", "requests", "tensorboardX (>=1.9)"]
+cu13 = ["nvidia-cutlass-dsl[cu13] (>=4.4.2)"]
+dev = ["pre-commit", "pytest", "pytest-xdist", "ruff"]
+heuristics = ["nvidia-matmul-heuristics"]
 
 [[package]]
 name = "referencing"
@@ -6755,15 +7632,15 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "restrictedpython"
-version = "8.0"
+version = "8.1"
 description = "RestrictedPython is a defined subset of the Python language which allows to provide a program input into a trusted environment."
 optional = true
-python-versions = "<3.14,>=3.9"
+python-versions = "<3.15,>=3.9"
 groups = ["main"]
 markers = "extra == \"tool\""
 files = [
-    {file = "RestrictedPython-8.0-py3-none-any.whl", hash = "sha256:ed3d894efd7d6cac0a5f13f75583b8458378d400d7dd4c083b59233eba85fe69"},
-    {file = "restrictedpython-8.0.tar.gz", hash = "sha256:3af2312bc67e5fced887fb85b006c89861da72488128b155beea81eb6a0a9b24"},
+    {file = "restrictedpython-8.1-py3-none-any.whl", hash = "sha256:4769449c6cdb10f2071649ba386902befff0eff2a8fd6217989fa7b16aeae926"},
+    {file = "restrictedpython-8.1.tar.gz", hash = "sha256:4a69304aceacf6bee74bdf153c728221d4e3109b39acbfe00b3494927080d898"},
 ]
 
 [package.extras]
@@ -7276,7 +8153,7 @@ description = "Fundamental algorithms for scientific computing in Python"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and (platform_system == \"Linux\" or extra == \"local\")"
+markers = "extra == \"local\""
 files = [
     {file = "scipy-1.16.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:6ab88ea43a57da1af33292ebd04b417e8e2eaf9d5aa05700be8d6e1b6501cd92"},
     {file = "scipy-1.16.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c95e96c7305c96ede73a7389f46ccd6c659c4da5ef1b2789466baeaed3622b6e"},
@@ -7406,7 +8283,7 @@ description = "Unsupervised text tokenizer and detokenizer."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"translation\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"translation\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"translation\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"translation\") or extra == \"translation\" and platform_system != \"Linux\""
 files = [
     {file = "sentencepiece-0.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e10fa50bdbaa5e2445dbd387979980d391760faf0ec99a09bd7780ff37eaec44"},
     {file = "sentencepiece-0.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f27ae6deea72efdb6f361750c92f6c21fd0ad087445082770cc34015213c526"},
@@ -7540,26 +8417,115 @@ tornado = ["tornado (>=6)"]
 unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
-name = "setuptools"
-version = "79.0.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
+name = "setproctitle"
+version = "1.3.7"
+description = "A Python module to customize the process title"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version == \"3.12\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51"},
-    {file = "setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88"},
+    {file = "setproctitle-1.3.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cf555b6299f10a6eb44e4f96d2f5a3884c70ce25dc5c8796aaa2f7b40e72cb1b"},
+    {file = "setproctitle-1.3.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:690b4776f9c15aaf1023bb07d7c5b797681a17af98a4a69e76a1d504e41108b7"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:00afa6fc507967d8c9d592a887cdc6c1f5742ceac6a4354d111ca0214847732c"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e02667f6b9fc1238ba753c0f4b0a37ae184ce8f3bbbc38e115d99646b3f4cd3"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:83fcd271567d133eb9532d3b067c8a75be175b2b3b271e2812921a05303a693f"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13fe37951dda1a45c35d77d06e3da5d90e4f875c4918a7312b3b4556cfa7ff64"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a05509cfb2059e5d2ddff701d38e474169e9ce2a298cf1b6fd5f3a213a553fe5"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6da835e76ae18574859224a75db6e15c4c2aaa66d300a57efeaa4c97ca4c7381"},
+    {file = "setproctitle-1.3.7-cp310-cp310-win32.whl", hash = "sha256:9e803d1b1e20240a93bac0bc1025363f7f80cb7eab67dfe21efc0686cc59ad7c"},
+    {file = "setproctitle-1.3.7-cp310-cp310-win_amd64.whl", hash = "sha256:a97200acc6b64ec4cada52c2ecaf1fba1ef9429ce9c542f8a7db5bcaa9dcbd95"},
+    {file = "setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0"},
+    {file = "setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1"},
+    {file = "setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d"},
+    {file = "setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4"},
+    {file = "setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e"},
+    {file = "setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739"},
+    {file = "setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f"},
+    {file = "setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300"},
+    {file = "setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922"},
+    {file = "setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c"},
+    {file = "setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd"},
+    {file = "setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9"},
+    {file = "setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63"},
+    {file = "setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8"},
+    {file = "setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed"},
+    {file = "setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a"},
+    {file = "setproctitle-1.3.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:376761125ab5dab822d40eaa7d9b7e876627ecd41de8fa5336713b611b47ccef"},
+    {file = "setproctitle-1.3.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a4e03bd9aa5d10b8702f00ec1b740691da96b5003432f3000d60c56f1c2b4d3"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:47d36e418ab86b3bc7946e27155e281a743274d02cd7e545f5d628a2875d32f9"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a74714ce836914063c36c8a26ae11383cf8a379698c989fe46883e38a8faa5be"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f2ae6c3f042fc866cc0fa2bc35ae00d334a9fa56c9d28dfc47d1b4f5ed23e375"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:be7e01f3ad8d0e43954bebdb3088cb466633c2f4acdd88647e7fbfcfe9b9729f"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:35a2cabcfdea4643d7811cfe9f3d92366d282b38ef5e7e93e25dafb6f97b0a59"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:8ce2e39a40fca82744883834683d833e0eb28623752cc1c21c2ec8f06a890b39"},
+    {file = "setproctitle-1.3.7-cp38-cp38-win32.whl", hash = "sha256:6f1be447456fe1e16c92f5fb479404a850d8f4f4ff47192fde14a59b0bae6a0a"},
+    {file = "setproctitle-1.3.7-cp38-cp38-win_amd64.whl", hash = "sha256:5ce2613e1361959bff81317dc30a60adb29d8132b6159608a783878fc4bc4bbc"},
+    {file = "setproctitle-1.3.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:deda9d79d1eb37b688729cac2dba0c137e992ebea960eadb7c2c255524c869e0"},
+    {file = "setproctitle-1.3.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a93e4770ac22794cfa651ee53f092d7de7105c76b9fc088bb81ca0dcf698f704"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:134e7f66703a1d92c0a9a0a417c580f2cc04b93d31d3fc0dd43c3aa194b706e1"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9796732a040f617fc933f9531c9a84bb73c5c27b8074abbe52907076e804b2b7"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ff3c1c32382fb71a200db8bab3df22f32e6ac7ec3170e92fa5b542cf42eed9a2"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:01f27b5b72505b304152cb0bd7ff410cc4f2d69ac70c21a7fdfa64400a68642d"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:80b6a562cbc92b289c28f34ce709a16b26b1696e9b9a0542a675ce3a788bdf3f"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c4fb90174d176473122e7eef7c6492d53761826f34ff61c81a1c1d66905025d3"},
+    {file = "setproctitle-1.3.7-cp39-cp39-win32.whl", hash = "sha256:c77b3f58a35f20363f6e0a1219b367fbf7e2d2efe3d2c32e1f796447e6061c10"},
+    {file = "setproctitle-1.3.7-cp39-cp39-win_amd64.whl", hash = "sha256:318ddcf88dafddf33039ad41bc933e1c49b4cb196fe1731a209b753909591680"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:eb440c5644a448e6203935ed60466ec8d0df7278cd22dc6cf782d07911bcbea6"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:502b902a0e4c69031b87870ff4986c290ebbb12d6038a70639f09c331b18efb2"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f6f268caeabb37ccd824d749e7ce0ec6337c4ed954adba33ec0d90cc46b0ab78"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a"},
+    {file = "setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
-core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+test = ["pytest"]
 
 [[package]]
 name = "setuptools"
@@ -7568,7 +8534,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.11\" and platform_machine == \"x86_64\" and platform_system == \"Linux\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") or python_version == \"3.12\" and (extra == \"local\" or extra == \"audio\" or extra == \"vision\") and platform_system != \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
 files = [
     {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
     {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
@@ -7607,7 +8573,7 @@ files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
-markers = {main = "extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or python_version == \"3.12\" and (extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""}
+markers = {main = "extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or (extra == \"memory\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"tool\" or extra == \"vllm\" or extra == \"nvidia\") and python_version >= \"3.12\" and platform_system == \"Linux\""}
 
 [[package]]
 name = "sniffio"
@@ -7629,7 +8595,7 @@ description = "An audio library based on libsndfile, CFFI and NumPy"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"audio\")"
+markers = "extra == \"audio\""
 files = [
     {file = "soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445"},
     {file = "soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33"},
@@ -7657,50 +8623,6 @@ files = [
     {file = "soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c"},
     {file = "soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f"},
 ]
-
-[[package]]
-name = "soxr"
-version = "1.0.0"
-description = "High quality, one-dimensional sample-rate conversion library"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
-files = [
-    {file = "soxr-1.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b876a3156f67c76aef0cff1084eaf4088d9ca584bb569cb993f89a52ec5f399f"},
-    {file = "soxr-1.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d3b957a7b0cc19ae6aa45d40b2181474e53a8dd00efd7bce6bcf4e60e020892"},
-    {file = "soxr-1.0.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89685faedebc45af71f08f9957b61cc6143bc94ba43fe38e97067f81e272969"},
-    {file = "soxr-1.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d255741b2f0084fd02d4a2ddd77cd495be9e7e7b6f9dba1c9494f86afefac65b"},
-    {file = "soxr-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:158a4a9055958c4b95ef91dbbe280cabb00946b5423b25a9b0ce31bd9e0a271e"},
-    {file = "soxr-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:28e19d74a5ef45c0d7000f3c70ec1719e89077379df2a1215058914d9603d2d8"},
-    {file = "soxr-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8dc69fc18884e53b72f6141fdf9d80997edbb4fec9dc2942edcb63abbe0d023"},
-    {file = "soxr-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f15450e6f65f22f02fcd4c5a9219c873b1e583a73e232805ff160c759a6b586"},
-    {file = "soxr-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f73f57452f9df37b4de7a4052789fcbd474a5b28f38bba43278ae4b489d4384"},
-    {file = "soxr-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f417c3d69236051cf5a1a7bad7c4bff04eb3d8fcaa24ac1cb06e26c8d48d8dc"},
-    {file = "soxr-1.0.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:abecf4e39017f3fadb5e051637c272ae5778d838e5c3926a35db36a53e3a607f"},
-    {file = "soxr-1.0.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e973d487ee46aa8023ca00a139db6e09af053a37a032fe22f9ff0cc2e19c94b4"},
-    {file = "soxr-1.0.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8ce273cca101aff3d8c387db5a5a41001ba76ef1837883438d3c652507a9ccc"},
-    {file = "soxr-1.0.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8f2a69686f2856d37823bbb7b78c3d44904f311fe70ba49b893af11d6b6047b"},
-    {file = "soxr-1.0.0-cp312-abi3-win_amd64.whl", hash = "sha256:2a3b77b115ae7c478eecdbd060ed4f61beda542dfb70639177ac263aceda42a2"},
-    {file = "soxr-1.0.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:392a5c70c04eb939c9c176bd6f654dec9a0eaa9ba33d8f1024ed63cf68cdba0a"},
-    {file = "soxr-1.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc41a1027ba46777186f26a8fba7893be913383414135577522da2fcc684490"},
-    {file = "soxr-1.0.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:449acd1dfaf10f0ce6dfd75c7e2ef984890df94008765a6742dafb42061c1a24"},
-    {file = "soxr-1.0.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38b35c99e408b8f440c9376a5e1dd48014857cd977c117bdaa4304865ae0edd0"},
-    {file = "soxr-1.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a39b519acca2364aa726b24a6fd55acf29e4c8909102e0b858c23013c38328e5"},
-    {file = "soxr-1.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:c120775b7d0ef9e974a5797a4695861e88653f7ecd0a2a532f089bc4452ba130"},
-    {file = "soxr-1.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e59e5f648bd6144e79a6e0596aa486218876293f5ddce3ca84b9d8f8aa34d6d"},
-    {file = "soxr-1.0.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb86c342862697dbd4a44043f275e5196f2d2c49dca374c78f19b7893988675d"},
-    {file = "soxr-1.0.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d2a4fadd88207c2991fb08c29fc189e7b2e298b598a94ea1747e42c8acb7a01"},
-    {file = "soxr-1.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:c7f5ace8f04f924b21caedeeb69f2a7b3d83d2d436639498c08b2cebe181af14"},
-    {file = "soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509"},
-]
-
-[package.dependencies]
-numpy = "*"
-
-[package.extras]
-docs = ["linkify-it-py", "myst-parser", "sphinx", "sphinx-book-theme"]
-test = ["pytest"]
 
 [[package]]
 name = "sqlalchemy"
@@ -7823,7 +8745,7 @@ description = "SSE plugin for Starlette"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"server\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
     {file = "sse_starlette-3.0.2-py3-none-any.whl", hash = "sha256:16b7cbfddbcd4eaca11f7b586f3b8a080f1afe952c15813455b162edea619e5a"},
     {file = "sse_starlette-3.0.2.tar.gz", hash = "sha256:ccd60b5765ebb3584d0de2d7a6e4f745672581de4f5005ab31c3a25d10b52b3a"},
@@ -7840,15 +8762,15 @@ uvicorn = ["uvicorn (>=0.34.0)"]
 
 [[package]]
 name = "starlette"
-version = "0.47.3"
+version = "0.52.1"
 description = "The little ASGI library that shines."
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"server\") and (platform_system == \"Linux\" or extra == \"server\")"
 files = [
-    {file = "starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51"},
-    {file = "starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9"},
+    {file = "starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74"},
+    {file = "starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933"},
 ]
 
 [package.dependencies]
@@ -7859,13 +8781,29 @@ typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "supervisor"
+version = "4.3.0"
+description = "A system for controlling process state under UNIX"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "supervisor-4.3.0-py2.py3-none-any.whl", hash = "sha256:0bcb763fddafba410f35cbde226aa7f8514b9fb82eb05a0c85f6588d1c13f8db"},
+    {file = "supervisor-4.3.0.tar.gz", hash = "sha256:4a2bf149adf42997e1bb44b70c43b613275ec9852c3edacca86a9166b27e945e"},
+]
+
+[package.extras]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\" or extra == \"tool\")"
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\" or extra == \"tool\" or extra == \"memory\") and (platform_system == \"Linux\" or extra == \"memory\" or extra == \"local\" or extra == \"vision\" or extra == \"tool\")"
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -7876,6 +8814,22 @@ mpmath = ">=1.1.0,<1.4"
 
 [package.extras]
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+description = "Pretty-print tabular data"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3"},
+    {file = "tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
 
 [[package]]
 name = "tenacity"
@@ -7909,127 +8863,110 @@ files = [
 
 [[package]]
 name = "tiktoken"
-version = "0.10.0"
+version = "0.13.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"translation\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"translation\" or extra == \"vendors\")"
 files = [
-    {file = "tiktoken-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1db7a65b196d757d18ef53193957d44549b88f373d4b87db532f04d18193b847"},
-    {file = "tiktoken-0.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f55701461267d025597ebb2290d612fe9c5c5fbb625ebf7495c9f0f8e4c30f01"},
-    {file = "tiktoken-0.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f83693279af9e8deac0363cbf21dc3d666807f22dcc1091f51e69e6fe6433f71"},
-    {file = "tiktoken-0.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f973bdeb68d645f73dcce60c7795cb5c6f8b7f3dcf92c40c39ad4aee398c075"},
-    {file = "tiktoken-0.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d5cab2a8e8974d6c9744264e94886a58b9087a39737c53fd65dbe2fe8522e719"},
-    {file = "tiktoken-0.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:7a49d2aedf911b68f23c9c84abce8eaf569cb02613f307cee4fb1bebd8c55ae9"},
-    {file = "tiktoken-0.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:29f55c6b7c9a6a7ea953691c3962ee8fe4ee2f0ceb2a3fded3925acfc45e4b0a"},
-    {file = "tiktoken-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f641d0735059b48252c4409d6546b6a62edeb4c4e48306499db11bbe403b872f"},
-    {file = "tiktoken-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad76e03676b36c2a5e5304b428cff48eb86a033af55212d41a6ac6faec25b2ad"},
-    {file = "tiktoken-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6420ecbd4dc4db3b82ca3421f50d1207d750de1a2856e6ca0544294fe58d2853"},
-    {file = "tiktoken-0.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d2e032cd44700a9ed511c50b9f302bb9e9e77e2ebf8e2d9b8ec12ce64ebf00c6"},
-    {file = "tiktoken-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:eb520960fa1788caf033489e3b63bb675c0f321db40569b2d3ca24d7fab5ca72"},
-    {file = "tiktoken-0.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c27021a605b2778af07f84a33fe7c74b5c960a8cfac5d2a7a1075ed592cbe4"},
-    {file = "tiktoken-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:45d654f049b4f7ed617ad0c66462c15cc41e5db120f37f122d5b57ffa2aec062"},
-    {file = "tiktoken-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34f73d93641b9cc73e19b18dbf9ce1baf086f1c4e18cfa36b952956843bca23c"},
-    {file = "tiktoken-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fbfc5dda624c0f85c56bbf8f2ffb42964c798fc6fc1c321a452bf31d4ba21f5"},
-    {file = "tiktoken-0.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:853671af10636b581d632fe7b64b755301c73bc1f2ce837a8cdd9a44ab51f846"},
-    {file = "tiktoken-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:56c4e7544be63c78265c82857b9f2a4e2190ae29541fe3467708fc7aabcb1522"},
-    {file = "tiktoken-0.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:10e779827ddb0490a415d09d95f8e7a982fd8e14f88c4c2348358f722af3c415"},
-    {file = "tiktoken-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:783892cdbec0d33f0f51373d8969e059ab1244af531a52338f702131a032a116"},
-    {file = "tiktoken-0.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43f38d62b6a62a7c82be3770fcdc24cdf5bff3bdf718909d038b804ac774a025"},
-    {file = "tiktoken-0.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72d0b30e08f1e856fa76ee423a3d3f0b1bc984cb6e86a21dbd7c5eee8f67f8f5"},
-    {file = "tiktoken-0.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa840eba09a0c1db0b436baf6cfe1ab7906f33fb663cf96f772a818bad5856a6"},
-    {file = "tiktoken-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:642b8d9f266004629ea2457aa29a9eed4f1a031fd804f8c489edbf32df7026c3"},
-    {file = "tiktoken-0.10.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:28fcb8555bb3e9cc6d625385b688b9781e7eb022e76826e721ad93198920034b"},
-    {file = "tiktoken-0.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b8e20f7da9086cb5b88eb53ef7ee2fd2db9f3b55c0bcddad51d1ad001a6fcf07"},
-    {file = "tiktoken-0.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f795e7c451d560142c2d88d239ae9fcc11f0b4647376db625c9d4be8f16da45"},
-    {file = "tiktoken-0.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8b3a5717679abb3e8a2097d9577e4c69b975c7fc0381d42598fa6f36f040fc3"},
-    {file = "tiktoken-0.10.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b061e5035a561a18aefcd969079f1952b4caee3bb204ecfadb4bb41b81b8331b"},
-    {file = "tiktoken-0.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a08250ef9b688c84a7f013fee01d587e73aaf41839bcd564105535276c55122b"},
-    {file = "tiktoken-0.10.0.tar.gz", hash = "sha256:7cd88c11699b18081822e6ae1beee55e8f20ea361d73c507d33f5a89a1898f1c"},
+    {file = "tiktoken-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:47b1df8d73390a24f94980c75158cdd5c56d256f16d55f30cb49c230caba9ba4"},
+    {file = "tiktoken-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d40c6c5aab171dcd6eb8455bc567bde404bb9def60cdb8c1299cc782b242bb9"},
+    {file = "tiktoken-0.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9b842981fa91accdffd48ff6408a977b7a91c3fbda55d353c3c68114d5c9d69e"},
+    {file = "tiktoken-0.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ed5a30027cb4d8c7ca8b273d4766f3db3cf58fad9e9f3b1a68a351ffb54873d5"},
+    {file = "tiktoken-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7ab10f4a21c2999846940113f6dbd72e0fa06a24119feddd74cc47e85818e06d"},
+    {file = "tiktoken-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a2937ad042d49d50eac6e1ba07c5661d4bd3942a5b1e0c0d08475c4df83676e1"},
+    {file = "tiktoken-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:44733b99bfd72b590cd0936b1c01b3b4dd73122db2d544bc1ceeb18a7678c910"},
+    {file = "tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb"},
+    {file = "tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26"},
+    {file = "tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4"},
+    {file = "tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173"},
+    {file = "tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff"},
+    {file = "tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed"},
+    {file = "tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94"},
+    {file = "tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791"},
+    {file = "tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b"},
+    {file = "tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7"},
+    {file = "tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649"},
+    {file = "tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b"},
+    {file = "tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91"},
+    {file = "tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41"},
+    {file = "tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154"},
+    {file = "tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545"},
+    {file = "tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2"},
+    {file = "tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf"},
+    {file = "tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486"},
+    {file = "tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615"},
+    {file = "tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f"},
+    {file = "tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec"},
+    {file = "tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471"},
+    {file = "tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd"},
+    {file = "tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881"},
+    {file = "tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24"},
+    {file = "tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273"},
+    {file = "tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51"},
+    {file = "tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424"},
+    {file = "tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07"},
+    {file = "tiktoken-0.13.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:35e1ea1e0631c04f551297284a1ab7e1f65a3c55a9a48728d5e0f66b4527c04a"},
+    {file = "tiktoken-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2a3b536c55802fe42f4b4644d2be4f04bf788506b48de0a0a658cb58f8bce232"},
+    {file = "tiktoken-0.13.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:b8ac2d6420ff05841a89ba5205c6d45f56c4f6843454f3c884b7eb1a2a8dddb2"},
+    {file = "tiktoken-0.13.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:477c9a38e20d0ed248090509acf1e839ad3967a4f00b4b0f958210049f656dee"},
+    {file = "tiktoken-0.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:da86f8c96ac1c235d7a3b3eebff1eacfdbcfb8ad792706943268d4d2938fbafe"},
+    {file = "tiktoken-0.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9b8858b29804b3a0add25ce9e62fb00f89f621dc754d75d03ca419d17e8ddf67"},
+    {file = "tiktoken-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:b967dfb9d0adf9a631953b1b40717684f04478270fc51bbccdd2f838d67a2f00"},
+    {file = "tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1"},
 ]
 
 [package.dependencies]
-regex = ">=2022.1.18"
-requests = ">=2.26.0"
+regex = "*"
+requests = "*"
 
 [package.extras]
-blobfile = ["blobfile (>=2)"]
+blobfile = ["blobfile (>=3)"]
 
 [[package]]
-name = "tiktoken"
-version = "0.12.0"
-description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
+name = "tilelang"
+version = "0.1.9"
+description = "A tile level programming language to generate high performance code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\") and (platform_system == \"Linux\" or extra == \"vendors\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970"},
-    {file = "tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16"},
-    {file = "tiktoken-0.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cde24cdb1b8a08368f709124f15b36ab5524aac5fa830cc3fdce9c03d4fb8030"},
-    {file = "tiktoken-0.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6de0da39f605992649b9cfa6f84071e3f9ef2cec458d08c5feb1b6f0ff62e134"},
-    {file = "tiktoken-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6faa0534e0eefbcafaccb75927a4a380463a2eaa7e26000f0173b920e98b720a"},
-    {file = "tiktoken-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82991e04fc860afb933efb63957affc7ad54f83e2216fe7d319007dab1ba5892"},
-    {file = "tiktoken-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:6fb2995b487c2e31acf0a9e17647e3b242235a20832642bb7a9d1a181c0c1bb1"},
-    {file = "tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb"},
-    {file = "tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa"},
-    {file = "tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc"},
-    {file = "tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded"},
-    {file = "tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd"},
-    {file = "tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967"},
-    {file = "tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def"},
-    {file = "tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8"},
-    {file = "tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b"},
-    {file = "tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37"},
-    {file = "tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad"},
-    {file = "tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5"},
-    {file = "tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3"},
-    {file = "tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd"},
-    {file = "tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3"},
-    {file = "tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160"},
-    {file = "tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa"},
-    {file = "tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be"},
-    {file = "tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a"},
-    {file = "tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3"},
-    {file = "tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25"},
-    {file = "tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f"},
-    {file = "tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646"},
-    {file = "tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88"},
-    {file = "tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff"},
-    {file = "tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830"},
-    {file = "tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b"},
-    {file = "tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b"},
-    {file = "tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0"},
-    {file = "tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71"},
-    {file = "tiktoken-0.12.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d51d75a5bffbf26f86554d28e78bfb921eae998edc2675650fd04c7e1f0cdc1e"},
-    {file = "tiktoken-0.12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:09eb4eae62ae7e4c62364d9ec3a57c62eea707ac9a2b2c5d6bd05de6724ea179"},
-    {file = "tiktoken-0.12.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:df37684ace87d10895acb44b7f447d4700349b12197a526da0d4a4149fde074c"},
-    {file = "tiktoken-0.12.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4c9614597ac94bb294544345ad8cf30dac2129c05e2db8dc53e082f355857af7"},
-    {file = "tiktoken-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:20cf97135c9a50de0b157879c3c4accbb29116bcf001283d26e073ff3b345946"},
-    {file = "tiktoken-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:15d875454bbaa3728be39880ddd11a5a2a9e548c29418b41e8fd8a767172b5ec"},
-    {file = "tiktoken-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cff3688ba3c639ebe816f8d58ffbbb0aa7433e23e08ab1cade5d175fc973fb3"},
-    {file = "tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931"},
+    {file = "tilelang-0.1.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:00ed594fdeb229c5505b9ffa895c3c5daeb28641c78f783fa1f724cf1e08cecd"},
+    {file = "tilelang-0.1.9-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bbccfe9035aed775ffafb6dc25a5994504b24e2c5d95d0f39643edfafa7bf12"},
+    {file = "tilelang-0.1.9-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:77ab0ee2f40f66ea015b6b21426d482751e28cbc635ef9d1198cbd6502454a7c"},
+    {file = "tilelang-0.1.9.tar.gz", hash = "sha256:287f727c913bb648fcf6c1968809ba3390e55eeed257a5c6bb9a80bc05966af4"},
 ]
 
 [package.dependencies]
-regex = ">=2022.1.18"
-requests = ">=2.26.0"
+apache-tvm-ffi = ">=0.1.2,<0.2.0"
+cloudpickle = "*"
+ml-dtypes = "*"
+numpy = ">=1.23.5"
+psutil = "*"
+torch = {version = "*", markers = "platform_system != \"Darwin\""}
+torch-c-dlpack-ext = {version = "*", markers = "python_version < \"3.14\""}
+tqdm = ">=4.62.3"
+typing-extensions = ">=4.10.0"
+z3-solver = ">=4.13.0,<4.15.5"
 
 [package.extras]
-blobfile = ["blobfile (>=2)"]
+fp4 = ["ml-dtypes (>=0.5.1)"]
+nvcc = ["nvidia-cuda-cccl (>=13.0.50)", "nvidia-cuda-nvcc (>=13.0.48)"]
+vis = ["matplotlib"]
 
 [[package]]
 name = "tokenizers"
@@ -8038,7 +8975,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"local\" or extra == \"vendors\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"local\" or extra == \"vendors\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\") or (extra == \"local\" or extra == \"vendors\") and platform_system != \"Linux\""
 files = [
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c"},
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001"},
@@ -8075,145 +9012,222 @@ docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
 testing = ["datasets", "numpy", "pytest", "pytest-asyncio", "requests", "ruff", "ty"]
 
 [[package]]
-name = "torch"
-version = "2.7.1"
-description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+name = "tokenspeed-mla"
+version = "0.1.2"
+description = "Speed-of-light TokenSpeed MLA kernels for Blackwell SM100 and SM103."
 optional = true
-python-versions = ">=3.9.0"
+python-versions = ">=3.10"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"audio\" or extra == \"vision\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a103b5d782af5bd119b81dbcc7ffc6fa09904c423ff8db397a1e6ea8fd71508f"},
-    {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fe955951bdf32d182ee8ead6c3186ad54781492bf03d547d31771a01b3d6fb7d"},
-    {file = "torch-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:885453d6fba67d9991132143bf7fa06b79b24352f4506fd4d10b309f53454162"},
-    {file = "torch-2.7.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:d72acfdb86cee2a32c0ce0101606f3758f0d8bb5f8f31e7920dc2809e963aa7c"},
-    {file = "torch-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:236f501f2e383f1cb861337bdf057712182f910f10aeaf509065d54d339e49b2"},
-    {file = "torch-2.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:06eea61f859436622e78dd0cdd51dbc8f8c6d76917a9cf0555a333f9eac31ec1"},
-    {file = "torch-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:8273145a2e0a3c6f9fd2ac36762d6ee89c26d430e612b95a99885df083b04e52"},
-    {file = "torch-2.7.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:aea4fc1bf433d12843eb2c6b2204861f43d8364597697074c8d38ae2507f8730"},
-    {file = "torch-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ea1e518df4c9de73af7e8a720770f3628e7f667280bce2be7a16292697e3fa"},
-    {file = "torch-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c33360cfc2edd976c2633b3b66c769bdcbbf0e0b6550606d188431c81e7dd1fc"},
-    {file = "torch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8bf6e1856ddd1807e79dc57e54d3335f2b62e6f316ed13ed3ecfe1fc1df3d8b"},
-    {file = "torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb"},
-    {file = "torch-2.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:03563603d931e70722dce0e11999d53aa80a375a3d78e6b39b9f6805ea0a8d28"},
-    {file = "torch-2.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d632f5417b6980f61404a125b999ca6ebd0b8b4bbdbb5fbbba44374ab619a412"},
-    {file = "torch-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:23660443e13995ee93e3d844786701ea4ca69f337027b05182f5ba053ce43b38"},
-    {file = "torch-2.7.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585"},
-    {file = "torch-2.7.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e08d7e6f21a617fe38eeb46dd2213ded43f27c072e9165dc27300c9ef9570934"},
-    {file = "torch-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:30207f672328a42df4f2174b8f426f354b2baa0b7cca3a0adb3d6ab5daf00dc8"},
-    {file = "torch-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:79042feca1c634aaf6603fe6feea8c6b30dfa140a6bbc0b973e2260c7e79a22e"},
-    {file = "torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946"},
-    {file = "torch-2.7.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e0d81e9a12764b6f3879a866607c8ae93113cbcad57ce01ebde63eb48a576369"},
-    {file = "torch-2.7.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8394833c44484547ed4a47162318337b88c97acdb3273d85ea06e03ffff44998"},
-    {file = "torch-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:df41989d9300e6e3c19ec9f56f856187a6ef060c3662fe54f4b6baf1fc90bd19"},
-    {file = "torch-2.7.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:a737b5edd1c44a5c1ece2e9f3d00df9d1b3fb9541138bee56d83d38293fb6c9d"},
+    {file = "tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:592590f36d85e624ecdc5e357ff35e29e761e6d879900dce8b67a6785c8ce75c"},
+    {file = "tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c9466a351fe039792e56cf49f3e79744c1dc28c7af10306a02e62b8e92fa5985"},
 ]
 
 [package.dependencies]
+apache-tvm-ffi = ">=0.1.5"
+nvidia-cutlass-dsl = "*"
+tokenspeed-triton = ">=3.7.10.post20260505"
+torch = "*"
+
+[[package]]
+name = "tokenspeed-triton"
+version = "3.7.10.post20260505"
+description = "A language and compiler for custom Deep Learning operations (vendor release for TokenSpeed)"
+optional = true
+python-versions = "<3.15,>=3.10"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82c222755095db261e32e3964e009573f3360806088fa493be65404276866344"},
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:060f657c78b5cd0c5645f01eb0f73b72cf385589235e3b96ca05f9b3d33a644f"},
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:15e867fbc3dc7f5d1d2ec80b6b783c0e58d6d5c470cbfa99e87a035ec6af6212"},
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a679e079f98023cf326f299c8150ebc8ef6f1d2cf744d5dc435bc0d9a6f8a5b"},
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp312-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06bad3e25ccaba22bb43eb8499f01008f9aaa0bfb3fbfb0cef1b37d2c006c6f0"},
+    {file = "tokenspeed_triton-3.7.10.post20260505-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19618c7db01a9bd33885f7acbf8945adb2f5534668aa97629b56d481753cbcad"},
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"local\" or extra == \"vision\")"
+files = [
+    {file = "torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e"},
+    {file = "torch-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4cf8687f4aec3900f748d553483ef40e0ac38411c3c48d0a86a438f6d7a99b18"},
+    {file = "torch-2.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1b32ceda909818a03b112006709b02be1877240c31750a8d9c6b7bf5f2d8a6e5"},
+    {file = "torch-2.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3c712ae6fb8e7a949051a953fc412fe0a6940337336c3b6f905e905dac5157f"},
+    {file = "torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4"},
+    {file = "torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6"},
+    {file = "torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a"},
+    {file = "torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708"},
+    {file = "torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34"},
+    {file = "torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f"},
+    {file = "torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756"},
+    {file = "torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10"},
+    {file = "torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18"},
+    {file = "torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd"},
+    {file = "torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db"},
+    {file = "torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd"},
+    {file = "torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4"},
+    {file = "torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea"},
+    {file = "torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778"},
+    {file = "torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db"},
+    {file = "torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7"},
+    {file = "torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7"},
+    {file = "torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60"},
+    {file = "torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718"},
+    {file = "torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd"},
+    {file = "torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6"},
+    {file = "torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2"},
+    {file = "torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0"},
+]
+
+[package.dependencies]
+cuda-bindings = {version = ">=13.0.3,<14", markers = "platform_system == \"Linux\""}
+cuda-toolkit = {version = "13.0.2", extras = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], markers = "platform_system == \"Linux\""}
 filelock = "*"
-fsspec = "*"
+fsspec = ">=0.8.5"
 jinja2 = "*"
-networkx = "*"
-nvidia-cublas-cu12 = {version = "12.6.4.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-cupti-cu12 = {version = "12.6.80", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-nvrtc-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-runtime-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "9.5.1.17", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufft-cu12 = {version = "11.3.0.4", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufile-cu12 = {version = "1.11.1.6", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-curand-cu12 = {version = "10.3.7.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusolver-cu12 = {version = "11.7.1.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparse-cu12 = {version = "12.5.4.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparselt-cu12 = {version = "0.6.3", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nccl-cu12 = {version = "2.26.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvjitlink-cu12 = {version = "12.6.85", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvtx-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-setuptools = {version = "*", markers = "python_version >= \"3.12\""}
+networkx = ">=2.5.1"
+nvidia-cudnn-cu13 = {version = "9.19.0.56", markers = "platform_system == \"Linux\""}
+nvidia-cusparselt-cu13 = {version = "0.8.0", markers = "platform_system == \"Linux\""}
+nvidia-nccl-cu13 = {version = "2.28.9", markers = "platform_system == \"Linux\""}
+nvidia-nvshmem-cu13 = {version = "3.4.5", markers = "platform_system == \"Linux\""}
+setuptools = "<82"
 sympy = ">=1.13.3"
-triton = {version = "3.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+triton = {version = "3.6.0", markers = "platform_system == \"Linux\""}
 typing-extensions = ">=4.10.0"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
 optree = ["optree (>=0.13.0)"]
+pyyaml = ["pyyaml"]
+
+[[package]]
+name = "torch-c-dlpack-ext"
+version = "0.1.5"
+description = "torch c dlpack ext"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "torch_c_dlpack_ext-0.1.5-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:e0f6c197d5293884898b9ebf13d07501de39cb94799b374ed43f91731087d557"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba3d88f0f7d5e1d9c3d4a3179037fc8e261c3b77ac1fad23edc0d3a9214ef193"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7468df84ec152d930fbc3acf460c44a60b3462b95af3d3a676d133629c7e176"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:78dd4904bd26170a2dd7c0eab56367756ee0a15672ce9b84146169e68f0c6ddc"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:56bd25a2af19280bf8a06aa62cff5510106f43235b9327d8561b3e9a659c4d84"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fba674110e1fab0b176bb5a28223e157db65c90767d4ba74abdbee9f537b0e9d"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3448c4f0d64104d0b2e58080a7efa72304a04960c18f338024b80b13cd3eca26"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:74676474e0afa9a4216c4755ea7cf05e8158be1d168f6bda669ba91097c263f2"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c0f2bd51fcd99c0e5b50314e1985f2728c4941bfa821f065e6c30951d1f995ca"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3562ee411258676f9c38b8ad39306d1c8d027b6a86f6a87c920d2d009a9d1510"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6f9da4bb9af70e27facc777458be62e10dbbbddda7672d16138db0553c5a524"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:670fbbab70123cc228bed41693a3720757af57a0ad22669063c9db25321e8f55"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:74acea2ed395cadda63342845b9e9ee7cd4537846223dacfb4431b4610109265"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f1e99d13c64e22dac0a34a1560e9e5a398a49a9fa81df83053e04fde6ec5bd"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:debe62e5ef93e631065d6b9f6e60d3d39bae6b89fa1b25d9523f40b3efbf8aba"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:30e3eab616dbc81dfdb7492aca557be551a9163ba9b585f97394a42b336b113a"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:cac94a4905d391889e679a8da31e46dc325af5d55d13b7c70c0ce3d71d1ced6d"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a58fdf45fb0bda7bc459632cec891570f31c11636d5851c825cf308ec8b73c2"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b985a324c68241cf83a9474b28015524b66775b12a91930dd4c0760aa628d01"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:d794e19fa3f330ab7a29987c07e031fc08e4953aec516d35701d0827863e356b"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:4a8680c42ead771773657dbdb88f6ea07d662640abf5f1a405f1da753b5a0dbc"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e43083f8f889cdde2b93d7458795aecc95c7268eab40a640d69f71bff7fbcac"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8244a2a6637f148627fdaec58504633a9751f9e00befafb2229c40b451735589"},
+    {file = "torch_c_dlpack_ext-0.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:4b272c1221c3f4988079ea084456f535a25656aa2da5781def43f5bd90afdfd7"},
+    {file = "torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe"},
+]
+
+[package.dependencies]
+torch = "*"
 
 [[package]]
 name = "torchaudio"
-version = "2.7.1"
+version = "2.11.0"
 description = "An audio package for PyTorch"
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\") and (platform_system == \"Linux\" or extra == \"audio\")"
 files = [
-    {file = "torchaudio-2.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4739af57d0eb94347d1c6a1b5668be78a7383afe826dde18a04883b9f9f263b1"},
-    {file = "torchaudio-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c089dbfc14c5f47091b7bf3f6bf2bbac93b86619299d04d9c102f4ad53758990"},
-    {file = "torchaudio-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6bb1e6db22fa2aad6b89b2a455ec5c6dc31df2635dbfafa213394f8b07b09516"},
-    {file = "torchaudio-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ba4df6e3ad35cb1e5bd162cf86b492526138f6476f5a06b10725b8880c618eb"},
-    {file = "torchaudio-2.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d5a62f88c629035913f506df03f710c48fc8bb9637191933f27c67088d5ca136"},
-    {file = "torchaudio-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:53bc4ba12e7468be34a7ca2ee837ee5c8bd5755b25c12f665af9339cae37e265"},
-    {file = "torchaudio-2.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f8bd69354a397753b9dea9699d9e1251f8496fbbdf3028c7086a57a615bf33c3"},
-    {file = "torchaudio-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:0ae0678ad27355eebea5a9fdd9ae9bfec444f8405f9b6c60026905ba3665c43a"},
-    {file = "torchaudio-2.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9306dcfc4586cebd7647a93fe9a448e791c4f83934da616b9433b75597a1f978"},
-    {file = "torchaudio-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d66bd76b226fdd4135c97650e1b7eb63fb7659b4ed0e3a778898e41dbba21b61"},
-    {file = "torchaudio-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9cbcdaab77ad9a73711acffee58f4eebc8a0685289a938a3fa6f660af9489aee"},
-    {file = "torchaudio-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:9cfb8f6ace8e01e2b89de74eb893ba5ce936b88b415383605b0a4d974009dec7"},
-    {file = "torchaudio-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5f0599a507f4683546878ed9667e1b32d7ca3c8a957e4c15c6b302378ef4dee"},
-    {file = "torchaudio-2.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:271f717844e5c7f9e05c8328de817bf90f46d83281c791e94f54d4edea2f5817"},
-    {file = "torchaudio-2.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1862b063d8d4e55cb4862bcbd63568545f549825a3c5605bd312224c3ebb1919"},
-    {file = "torchaudio-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb4deaa6f95acd5522912ed643303d0b86d79a6f15914362f5a5d49baaf5d13"},
-    {file = "torchaudio-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:18560955b8beb2a8d39a6bfae20a442337afcefb3dfd4ee007ce82233a796799"},
-    {file = "torchaudio-2.7.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1850475ef9101ea0b3593fe93ff6ee4e7a20598f6da6510761220b9fe56eb7fa"},
-    {file = "torchaudio-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98257fc14dd493ba5a3258fb6d61d27cd64a48ee79537c3964c4da26b9bf295f"},
-    {file = "torchaudio-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:c802e0dcbf38669007327bb52f065573cc5cac106eaca987f6e1a32e6282263a"},
-    {file = "torchaudio-2.7.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a07100fe2cf7af4fa69d8cb046a2b74046612621a1a548afa5af1c69e02eaf81"},
-    {file = "torchaudio-2.7.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e8b2da11a7f7782b00b823c99e812eb00ee8b3455ad474f8fd42a0da0bc4f46a"},
-    {file = "torchaudio-2.7.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:9ce8aed225d5ce65705d30f6ef8e457d329fe6ea0b8729ad953ba99e87da264e"},
-    {file = "torchaudio-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:30e21f043f5cc50f703c2cf0de75633e2c720227f9bf848ffc9b8b987871b3fc"},
+    {file = "torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ebb59c694909eccb5d61b7cc199d297692012c43286e36d92983aa7bad7586d"},
+    {file = "torchaudio-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:be7ad472acb16d16e98c005f0219b0db06a47dfe8f7b4d177062e1638f871e3b"},
+    {file = "torchaudio-2.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:5847fe2022b17c6580aeb39c8797a443411cc09edfd9183cd50ac1a3b8ccf97c"},
+    {file = "torchaudio-2.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:7e2da1df4f6fe885c46db350a0dc90a0dff4b54541dff8846faa904d255e2bfe"},
+    {file = "torchaudio-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:492dd64645e9d0bb843e94f1d9a4d1e31426262ffc594fafecc1697df9df5eb9"},
+    {file = "torchaudio-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:73dab4841f94d888bc7c2aed7b5547c643edc974306919fe1adfb65d57cccf4b"},
+    {file = "torchaudio-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1a07ec72fd6f26a588c39b5f029e0130d16bb40bc4221635580bf8fb18fcbc80"},
+    {file = "torchaudio-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:bb59ba4452bbbe95d75ad3ef18df9824955625f36698ce9a5998a4a9f3c1ba1d"},
+    {file = "torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b"},
+    {file = "torchaudio-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:bc653defca1c16154398517a1adc98d0fb7f1dd08e58ced217558d213c2c6e29"},
+    {file = "torchaudio-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6503c0bdb29daf2e6281bb70ea2dfe2c3553b782b619eb5d73bdadd8a3f7cecf"},
+    {file = "torchaudio-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:478110f981e5d40a8d82221732c57a56c85a1d5895fb8fe646e86ee15eded3bd"},
+    {file = "torchaudio-2.11.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e3f9696a9ef1d49acc452159b052370c636406d072e9d8f10895fda87b591ea9"},
+    {file = "torchaudio-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b034d7672f1c415434f48ef17807f2cce47f29e8795338c751d4e596c9fbe8b5"},
+    {file = "torchaudio-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1c1101c1243ef0e4063ec63298977e2d3655c15cf88d9eb0a1bd4fe2db9f47ea"},
+    {file = "torchaudio-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:986f4df5ed17b003dc52489468601720090e65f964f8bebccf90eb45bba75744"},
+    {file = "torchaudio-2.11.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:bda09ea630ae7207384fb0f28c35e4f8c0d82dd6eba020b6b335ad0caa9fed49"},
+    {file = "torchaudio-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:9fe3083c62e035646483a14e180d33561bdc2eed436c9ab1259c137fb7120b4a"},
+    {file = "torchaudio-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:13cff988697ccbad539987599f9dc672f40c417bed67570b365e4e5002bbd096"},
+    {file = "torchaudio-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ed404c4399ad7f172c86a47c1b25293d322d1d58e26b10b0456a86cf67d37d84"},
+    {file = "torchaudio-2.11.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:cc09cd1f6015b8549e7fe255fb1be5346b57e7fee06541d3f3dbb012d8c4715f"},
+    {file = "torchaudio-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:79fb3cb99169fd41bd9719647261402a164da0d105a4d81f42a3260844ec5e79"},
+    {file = "torchaudio-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:00e9f71ab9c656f0abdb40c515bd65d4658ab0ad380dee27a2efd7d51dabd3d6"},
+    {file = "torchaudio-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:1424638adb8bb40087bc7b6eb103e8e4fe398210f09076f33b7b5e61501b5d66"},
+    {file = "torchaudio-2.11.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:da2725e250866da42a12934c9a6552f65a18b7187fd7a6221387f0e605fb3b96"},
+    {file = "torchaudio-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1be3767064364ae82705bdf2b15c1e8b41fea82c4cd04d47428a8684b634b6ed"},
+    {file = "torchaudio-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:67f6edac29ed004652c11db5c19d9debb5d835695930574f564efc8bdd061bba"},
+    {file = "torchaudio-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:88fb5e29f670a33d9bac6aabb1d2734460cf6e461bde5cdc352826035851b16d"},
 ]
-
-[package.dependencies]
-torch = "2.7.1"
 
 [[package]]
 name = "torchvision"
-version = "0.22.1"
+version = "0.26.0"
 description = "image and video datasets and models for torch deep learning"
 optional = true
-python-versions = ">=3.9"
+python-versions = "!=3.14.1,>=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"vision\")"
 files = [
-    {file = "torchvision-0.22.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3b47d8369ee568c067795c0da0b4078f39a9dfea6f3bc1f3ac87530dfda1dd56"},
-    {file = "torchvision-0.22.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:990de4d657a41ed71680cd8be2e98ebcab55371f30993dc9bd2e676441f7180e"},
-    {file = "torchvision-0.22.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:3347f690c2eed6d02aa0edfb9b01d321e7f7cf1051992d96d8d196c39b881d49"},
-    {file = "torchvision-0.22.1-cp310-cp310-win_amd64.whl", hash = "sha256:86ad938f5a6ca645f0d5fb19484b1762492c2188c0ffb05c602e9e9945b7b371"},
-    {file = "torchvision-0.22.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4addf626e2b57fc22fd6d329cf1346d474497672e6af8383b7b5b636fba94a53"},
-    {file = "torchvision-0.22.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:8b4a53a6067d63adba0c52f2b8dd2290db649d642021674ee43c0c922f0c6a69"},
-    {file = "torchvision-0.22.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7866a3b326413e67724ac46f1ee594996735e10521ba9e6cdbe0fa3cd98c2f2"},
-    {file = "torchvision-0.22.1-cp311-cp311-win_amd64.whl", hash = "sha256:bb3f6df6f8fd415ce38ec4fd338376ad40c62e86052d7fc706a0dd51efac1718"},
-    {file = "torchvision-0.22.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:153f1790e505bd6da123e21eee6e83e2e155df05c0fe7d56347303067d8543c5"},
-    {file = "torchvision-0.22.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:964414eef19459d55a10e886e2fca50677550e243586d1678f65e3f6f6bac47a"},
-    {file = "torchvision-0.22.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:699c2d70d33951187f6ed910ea05720b9b4aaac1dcc1135f53162ce7d42481d3"},
-    {file = "torchvision-0.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:75e0897da7a8e43d78632f66f2bdc4f6e26da8d3f021a7c0fa83746073c2597b"},
-    {file = "torchvision-0.22.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9c3ae3319624c43cc8127020f46c14aa878406781f0899bb6283ae474afeafbf"},
-    {file = "torchvision-0.22.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4a614a6a408d2ed74208d0ea6c28a2fbb68290e9a7df206c5fef3f0b6865d307"},
-    {file = "torchvision-0.22.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7ee682be589bb1a002b7704f06b8ec0b89e4b9068f48e79307d2c6e937a9fdf4"},
-    {file = "torchvision-0.22.1-cp313-cp313-win_amd64.whl", hash = "sha256:2566cafcfa47ecfdbeed04bab8cef1307c8d4ef75046f7624b9e55f384880dfe"},
-    {file = "torchvision-0.22.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:043d9e35ed69c2e586aff6eb9e2887382e7863707115668ac9d140da58f42cba"},
-    {file = "torchvision-0.22.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:27142bcc8a984227a6dcf560985e83f52b82a7d3f5fe9051af586a2ccc46ef26"},
-    {file = "torchvision-0.22.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ef46e065502f7300ad6abc98554131c35dc4c837b978d91306658f1a65c00baa"},
-    {file = "torchvision-0.22.1-cp313-cp313t-win_amd64.whl", hash = "sha256:7414eeacfb941fa21acddcd725f1617da5630ec822e498660a4b864d7d998075"},
-    {file = "torchvision-0.22.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8be941b4d35c0aba819be70fdbbbed8ceb60401ce6996b8cfaaba1300ce62263"},
-    {file = "torchvision-0.22.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:154a2bdc37a16122c2024f2f77e65f5986020b40c013515c694b5d357fac99a1"},
-    {file = "torchvision-0.22.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:ef7dee376f42900c0e7b0e34624f391d9ece70ab90ee74b42de0c1fffe371284"},
-    {file = "torchvision-0.22.1-cp39-cp39-win_amd64.whl", hash = "sha256:e01631046fda25a1eca2f58d5fdc9a152b93740eb82435cdb27c5151b8d20c02"},
+    {file = "torchvision-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a06d4772a8e13e772906ed736cc53ec6639e5e60554f8e5fa6ca165aabebc464"},
+    {file = "torchvision-0.26.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2adfbe438473236191ff077a4a9a0c767436879c89628aa97137e959b0c11a94"},
+    {file = "torchvision-0.26.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b6f9ad1ecc0eab52647298b379ee9426845f8903703e6127973f8f3d049a798b"},
+    {file = "torchvision-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:f13f12b3791a266de2d599cb8162925261622a037d87fc03132848343cf68f75"},
+    {file = "torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c"},
+    {file = "torchvision-0.26.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1c55dc8affbcc0eb2060fbabbe996ae9e5839b24bb6419777f17848945a411b1"},
+    {file = "torchvision-0.26.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10b5f994c210f4f6d6761cf686f82d748554adf486cb0979770c3252868c8f"},
+    {file = "torchvision-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:de6424b12887ad884f39a0ee446994ae3cd3b6a00a9cafe1bead85a031132af0"},
+    {file = "torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4"},
+    {file = "torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547"},
+    {file = "torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa"},
+    {file = "torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1"},
+    {file = "torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4"},
+    {file = "torchvision-0.26.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a39c7a26538c41fda453f9a9692b5ff9b35a5437db1d94f3027f6f509c160eac"},
+    {file = "torchvision-0.26.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7e6213620bbf97742e5f79832f9e9d769e6cf0f744c5b53dad80b76db633691"},
+    {file = "torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474"},
+    {file = "torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23"},
+    {file = "torchvision-0.26.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:3daf9cc149cf3cdcbd4df9c59dae69ffca86c6823250442c3bbfd63fc2e26c61"},
+    {file = "torchvision-0.26.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:82c3965eca27e86a316e31e4c3e5a16d353e0bcbe0ef8efa2e66502c54493c4b"},
+    {file = "torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea"},
+    {file = "torchvision-0.26.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:eb61804eb9dbe88c5a2a6c4da8dec1d80d2d0a6f18c999c524e32266cb1ebcd3"},
+    {file = "torchvision-0.26.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9a904f2131cbfadab4df828088a9f66291ad33f49ff853872aed1f86848ef776"},
+    {file = "torchvision-0.26.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0f3e572efe62ad645017ea847e0b5e4f2f638d4e39f05bc011d1eb9ac68d4806"},
+    {file = "torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800"},
+    {file = "torchvision-0.26.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:b7d3e295624a28b3b1769228ce1345d94cf4d390dd31136766f76f2d20f718da"},
+    {file = "torchvision-0.26.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7058c5878262937e876f20c25867b33724586aa4499e2853b2d52b99a5e51953"},
+    {file = "torchvision-0.26.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8008474855623c6ba52876589dc52df0aa66e518c25eca841445348e5f79844c"},
+    {file = "torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c"},
 ]
 
 [package.dependencies]
 numpy = "*"
 pillow = ">=5.3.0,<8.3.dev0 || >=8.4.dev0"
-torch = "2.7.1"
+torch = "2.11.0"
 
 [package.extras]
 gdown = ["gdown (>=4.7.3)"]
@@ -8249,7 +9263,7 @@ description = "Transformers: the model-definition framework for state-of-the-art
 optional = true
 python-versions = ">=3.10.0"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and platform_system == \"Linux\" or (platform_system == \"Darwin\" or extra == \"local\") and platform_system != \"Linux\" and (platform_machine == \"arm64\" or extra == \"local\") and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\")"
+markers = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\") or extra == \"local\" and platform_system != \"Linux\""
 files = [
     {file = "transformers-5.7.0-py3-none-any.whl", hash = "sha256:869660cd8fc92badc041f5551bf755a42f4b9558c93341bf3fa3eeed7065079c"},
     {file = "transformers-5.7.0.tar.gz", hash = "sha256:a9d35cf39804e3456c1f9bc1a79ad5ffa878640a61f51f66f71c97f4b4e2ce10"},
@@ -8373,26 +9387,31 @@ core = ["tree-sitter (>=0.22,<1.0)"]
 
 [[package]]
 name = "triton"
-version = "3.3.1"
+version = "3.6.0"
 description = "A language and compiler for custom Deep Learning operations"
 optional = true
-python-versions = "*"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"audio\" or extra == \"local\" or extra == \"quantization\" or extra == \"vision\") and platform_system == \"Linux\""
+markers = "(extra == \"quantization\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vllm\" or extra == \"vision\") and platform_system == \"Linux\""
 files = [
-    {file = "triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e"},
-    {file = "triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b"},
-    {file = "triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43"},
-    {file = "triton-3.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b89d846b5a4198317fec27a5d3a609ea96b6d557ff44b56c23176546023c4240"},
-    {file = "triton-3.3.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3198adb9d78b77818a5388bff89fa72ff36f9da0bc689db2f0a651a67ce6a42"},
-    {file = "triton-3.3.1-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f6139aeb04a146b0b8e0fbbd89ad1e65861c57cfed881f21d62d3cb94a36bab7"},
+    {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781"},
+    {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea"},
+    {file = "triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651"},
+    {file = "triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3"},
+    {file = "triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4"},
+    {file = "triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca"},
+    {file = "triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd"},
+    {file = "triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9"},
+    {file = "triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6"},
+    {file = "triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f"},
+    {file = "triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43"},
+    {file = "triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803"},
+    {file = "triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d"},
+    {file = "triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7"},
 ]
 
-[package.dependencies]
-setuptools = ">=40.8.0"
-
 [package.extras]
-build = ["cmake (>=3.20)", "lit"]
+build = ["cmake (>=3.20,<4.0)", "lit"]
 tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked", "pytest-xdist", "scipy (>=1.7.1)"]
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
@@ -8426,7 +9445,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"audio\" or extra == \"quantization\" or extra == \"memory\" or extra == \"tool\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"audio\" or extra == \"memory\" or extra == \"tool\") or (extra == \"vendors\" or extra == \"server\" or extra == \"local\" or extra == \"vision\" or extra == \"audio\" or extra == \"memory\" or extra == \"tool\") and platform_system != \"Linux\""}
+markers = {main = "(extra == \"vllm\" or extra == \"nvidia\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"quantization\" or extra == \"memory\" or extra == \"server\" or extra == \"tool\") and platform_system == \"Linux\" or platform_system == \"Darwin\" and platform_machine == \"arm64\" and (extra == \"mlx\" or extra == \"apple\" or extra == \"local\" or extra == \"vendors\" or extra == \"vision\" or extra == \"server\" or extra == \"memory\" or extra == \"tool\") or (extra == \"vendors\" or extra == \"server\" or extra == \"local\" or extra == \"vision\" or extra == \"memory\" or extra == \"tool\") and platform_system != \"Linux\""}
 
 [[package]]
 name = "typing-inspection"
@@ -8558,79 +9577,102 @@ test = ["aiohttp (>=3.10.5)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil",
 
 [[package]]
 name = "vllm"
-version = "0.10.0"
+version = "0.21.0"
 description = "A high-throughput and memory-efficient inference and serving engine for LLMs"
 optional = true
-python-versions = "<3.13,>=3.9"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
 files = [
-    {file = "vllm-0.10.0-cp38-abi3-manylinux1_x86_64.whl", hash = "sha256:8ca37559d82b43b5e8c8248d2e4a1ecb51d6d4e5d517491d656df6491ed93dab"},
-    {file = "vllm-0.10.0.tar.gz", hash = "sha256:a44e9013db26082a82c3931ed8772ac884d6d60566d36ecdb0e8dc01c65b241a"},
+    {file = "vllm-0.21.0-1-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:dc62135a50dc4b412b4f79549208e782f1665e49e8c13c2d29d2c3d94ff8ac97"},
+    {file = "vllm-0.21.0-1-cp38-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:f4a75b1391f44c67dc1ca268f5ffed9f6b7fdbc657c93db64e6892c5d1bc320b"},
+    {file = "vllm-0.21.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d6e63955b595bd2aa364e90f85c0a2e99573e701146db58394da569ddc6f4eea"},
+    {file = "vllm-0.21.0-cp38-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b241b085742cf04a68c82c089d12afe4d9ee729e0c7f81b2b2b9961d36105ee5"},
+    {file = "vllm-0.21.0.tar.gz", hash = "sha256:05ff89c3e926b88b77d7878e317a659ffba678afc21c1d48952037aa5457f058"},
 ]
 
 [package.dependencies]
-aiohttp = "*"
+aiohttp = ">=3.13.3"
+anthropic = ">=0.71.0"
+apache-tvm-ffi = "0.1.9"
 blake3 = "*"
 cachetools = "*"
 cbor2 = "*"
 cloudpickle = "*"
-compressed-tensors = "0.10.2"
-depyf = "0.19.0"
+compressed-tensors = "0.15.0.1"
+depyf = "0.20.0"
 diskcache = "5.6.3"
 einops = "*"
 fastapi = {version = ">=0.115.0", extras = ["standard"]}
+fastsafetensors = ">=0.2.2"
 filelock = ">=3.16.1"
-gguf = ">=0.13.0"
-huggingface-hub = {version = ">=0.33.0", extras = ["hf-xet"]}
+flashinfer-cubin = "0.6.8.post1"
+flashinfer-python = "0.6.8.post1"
+gguf = ">=0.17.0"
+ijson = "*"
 lark = "1.2.2"
-llguidance = {version = ">=0.7.11,<0.8.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
-lm-format-enforcer = ">=0.10.11,<0.11"
-mistral_common = {version = ">=1.8.2", extras = ["audio", "image"]}
+llguidance = {version = ">=1.3.0,<1.4.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\" or platform_machine == \"ppc64le\""}
+lm-format-enforcer = "0.11.3"
+mcp = "*"
+mistral_common = {version = ">=1.11.2", extras = ["image"]}
+model-hosting-container-standards = ">=0.1.14,<1.0.0"
 msgspec = "*"
 ninja = "*"
-numba = {version = "0.61.2", markers = "python_version > \"3.9\""}
+numba = "0.65.0"
 numpy = "*"
-openai = ">=1.87.0,<=1.90.0"
-opencv-python-headless = ">=4.11.0"
-outlines_core = "0.2.10"
+nvidia-cudnn-frontend = ">=1.13.0,<1.19.0"
+nvidia-cutlass-dsl = "4.4.2"
+openai = ">=2.0.0"
+openai-harmony = ">=0.0.3"
+opencv-python-headless = ">=4.13.0"
+opentelemetry-api = ">=1.27.0"
+opentelemetry-exporter-otlp = ">=1.27.0"
+opentelemetry-sdk = ">=1.27.0"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
+outlines_core = "0.2.14"
 partial-json-parser = "*"
 pillow = "*"
 prometheus_client = ">=0.18.0"
 prometheus-fastapi-instrumentator = ">=7.0.0"
-protobuf = "*"
+protobuf = ">=5.29.6,<6.30.dev0 || >=6.33.5.dev0"
 psutil = "*"
 py-cpuinfo = "*"
 pybase64 = "*"
-pydantic = ">=2.10"
+pydantic = ">=2.12.0"
 python-json-logger = "*"
 pyyaml = "*"
 pyzmq = ">=25.0.0"
-ray = {version = ">=2.43.0,<2.44.dev0 || >=2.45.dev0", extras = ["cgraph"]}
+quack-kernels = ">=0.3.3"
 regex = "*"
 requests = ">=2.26.0"
-scipy = "*"
 sentencepiece = "*"
-setuptools = {version = ">=77.0.3,<80", markers = "python_version > \"3.11\""}
+setproctitle = "*"
+setuptools = {version = ">=77.0.3,<81.0.0", markers = "python_version > \"3.11\""}
 six = {version = ">=1.16.0", markers = "python_version > \"3.11\""}
 tiktoken = ">=0.6.0"
+tilelang = "0.1.9"
 tokenizers = ">=0.21.1"
-torch = "2.7.1"
-torchaudio = "2.7.1"
-torchvision = "0.22.1"
+tokenspeed-mla = "0.1.2"
+torch = "2.11.0"
+torchaudio = "2.11.0"
+torchvision = "0.26.0"
 tqdm = "*"
-transformers = ">=4.53.2"
+transformers = ">=4.56.0,<5.0.dev0 || >5.5.0"
 typing_extensions = ">=4.10"
 watchfiles = "*"
-xformers = {version = "0.0.31", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-xgrammar = {version = "0.1.21", markers = "platform_machine == \"x86_64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\""}
+xgrammar = {version = ">=0.2.0,<1.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\" or platform_machine == \"s390x\" or platform_machine == \"ppc64le\""}
 
 [package.extras]
-audio = ["librosa", "mistral_common[audio]", "soundfile"]
-bench = ["datasets", "pandas"]
-fastsafetensors = ["fastsafetensors (>=0.1.10)"]
-runai = ["boto3", "runai-model-streamer (>=0.13.3)", "runai-model-streamer-s3"]
+audio = ["av", "mistral_common[audio]", "scipy", "soundfile"]
+bench = ["datasets", "matplotlib", "pandas", "plotly", "scipy", "seaborn"]
+fastsafetensors = ["fastsafetensors (>=0.2.2)"]
+grpc = ["smg-grpc-servicer[vllm] (>=0.5.2)"]
+helion = ["helion (==1.0.0)"]
+instanttensor = ["instanttensor (>=0.1.5)"]
+otel = ["opentelemetry-api (>=1.26.0)", "opentelemetry-exporter-otlp (>=1.26.0)", "opentelemetry-sdk (>=1.26.0)", "opentelemetry-semantic-conventions-ai (>=0.4.1)"]
+runai = ["runai-model-streamer[azure,gcs,s3] (>=0.15.7)"]
 tensorizer = ["tensorizer (==2.10.1)"]
+zen = ["zentorch-weekly (==5.2.1.dev20260408)"]
 
 [[package]]
 name = "watchfiles"
@@ -8833,6 +9875,22 @@ files = [
 ]
 
 [[package]]
+name = "win32-setctime"
+version = "1.2.0"
+description = "A small Python utility to set file creation time on Windows"
+optional = true
+python-versions = ">=3.5"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and sys_platform == \"win32\" and platform_system == \"Linux\""
+files = [
+    {file = "win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390"},
+    {file = "win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
+
+[[package]]
 name = "wrapt"
 version = "1.17.3"
 description = "Module for decorators, wrappers and monkey patching."
@@ -8925,66 +9983,62 @@ files = [
 ]
 
 [[package]]
-name = "xformers"
-version = "0.0.31"
-description = "XFormers: A collection of composable Transformer building blocks."
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "xformers-0.0.31-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:50aedaea82a38d7d28631f77617d1ed1f6f37c60bdc4bf167a69cbc0e39cee76"},
-    {file = "xformers-0.0.31-cp39-abi3-win_amd64.whl", hash = "sha256:23331bdb9831ba0df96f55258537ca0df7ad888efc75cea97a0de79b5e2291c4"},
-    {file = "xformers-0.0.31.tar.gz", hash = "sha256:3fccb159c6327c13fc1b08f8b963c2779ca526e2e50755dee9bcc1bac67d20c6"},
-]
-
-[package.dependencies]
-numpy = "*"
-torch = "2.7.1"
-
-[[package]]
 name = "xgrammar"
-version = "0.1.21"
+version = "0.2.1"
 description = "Efficient, Flexible and Portable Structured Generation"
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "(extra == \"vllm\" or extra == \"nvidia\") and (platform_machine == \"x86_64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\") and platform_system == \"Linux\""
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and (platform_machine == \"x86_64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\" or platform_machine == \"s390x\" or platform_machine == \"ppc64le\") and platform_system == \"Linux\""
 files = [
-    {file = "xgrammar-0.1.21-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:77af5e5487992489131047e38e7136733a24f9c1aa73ef80665a85effd835f77"},
-    {file = "xgrammar-0.1.21-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae38de964a1d56437bc84c0aedf1b0a5a48ff2e805a0ec454b0caaa25b3c7f84"},
-    {file = "xgrammar-0.1.21-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce25b17690d6abebf79d287330578203a361819058f6e893aefa69049f173ad8"},
-    {file = "xgrammar-0.1.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b181f45bbba8563fcaf20a6338ebcbb663d804ab22d160b446c810c6fc397477"},
-    {file = "xgrammar-0.1.21-cp310-cp310-win_amd64.whl", hash = "sha256:55625383b506f1dd64a510605df5d852cfcadbfc5fcd962f400656b67542ad8e"},
-    {file = "xgrammar-0.1.21-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:50d9519211bb76c80a34b25278fcfb0253057b4f2db8fca81da19a53ea61f071"},
-    {file = "xgrammar-0.1.21-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b43c1c8b2e7b0f78067b30a0661ae3b2dfa260a45b0341749d829a27df94faf4"},
-    {file = "xgrammar-0.1.21-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6e5a171ed0b79712e82f1e2726f4deb0bc1db4476b70187fa7aea04afea3350"},
-    {file = "xgrammar-0.1.21-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f43ee3b944da5114f564a1ca734c2e0c5baf849ae824646d3e689c5c78bc6aae"},
-    {file = "xgrammar-0.1.21-cp311-cp311-win_amd64.whl", hash = "sha256:328c35bd62541df41f8e71b544ea73c35dd990e275cf45bad4210e4c94f4a451"},
-    {file = "xgrammar-0.1.21-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:f89d9ddb4d00fadcffa4bcabd0c3ae75d47c844c728bbb6be695056df3767524"},
-    {file = "xgrammar-0.1.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6edc396727d12a36a84f09ad4a688eeeb73fe23620fc4fed5b97e9a0f03107b2"},
-    {file = "xgrammar-0.1.21-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:140628376fc701a535600dc64752603ddaed619461dc50669e90626e9f61b8aa"},
-    {file = "xgrammar-0.1.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9247641c73eec6e972cec15156a8844957334204ba79ad1abdb0d7b03def8a1"},
-    {file = "xgrammar-0.1.21-cp312-cp312-win_amd64.whl", hash = "sha256:8e572bf7b8332c449a071a47fc0e6efe90274197cb701293da331d03d5a071e5"},
-    {file = "xgrammar-0.1.21-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1f128511bf354f6e3a027fedb3eb38e8749e2eefbb3874a7edefd054e2b677a"},
-    {file = "xgrammar-0.1.21-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f5936ea42b8005a963f0f51e713fb94f6766159f4380f339f504f3f1bd6b489"},
-    {file = "xgrammar-0.1.21-cp313-cp313-win_amd64.whl", hash = "sha256:20a217a760fd0633a704929320ad2004ff90951fdcf758351f54a9271ab36a6c"},
-    {file = "xgrammar-0.1.21-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:633d1af2fefdd797e94d8c68cf74fd71bb994c9a420436310f7e6e05a7e8f2a3"},
-    {file = "xgrammar-0.1.21-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:da3c43058a86b7a34427bea5d15f7e5521894ed67417cb3d92d9c078927c4225"},
-    {file = "xgrammar-0.1.21-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e91cc28cb5ca8dc23641b9fc4f358fb0d3bc6be231a39b175206f95c88bc11d"},
-    {file = "xgrammar-0.1.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b07199744b736bf81edae5b68c894d09a1ca8494fc1a80d8f064aa36252ace5a"},
-    {file = "xgrammar-0.1.21-cp39-cp39-win_amd64.whl", hash = "sha256:8ed509c6e75e81fd322a5dd05b0372d73099421d26f3308186de92a8f19539fb"},
-    {file = "xgrammar-0.1.21.tar.gz", hash = "sha256:2ce1e81417ff46aa7ef26d8c0627275cb20dd1f2e8ead5bb261aecde1cc8ba57"},
+    {file = "xgrammar-0.2.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b8affc93b5c48b1db52d82b9f32a72ebee9f1f54322a1abd25aee63ed7c4c31d"},
+    {file = "xgrammar-0.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f4a37e1676346b9c87858f5252f35148eab4a3d6aecae9361906b870635d7cc0"},
+    {file = "xgrammar-0.2.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b4f2d570db0da6e85533f6a46c714f59fafaa0fb5b83734c824020318c61c94"},
+    {file = "xgrammar-0.2.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b80b8060fcf6c94324f563e1d4778029b21d35c556dca5bbf49428d307eca37"},
+    {file = "xgrammar-0.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:a6406aac801b1cea342477ab1fb26784d2a88d41402619681b87d9f2ddc85343"},
+    {file = "xgrammar-0.2.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:62ac4b8ed9eeb7d48c71c3d4c641bdc0e11f1b4c20c4b36ee670412238d9854d"},
+    {file = "xgrammar-0.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7dfe4b50d12325dc50f65ec837c03e02f2e2c366b7ae88d93bdcf4351e8bd440"},
+    {file = "xgrammar-0.2.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f16c1adf6bf31d0f2ba40a7fc5df69a01757641a06e1cbf17f2143a830180646"},
+    {file = "xgrammar-0.2.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a1ae52372ae981c518a83576209343ec0e79a4ac3a1ed104b0126b870c0ca3b"},
+    {file = "xgrammar-0.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:8a0f7cc19f058dd9d210b55c1429aea2efb5ab25602885661460bae864c7012d"},
+    {file = "xgrammar-0.2.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:0560568654e7745a80715dd87457f1feb3a4edf9d3894e47ab5c967f5d799ade"},
+    {file = "xgrammar-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29756a266a62da398151946f3d912a5b737df2000a7023696449f9eec0996208"},
+    {file = "xgrammar-0.2.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e8dd9853958a263b4015ce79133a0ff4eaa9d22ef781fb2350c7dfc40c2c012"},
+    {file = "xgrammar-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbc6014dc1c92fc317b14519121c8163fe35fd934179e5a45d83f780ff231826"},
+    {file = "xgrammar-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:9bd16e92b4385cb5ded48d65de80e4ee871b6b427b2ded99ac5028b907bf870f"},
+    {file = "xgrammar-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2e1964e2a1a5f59e138205996b8b41128c2f385a4de952292e8e47add556aa3c"},
+    {file = "xgrammar-0.2.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb015d246a8c87bf46b11759442924cd6f96baf3ba444062a98e9a45ec5a1021"},
+    {file = "xgrammar-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba024024a454f31d3cb88679a1b073eba0133860f14525f1f5856fa46dec5228"},
+    {file = "xgrammar-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:58ab4d1b2a9f23e38e9a53ceb30ae5c8363e9a9e14d686bbb9f06147fb2e050c"},
+    {file = "xgrammar-0.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5206c23b383e5a6d7743792cf85da4aee76dfb9f11a202cb15d08cc017ca87a3"},
+    {file = "xgrammar-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4f8c7b50130f2d09cf19c43f40a4a7ef0421d14e73b68778d8d2ad50d8fb054b"},
+    {file = "xgrammar-0.2.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34b7564e4074e41ec670973db92a7b8432e2095922db4389267a60da60824c40"},
+    {file = "xgrammar-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fffb35a49df2c825e706bd559a9d0bd59b1772a58c9aa90fbf9d7a929634048d"},
+    {file = "xgrammar-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:5831ae6e0c8a14b151e3a0d4cd2158b4442f498241aef0cb3ed6f5a8af874057"},
+    {file = "xgrammar-0.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b2cbea6a93837ee81a2524839c93ccfe7da40f7cae4e9ee4859fb4a5a60433ab"},
+    {file = "xgrammar-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0cd55c698f2859053009ea9e1040ae1503265a3db717ce0580ca286663fe5da9"},
+    {file = "xgrammar-0.2.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a3569ca924eaf0ac2380c3c421dfd08eefa0658ef000e7ae7545c7499c7b36c"},
+    {file = "xgrammar-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fff6a09f844e6bbb5e4bd9cbc0bd5e07e21962c54b661dfeb2ec4ecd96e0eded"},
+    {file = "xgrammar-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:743196d955b82181af265c358a84b9e1e80ea0e368f129e560c898555a8df9f6"},
+    {file = "xgrammar-0.2.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:8346eb0d144780ccccdb611d0fe3f9faa9fe3b002e983864b7f2576042d02583"},
+    {file = "xgrammar-0.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:94d0e5e9af4808f2ee8f0b9af66cdda5fb0bee5602e25b00844fc70dc4549f7b"},
+    {file = "xgrammar-0.2.1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb007987219c2f9e781db9bc9f989ece2792a0c6544ccabcb347c70b3487159"},
+    {file = "xgrammar-0.2.1-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:731ef20a10e541543fbcac6cfde645cd7beaaae8382df7e340cb35afa211d405"},
+    {file = "xgrammar-0.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:78a55751f096b6d402eb91ff1fa82ca2fd5e4f0d37f7740b0c799e8e04ef696e"},
+    {file = "xgrammar-0.2.1.tar.gz", hash = "sha256:4c48c251b75d211e9ffa7f4f4ac8b5b0164f89fd5f0d1883ad7ff4554922030d"},
 ]
 
 [package.dependencies]
-ninja = "*"
+apache-tvm-ffi = ">=0.1.9"
+numpy = "*"
 pydantic = "*"
 torch = ">=1.10.0"
 transformers = ">=4.38.0"
 triton = {version = "*", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+typing-extensions = ">=4.9.0"
 
 [package.extras]
+metal = ["mlx-lm ; platform_system == \"Darwin\" and platform_machine == \"arm64\""]
 test = ["huggingface-hub[cli]", "protobuf", "pytest", "sentencepiece", "tiktoken", "transformers (<4.50.0) ; platform_system == \"Darwin\""]
 
 [[package]]
@@ -9135,20 +10189,38 @@ propcache = ">=0.2.1"
 
 [[package]]
 name = "youtube-transcript-api"
-version = "1.2.2"
-description = "This is an python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles, supports translating subtitles and it does not require a headless browser, like other selenium based solutions do!"
+version = "1.2.4"
+description = "This is a python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles, supports translating subtitles and it does not require a headless browser, like other selenium based solutions do!"
 optional = true
-python-versions = "<3.14,>=3.8"
+python-versions = "<3.15,>=3.8"
 groups = ["main"]
 markers = "extra == \"tool\""
 files = [
-    {file = "youtube_transcript_api-1.2.2-py3-none-any.whl", hash = "sha256:feca8c7f7c9d65188ef6377fc0e01cf466e6b68f1b3e648019646ab342f994d2"},
-    {file = "youtube_transcript_api-1.2.2.tar.gz", hash = "sha256:5f67cfaff3621d969778817a3d7b2172c16784855f45fcaed4f0529632e2fef4"},
+    {file = "youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff"},
+    {file = "youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd"},
 ]
 
 [package.dependencies]
 defusedxml = ">=0.7.1,<0.8.0"
 requests = "*"
+
+[[package]]
+name = "z3-solver"
+version = "4.15.4.0"
+description = "an efficient SMT solver library"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "(extra == \"vllm\" or extra == \"nvidia\") and platform_system == \"Linux\""
+files = [
+    {file = "z3_solver-4.15.4.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:407e825cc9211f95ef46bdc8d151bf630e7ab2d62a21d24cd74c09cc5b73f3aa"},
+    {file = "z3_solver-4.15.4.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:00bd10c5a6a5f6112d3a9a810d0799227e52f76caa860dafa5e00966bb47eb13"},
+    {file = "z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e"},
+    {file = "z3_solver-4.15.4.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:62c7e9cbdd711932301f29919ad9158de9b2f58b4d281dd259bbcd0a2f408ba1"},
+    {file = "z3_solver-4.15.4.0-py3-none-win32.whl", hash = "sha256:be3bc916545c96ffbf89e00d07104ff14f78336e55db069177a1bfbcc01b269d"},
+    {file = "z3_solver-4.15.4.0-py3-none-win_amd64.whl", hash = "sha256:00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431"},
+    {file = "z3_solver-4.15.4.0.tar.gz", hash = "sha256:928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946"},
+]
 
 [[package]]
 name = "zipp"
@@ -9157,7 +10229,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
+markers = "(python_version == \"3.11\" or extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\") and (extra == \"vllm\" or extra == \"nvidia\" or extra == \"vendors\" or extra == \"vision\" or extra == \"secrets\") and (platform_system == \"Linux\" or python_version == \"3.11\" or extra == \"vendors\" or extra == \"vision\") and (platform_system == \"Linux\" or extra == \"secrets\" or extra == \"vendors\" or extra == \"vision\")"
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
@@ -9191,5 +10263,5 @@ vllm = ["vllm"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11,<3.13"
-content-hash = "3d74a726e4c19e14b6c4afb6682adafadf138045087bd3659e43a296526ee639"
+python-versions = ">=3.11,!=3.14.1,<3.15"
+content-hash = "e720883a7c26c7fe2fcedb09652e46e8d65142c5acbcf6cf7b34d9212d38c187"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5994,25 +5994,22 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pyds4"
-version = "0.1.0"
+version = "1.0.0"
 description = "Python bindings for the DS4 native inference engine"
-optional = true
+optional = false
 python-versions = ">=3.11"
-groups = ["main"]
-markers = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")"
-files = []
-develop = false
+groups = ["main", "test"]
+files = [
+    {file = "pyds4-1.0.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:42928d6c2a00242201d27076cd686818de699d330afe514c627bcd51d523f650"},
+    {file = "pyds4-1.0.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:ec5d90e934d60fcb02f52bc1567bf9eb832c71283f5d13c4b1c1c644e6d562b6"},
+    {file = "pyds4-1.0.0.tar.gz", hash = "sha256:cf83f97d281b9e5faf5c33ab51d228e1644eeaf24773d9d88d9e1a505ba1a4b3"},
+]
+markers = {main = "extra == \"ds4\" and (platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")", test = "(platform_system == \"Linux\" or platform_system == \"Darwin\") and (platform_system == \"Linux\" or platform_machine == \"arm64\")"}
 
 [package.extras]
 dev = ["black (>=25.1.0)", "mypy (>=1.20.0)", "pybind11 (>=2.12)", "ruff (>=0.11.11)"]
-release = ["build (>=1.2)"]
+release = ["auditwheel (>=6.0) ; sys_platform == \"linux\"", "build (>=1.2)", "cmake (>=3.20)", "ninja (>=1.5)", "twine (>=6.0)"]
 test = ["pytest (>=8)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/avalan-ai/pyds4.git"
-reference = "main"
-resolved_reference = "a4146fd9b1e16aa666cbe6f8fa68d15998f45e6e"
 
 [[package]]
 name = "pyee"
@@ -9176,7 +9173,7 @@ type = ["pytest-mypy"]
 agent = ["jinja2"]
 apple = ["mlx", "mlx-lm"]
 audio = ["soundfile", "torchaudio"]
-ds4 = ["pyds4", "pyds4"]
+ds4 = ["pyds4"]
 local = ["accelerate", "hf-xet", "huggingface-hub", "sentence-transformers", "torch", "transformers"]
 memory = ["beautifulsoup4", "boto3", "elasticsearch", "faiss-cpu", "markdownify", "markitdown", "pgvector", "psycopg", "pypdf", "tree-sitter", "tree-sitter-python"]
 mlx = ["mlx", "mlx-lm"]
@@ -9193,4 +9190,4 @@ vllm = ["vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "599d2d9808bac5866f70ff077c6044deb0d112e829c831960786e625bee3e385"
+content-hash = "d3be021bad6349adef60863dc5c9606b5cbe8a8831b92d9185d66b50fe38893f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,7 @@ apple = [
   "mlx-lm>=0.31.3,<0.32.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 ds4 = [
-  "pyds4 @ git+https://github.com/avalan-ai/pyds4.git@main ; platform_system == 'Darwin' and platform_machine == 'arm64'",
-  "pyds4 @ git+https://github.com/avalan-ai/pyds4.git@main ; platform_system == 'Linux'",
+  "pyds4>=1.0.0,<2.0.0 ; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
 ]
 nvidia = [
   "vllm>=0.10.0,<0.11.0 ; platform_system == 'Linux'",
@@ -203,6 +202,7 @@ optional = true
 
 [tool.poetry.group.test.dependencies]
 matplotlib = ">=3.8.0,<4.0.0"
+pyds4 = {version = ">=1.0.0,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
 pytest = ">=8.4.1,<9.0.0"
 pytest-cov = ">=6.2.1,<7.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ apple = [
   "mlx-lm>=0.31.3,<0.32.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 ds4 = [
-  "pyds4>=1.0.0,<2.0.0 ; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
+  "pyds4>=1.0.1,<2.0.0 ; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
 ]
 nvidia = [
   "vllm>=0.10.0,<0.11.0 ; platform_system == 'Linux'",
@@ -202,7 +202,7 @@ optional = true
 
 [tool.poetry.group.test.dependencies]
 matplotlib = ">=3.8.0,<4.0.0"
-pyds4 = {version = ">=1.0.0,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
+pyds4 = {version = ">=1.0.1,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
 pytest = ">=8.4.1,<9.0.0"
 pytest-cov = ">=6.2.1,<7.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ license = { text = "MIT" }
 authors = [
   { name = "The Avalan Team", email = "avalan@avalan.ai" },
 ]
-# the upper 3.13 python version limit is because of vllm
-# @see https://github.com/vllm-project/vllm/issues/12083
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,!=3.14.1,<3.15"
 dependencies = [
   "packaging>=25.0,<26.0",
   "humanize>=4.12.3,<5.0.0",
@@ -28,6 +26,9 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent"
 ]
 
@@ -43,10 +44,9 @@ avalan = "avalan.cli.__main__:main"
 
 [project.optional-dependencies]
 local = [
-  # version limited because of vllm
   "huggingface-hub>=1.0.0,<2.0.0",
   "hf-xet>=1.4.3,<2.0.0 ; platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'aarch64'",
-  "torch>=2.7.1,<2.8.0",
+  "torch>=2.11.0,<2.12.0",
   "transformers>=5.5.4,<6.0.0",
   "accelerate>=1.9.0,<2.0.0",
   "sentence-transformers>=5.4.1,<6.0.0",
@@ -57,8 +57,7 @@ agent = [
 ]
 audio = [
   "soundfile>=0.13.1,<0.14.0",
-  # version limited because of vllm
-  "torchaudio>=2.7.1,<2.8.0",
+  "torchaudio>=2.11.0,<2.12.0",
 ]
 memory = [
   "beautifulsoup4>=4.14.2,<5.0.0",
@@ -78,7 +77,7 @@ quantization = [
 ]
 server = [
   "a2a-sdk>=0.3.6,<0.4.0",
-  "fastapi>=0.116.1,<0.117.0",
+  "fastapi>=0.136.1,<0.137.0",
   "mcp>=1.12.3,<2.0.0",
   "pydantic>=2.11.7,<3.0.0",
   "uvicorn>=0.35.0,<0.36.0",
@@ -103,18 +102,17 @@ secrets = [
 translation = [
   "protobuf>=6.31.1,<7.0.0",
   "sentencepiece>=0.2.0,<0.3.0",
-  "tiktoken>=0.10.0,<0.11.0",
+  "tiktoken>=0.13.0,<0.14.0",
 ]
 vendors = [
   "aioboto3>=15.0.0,<16.0.0",
-  "anthropic>=0.61.0,<0.62.0",
+  "anthropic>=0.71.0,<0.72.0",
   "diffusers>=0.37.1,<0.38.0",
   "google-genai>=1.28.0,<2.0.0",
   "litellm>=1.75.0,<2.0.0",
-  # version limited because of vllm
-  "openai>=1.90.0,<1.91.0",
+  "openai>=2.0.0,<3.0.0",
   "pillow>=11.3.0,<12.0.0",
-  "tiktoken>=0.10.0,<0.11.0",
+  "tiktoken>=0.13.0,<0.14.0",
 ]
 vision = [
   "diffusers>=0.37.1,<0.38.0",
@@ -122,10 +120,10 @@ vision = [
   "imageio-ffmpeg>=0.6.0,<0.7.0",
   "opencv-python>=4.12.0.88,<5.0.0",
   "pillow>=11.3.0,<12.0.0",
-  "torchvision>=0.22.1,<0.23.0",
+  "torchvision>=0.26.0,<0.27.0",
 ]
 vllm = [
-  "vllm>=0.10.0,<0.11.0 ; platform_system == 'Linux'",
+  "vllm>=0.21.0,<0.22.0 ; platform_system == 'Linux'",
 ]
 mlx = [
   "mlx>=0.31.2,<0.32.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
@@ -136,10 +134,10 @@ apple = [
   "mlx-lm>=0.31.3,<0.32.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 ds4 = [
-  "pyds4>=1.0.1,<2.0.0 ; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
+  "pyds4>=1.0.2,<2.0.0 ; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
 ]
 nvidia = [
-  "vllm>=0.10.0,<0.11.0 ; platform_system == 'Linux'",
+  "vllm>=0.21.0,<0.22.0 ; platform_system == 'Linux'",
   "bitsandbytes>=0.46.1,<0.47.0 ; platform_system == 'Linux'",
 ]
 
@@ -202,7 +200,7 @@ optional = true
 
 [tool.poetry.group.test.dependencies]
 matplotlib = ">=3.8.0,<4.0.0"
-pyds4 = {version = ">=1.0.1,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
+pyds4 = {version = ">=1.0.2,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
 pytest = ">=8.4.1,<9.0.0"
 pytest-cov = ">=6.2.1,<7.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 authors = [
   { name = "The Avalan Team", email = "avalan@avalan.ai" },
 ]
-requires-python = ">=3.11,!=3.14.1,<3.15"
+requires-python = ">=3.11,<3.14"
 dependencies = [
   "packaging>=25.0,<26.0",
   "humanize>=4.12.3,<5.0.0",
@@ -28,7 +28,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent"
 ]
 

--- a/src/avalan/backends/ds4_native/availability.py
+++ b/src/avalan/backends/ds4_native/availability.py
@@ -85,11 +85,19 @@ def _binding_api_version(capabilities: object) -> int | None:
     )
 
 
+def _backend_name(value: object) -> str | None:
+    raw_value = getattr(value, "value", value)
+    if raw_value is None:
+        return None
+    name = str(raw_value)
+    return name if name else None
+
+
 def _binding_native_backend_name(
     binding: object, fallback_backend_name: str, capabilities: object
 ) -> str:
-    capability_backend = getattr(capabilities, "backend", None)
-    if isinstance(capability_backend, str) and capability_backend:
+    capability_backend = _backend_name(getattr(capabilities, "backend", None))
+    if capability_backend:
         return capability_backend
     native_backend_name = getattr(binding, "__ds4_native_backend__", None)
     if isinstance(native_backend_name, str) and native_backend_name:
@@ -171,7 +179,11 @@ def require_backend_available(binding: object, backend: str) -> None:
             "DS4 binding capabilities available_backends must be a collection "
             "of backend names."
         )
-    if backend in {str(item) for item in available_backends}:
+    if backend in {
+        name
+        for name in (_backend_name(item) for item in available_backends)
+        if name is not None
+    }:
         return
     reason = _backend_unavailable_reason(binding, backend)
     details = f" {reason}" if reason else ""

--- a/src/avalan/backends/ds4_native/availability.py
+++ b/src/avalan/backends/ds4_native/availability.py
@@ -32,7 +32,40 @@ class Ds4BindingMetadata:
     native_backend_name: str
 
 
-def _binding_symbols(binding: object) -> set[str]:
+def binding_capabilities(binding: object) -> object | None:
+    """Return pyds4 capability metadata when the binding exposes it."""
+    capabilities = getattr(binding, "capabilities", None)
+    if not callable(capabilities):
+        return None
+    value = capabilities()
+    return value if value is not None else None
+
+
+def _binding_capability_symbols(
+    capabilities: object | None,
+) -> set[str] | None:
+    if capabilities is None:
+        return None
+    symbols = getattr(capabilities, "required_symbols", None)
+    if symbols is None:
+        return None
+    if isinstance(symbols, Collection) and not isinstance(
+        symbols, (bytes, str)
+    ):
+        return {str(symbol) for symbol in symbols}
+    raise Ds4ApiVersionError(
+        "DS4 binding capabilities required_symbols must be a collection of "
+        "public C symbol names."
+    )
+
+
+def _binding_symbols(
+    binding: object, capabilities: object | None = None
+) -> set[str]:
+    capability_symbols = _binding_capability_symbols(capabilities)
+    if capability_symbols is not None:
+        return capability_symbols
+
     symbols = getattr(binding, "__ds4_symbols__", None)
     if symbols is None:
         return {
@@ -59,8 +92,14 @@ def _binding_version(binding: object) -> str:
     )
 
 
-def _binding_api_version(binding: object) -> int | None:
-    version = getattr(binding, "__ds4_api_version__", DS4_API_VERSION)
+def _binding_api_version(
+    binding: object, capabilities: object | None = None
+) -> int | None:
+    version = (
+        getattr(capabilities, "ds4_api_version", None)
+        if capabilities is not None
+        else getattr(binding, "__ds4_api_version__", DS4_API_VERSION)
+    )
     if isinstance(version, int) or version is None:
         return version
     raise Ds4ApiVersionError(
@@ -96,14 +135,19 @@ def _require_safe_import(binding: object, module_name: str) -> None:
 
 def require_compatible_binding(binding: object) -> None:
     """Validate that a DS4 binding matches Avalan's pinned API surface."""
-    binding_commit = getattr(binding, "__ds4_commit__", None)
+    capabilities = binding_capabilities(binding)
+    binding_commit = (
+        getattr(capabilities, "ds4_commit", None)
+        if capabilities is not None
+        else getattr(binding, "__ds4_commit__", None)
+    )
     if binding_commit != DS4_API_COMMIT:
         raise Ds4ApiVersionError(
             "DS4 binding API mismatch: expected DS4 C API commit "
             f"{DS4_API_COMMIT}, got {binding_commit!r}."
         )
 
-    symbols = _binding_symbols(binding)
+    symbols = _binding_symbols(binding, capabilities)
     missing = tuple(
         symbol for symbol in DS4_REQUIRED_C_SYMBOLS if symbol not in symbols
     )
@@ -114,7 +158,7 @@ def require_compatible_binding(binding: object) -> None:
             f"{missing_symbols}."
         )
 
-    binding_api_version = _binding_api_version(binding)
+    binding_api_version = _binding_api_version(binding, capabilities)
     if binding_api_version != DS4_API_VERSION:
         raise Ds4ApiVersionError(
             "DS4 binding API mismatch: expected DS4 C API version "
@@ -140,6 +184,21 @@ def require_backend_available(binding: object, backend: str) -> None:
             f"Unsupported DS4 native backend {backend!r}. "
             f"Supported native backends: {supported}."
         )
+
+    capabilities = binding_capabilities(binding)
+    if capabilities is not None:
+        available_backends = getattr(capabilities, "available_backends", None)
+        if isinstance(available_backends, Collection) and not isinstance(
+            available_backends, (bytes, str)
+        ):
+            if backend in {str(item) for item in available_backends}:
+                return
+            reason = _backend_unavailable_reason(binding, backend)
+            details = f" {reason}" if reason else ""
+            raise Ds4BackendUnavailable(
+                f"DS4 native backend {backend!r} is unavailable on this "
+                f"platform.{details} {_UNAVAILABLE_SUFFIX}"
+            )
 
     available = getattr(binding, "is_backend_available", None)
     if callable(available):

--- a/src/avalan/backends/ds4_native/availability.py
+++ b/src/avalan/backends/ds4_native/availability.py
@@ -12,7 +12,7 @@ from .metadata import (
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 _UNAVAILABLE_SUFFIX = (
     "Install avalan[ds4] and ensure DS4 supports this platform. "
@@ -41,44 +41,28 @@ def binding_capabilities(binding: object) -> object | None:
     return value if value is not None else None
 
 
-def _binding_capability_symbols(
-    capabilities: object | None,
-) -> set[str] | None:
+def _missing_capabilities_error() -> NoReturn:
+    raise Ds4ApiVersionError(
+        "DS4 binding must expose pyds4 capabilities(). Install a current "
+        "pyds4 build."
+    )
+
+
+def _require_binding_capabilities(binding: object) -> object:
+    capabilities = binding_capabilities(binding)
     if capabilities is None:
-        return None
+        _missing_capabilities_error()
+    return capabilities
+
+
+def _binding_capability_symbols(capabilities: object) -> set[str]:
     symbols = getattr(capabilities, "required_symbols", None)
-    if symbols is None:
-        return None
     if isinstance(symbols, Collection) and not isinstance(
         symbols, (bytes, str)
     ):
         return {str(symbol) for symbol in symbols}
     raise Ds4ApiVersionError(
         "DS4 binding capabilities required_symbols must be a collection of "
-        "public C symbol names."
-    )
-
-
-def _binding_symbols(
-    binding: object, capabilities: object | None = None
-) -> set[str]:
-    capability_symbols = _binding_capability_symbols(capabilities)
-    if capability_symbols is not None:
-        return capability_symbols
-
-    symbols = getattr(binding, "__ds4_symbols__", None)
-    if symbols is None:
-        return {
-            symbol
-            for symbol in DS4_REQUIRED_C_SYMBOLS
-            if hasattr(binding, symbol)
-        }
-    if isinstance(symbols, Collection) and not isinstance(
-        symbols, (bytes, str)
-    ):
-        return {str(symbol) for symbol in symbols}
-    raise Ds4ApiVersionError(
-        "DS4 binding metadata __ds4_symbols__ must be a collection of "
         "public C symbol names."
     )
 
@@ -92,24 +76,21 @@ def _binding_version(binding: object) -> str:
     )
 
 
-def _binding_api_version(
-    binding: object, capabilities: object | None = None
-) -> int | None:
-    version = (
-        getattr(capabilities, "ds4_api_version", None)
-        if capabilities is not None
-        else getattr(binding, "__ds4_api_version__", DS4_API_VERSION)
-    )
+def _binding_api_version(capabilities: object) -> int | None:
+    version = getattr(capabilities, "ds4_api_version", None)
     if isinstance(version, int) or version is None:
         return version
     raise Ds4ApiVersionError(
-        "DS4 binding metadata __ds4_api_version__ must be an integer or None."
+        "DS4 binding capabilities ds4_api_version must be an integer or None."
     )
 
 
 def _binding_native_backend_name(
-    binding: object, fallback_backend_name: str
+    binding: object, fallback_backend_name: str, capabilities: object
 ) -> str:
+    capability_backend = getattr(capabilities, "backend", None)
+    if isinstance(capability_backend, str) and capability_backend:
+        return capability_backend
     native_backend_name = getattr(binding, "__ds4_native_backend__", None)
     if isinstance(native_backend_name, str) and native_backend_name:
         return native_backend_name
@@ -135,19 +116,15 @@ def _require_safe_import(binding: object, module_name: str) -> None:
 
 def require_compatible_binding(binding: object) -> None:
     """Validate that a DS4 binding matches Avalan's pinned API surface."""
-    capabilities = binding_capabilities(binding)
-    binding_commit = (
-        getattr(capabilities, "ds4_commit", None)
-        if capabilities is not None
-        else getattr(binding, "__ds4_commit__", None)
-    )
+    capabilities = _require_binding_capabilities(binding)
+    binding_commit = getattr(capabilities, "ds4_commit", None)
     if binding_commit != DS4_API_COMMIT:
         raise Ds4ApiVersionError(
             "DS4 binding API mismatch: expected DS4 C API commit "
             f"{DS4_API_COMMIT}, got {binding_commit!r}."
         )
 
-    symbols = _binding_symbols(binding, capabilities)
+    symbols = _binding_capability_symbols(capabilities)
     missing = tuple(
         symbol for symbol in DS4_REQUIRED_C_SYMBOLS if symbol not in symbols
     )
@@ -158,7 +135,7 @@ def require_compatible_binding(binding: object) -> None:
             f"{missing_symbols}."
         )
 
-    binding_api_version = _binding_api_version(binding, capabilities)
+    binding_api_version = _binding_api_version(capabilities)
     if binding_api_version != DS4_API_VERSION:
         raise Ds4ApiVersionError(
             "DS4 binding API mismatch: expected DS4 C API version "
@@ -185,45 +162,22 @@ def require_backend_available(binding: object, backend: str) -> None:
             f"Supported native backends: {supported}."
         )
 
-    capabilities = binding_capabilities(binding)
-    if capabilities is not None:
-        available_backends = getattr(capabilities, "available_backends", None)
-        if isinstance(available_backends, Collection) and not isinstance(
-            available_backends, (bytes, str)
-        ):
-            if backend in {str(item) for item in available_backends}:
-                return
-            reason = _backend_unavailable_reason(binding, backend)
-            details = f" {reason}" if reason else ""
-            raise Ds4BackendUnavailable(
-                f"DS4 native backend {backend!r} is unavailable on this "
-                f"platform.{details} {_UNAVAILABLE_SUFFIX}"
-            )
-
-    available = getattr(binding, "is_backend_available", None)
-    if callable(available):
-        available_fn = cast(Callable[[str], object], available)
-        if bool(available_fn(backend)):
-            return
-        reason = _backend_unavailable_reason(binding, backend)
-        details = f" {reason}" if reason else ""
-        raise Ds4BackendUnavailable(
-            f"DS4 native backend {backend!r} is unavailable on this "
-            f"platform.{details} {_UNAVAILABLE_SUFFIX}"
-        )
-
-    available_backends = getattr(binding, "__ds4_available_backends__", None)
-    if available_backends is None:
-        return
-    if (
-        isinstance(available_backends, Collection)
-        and not isinstance(available_backends, (bytes, str))
-        and backend in {str(item) for item in available_backends}
+    capabilities = _require_binding_capabilities(binding)
+    available_backends = getattr(capabilities, "available_backends", None)
+    if not isinstance(available_backends, Collection) or isinstance(
+        available_backends, (bytes, str)
     ):
+        raise Ds4ApiVersionError(
+            "DS4 binding capabilities available_backends must be a collection "
+            "of backend names."
+        )
+    if backend in {str(item) for item in available_backends}:
         return
+    reason = _backend_unavailable_reason(binding, backend)
+    details = f" {reason}" if reason else ""
     raise Ds4BackendUnavailable(
-        f"DS4 native backend {backend!r} is unavailable on this platform. "
-        f"{_UNAVAILABLE_SUFFIX}"
+        f"DS4 native backend {backend!r} is unavailable on this "
+        f"platform.{details} {_UNAVAILABLE_SUFFIX}"
     )
 
 
@@ -241,13 +195,14 @@ def binding_metadata(
 ) -> Ds4BindingMetadata:
     """Return stable metadata for a compatible DS4 binding."""
     require_compatible_binding(binding)
+    capabilities = _require_binding_capabilities(binding)
     return Ds4BindingMetadata(
         module_name=module_name,
         binding_version=_binding_version(binding),
         ds4_commit=DS4_API_COMMIT,
         ds4_api_version=DS4_API_VERSION,
         native_backend_name=_binding_native_backend_name(
-            binding, native_backend_name
+            binding, native_backend_name, capabilities
         ),
     )
 

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -48,6 +48,7 @@ from collections.abc import (
     Iterator,
 )
 from dataclasses import dataclass, replace
+from inspect import Parameter, signature
 from logging import Logger, getLogger
 from math import exp
 from pathlib import Path
@@ -93,6 +94,10 @@ _DSML_TOOL_START_MARKERS = (
     "\n<tool_calls>",
     "<tool_calls>",
 )
+_TOKEN_SCORE_MODE_VALUES = {
+    "TOKEN_LOGPROB": "token_logprob",
+    "TOKEN_LOGPROB_AND_TOP_LOGPROBS": "token_logprob_and_top_logprobs",
+}
 
 _T = TypeVar("_T")
 
@@ -872,6 +877,27 @@ class Ds4Worker:
         self._require_logprob_support(
             session, generation_plan.top_logprobs, self._capabilities
         )
+        score_options = self._generation_score_options(generation_plan)
+        if score_options is not None and self._method_supports_keyword(
+            session, "next_token", "scores"
+        ):
+            step = await self._call_async(
+                session,
+                "next_token",
+                (
+                    self._native_sampling_options(
+                        generation_plan.sampling_options
+                    )
+                    if generation_plan.use_sampling
+                    else None
+                ),
+                decode=True,
+                scores=score_options,
+            )
+            return await self._token_detail_step_from_generation_step(
+                engine, step, generation_plan, step_index
+            )
+
         token_id = await self._select_token(session, generation_plan)
         eos_token_id = await self._eos_token_id(engine)
         is_eos = token_id == eos_token_id
@@ -888,6 +914,112 @@ class Ds4Worker:
         token_text = await self._call_async(engine, "token_text", token_id)
         token_bytes = self._bytes_value(token_text, "token_text")
         text = token_bytes.decode("utf-8", errors="replace")
+        detail = TokenDetail(
+            id=token_id,
+            token=text,
+            probability=chosen_probability,
+            probability_distribution=generation_plan.probability_distribution,
+            step=step_index,
+            tokens=(
+                [
+                    Token(
+                        id=alternative.token_id,
+                        token=await self._token_string(
+                            engine, alternative.token_id
+                        ),
+                        probability=alternative.probability,
+                    )
+                    for alternative in alternatives
+                ]
+                if alternatives
+                else None
+            ),
+        )
+        return _Ds4Step(token_id, False, token_bytes, detail)
+
+    def _generation_score_options(
+        self, generation_plan: _Ds4GenerationPlan
+    ) -> object | None:
+        binding = self._require_binding()
+        score_options_type = getattr(binding, "GenerationScoreOptions", None)
+        score_mode_type = getattr(binding, "TokenScoreMode", None)
+        if not callable(score_options_type) or score_mode_type is None:
+            return None
+
+        mode_name = (
+            "TOKEN_LOGPROB_AND_TOP_LOGPROBS"
+            if generation_plan.top_logprobs > 0
+            else "TOKEN_LOGPROB"
+        )
+        mode = getattr(score_mode_type, mode_name, None)
+        if mode is None and callable(score_mode_type):
+            try:
+                mode = score_mode_type(_TOKEN_SCORE_MODE_VALUES[mode_name])
+            except (TypeError, ValueError):
+                return None
+        if mode is None:
+            return None
+
+        try:
+            return cast(
+                object,
+                score_options_type(
+                    mode=mode,
+                    top_k=generation_plan.top_logprobs,
+                ),
+            )
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _method_supports_keyword(
+        target: object, name: str, keyword: str
+    ) -> bool:
+        method = getattr(target, name, None)
+        if not callable(method):
+            return False
+        try:
+            parameters = signature(method).parameters
+        except (TypeError, ValueError):
+            return True
+        return keyword in parameters or any(
+            parameter.kind is Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+
+    async def _token_detail_step_from_generation_step(
+        self,
+        engine: object,
+        step: object,
+        generation_plan: _Ds4GenerationPlan,
+        step_index: int,
+    ) -> _Ds4Step:
+        token_id = self._token_id(
+            getattr(step, "token_id", None), "next_token"
+        )
+        if bool(getattr(step, "is_eos", False)):
+            return _Ds4Step(token_id, True, None, None)
+
+        token_bytes = getattr(step, "token_bytes", None)
+        if token_bytes is None:
+            token_bytes = await self._call_async(
+                engine, "token_text", token_id
+            )
+        token_bytes = self._bytes_value(token_bytes, "token_text")
+        text = token_bytes.decode("utf-8", errors="replace")
+
+        alternatives = [
+            self._token_probability(score, "top_logprobs")
+            for score in getattr(step, "top_logprobs", ()) or ()
+        ]
+        token_logprob = getattr(step, "token_logprob", None)
+        chosen_probability = (
+            self._probability_from_logprob(token_logprob, "token_logprob")
+            if token_logprob is not None
+            else await self._chosen_token_probability(
+                object(), token_id, alternatives
+            )
+        )
         detail = TokenDetail(
             id=token_id,
             token=text,

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -12,6 +12,7 @@ from ....backends.ds4_native import (
     import_compatible_binding,
 )
 from ....backends.ds4_native import Engine as Ds4Engine
+from ....backends.ds4_native.availability import binding_capabilities
 from ....backends.ds4_native.metadata import DS4_BINDING_IMPORT_NAME
 from ....entities import (
     GenerationSettings,
@@ -94,6 +95,17 @@ _DSML_TOOL_START_MARKERS = (
 )
 
 _T = TypeVar("_T")
+
+
+def _capability_bool(capabilities: object | None, name: str) -> bool | None:
+    if capabilities is None:
+        return None
+    value = getattr(capabilities, name, None)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise Ds4LoadError(f"DS4 capability {name!r} must be a boolean.")
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -468,6 +480,7 @@ class Ds4Worker:
         disk_cache_config: _Ds4DiskCacheConfig | None = None,
     ) -> None:
         self._binding: object | None = None
+        self._capabilities: object | None = None
         self._closed = True
         self._ctx_size = ctx_size
         self._engine: object | None = None
@@ -669,6 +682,9 @@ class Ds4Worker:
         self._binding = import_compatible_binding(
             backend=self._options.backend.value
         )
+        self._capabilities = binding_capabilities(self._binding)
+        if _capability_bool(self._capabilities, "payloads") is False:
+            self._disk_cache = None
         async_engine_type = getattr(self._binding, "AsyncEngine", None)
         if not callable(async_engine_type):
             raise Ds4LoadError(
@@ -853,7 +869,9 @@ class Ds4Worker:
         generation_plan: _Ds4GenerationPlan,
         step_index: int,
     ) -> object:
-        self._require_logprob_support(session, generation_plan.top_logprobs)
+        self._require_logprob_support(
+            session, generation_plan.top_logprobs, self._capabilities
+        )
         token_id = await self._select_token(session, generation_plan)
         eos_token_id = await self._eos_token_id(engine)
         is_eos = token_id == eos_token_id
@@ -910,13 +928,28 @@ class Ds4Worker:
         return self._token_id(value, operation)
 
     @staticmethod
-    def _require_logprob_support(session: object, top_k: int) -> None:
-        if not callable(getattr(session, "token_logprob", None)):
+    def _require_logprob_support(
+        session: object,
+        top_k: int,
+        capabilities: object | None = None,
+    ) -> None:
+        logprobs = _capability_bool(capabilities, "logprobs")
+        top_logprobs = _capability_bool(capabilities, "top_logprobs")
+        if logprobs is False or (
+            logprobs is None
+            and not callable(getattr(session, "token_logprob", None))
+        ):
             raise NotImplementedError(
                 "DS4 native backend does not support token logprobs. Install a"
                 " pyds4 build with token_logprob support."
             )
-        if top_k > 0 and not callable(getattr(session, "top_logprobs", None)):
+        if top_k > 0 and (
+            top_logprobs is False
+            or (
+                top_logprobs is None
+                and not callable(getattr(session, "top_logprobs", None))
+            )
+        ):
             raise NotImplementedError(
                 "DS4 native backend does not support token logprobs. "
                 "Install a pyds4 build with top_logprobs support."
@@ -933,9 +966,14 @@ class Ds4Worker:
     async def _token_probabilities(
         self, engine: object, session: object, top_k: int
     ) -> list[_Ds4TokenProbability]:
+        _ = engine
         if top_k == 0:
             return []
-        if not callable(getattr(session, "top_logprobs", None)):
+        top_logprobs = _capability_bool(self._capabilities, "top_logprobs")
+        if top_logprobs is False or (
+            top_logprobs is None
+            and not callable(getattr(session, "top_logprobs", None))
+        ):
             raise NotImplementedError(
                 "DS4 native backend does not support token logprobs. "
                 "Install a pyds4 build with top_logprobs support."
@@ -1109,12 +1147,16 @@ class Ds4Worker:
         task.add_done_callback(self._reset_tasks.discard)
 
     async def _save_snapshot(self, session: object) -> bytes | None:
+        if _capability_bool(self._capabilities, "snapshots") is False:
+            return None
         if not callable(getattr(session, "save_snapshot", None)):
             return None
         value = await self._call_async(session, "save_snapshot")
         return self._snapshot_bytes(value, "save_snapshot")
 
     async def _load_snapshot(self, session: object, snapshot: bytes) -> bool:
+        if _capability_bool(self._capabilities, "snapshots") is False:
+            return False
         if not callable(getattr(session, "load_snapshot", None)):
             return False
         await self._call_async(session, "load_snapshot", snapshot)

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -38,6 +38,7 @@ from .generation import TextGenerationModel
 
 import asyncio
 import hashlib
+import importlib
 import json
 from asyncio import CancelledError
 from collections.abc import (
@@ -54,8 +55,7 @@ from math import exp
 from pathlib import Path
 from queue import Queue
 from threading import Thread
-from time import time
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 _CPU_WARNING = (
     "DS4 CPU backend is debug/reference only and is not recommended for "
@@ -80,7 +80,6 @@ _CONTEXT_ERROR_MARKERS = (
     "prompt exceeds context",
 )
 _WORKER_JOIN_TIMEOUT_SECONDS = 2.0
-_DS4_KV_CACHE_VERSION = 1
 _BYTES_PER_MIB = 1024 * 1024
 _DS4_TOOL_REPLAY_MAX_ENTRIES = 10000
 _DSML_TOOL_START_MARKERS = (
@@ -161,7 +160,7 @@ class _Ds4CacheEntryPath:
 
 
 class _Ds4DiskKvCache:
-    """Store DS4 payload helper bytes by token-prefix cache key."""
+    """Adapt Avalan's async DS4 worker to pyds4's generic cache helper."""
 
     def __init__(
         self,
@@ -169,11 +168,17 @@ class _Ds4DiskKvCache:
         budget_bytes: int,
         logger: Logger,
         namespace: str,
+        backend: str = _DEFAULT_NATIVE_BACKEND.value,
     ) -> None:
         self._budget_bytes = budget_bytes
         self._directory = directory
         self._logger = logger
         self._namespace = namespace
+        self._cache: Any = self._cache_type()(
+            directory,
+            namespace,
+            backend=backend,
+        )
 
     async def restore(
         self,
@@ -185,36 +190,25 @@ class _Ds4DiskKvCache:
         if not callable(getattr(session, "load_payload", None)):
             return False
 
-        entry = self._entry_path(prompt_tokens, ctx_size)
-        metadata = self._read_metadata(entry.metadata_path)
-        if metadata is None:
-            return False
-        if not self._metadata_matches(metadata, entry, ctx_size):
-            self._delete_entry(entry)
-            return False
-
-        try:
-            payload = entry.payload_path.read_bytes()
-        except OSError as error:
+        result = await self._cache.arestore(
+            session,
+            prompt_tokens,
+            ctx_size,
+            sync_on_miss=False,
+        )
+        if result.status == "hit":
+            if result.warning:
+                self._logger.warning(
+                    "DS4 disk KV cache metadata update failed: %s",
+                    result.warning,
+                )
+            return True
+        if result.error:
             self._logger.warning(
-                "DS4 disk KV cache payload read failed; using live"
-                " session: %s",
-                error,
+                "DS4 disk KV cache restore failed; using live session: %s",
+                result.error,
             )
-            return False
-
-        try:
-            await Ds4Worker._call_async(session, "load_payload", payload)
-        except Exception as error:
-            self._logger.warning(
-                "DS4 disk KV cache payload restore failed; "
-                "using live session: %s",
-                error,
-            )
-            return False
-
-        self._record_hit(metadata, entry)
-        return True
+        return False
 
     async def store(
         self,
@@ -226,198 +220,41 @@ class _Ds4DiskKvCache:
         if not callable(getattr(session, "save_payload", None)):
             return
 
-        try:
-            payload = await Ds4Worker._call_async(session, "save_payload")
-            payload_bytes = Ds4Worker._bytes_value(payload, "save_payload")
-        except Exception as error:
+        result = await self._cache.astore(
+            session,
+            prompt_tokens,
+            ctx_size,
+            size_budget_bytes=self._budget_bytes,
+        )
+        if result.status == "stored":
+            return
+        if result.error:
             self._logger.warning(
                 "DS4 disk KV cache payload save failed; "
                 "continuing without cache: %s",
-                error,
-            )
-            return
-
-        entry = self._entry_path(prompt_tokens, ctx_size)
-        now = time()
-        metadata: dict[str, object] = {
-            "version": _DS4_KV_CACHE_VERSION,
-            "key": entry.key,
-            "namespace": self._namespace,
-            "ctx_size": ctx_size,
-            "token_count": len(prompt_tokens),
-            "token_sha256": entry.token_digest,
-            "payload_file": entry.payload_path.name,
-            "payload_size": len(payload_bytes),
-            "hit_count": 0,
-            "created_at": now,
-            "accessed_at": now,
-        }
-
-        try:
-            self._directory.mkdir(parents=True, exist_ok=True)
-            payload_tmp = entry.payload_path.with_suffix(".payload.tmp")
-            metadata_tmp = entry.metadata_path.with_suffix(".json.tmp")
-            payload_tmp.write_bytes(payload_bytes)
-            metadata_tmp.write_text(
-                json.dumps(metadata, sort_keys=True),
-                encoding="utf-8",
-            )
-            payload_tmp.replace(entry.payload_path)
-            metadata_tmp.replace(entry.metadata_path)
-            self._enforce_budget()
-        except OSError as error:
-            self._logger.warning(
-                "DS4 disk KV cache write failed; continuing without cache: %s",
-                error,
+                result.error,
             )
 
     def _entry_path(
         self, prompt_tokens: list[int], ctx_size: int
     ) -> _Ds4CacheEntryPath:
-        token_digest = self._token_digest(prompt_tokens)
-        key_source = (
-            f"{self._namespace}:{ctx_size}:{len(prompt_tokens)}:{token_digest}"
-        )
-        key = hashlib.sha256(key_source.encode("utf-8")).hexdigest()
+        entry = self._cache.entry_for(prompt_tokens, ctx_size)
         return _Ds4CacheEntryPath(
-            key=key,
-            metadata_path=self._directory / f"{key}.json",
-            payload_path=self._directory / f"{key}.payload",
-            token_digest=token_digest,
+            key=entry.key,
+            metadata_path=entry.metadata_path,
+            payload_path=entry.payload_path,
+            token_digest=entry.token_sha256,
         )
 
     @staticmethod
-    def _token_digest(prompt_tokens: list[int]) -> str:
-        payload = json.dumps(
-            prompt_tokens,
-            separators=(",", ":"),
-        ).encode("utf-8")
-        return hashlib.sha256(payload).hexdigest()
-
-    @staticmethod
-    def _read_metadata(path: Path) -> dict[str, object] | None:
-        try:
-            value = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError, TypeError, ValueError):
-            return None
-        return value if isinstance(value, dict) else None
-
-    def _metadata_matches(
-        self,
-        metadata: dict[str, object],
-        entry: _Ds4CacheEntryPath,
-        ctx_size: int,
-    ) -> bool:
-        return (
-            metadata.get("version") == _DS4_KV_CACHE_VERSION
-            and metadata.get("key") == entry.key
-            and metadata.get("namespace") == self._namespace
-            and metadata.get("ctx_size") == ctx_size
-            and metadata.get("token_sha256") == entry.token_digest
-            and metadata.get("payload_file") == entry.payload_path.name
-        )
-
-    def _record_hit(
-        self, metadata: dict[str, object], entry: _Ds4CacheEntryPath
-    ) -> None:
-        hit_count = metadata.get("hit_count", 0)
-        metadata["hit_count"] = (
-            hit_count + 1 if isinstance(hit_count, int) else 1
-        )
-        metadata["accessed_at"] = time()
-        try:
-            entry.metadata_path.write_text(
-                json.dumps(metadata, sort_keys=True),
-                encoding="utf-8",
+    def _cache_type() -> Any:
+        module = importlib.import_module("pyds4.kv_cache")
+        cache_type = getattr(module, "Ds4DiskKvCache", None)
+        if not callable(cache_type):
+            raise Ds4LoadError(
+                "DS4 binding does not expose pyds4.kv_cache.Ds4DiskKvCache."
             )
-        except OSError as error:
-            self._logger.warning(
-                "DS4 disk KV cache metadata update failed: %s", error
-            )
-
-    def _enforce_budget(self) -> None:
-        entries = self._cache_entries()
-        total_size = sum(size for _, _, size in entries)
-        if total_size <= self._budget_bytes:
-            return
-
-        for metadata, entry, size in sorted(
-            entries,
-            key=lambda item: (
-                self._metadata_int(item[0], "hit_count"),
-                self._metadata_float(item[0], "accessed_at"),
-                self._metadata_float(item[0], "created_at"),
-                item[1].key,
-            ),
-        ):
-            _ = metadata
-            self._delete_entry(entry)
-            total_size -= size
-            if total_size <= self._budget_bytes:
-                return
-
-    def _cache_entries(
-        self,
-    ) -> list[tuple[dict[str, object], _Ds4CacheEntryPath, int]]:
-        entries: list[tuple[dict[str, object], _Ds4CacheEntryPath, int]] = []
-        try:
-            metadata_paths = tuple(self._directory.glob("*.json"))
-        except OSError:
-            return entries
-
-        for metadata_path in metadata_paths:
-            metadata = self._read_metadata(metadata_path)
-            if metadata is None:
-                continue
-            key = metadata.get("key")
-            token_digest = metadata.get("token_sha256")
-            payload_file = metadata.get("payload_file")
-            if (
-                not isinstance(key, str)
-                or not isinstance(token_digest, str)
-                or not isinstance(payload_file, str)
-            ):
-                continue
-            payload_path = self._directory / payload_file
-            entry = _Ds4CacheEntryPath(
-                key=key,
-                metadata_path=metadata_path,
-                payload_path=payload_path,
-                token_digest=token_digest,
-            )
-            size = self._path_size(metadata_path) + self._path_size(
-                payload_path
-            )
-            entries.append((metadata, entry, size))
-        return entries
-
-    @staticmethod
-    def _metadata_int(metadata: dict[str, object], key: str) -> int:
-        value = metadata.get(key, 0)
-        return value if isinstance(value, int) else 0
-
-    @staticmethod
-    def _metadata_float(metadata: dict[str, object], key: str) -> float:
-        value = metadata.get(key, 0.0)
-        return float(value) if isinstance(value, (float, int)) else 0.0
-
-    @staticmethod
-    def _path_size(path: Path) -> int:
-        try:
-            return path.stat().st_size
-        except OSError:
-            return 0
-
-    def _delete_entry(self, entry: _Ds4CacheEntryPath) -> None:
-        for path in (entry.payload_path, entry.metadata_path):
-            try:
-                path.unlink(missing_ok=True)
-            except OSError as error:
-                self._logger.warning(
-                    "DS4 disk KV cache eviction failed for %s: %s",
-                    path,
-                    error,
-                )
+        return cast(type[object], cache_type)
 
 
 class _StopStringBuffer:
@@ -1482,6 +1319,7 @@ class Ds4Worker:
             config.budget_bytes,
             logger,
             namespace,
+            backend=options.backend.value,
         )
 
     def _require_binding(self) -> object:

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -82,17 +82,6 @@ _CONTEXT_ERROR_MARKERS = (
 _WORKER_JOIN_TIMEOUT_SECONDS = 2.0
 _BYTES_PER_MIB = 1024 * 1024
 _DS4_TOOL_REPLAY_MAX_ENTRIES = 10000
-_DSML_TOOL_START_MARKERS = (
-    "\n\n<｜DSML｜tool_calls>",
-    "\n<｜DSML｜tool_calls>",
-    DsmlTools.TOOL_CALLS_START,
-    "\n\n<DSML｜tool_calls>",
-    "\n<DSML｜tool_calls>",
-    "<DSML｜tool_calls>",
-    "\n\n<tool_calls>",
-    "\n<tool_calls>",
-    "<tool_calls>",
-)
 _TOKEN_SCORE_MODE_VALUES = {
     "TOKEN_LOGPROB": "token_logprob",
     "TOKEN_LOGPROB_AND_TOP_LOGPROBS": "token_logprob_and_top_logprobs",
@@ -606,7 +595,10 @@ class Ds4Worker:
             if dsml_start is None:
                 start_span = DsmlTools.tool_call_start_span(text)
                 if start_span is None:
-                    safe_end = len(text) - self._dsml_start_suffix_length(text)
+                    suffix_length = DsmlTools.tool_call_start_suffix_length(
+                        text
+                    )
+                    safe_end = len(text) - suffix_length
                     if content_emitted_until < safe_end:
                         yield text[content_emitted_until:safe_end]
                         content_emitted_until = safe_end
@@ -633,21 +625,6 @@ class Ds4Worker:
             yield text[content_emitted_until:]
         for call in parsed.calls:
             yield ToolCallToken(token="", call=call)
-
-    @staticmethod
-    def _dsml_start_suffix_length(text: str) -> int:
-        """Return unsafe suffix length that may become a DSML start marker."""
-        max_length = min(
-            len(text), max(len(marker) for marker in _DSML_TOOL_START_MARKERS)
-        )
-        for length in range(max_length, 0, -1):
-            suffix = text[-length:]
-            if any(
-                marker.startswith(suffix)
-                for marker in _DSML_TOOL_START_MARKERS
-            ):
-                return length
-        return 0
 
     def _remember_dsml_tool_replay(self, parsed: DsmlParseResult) -> None:
         if not parsed.raw_dsml or not parsed.calls:

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -46,7 +46,7 @@ from collections.abc import (
     Awaitable,
     Callable,
     Coroutine,
-    Iterator,
+    Iterable,
 )
 from dataclasses import dataclass, replace
 from inspect import Parameter, signature
@@ -55,7 +55,7 @@ from math import exp
 from pathlib import Path
 from queue import Queue
 from threading import Thread
-from typing import Any, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast
 
 _CPU_WARNING = (
     "DS4 CPU backend is debug/reference only and is not recommended for "
@@ -246,58 +246,13 @@ class _Ds4DiskKvCache:
         return cast(type[object], cache_type)
 
 
-class _StopStringBuffer:
-    """Buffer recent text so stop strings spanning tokens are suppressed."""
-
-    def __init__(self, stop_strings: tuple[str, ...]) -> None:
-        self._pending = ""
-        self._stopped = False
-        self._stop_strings = stop_strings
-        self._keep = (
-            max(len(stop_string) for stop_string in stop_strings) - 1
-            if stop_strings
-            else 0
-        )
-
+class _StopStringBufferProtocol(Protocol):
     @property
-    def stopped(self) -> bool:
-        return self._stopped
+    def stopped(self) -> bool: ...
 
-    def push(self, text: str) -> Iterator[str]:
-        if not self._stop_strings:
-            if text:
-                yield text
-            return
+    def push(self, text: str) -> Iterable[str]: ...
 
-        self._pending += text
-        stop_index = self._stop_index()
-        if stop_index is not None:
-            text_before_stop = self._pending[:stop_index]
-            self._pending = ""
-            self._stopped = True
-            if text_before_stop:
-                yield text_before_stop
-            return
-
-        emit_length = len(self._pending) - self._keep
-        if emit_length > 0:
-            chunk = self._pending[:emit_length]
-            self._pending = self._pending[emit_length:]
-            if chunk:
-                yield chunk
-
-    def flush(self) -> Iterator[str]:
-        if self._pending and not self._stopped:
-            yield self._pending
-        self._pending = ""
-
-    def _stop_index(self) -> int | None:
-        first_index: int | None = None
-        for stop_string in self._stop_strings:
-            index = self._pending.find(stop_string)
-            if index >= 0 and (first_index is None or index < first_index):
-                first_index = index
-        return first_index
+    def flush(self) -> Iterable[str]: ...
 
 
 class Ds4Worker:
@@ -639,7 +594,7 @@ class Ds4Worker:
         self, session: object, generation_plan: _Ds4GenerationPlan
     ) -> AsyncGenerator[str | TokenDetail, None]:
         engine = self._require_engine()
-        stop_buffer = _StopStringBuffer(generation_plan.stop_strings)
+        stop_buffer = self._stop_string_buffer(generation_plan.stop_strings)
 
         for step_index in range(generation_plan.max_new_tokens):
             step = (
@@ -666,6 +621,19 @@ class Ds4Worker:
 
         for chunk in stop_buffer.flush():
             yield chunk
+
+    def _stop_string_buffer(
+        self, stop_strings: tuple[str, ...]
+    ) -> _StopStringBufferProtocol:
+        buffer_type = getattr(
+            self._require_binding(), "StopStringBuffer", None
+        )
+        if not callable(buffer_type):
+            raise Ds4LoadError(
+                "DS4 binding does not expose StopStringBuffer. Install a "
+                "current pyds4 build with public stop-string buffering."
+            )
+        return cast(_StopStringBufferProtocol, buffer_type(stop_strings))
 
     async def _plain_generation_step(
         self, session: object, generation_plan: _Ds4GenerationPlan

--- a/src/avalan/model/transformer.py
+++ b/src/avalan/model/transformer.py
@@ -189,6 +189,8 @@ class TransformerModel(Engine, ABC):
     ) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
         _l = self._log
         tokenizer = self._load_tokenizer(tokenizer_name_or_path, use_fast)
+        # Cleanup is intended for WordPiece and can corrupt BPE output.
+        tokenizer.clean_up_tokenization_spaces = False
         if self._settings.tokens:
             _l(
                 f"Adding {len(self._settings.tokens)} tokens to tokenizer "

--- a/src/avalan/tool/dsml.py
+++ b/src/avalan/tool/dsml.py
@@ -170,6 +170,11 @@ class DsmlTools:
         try:
             return import_module("pyds4.dsml")
         except ModuleNotFoundError as error:
+            if error.name is not None and error.name not in {
+                "pyds4",
+                "pyds4.dsml",
+            }:
+                raise
             raise RuntimeError(
                 "Avalan DSML helpers require pyds4. Install avalan[ds4]."
             ) from error

--- a/src/avalan/tool/dsml.py
+++ b/src/avalan/tool/dsml.py
@@ -141,6 +141,14 @@ class DsmlTools:
         )
 
     @classmethod
+    def tool_call_start_suffix_length(cls, text: str) -> int:
+        """Return trailing text length that may become a DSML start marker."""
+        return cast(
+            int,
+            cls._pyds4_dsml().tool_call_start_suffix_length(text),
+        )
+
+    @classmethod
     def stream_argument_deltas(
         cls, raw_dsml: str, emitted_until: int
     ) -> tuple[tuple[str, ...], int]:

--- a/src/avalan/tool/dsml.py
+++ b/src/avalan/tool/dsml.py
@@ -31,24 +31,6 @@ class DsmlParseResult:
 class DsmlTools:
     """Render and parse DSML tool-call blocks through pyds4."""
 
-    TOOL_CALLS_START = "<｜DSML｜tool_calls>"
-    TOOL_CALLS_END = "</｜DSML｜tool_calls>"
-    TOOL_CALL_START_PREFIXES = (
-        "<｜DSML｜tool_calls",
-        "<DSML｜tool_calls",
-        "<tool_calls",
-    )
-    TOOL_CALL_END_MARKERS = (
-        "</｜DSML｜tool_calls>",
-        "</DSML｜tool_calls>",
-        "</tool_calls>",
-    )
-    PARAMETER_END_MARKERS = (
-        "</｜DSML｜parameter>",
-        "</DSML｜parameter>",
-        "</parameter>",
-    )
-
     @classmethod
     def render_prompt(
         cls,
@@ -147,6 +129,12 @@ class DsmlTools:
             int,
             cls._pyds4_dsml().tool_call_start_suffix_length(text),
         )
+
+    @classmethod
+    def tool_call_buffer_status(cls, text: str) -> str:
+        """Return pyds4's DSML buffer status value for ``text``."""
+        status = cls._pyds4_dsml().tool_call_buffer_status(text)
+        return cast(str, getattr(status, "value", status))
 
     @classmethod
     def stream_argument_deltas(

--- a/src/avalan/tool/dsml.py
+++ b/src/avalan/tool/dsml.py
@@ -1,11 +1,10 @@
 from ..entities import MessageRole, MessageToolCall, ToolCall, ToolValue
 
-import html
-import json
-import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from importlib import import_module
+from types import ModuleType
+from typing import Any, cast
 from uuid import uuid4
 
 
@@ -30,7 +29,7 @@ class DsmlParseResult:
 
 
 class DsmlTools:
-    """Render and parse DSML tool-call blocks."""
+    """Render and parse DSML tool-call blocks through pyds4."""
 
     TOOL_CALLS_START = "<｜DSML｜tool_calls>"
     TOOL_CALLS_END = "</｜DSML｜tool_calls>"
@@ -49,24 +48,6 @@ class DsmlTools:
         "</DSML｜parameter>",
         "</parameter>",
     )
-    _INVOKE_START_RE = re.compile(
-        r"<(?:｜DSML｜|DSML｜)?invoke\s+name=\"([^\"]+)\"\s*>",
-        re.DOTALL,
-    )
-    _PARAM_START_RE = re.compile(
-        r"<(?:｜DSML｜|DSML｜)?parameter\b[^>]*>",
-        re.DOTALL,
-    )
-    _TOOL_CALLS_START_RE = re.compile(
-        r"\n?\n?<(?:(?:｜DSML｜|DSML｜)tool_calls|tool_calls)>",
-    )
-    _PARAM_RE = re.compile(
-        r"<(?:｜DSML｜|DSML｜)?parameter\s+"
-        r"name=\"([^\"]+)\"(?:\s+string=\"(true|false)\")?\s*>"
-        r"(.*?)"
-        r"</(?:｜DSML｜|DSML｜)?parameter>",
-        re.DOTALL,
-    )
 
     @classmethod
     def render_prompt(
@@ -80,94 +61,29 @@ class DsmlTools:
         ) = None,
     ) -> str:
         """Return a rendered DSML chat prompt including tool context."""
-        system_parts = [system_content] if system_content else []
-        if tool_schemas:
-            system_parts.append(cls.tools_prompt(tool_schemas))
-
-        rendered = [
-            "<｜begin▁of▁sentence｜>",
-            "\n\n".join(system_parts),
-        ]
-        pending_assistant = False
-        pending_tool_result = False
-        think = cls._thinking_enabled(think_mode)
-        tool_context = bool(tool_schemas) or any(
-            message.tool_calls or message.role is MessageRole.TOOL
-            for message in messages
+        dsml = cls._pyds4_dsml()
+        prompt = dsml.DsmlPrompt(
+            system_content=system_content,
+            messages=[
+                cls._to_pyds4_message(dsml, message) for message in messages
+            ],
+            tool_schemas=tool_schemas or (),
         )
-        last_user_index = max(
-            (
-                index
-                for index, message in enumerate(messages)
-                if message.role in {MessageRole.USER, MessageRole.TOOL}
+        return cast(
+            str,
+            dsml.render_prompt(
+                prompt,
+                think_mode,
+                replay_lookup=cls._replay_adapter(replay_lookup),
             ),
-            default=-1,
         )
-
-        for index, message in enumerate(messages):
-            if message.role is MessageRole.USER:
-                rendered.extend(("<｜User｜>", message.content))
-                pending_assistant = True
-                pending_tool_result = False
-            elif message.role is MessageRole.TOOL:
-                if not pending_tool_result:
-                    rendered.append("<｜User｜>")
-                rendered.append(cls.render_tool_result(message.content))
-                pending_assistant = True
-                pending_tool_result = True
-            elif message.role is MessageRole.ASSISTANT:
-                if pending_assistant:
-                    rendered.append("<｜Assistant｜>")
-                    if think:
-                        if tool_context or index > last_user_index:
-                            rendered.extend(
-                                (
-                                    "<think>",
-                                    message.reasoning or "",
-                                    "</think>",
-                                )
-                            )
-                        else:
-                            rendered.append("</think>")
-                    else:
-                        rendered.append("</think>")
-                rendered.append(message.content)
-                rendered.append(
-                    cls.render_tool_calls(message.tool_calls, replay_lookup)
-                )
-                rendered.append("<｜end▁of▁sentence｜>")
-                pending_assistant = False
-                pending_tool_result = False
-
-        if pending_assistant:
-            rendered.append("<｜Assistant｜>")
-            rendered.append("<think>" if think else "</think>")
-        return "".join(rendered)
 
     @classmethod
     def render_tool_schemas(
         cls, schemas: list[dict[str, object]] | None
     ) -> str | None:
         """Return DSML newline-delimited tool schemas."""
-        if not schemas:
-            return None
-        lines = []
-        for schema in schemas:
-            function_schema = (
-                schema.get("function")
-                if schema.get("type") == "function"
-                and isinstance(schema.get("function"), dict)
-                else schema
-            )
-            lines.append(
-                json.dumps(
-                    function_schema,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                    sort_keys=False,
-                )
-            )
-        return "\n".join(lines)
+        return cast(str | None, cls._pyds4_dsml().tool_schema_text(schemas))
 
     @classmethod
     def render_tool_calls(
@@ -178,36 +94,20 @@ class DsmlTools:
         ) = None,
     ) -> str:
         """Return canonical DSML text for assistant tool calls."""
-        if not calls:
-            return ""
-        if replay_lookup is not None:
-            replay = replay_lookup(calls)
-            if replay is not None:
-                return replay
-        parts = ["\n\n", cls.TOOL_CALLS_START, "\n"]
-        for call in calls:
-            parts.extend(
-                (
-                    '<｜DSML｜invoke name="',
-                    cls._escape_attr(call.name),
-                    '">\n',
-                )
-            )
-            arguments = (
-                call.arguments
-                if isinstance(call.arguments, dict)
-                else {"arguments": call.arguments}
-            )
-            for name, value in arguments.items():
-                parts.append(cls._render_parameter(str(name), value))
-            parts.append("</｜DSML｜invoke>\n")
-        parts.append(cls.TOOL_CALLS_END)
-        return "".join(parts)
+        dsml = cls._pyds4_dsml()
+        native_calls = tuple(cls._to_pyds4_call(dsml, call) for call in calls)
+        return cast(
+            str,
+            dsml.render_tool_calls(
+                native_calls,
+                cls._replay_adapter(replay_lookup),
+            ),
+        )
 
     @classmethod
     def render_tool_result(cls, content: str) -> str:
         """Return canonical DSML text for a tool result."""
-        return f"<tool_result>{cls._escape_text(content)}</tool_result>"
+        return cast(str, cls._pyds4_dsml().render_tool_result(content))
 
     @classmethod
     def parse_tool_calls(cls, text: str) -> list[ToolCall] | None:
@@ -220,238 +120,120 @@ class DsmlTools:
     @classmethod
     def parse_generated_message(cls, text: str) -> DsmlParseResult | None:
         """Parse generated DSML text into content, calls, and metadata."""
-        start_match = cls._TOOL_CALLS_START_RE.search(text)
-        if not start_match:
-            content, reasoning = cls.split_reasoning(text)
-            return DsmlParseResult(content, (), reasoning)
-
-        end_match = re.search(
-            r"</(?:(?:｜DSML｜|DSML｜)tool_calls|tool_calls)>",
-            text[start_match.end() :],
-        )
-        if not end_match:
+        parsed = cls._pyds4_dsml().parse_generated_message(text)
+        status = getattr(parsed.status, "value", parsed.status)
+        if status != "complete":
             return None
-
-        content, reasoning = cls.split_reasoning(
-            text[: start_match.start()].rstrip()
-        )
-        block_start = start_match.end()
-        block_end = block_start + end_match.start()
-        raw_end = start_match.end() + end_match.end()
-        block = text[block_start:block_end]
-        calls = cls._parse_calls(block)
+        calls = tuple(cls._to_tool_call(call) for call in parsed.calls)
         return DsmlParseResult(
-            content,
-            tuple(calls),
-            reasoning,
-            text[start_match.start() : raw_end],
+            parsed.content,
+            calls,
+            parsed.reasoning,
+            parsed.raw_dsml,
         )
 
     @classmethod
     def tool_call_start_span(cls, text: str) -> tuple[int, int] | None:
         """Return the first generated DSML tool-call block start span."""
-        match = cls._TOOL_CALLS_START_RE.search(text)
-        return (match.start(), match.end()) if match else None
+        return cast(
+            tuple[int, int] | None,
+            cls._pyds4_dsml().tool_call_start_span(text),
+        )
 
     @classmethod
     def stream_argument_deltas(
         cls, raw_dsml: str, emitted_until: int
     ) -> tuple[tuple[str, ...], int]:
-        """Return new DSML parameter-value deltas from ``raw_dsml``.
-
-        ``emitted_until`` is an absolute character offset into ``raw_dsml``.
-        The returned offset should be passed into the next call for the same
-        growing DSML block. Incomplete parameter close tags are retained so
-        tag text is not emitted as argument data.
-        """
-        assert emitted_until >= 0
-
-        deltas: list[str] = []
-        cursor = 0
-        new_emitted_until = emitted_until
-        keep = max(len(marker) for marker in cls.PARAMETER_END_MARKERS) - 1
-
-        while True:
-            start_match = cls._PARAM_START_RE.search(raw_dsml, cursor)
-            if not start_match:
-                break
-
-            value_start = start_match.end()
-            end_index = cls._first_parameter_end_index(raw_dsml, value_start)
-            if end_index is None:
-                value_end = max(value_start, len(raw_dsml) - keep)
-                next_cursor = len(raw_dsml)
-            else:
-                value_end = end_index
-                next_cursor = cls._parameter_end_after(raw_dsml, end_index)
-
-            segment_start = max(value_start, new_emitted_until)
-            if segment_start < value_end:
-                deltas.append(raw_dsml[segment_start:value_end])
-                new_emitted_until = value_end
-
-            if end_index is None:
-                break
-            cursor = next_cursor
-
-        return tuple(delta for delta in deltas if delta), new_emitted_until
+        """Return new DSML parameter-value deltas from ``raw_dsml``."""
+        return cast(
+            tuple[tuple[str, ...], int],
+            cls._pyds4_dsml().stream_argument_deltas(
+                raw_dsml,
+                emitted_until,
+            ),
+        )
 
     @classmethod
     def split_reasoning(cls, text: str) -> tuple[str, str | None]:
         """Return visible content and optional DSML thinking text."""
-        if text.startswith("<think>") and "</think>" in text:
-            reasoning, content = text.removeprefix("<think>").split(
-                "</think>", 1
-            )
-            return content, reasoning
-        return text, None
+        return cast(
+            tuple[str, str | None],
+            cls._pyds4_dsml().split_reasoning(text),
+        )
 
     @classmethod
     def tools_prompt(cls, tool_schemas: str) -> str:
         """Return DSML tool-use instructions for a system prompt."""
-        return (
-            "## Tools\n\n"
-            "You have access to a set of tools to help answer the user "
-            "question. You can invoke tools by writing a "
-            '"<｜DSML｜tool_calls>" block like the following:\n\n'
-            "<｜DSML｜tool_calls>\n"
-            '<｜DSML｜invoke name="$TOOL_NAME">\n'
-            '<｜DSML｜parameter name="$PARAMETER_NAME" '
-            'string="true|false">$PARAMETER_VALUE'
-            "</｜DSML｜parameter>\n"
-            "...\n"
-            "</｜DSML｜invoke>\n"
-            '<｜DSML｜invoke name="$TOOL_NAME2">\n'
-            "...\n"
-            "</｜DSML｜invoke>\n"
-            "</｜DSML｜tool_calls>\n\n"
-            "String parameters should be specified as raw text and set "
-            '`string="true"`. Preserve characters such as `>`, `&`, and '
-            "`&&` exactly; never replace normal string characters with XML "
-            "or HTML entity escapes. Only if a string value itself contains "
-            "the exact closing parameter tag `</｜DSML｜parameter>`, write "
-            "that tag as `&lt;/｜DSML｜parameter>` inside the value. For all "
-            "other types (numbers, booleans, arrays, objects), pass the "
-            'value in JSON format and set `string="false"`.\n\n'
-            "If thinking_mode is enabled (triggered by <think>), you MUST "
-            "output your complete reasoning inside <think>...</think> "
-            "BEFORE any tool calls or final response.\n\n"
-            "Otherwise, output directly after </think> with tool calls or "
-            "final response.\n\n"
-            "### Available Tool Schemas\n\n"
-            f"{tool_schemas}\n\n"
-            "You MUST strictly follow the above defined tool name and "
-            "parameter schemas to invoke tool calls. Use the exact parameter "
-            "names from the schemas."
-        )
+        rendered = cls._pyds4_dsml().tools_prompt(tool_schemas)
+        if rendered is None:
+            raise ValueError("tool_schemas must not be empty.")
+        return cast(str, rendered)
 
     @staticmethod
-    def _thinking_enabled(think_mode: object) -> bool:
-        value = getattr(think_mode, "value", think_mode)
-        return value in {"high", "max"}
-
-    @classmethod
-    def _parse_calls(cls, block: str) -> list[ToolCall]:
-        calls: list[ToolCall] = []
-        position = 0
-        while True:
-            match = cls._INVOKE_START_RE.search(block, position)
-            if not match:
-                return calls
-            invoke_end = re.search(
-                r"</(?:｜DSML｜|DSML｜)?invoke>", block[match.end() :]
-            )
-            if not invoke_end:
-                return []
-            body_end = match.end() + invoke_end.start()
-            body = block[match.end() : body_end]
-            arguments: dict[str, ToolValue] = {}
-            for parameter in cls._PARAM_RE.finditer(body):
-                name = html.unescape(parameter.group(1))
-                raw_value = parameter.group(3)
-                if parameter.group(2) == "false":
-                    value = cls._json_value(raw_value)
-                else:
-                    value = html.unescape(raw_value)
-                arguments[name] = value
-            calls.append(
-                ToolCall(
-                    id=f"ds4_tool_{uuid4().hex}",
-                    name=html.unescape(match.group(1)),
-                    arguments=arguments,
-                )
-            )
-            position = body_end + invoke_end.end()
-
-    @classmethod
-    def _first_parameter_end_index(cls, text: str, start: int) -> int | None:
-        indexes = [
-            index
-            for marker in cls.PARAMETER_END_MARKERS
-            for index in (text.find(marker, start),)
-            if index >= 0
-        ]
-        return min(indexes) if indexes else None
-
-    @classmethod
-    def _parameter_end_after(cls, text: str, index: int) -> int:
-        for marker in cls.PARAMETER_END_MARKERS:
-            if text.startswith(marker, index):
-                return index + len(marker)
-        return index
-
-    @staticmethod
-    def _json_value(value: str) -> ToolValue:
+    def _pyds4_dsml() -> ModuleType:
         try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return None
-        return cast(ToolValue, parsed)
+            return import_module("pyds4.dsml")
+        except ModuleNotFoundError as error:
+            raise RuntimeError(
+                "Avalan DSML helpers require pyds4. Install avalan[ds4]."
+            ) from error
 
     @classmethod
-    def _render_parameter(cls, name: str, value: object) -> str:
-        is_string = isinstance(value, str)
-        rendered_value = (
-            cls._escape_parameter_text(cast(str, value))
-            if is_string
-            else cls._escape_json_literal(
-                json.dumps(
-                    value,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                    sort_keys=False,
-                )
+    def _replay_adapter(
+        cls,
+        replay_lookup: (
+            Callable[[tuple[MessageToolCall, ...]], str | None] | None
+        ),
+    ) -> Callable[[tuple[object, ...]], str | None] | None:
+        if replay_lookup is None:
+            return None
+
+        def replay(calls: tuple[object, ...]) -> str | None:
+            avalan_calls = tuple(
+                cls._to_message_tool_call(call) for call in calls
             )
-        )
-        return (
-            f'<｜DSML｜parameter name="{cls._escape_attr(name)}" '
-            f'string="{"true" if is_string else "false"}">'
-            f"{rendered_value}</｜DSML｜parameter>\n"
-        )
+            return replay_lookup(avalan_calls)
 
-    @staticmethod
-    def _escape_attr(value: str) -> str:
-        return (
-            value.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace('"', "&quot;")
-        )
+        return replay
 
-    @staticmethod
-    def _escape_text(value: str) -> str:
-        return (
-            value.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
+    @classmethod
+    def _to_pyds4_message(
+        cls,
+        dsml: ModuleType,
+        message: DsmlPromptMessage,
+    ) -> object:
+        return dsml.DsmlMessage(
+            role=message.role.value,
+            content=message.content,
+            reasoning=message.reasoning,
+            tool_calls=tuple(
+                cls._to_pyds4_call(dsml, call) for call in message.tool_calls
+            ),
         )
 
     @staticmethod
-    def _escape_parameter_text(value: str) -> str:
-        return value.replace("</｜DSML｜parameter>", "&lt;/｜DSML｜parameter>")
+    def _to_pyds4_call(dsml: ModuleType, call: MessageToolCall) -> object:
+        return dsml.DsmlToolCall(
+            id=call.id,
+            name=call.name,
+            arguments=cast(object, call.arguments),
+        )
 
     @staticmethod
-    def _escape_json_literal(value: str) -> str:
-        return value.replace(
-            "</｜DSML｜parameter>", "\\u003c/｜DSML｜parameter>"
+    def _to_message_tool_call(call: object) -> MessageToolCall:
+        return MessageToolCall(
+            id=cast(str | None, getattr(call, "id", None)),
+            name=cast(str, getattr(call, "name")),
+            arguments=cast(Any, getattr(call, "arguments", {})),
+        )
+
+    @staticmethod
+    def _to_tool_call(call: object) -> ToolCall:
+        arguments = getattr(call, "arguments", None)
+        if not isinstance(arguments, dict):
+            arguments = {}
+        return ToolCall(
+            id=f"ds4_tool_{uuid4().hex}",
+            name=cast(str, getattr(call, "name")),
+            arguments=cast(dict[str, ToolValue], arguments),
         )

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -153,14 +153,7 @@ class ToolCallParser:
         parsed: tuple[str, dict[str, Any]] | list[ToolCall] | None = None
         if "<|call|>" in text and "<|channel|>" in text:
             parsed = self._parse_harmony(text)
-        elif any(
-            marker in text
-            for marker in (
-                DsmlTools.TOOL_CALLS_START,
-                "<DSML｜tool_calls>",
-                "<tool_calls>",
-            )
-        ):
+        elif "tool_calls" in text and self._has_dsml_tool_call_start(text):
             parsed = DsmlTools.parse_tool_calls(text)
         elif self._tool_format:
             parsed = self(text)
@@ -260,6 +253,14 @@ class ToolCallParser:
 
         return None
 
+    def _has_dsml_tool_call_start(self, text: str) -> bool:
+        try:
+            return DsmlTools.tool_call_start_span(text) is not None
+        except RuntimeError:
+            if self._tool_format is ToolFormat.DSML:
+                raise
+            return False
+
     @staticmethod
     def _merge_thinking(
         message_dict: dict[str, object], thinking: str | None
@@ -299,6 +300,11 @@ class ToolCallParser:
     def tool_call_status(
         self, buffer: str
     ) -> "ToolCallParser.ToolCallBufferStatus":
+        if self._tool_format is ToolFormat.DSML:
+            dsml_status = self._dsml_tool_call_status(buffer)
+            if dsml_status is not self.ToolCallBufferStatus.NONE:
+                return dsml_status
+
         start = ["<tool_call", "<tool ", "<tool>"]
         end = ["</tool_call>", "</tool>", "/>", "<|call|>"]
         if self._tool_format is ToolFormat.HARMONY:
@@ -311,9 +317,6 @@ class ToolCallParser:
                 ]
             )
             end.append("<|channel|>final<|message|>")
-        elif self._tool_format is ToolFormat.DSML:
-            start.extend(DsmlTools.TOOL_CALL_START_PREFIXES)
-            end.extend(DsmlTools.TOOL_CALL_END_MARKERS)
         max_len = max(len(s) for s in start)
         tail = buffer[-max_len:]
         for s in start:
@@ -327,6 +330,20 @@ class ToolCallParser:
                     return self.ToolCallBufferStatus.CLOSED
                 return self.ToolCallBufferStatus.OPEN
         return self.ToolCallBufferStatus.NONE
+
+    def _dsml_tool_call_status(
+        self, buffer: str
+    ) -> "ToolCallParser.ToolCallBufferStatus":
+        status = DsmlTools.tool_call_buffer_status(buffer)
+        match status:
+            case "prefix":
+                return self.ToolCallBufferStatus.PREFIX
+            case "open":
+                return self.ToolCallBufferStatus.OPEN
+            case "closed":
+                return self.ToolCallBufferStatus.CLOSED
+            case _:
+                return self.ToolCallBufferStatus.NONE
 
     def _parse_json(self, text: str) -> tuple[str, dict[str, Any]] | None:
         try:

--- a/tests/model/ds4_api_verification_test.py
+++ b/tests/model/ds4_api_verification_test.py
@@ -39,6 +39,25 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**values)
 
 
+def _fake_capabilities(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "available_backends": ("metal",),
+        "backend": "metal",
+        "ds4_api_version": DS4_API_VERSION,
+        "ds4_commit": DS4_API_COMMIT,
+        "logprobs": True,
+        "mtp": True,
+        "payloads": True,
+        "progress": True,
+        "required_symbols": DS4_REQUIRED_C_SYMBOLS,
+        "snapshots": True,
+        "speculative_eval": True,
+        "top_logprobs": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
 def test_ds4_api_metadata_locks_verified_commit_and_symbols() -> None:
     assert DS4_BACKEND_NAME == "ds4"
     assert DS4_BINDING_IMPORT_NAME == "pyds4"
@@ -68,6 +87,47 @@ def test_ds4_api_metadata_locks_verified_commit_and_symbols() -> None:
 
 def test_require_compatible_startup_accepts_fake_binding() -> None:
     require_compatible_startup(_fake_binding(), "metal")
+
+
+def test_require_compatible_startup_accepts_pyds4_capabilities() -> None:
+    binding = _fake_binding(
+        __ds4_symbols__=None,
+        capabilities=lambda: _fake_capabilities(),
+        is_backend_available=lambda backend: False,
+    )
+
+    require_compatible_startup(binding, "metal")
+
+
+def test_require_compatible_binding_rejects_missing_capability_symbol() -> (
+    None
+):
+    symbols = tuple(
+        symbol
+        for symbol in DS4_REQUIRED_C_SYMBOLS
+        if symbol != "ds4_session_eval"
+    )
+
+    with pytest.raises(Ds4ApiVersionError, match="ds4_session_eval"):
+        require_compatible_binding(
+            _fake_binding(
+                capabilities=lambda: _fake_capabilities(
+                    required_symbols=symbols
+                )
+            )
+        )
+
+
+def test_require_backend_available_uses_pyds4_capabilities() -> None:
+    binding = _fake_binding(
+        capabilities=lambda: _fake_capabilities(available_backends=("cuda",)),
+        is_backend_available=lambda backend: True,
+    )
+
+    with pytest.raises(
+        Ds4BackendUnavailable, match="unavailable on this platform"
+    ):
+        require_backend_available(binding, "metal")
 
 
 def test_require_compatible_binding_rejects_missing_symbol() -> None:

--- a/tests/model/ds4_api_verification_test.py
+++ b/tests/model/ds4_api_verification_test.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from os import environ
 from pathlib import Path
 from subprocess import run
@@ -120,6 +121,19 @@ def test_require_backend_available_uses_pyds4_capabilities() -> None:
         Ds4BackendUnavailable, match="unavailable on this platform"
     ):
         require_backend_available(binding, "metal")
+
+
+def test_require_backend_available_normalizes_enum_capabilities() -> None:
+    class Backend(Enum):
+        METAL = "metal"
+
+    binding = _fake_binding(
+        capabilities=lambda: _fake_capabilities(
+            available_backends=(Backend.METAL,)
+        ),
+    )
+
+    require_backend_available(binding, "metal")
 
 
 @pytest.mark.parametrize(

--- a/tests/model/ds4_api_verification_test.py
+++ b/tests/model/ds4_api_verification_test.py
@@ -31,9 +31,7 @@ from avalan.backends.ds4_native.metadata import (
 
 def _fake_binding(**overrides: object) -> SimpleNamespace:
     values: dict[str, object] = {
-        "__ds4_commit__": DS4_API_COMMIT,
-        "__ds4_symbols__": DS4_REQUIRED_C_SYMBOLS,
-        "is_backend_available": lambda backend: backend == "metal",
+        "capabilities": lambda: _fake_capabilities(),
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -85,18 +83,13 @@ def test_ds4_api_metadata_locks_verified_commit_and_symbols() -> None:
     assert set(DS4_REQUIRED_C_SYMBOLS) <= set(DS4_PUBLIC_C_SYMBOLS)
 
 
-def test_require_compatible_startup_accepts_fake_binding() -> None:
+def test_require_compatible_startup_accepts_pyds4_capabilities() -> None:
     require_compatible_startup(_fake_binding(), "metal")
 
 
-def test_require_compatible_startup_accepts_pyds4_capabilities() -> None:
-    binding = _fake_binding(
-        __ds4_symbols__=None,
-        capabilities=lambda: _fake_capabilities(),
-        is_backend_available=lambda backend: False,
-    )
-
-    require_compatible_startup(binding, "metal")
+def test_require_compatible_startup_rejects_missing_capabilities() -> None:
+    with pytest.raises(Ds4ApiVersionError, match="capabilities"):
+        require_compatible_startup(SimpleNamespace(), "metal")
 
 
 def test_require_compatible_binding_rejects_missing_capability_symbol() -> (
@@ -121,7 +114,6 @@ def test_require_compatible_binding_rejects_missing_capability_symbol() -> (
 def test_require_backend_available_uses_pyds4_capabilities() -> None:
     binding = _fake_binding(
         capabilities=lambda: _fake_capabilities(available_backends=("cuda",)),
-        is_backend_available=lambda backend: True,
     )
 
     with pytest.raises(
@@ -130,35 +122,23 @@ def test_require_backend_available_uses_pyds4_capabilities() -> None:
         require_backend_available(binding, "metal")
 
 
-def test_require_compatible_binding_rejects_missing_symbol() -> None:
-    symbols = tuple(
-        symbol
-        for symbol in DS4_REQUIRED_C_SYMBOLS
-        if symbol != "ds4_session_eval"
-    )
-
-    with pytest.raises(Ds4ApiVersionError, match="ds4_session_eval"):
-        require_compatible_binding(_fake_binding(__ds4_symbols__=symbols))
-
-
-def test_require_compatible_binding_discovers_symbols_from_attributes() -> (
-    None
-):
-    symbol_attributes: dict[str, object] = {
-        symbol: object() for symbol in DS4_REQUIRED_C_SYMBOLS
-    }
-
-    require_compatible_binding(
-        _fake_binding(__ds4_symbols__=None, **symbol_attributes)
-    )
-
-
 @pytest.mark.parametrize(
     ("overrides", "match"),
     [
-        ({"__ds4_symbols__": "ds4_engine_open"}, "__ds4_symbols__"),
         (
-            {"__ds4_api_version__": 0 if DS4_API_VERSION != 0 else 1},
+            {
+                "capabilities": lambda: _fake_capabilities(
+                    required_symbols="ds4_engine_open"
+                )
+            },
+            "required_symbols",
+        ),
+        (
+            {
+                "capabilities": lambda: _fake_capabilities(
+                    ds4_api_version=0 if DS4_API_VERSION != 0 else 1
+                )
+            },
             "expected DS4 C API version",
         ),
     ],
@@ -172,7 +152,11 @@ def test_require_compatible_binding_rejects_metadata_mismatches(
 
 def test_require_compatible_binding_rejects_wrong_commit() -> None:
     with pytest.raises(Ds4ApiVersionError, match="expected DS4 C API commit"):
-        require_compatible_binding(_fake_binding(__ds4_commit__="old"))
+        require_compatible_binding(
+            _fake_binding(
+                capabilities=lambda: _fake_capabilities(ds4_commit="old")
+            )
+        )
 
 
 def test_require_backend_available_rejects_unsupported_backend() -> None:
@@ -182,7 +166,7 @@ def test_require_backend_available_rejects_unsupported_backend() -> None:
 
 def test_require_backend_available_reports_platform_unavailable() -> None:
     binding = _fake_binding(
-        is_backend_available=lambda backend: False,
+        capabilities=lambda: _fake_capabilities(available_backends=("cuda",)),
         backend_unavailable_reason=lambda backend: "Metal runtime missing.",
     )
 
@@ -193,26 +177,25 @@ def test_require_backend_available_reports_platform_unavailable() -> None:
         require_backend_available(binding, "metal")
 
 
-@pytest.mark.parametrize(
-    "overrides",
-    [
-        {"is_backend_available": None},
-        {
-            "is_backend_available": None,
-            "__ds4_available_backends__": ("metal",),
-        },
-    ],
-)
-def test_require_backend_available_accepts_metadata_fallbacks(
-    overrides: dict[str, object],
-) -> None:
-    require_backend_available(_fake_binding(**overrides), "metal")
+def test_require_backend_available_rejects_missing_capabilities() -> None:
+    with pytest.raises(Ds4ApiVersionError, match="capabilities"):
+        require_backend_available(SimpleNamespace(), "metal")
 
 
-def test_require_backend_available_rejects_missing_metadata_entry() -> None:
+def test_require_backend_available_rejects_malformed_available_backends() -> (
+    None
+):
     binding = _fake_binding(
-        is_backend_available=None,
-        __ds4_available_backends__=("cuda",),
+        capabilities=lambda: _fake_capabilities(available_backends="metal")
+    )
+
+    with pytest.raises(Ds4ApiVersionError, match="available_backends"):
+        require_backend_available(binding, "metal")
+
+
+def test_require_backend_available_rejects_unavailable_backend() -> None:
+    binding = _fake_binding(
+        capabilities=lambda: _fake_capabilities(available_backends=("cuda",)),
     )
 
     with pytest.raises(

--- a/tests/model/ds4_binding_packaging_test.py
+++ b/tests/model/ds4_binding_packaging_test.py
@@ -23,11 +23,21 @@ from avalan.backends.ds4_native.metadata import (
 
 def _fake_binding(**overrides: object) -> SimpleNamespace:
     values: dict[str, object] = {
-        "__ds4_commit__": DS4_API_COMMIT,
-        "__ds4_symbols__": DS4_REQUIRED_C_SYMBOLS,
         "__version__": "0.1.0",
         "__ds4_native_backend__": "metal",
-        "is_backend_available": lambda backend: backend == "metal",
+        "capabilities": lambda: _fake_capabilities(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _fake_capabilities(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "available_backends": ("metal",),
+        "backend": "metal",
+        "ds4_api_version": DS4_API_VERSION,
+        "ds4_commit": DS4_API_COMMIT,
+        "required_symbols": DS4_REQUIRED_C_SYMBOLS,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -70,7 +80,7 @@ def test_import_compatible_binding_accepts_installed_local_pyds4() -> None:
     assert set(DS4_REQUIRED_C_SYMBOLS) <= set(capabilities.required_symbols)
 
 
-def test_binding_metadata_reports_stable_fallback_fields() -> None:
+def test_binding_metadata_reports_stable_capability_fields() -> None:
     metadata = binding_metadata(_fake_binding())
 
     assert metadata.module_name == DS4_BINDING_IMPORT_NAME
@@ -82,7 +92,11 @@ def test_binding_metadata_reports_stable_fallback_fields() -> None:
 
 def test_binding_metadata_falls_back_without_binding_version() -> None:
     metadata = binding_metadata(
-        _fake_binding(__version__=None, __ds4_native_backend__=""),
+        _fake_binding(
+            __version__=None,
+            __ds4_native_backend__="",
+            capabilities=lambda: _fake_capabilities(backend=""),
+        ),
         native_backend_name="cpu",
     )
 
@@ -121,7 +135,9 @@ def test_import_compatible_binding_rejects_unsafe_import(
 def test_import_compatible_binding_rejects_platform_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    binding = _fake_binding(is_backend_available=lambda backend: False)
+    binding = _fake_binding(
+        capabilities=lambda: _fake_capabilities(available_backends=())
+    )
     monkeypatch.setattr(availability, "import_module", lambda _: binding)
 
     with pytest.raises(
@@ -132,7 +148,9 @@ def test_import_compatible_binding_rejects_platform_unavailable(
 
 
 def test_require_compatible_binding_rejects_invalid_api_version() -> None:
-    with pytest.raises(Ds4ApiVersionError, match="__ds4_api_version__"):
+    with pytest.raises(Ds4ApiVersionError, match="ds4_api_version"):
         availability.require_compatible_binding(
-            _fake_binding(__ds4_api_version__="1")
+            _fake_binding(
+                capabilities=lambda: _fake_capabilities(ds4_api_version="1")
+            )
         )

--- a/tests/model/ds4_binding_packaging_test.py
+++ b/tests/model/ds4_binding_packaging_test.py
@@ -104,6 +104,15 @@ def test_binding_metadata_falls_back_without_binding_version() -> None:
     assert metadata.native_backend_name == "cpu"
 
 
+def test_binding_metadata_uses_binding_backend_when_capability_empty() -> None:
+    metadata = binding_metadata(
+        _fake_binding(capabilities=lambda: _fake_capabilities(backend="")),
+        native_backend_name="cpu",
+    )
+
+    assert metadata.native_backend_name == "metal"
+
+
 def test_import_compatible_binding_rejects_import_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/model/ds4_binding_packaging_test.py
+++ b/tests/model/ds4_binding_packaging_test.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -52,6 +53,21 @@ def test_import_compatible_binding_uses_pyds4_without_opening_model(
 
     assert import_compatible_binding() is binding
     assert opened is False
+
+
+def test_import_compatible_binding_accepts_installed_local_pyds4() -> None:
+    pyds4 = pytest.importorskip("pyds4")
+
+    binding = import_compatible_binding()
+    metadata = binding_metadata(binding)
+    capabilities = binding.capabilities()
+
+    assert binding is pyds4
+    assert Path(binding.__file__).resolve().name == "__init__.py"
+    assert metadata.ds4_commit == DS4_API_COMMIT
+    assert metadata.ds4_api_version == DS4_API_VERSION
+    assert capabilities.ds4_commit == DS4_API_COMMIT
+    assert set(DS4_REQUIRED_C_SYMBOLS) <= set(capabilities.required_symbols)
 
 
 def test_binding_metadata_reports_stable_fallback_fields() -> None:

--- a/tests/model/ds4_engine_api_test.py
+++ b/tests/model/ds4_engine_api_test.py
@@ -19,6 +19,7 @@ from avalan.backends.ds4_native.errors import (
 )
 from avalan.backends.ds4_native.metadata import (
     DS4_API_COMMIT,
+    DS4_API_VERSION,
     DS4_REQUIRED_C_SYMBOLS,
 )
 from avalan.backends.ds4_native.types import (
@@ -230,19 +231,30 @@ class FakeSession:
 
 def _fake_binding(**overrides: object) -> SimpleNamespace:
     values: dict[str, object] = {
-        "__ds4_commit__": DS4_API_COMMIT,
-        "__ds4_symbols__": DS4_REQUIRED_C_SYMBOLS,
         "Backend": NativeBackend,
         "Engine": FakeNativeEngine,
         "EngineOptions": FakeNativeOptions,
         "SamplingOptions": FakeNativeSamplingOptions,
         "ThinkMode": NativeThinkMode,
+        "capabilities": lambda: _fake_capabilities(),
         "is_backend_available": lambda backend: backend == "metal",
         "think_mode_for_context": lambda mode, ctx_size: (
             NativeThinkMode.HIGH
             if mode == NativeThinkMode.MAX and ctx_size < 8192
             else mode
         ),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _fake_capabilities(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "available_backends": ("metal",),
+        "backend": "metal",
+        "ds4_api_version": DS4_API_VERSION,
+        "ds4_commit": DS4_API_COMMIT,
+        "required_symbols": DS4_REQUIRED_C_SYMBOLS,
     }
     values.update(overrides)
     return SimpleNamespace(**values)

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -36,6 +36,7 @@ from avalan.backends.ds4_native.errors import (
 )
 from avalan.backends.ds4_native.metadata import (
     DS4_API_COMMIT,
+    DS4_API_VERSION,
     DS4_REQUIRED_C_SYMBOLS,
 )
 from avalan.entities import (
@@ -592,6 +593,25 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**values)
 
 
+def _fake_capabilities(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "available_backends": ("metal", "cuda", "cpu"),
+        "backend": "metal",
+        "ds4_api_version": DS4_API_VERSION,
+        "ds4_commit": DS4_API_COMMIT,
+        "logprobs": False,
+        "mtp": True,
+        "payloads": False,
+        "progress": True,
+        "required_symbols": DS4_REQUIRED_C_SYMBOLS,
+        "snapshots": False,
+        "speculative_eval": False,
+        "top_logprobs": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
 def _install_binding(monkeypatch: pytest.MonkeyPatch, binding: object) -> None:
     monkeypatch.setattr(availability, "import_module", lambda _: binding)
 
@@ -711,6 +731,29 @@ def test_ds4_model_load_passes_normalized_engine_options_to_pyds4(
         quality=True,
         native_log=False,
     )
+    model.close()
+
+
+def test_ds4_model_load_accepts_complete_pyds4_capabilities(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    FakeNativeEngine.instances.clear()
+    _install_binding(
+        monkeypatch,
+        _fake_binding(
+            capabilities=lambda: _fake_capabilities(
+                logprobs=True,
+                payloads=True,
+                snapshots=True,
+                speculative_eval=True,
+                top_logprobs=True,
+            )
+        ),
+    )
+
+    model = Ds4Model(str(_model_file(tmp_path)))
+
+    assert len(FakeNativeEngine.instances) == 1
     model.close()
 
 
@@ -2068,6 +2111,56 @@ def test_ds4_token_details_require_native_logprob_support(
     model.close()
 
 
+def test_ds4_missing_logprob_capability_only_blocks_token_details(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_binding(
+        monkeypatch,
+        _fake_binding(
+            AsyncEngine=_fake_async_engine_type(
+                FakeNativeEngine, logprobs=True
+            ),
+            capabilities=lambda: _fake_capabilities(
+                logprobs=False,
+                top_logprobs=False,
+            ),
+        ),
+    )
+    model = Ds4Model(str(_model_file(tmp_path)))
+    fake = _latest_fake_engine()
+    fake.argmax_script = [101]
+    fake.token_text_map = {101: b"A"}
+
+    plain = run(
+        model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                temperature=0.0,
+                use_async_generator=False,
+            ),
+        )
+    )
+    assert run(plain.to_str()) == "A"
+
+    detailed = run(
+        model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                temperature=0.0,
+                use_async_generator=False,
+            ),
+            manual_sampling=True,
+            pick=1,
+        )
+    )
+    with pytest.raises(NotImplementedError, match="token logprobs"):
+        run(detailed.to_str())
+    assert fake.sessions[0].token_logprob_calls == []
+    model.close()
+
+
 def test_ds4_eval_call_order_matches_verified_session_semantics(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2187,6 +2280,44 @@ def test_ds4_token_text_failure_restores_snapshot_when_available(
     assert fake.sessions[0].invalidate_calls == 0
     assert fake.sessions[0].tokens == [30, 0, 5, 20]
     assert len(fake.sessions) == 1
+    model.close()
+
+
+def test_ds4_missing_snapshot_capability_rebuilds_on_generation_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_binding(
+        monkeypatch,
+        _fake_binding(
+            AsyncEngine=_fake_async_engine_type(
+                FakeNativeEngine, snapshots=True
+            ),
+            capabilities=lambda: _fake_capabilities(snapshots=False),
+        ),
+    )
+    model = Ds4Model(str(_model_file(tmp_path)))
+    fake = _latest_fake_engine()
+    fake.argmax_script = [101]
+    fake.fail_token_text_ids = {101}
+
+    response = run(
+        model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                temperature=0.0,
+                use_async_generator=False,
+            ),
+        )
+    )
+
+    with pytest.raises(Ds4GenerationError, match="token_text failed"):
+        run(response.to_str())
+
+    assert fake.sessions[0].save_snapshot_calls == 0
+    assert fake.sessions[0].load_snapshot_calls == 0
+    assert fake.sessions[0].invalidate_calls == 1
+    assert len(fake.sessions) == 2
     model.close()
 
 
@@ -2455,6 +2586,62 @@ def test_ds4_disk_kv_cache_disabled_leaves_no_files(
 
     assert run(response.to_str()) == "<101>"
     assert fake.sessions[0].save_payload_calls == 0
+    assert not cache_dir.exists()
+    model.close()
+
+
+def test_ds4_missing_payload_capability_disables_disk_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_binding(
+        monkeypatch,
+        _fake_binding(
+            AsyncEngine=_fake_async_engine_type(
+                FakeNativeEngine, payloads=True
+            ),
+            capabilities=lambda: _fake_capabilities(payloads=False),
+        ),
+    )
+    cache_dir = tmp_path / "kv"
+    model = Ds4Model(
+        str(_model_file(tmp_path)),
+        TransformerEngineSettings(
+            backend_config={
+                "kv_disk_dir": str(cache_dir),
+                "kv_disk_space_mb": 1,
+            }
+        ),
+    )
+    fake = _latest_fake_engine()
+    fake.argmax_script = [101, 102]
+
+    first = run(
+        model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                use_async_generator=False,
+            ),
+        )
+    )
+    second = run(
+        model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                use_async_generator=False,
+            ),
+        )
+    )
+
+    assert run(first.to_str()) == "<101>"
+    assert run(second.to_str()) == "<102>"
+    assert fake.session_sync_calls == [
+        (30, 0, 5, 20),
+        (30, 0, 5, 20),
+    ]
+    assert fake.sessions[0].save_payload_calls == 0
+    assert fake.sessions[0].load_payload_calls == 0
     assert not cache_dir.exists()
     model.close()
 

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -4019,6 +4019,8 @@ def test_ds4_worker_aclose_snapshot_and_pending_reset_edges(
 
     run(worker.aclose())
     assert run(worker._load_snapshot(object(), b"snapshot")) is False
+    worker._capabilities = SimpleNamespace(snapshots=False)
+    assert run(worker._load_snapshot(object(), b"snapshot")) is False
     run(worker._store_disk_cache(object(), [1]))
 
     async def run_case() -> bool:
@@ -4180,6 +4182,95 @@ def test_ds4_worker_logprob_probability_and_bytes_edge_helpers(
     )
     assert step.is_eos is True
 
+    class ManualSession:
+        def __init__(self) -> None:
+            self.eval_calls: list[int] = []
+
+        def argmax(self) -> int:
+            return 5
+
+        def eval(self, token_id: int) -> None:
+            self.eval_calls.append(token_id)
+
+        def token_logprob(self, token_id: int) -> float:
+            assert token_id == 5
+            return -0.4
+
+        def top_logprobs(self, top_k: int) -> list[tuple[int, float]]:
+            assert top_k == 2
+            return [(5, -0.4), (6, -1.4)]
+
+    manual_session = ManualSession()
+    manual_step = run(
+        worker._detailed_generation_step(
+            SimpleNamespace(
+                eos_token_id=9,
+                token_text=lambda token_id: f"T{token_id}".encode(),
+            ),
+            manual_session,
+            _Ds4GenerationPlan(
+                max_new_tokens=1,
+                sampling_options=SamplingOptions(),
+                stop_strings=(),
+                use_sampling=False,
+                emit_token_details=True,
+                top_logprobs=2,
+            ),
+            3,
+        )
+    )
+    assert manual_step.token_id == 5
+    assert manual_step.token_bytes == b"T5"
+    assert manual_step.token_detail == TokenDetail(
+        id=5,
+        token="T5",
+        probability=pytest.approx(exp(-0.4)),
+        probability_distribution="log_softmax",
+        step=3,
+        tokens=[
+            Token(id=5, token="T5", probability=exp(-0.4)),
+            Token(id=6, token="T6", probability=exp(-1.4)),
+        ],
+    )
+    assert manual_session.eval_calls == [5]
+
+    eos_from_step = run(
+        worker._token_detail_step_from_generation_step(
+            SimpleNamespace(),
+            SimpleNamespace(token_id=9, is_eos=True),
+            _Ds4GenerationPlan(
+                max_new_tokens=1,
+                sampling_options=SamplingOptions(),
+                stop_strings=(),
+                use_sampling=False,
+            ),
+            0,
+        )
+    )
+    assert eos_from_step.is_eos is True
+
+    decoded_step = run(
+        worker._token_detail_step_from_generation_step(
+            SimpleNamespace(token_text=lambda token_id: b"decoded"),
+            SimpleNamespace(
+                token_id=7,
+                is_eos=False,
+                token_logprob=None,
+                top_logprobs=((7, -0.7),),
+            ),
+            _Ds4GenerationPlan(
+                max_new_tokens=1,
+                sampling_options=SamplingOptions(),
+                stop_strings=(),
+                use_sampling=False,
+            ),
+            1,
+        )
+    )
+    assert decoded_step.token_bytes == b"decoded"
+    assert decoded_step.token_detail is not None
+    assert decoded_step.token_detail.probability == pytest.approx(exp(-0.7))
+
     class SampleSession:
         def sample(self, options: object) -> int:
             assert isinstance(options, FakeNativeSamplingOptions)
@@ -4202,6 +4293,12 @@ def test_ds4_worker_logprob_probability_and_bytes_edge_helpers(
         Ds4Worker._require_logprob_support(
             SimpleNamespace(token_logprob=lambda token_id: 0.0),
             1,
+        )
+    with pytest.raises(Ds4LoadError, match="must be a boolean"):
+        Ds4Worker._require_logprob_support(
+            SimpleNamespace(token_logprob=lambda token_id: 0.0),
+            0,
+            SimpleNamespace(logprobs="yes"),
         )
 
     class AwaitableEosEngine:
@@ -4284,6 +4381,64 @@ def test_ds4_worker_logprob_probability_and_bytes_edge_helpers(
     assert Ds4Worker._bytes_value(memoryview(b"B"), "bytes") == b"B"
     with pytest.raises(Ds4GenerationError, match="must return bytes"):
         Ds4Worker._bytes_value("bad", "bytes")
+
+
+def test_ds4_worker_score_option_and_signature_edge_helpers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    worker = Ds4Worker(
+        _worker_options(_model_file(tmp_path)), 16, MagicMock(spec=Logger)
+    )
+    assert ds4_module._capability_bool(SimpleNamespace(), "missing") is None
+    plan = _Ds4GenerationPlan(
+        max_new_tokens=1,
+        sampling_options=SamplingOptions(),
+        stop_strings=(),
+        use_sampling=False,
+    )
+
+    worker._binding = _fake_binding(GenerationScoreOptions=None)
+    assert worker._generation_score_options(plan) is None
+
+    class BadTokenScoreMode:
+        def __new__(cls, value: str) -> "BadTokenScoreMode":
+            _ = value
+            raise ValueError("bad mode")
+
+    worker._binding = _fake_binding(TokenScoreMode=BadTokenScoreMode)
+    assert worker._generation_score_options(plan) is None
+
+    worker._binding = _fake_binding(TokenScoreMode=SimpleNamespace())
+    assert worker._generation_score_options(plan) is None
+
+    def bad_score_options(*, mode: object, top_k: int) -> object:
+        _ = mode, top_k
+        raise TypeError("bad score options")
+
+    worker._binding = _fake_binding(
+        GenerationScoreOptions=bad_score_options,
+        TokenScoreMode=SimpleNamespace(TOKEN_LOGPROB="token_logprob"),
+    )
+    assert worker._generation_score_options(plan) is None
+
+    def next_token() -> None:
+        pass
+
+    next_token.__signature__ = "bad"  # type: ignore[attr-defined]
+    assert (
+        Ds4Worker._method_supports_keyword(
+            SimpleNamespace(next_token=next_token), "next_token", "scores"
+        )
+        is True
+    )
+
+    monkeypatch.setattr(
+        ds4_module.importlib,
+        "import_module",
+        lambda _: SimpleNamespace(Ds4DiskKvCache=None),
+    )
+    with pytest.raises(Ds4LoadError, match="Ds4DiskKvCache"):
+        _Ds4DiskKvCache._cache_type()
 
 
 def test_ds4_worker_reset_session_warns_and_returns_create_error(

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -70,6 +70,10 @@ from avalan.tool.dsml import DsmlParseResult, DsmlPromptMessage
 from avalan.tool.manager import ToolManager
 from avalan.tool.math import MathToolSet
 
+_PYDS4_SKIP_REASON = (
+    "pyds4 is not installed; install the test group to run DS4 bridge tests."
+)
+
 
 class NativeBackend(StrEnum):
     METAL = "metal"
@@ -711,6 +715,11 @@ def _fake_capabilities(**overrides: object) -> SimpleNamespace:
 
 def _install_binding(monkeypatch: pytest.MonkeyPatch, binding: object) -> None:
     monkeypatch.setattr(availability, "import_module", lambda _: binding)
+
+
+@pytest.fixture
+def require_pyds4() -> None:
+    pytest.importorskip("pyds4", reason=_PYDS4_SKIP_REASON)
 
 
 def _model_file(tmp_path: Path) -> Path:
@@ -2199,7 +2208,7 @@ def test_ds4_generation_stream_returns_token_details_when_requested(
 def test_ds4_generation_stream_accepts_real_pyds4_score_types(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    pyds4 = pytest.importorskip("pyds4")
+    pyds4 = pytest.importorskip("pyds4", reason=_PYDS4_SKIP_REASON)
     fake_async_engine = _fake_async_engine_type(
         FakeNativeEngine, logprobs=True
     )
@@ -2513,7 +2522,9 @@ def test_ds4_missing_snapshot_capability_rebuilds_on_generation_failure(
 
 
 def test_ds4_disk_kv_cache_hit_restores_matching_token_prefix(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     _install_binding(
         monkeypatch,
@@ -2569,7 +2580,9 @@ def test_ds4_disk_kv_cache_hit_restores_matching_token_prefix(
 
 
 def test_ds4_disk_kv_cache_misses_for_different_prefix_or_context(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     _install_binding(
         monkeypatch,
@@ -2647,7 +2660,9 @@ def test_ds4_disk_kv_cache_misses_for_different_prefix_or_context(
 
 
 def test_ds4_disk_kv_cache_corrupt_payload_is_skipped(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     _install_binding(
         monkeypatch,
@@ -2700,7 +2715,9 @@ def test_ds4_disk_kv_cache_corrupt_payload_is_skipped(
 
 
 def test_ds4_disk_kv_cache_write_failure_falls_back_to_live_session(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     _install_binding(
         monkeypatch,
@@ -2782,7 +2799,9 @@ def test_ds4_disk_kv_cache_disabled_leaves_no_files(
 
 
 def test_ds4_missing_payload_capability_disables_disk_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     _install_binding(
         monkeypatch,
@@ -2839,6 +2858,7 @@ def test_ds4_missing_payload_capability_disables_disk_cache(
 
 def test_ds4_disk_kv_cache_budget_evicts_least_useful_entries(
     tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     logger = cast(Logger, MagicMock(spec=Logger))
     cache = _Ds4DiskKvCache(tmp_path / "kv", 150, logger, "namespace")
@@ -3834,6 +3854,7 @@ def test_ds4_generation_string_and_extra_validation(
 
 def test_ds4_disk_kv_cache_handles_payload_edge_cases(
     tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     logger = MagicMock(spec=Logger)
     cache = _Ds4DiskKvCache(tmp_path / "kv", 1024, logger, "namespace")
@@ -3869,7 +3890,9 @@ def test_ds4_disk_kv_cache_handles_payload_edge_cases(
 
 
 def test_ds4_disk_kv_cache_delegated_metadata_edges(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     logger = MagicMock(spec=Logger)
     cache = _Ds4DiskKvCache(tmp_path / "kv", 1024, logger, "namespace")
@@ -3894,6 +3917,7 @@ def test_ds4_disk_kv_cache_delegated_metadata_edges(
 
 def test_ds4_disk_kv_cache_skips_invalid_metadata_entries(
     tmp_path: Path,
+    require_pyds4: None,
 ) -> None:
     logger = MagicMock(spec=Logger)
     cache_dir = tmp_path / "kv"

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -3,7 +3,7 @@ import json
 import os
 import threading
 from asyncio import run
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import StrEnum
@@ -119,6 +119,65 @@ class FakeNativeSamplingOptions:
 class FakeNativeGenerationScoreOptions:
     mode: NativeTokenScoreMode = NativeTokenScoreMode.NONE
     top_k: int = 0
+
+
+class FakeStopStringBuffer:
+    def __init__(self, stop_strings: Iterable[str] | str = ()) -> None:
+        if isinstance(stop_strings, str):
+            normalized = (stop_strings,)
+        else:
+            normalized = tuple(stop_strings)
+        if any(not isinstance(item, str) or not item for item in normalized):
+            raise ValueError("stop_strings must be non-empty strings")
+        self._stop_strings = normalized
+        self._pending = ""
+        self._stopped = False
+        self._keep = (
+            max(len(stop_string) for stop_string in normalized) - 1
+            if normalized
+            else 0
+        )
+
+    @property
+    def stopped(self) -> bool:
+        return self._stopped
+
+    def push(self, text: str) -> tuple[str, ...]:
+        if self._stopped:
+            return ()
+        if not self._stop_strings:
+            return (text,) if text else ()
+
+        self._pending += text
+        stop_index = self._stop_index()
+        if stop_index is not None:
+            chunk = self._pending[:stop_index]
+            self._pending = ""
+            self._stopped = True
+            return (chunk,) if chunk else ()
+
+        emit_length = len(self._pending) - self._keep
+        if emit_length <= 0:
+            return ()
+        chunk = self._pending[:emit_length]
+        self._pending = self._pending[emit_length:]
+        return (chunk,) if chunk else ()
+
+    def flush(self) -> tuple[str, ...]:
+        if self._pending and not self._stopped:
+            chunk = self._pending
+            self._pending = ""
+            return (chunk,)
+        self._pending = ""
+        return ()
+
+    def _stop_index(self) -> int | None:
+        first_index: int | None = None
+        for stop_string in self._stop_strings:
+            index = self._pending.find(stop_string)
+            if index >= 0 and (first_index is None or index < first_index):
+                first_index = index
+        return first_index
 
 
 class FakeNativeSession:
@@ -618,6 +677,7 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
         "EngineOptions": FakeNativeOptions,
         "GenerationScoreOptions": FakeNativeGenerationScoreOptions,
         "SamplingOptions": FakeNativeSamplingOptions,
+        "StopStringBuffer": FakeStopStringBuffer,
         "ThinkMode": NativeThinkMode,
         "TokenScoreMode": NativeTokenScoreMode,
         "capabilities": lambda: _fake_capabilities(),
@@ -1497,6 +1557,31 @@ def test_ds4_stop_string_spanning_token_boundaries_is_detected(
 
     assert run(response.to_str()) == "hello "
     assert fake.sessions[0].eval_calls == [101, 102]
+    model.close()
+
+
+def test_ds4_generation_requires_pyds4_stop_string_buffer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install_binding(monkeypatch, _fake_binding(StopStringBuffer=None))
+    model = Ds4Model(str(_model_file(tmp_path)))
+    fake = _latest_fake_engine()
+    fake.argmax_script = [101]
+    fake.token_text_map = {101: b"A"}
+
+    with pytest.raises(Ds4LoadError, match="StopStringBuffer"):
+        response = run(
+            model(
+                "hello",
+                settings=GenerationSettings(
+                    max_new_tokens=1,
+                    temperature=0.0,
+                    use_async_generator=False,
+                ),
+            )
+        )
+        run(response.to_str())
+
     model.close()
 
 

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -2548,7 +2548,7 @@ def test_ds4_disk_kv_cache_corrupt_payload_is_skipped(
 
     assert run(response.to_str()) == "<102>"
     assert fake.session_sync_calls == [(30, 0, 5, 20), (30, 0, 5, 20)]
-    assert fake.sessions[0].load_payload_calls == 1
+    assert fake.sessions[0].load_payload_calls == 0
     model.close()
 
 
@@ -2694,7 +2694,7 @@ def test_ds4_disk_kv_cache_budget_evicts_least_useful_entries(
     tmp_path: Path,
 ) -> None:
     logger = cast(Logger, MagicMock(spec=Logger))
-    cache = _Ds4DiskKvCache(tmp_path / "kv", 700, logger, "namespace")
+    cache = _Ds4DiskKvCache(tmp_path / "kv", 150, logger, "namespace")
     session = SimpleNamespace(save_payload=lambda: b"x" * 100)
 
     run(cache.store(session, [1], 16))
@@ -3704,82 +3704,45 @@ def test_ds4_disk_kv_cache_handles_payload_edge_cases(
     cache_dir = tmp_path / "kv"
     cache_dir.mkdir()
     entry = cache._entry_path([1], 16)
-    entry.metadata_path.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "key": entry.key,
-                "namespace": "namespace",
-                "ctx_size": 32,
-                "token_sha256": entry.token_digest,
-                "payload_file": entry.payload_path.name,
-            }
-        ),
-        encoding="utf-8",
-    )
+    metadata = cache._cache.metadata_for([1], 16, payload_size=99)
+    cache._cache.write_metadata(metadata)
     entry.payload_path.write_bytes(b"payload")
     session = SimpleNamespace(load_payload=lambda payload: None)
 
     assert run(cache.restore(session, [1], 16)) is False
-    assert not entry.metadata_path.exists()
-    assert not entry.payload_path.exists()
+    assert entry.metadata_path.exists()
+    assert entry.payload_path.exists()
 
     entry = cache._entry_path([2], 16)
-    entry.metadata_path.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "key": entry.key,
-                "namespace": "namespace",
-                "ctx_size": 16,
-                "token_sha256": entry.token_digest,
-                "payload_file": entry.payload_path.name,
-            }
-        ),
-        encoding="utf-8",
-    )
+    metadata = cache._cache.metadata_for([2], 16, payload_size=0)
+    cache._cache.write_metadata(metadata)
     entry.payload_path.mkdir()
 
     assert run(cache.restore(session, [2], 16)) is False
 
 
-def test_ds4_disk_kv_cache_metadata_edges(
+def test_ds4_disk_kv_cache_delegated_metadata_edges(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     logger = MagicMock(spec=Logger)
     cache = _Ds4DiskKvCache(tmp_path / "kv", 1024, logger, "namespace")
     entry = cache._entry_path([1], 16)
-    entry.metadata_path.parent.mkdir(parents=True)
+    cache._cache.store(
+        SimpleNamespace(save_payload=lambda: b"payload"),
+        [1],
+        16,
+    )
 
     def fail_write_text(self: Path, text: str, encoding: str) -> int:
         _ = self, text, encoding
         raise OSError("metadata write failed")
 
     monkeypatch.setattr(Path, "write_text", fail_write_text)
-    cache._record_hit({"hit_count": "bad"}, entry)
+    session = SimpleNamespace(load_payload=lambda payload: None)
+    assert run(cache.restore(session, [1], 16)) is True
     logger.warning.assert_called()
 
-    def fail_glob(self: Path, pattern: str) -> tuple[Path, ...]:
-        _ = self, pattern
-        raise OSError("glob failed")
-
-    monkeypatch.setattr(Path, "glob", fail_glob)
-    assert cache._cache_entries() == []
-
-    def fail_stat(self: Path) -> object:
-        _ = self
-        raise OSError("stat failed")
-
-    monkeypatch.setattr(Path, "stat", fail_stat)
-    assert cache._path_size(entry.metadata_path) == 0
-
-    def fail_unlink(self: Path, missing_ok: bool = False) -> None:
-        _ = self, missing_ok
-        raise OSError("unlink failed")
-
-    monkeypatch.setattr(Path, "unlink", fail_unlink)
-    cache._delete_entry(entry)
-    assert logger.warning.call_count >= 3
+    assert entry.payload_path.exists()
 
 
 def test_ds4_disk_kv_cache_skips_invalid_metadata_entries(
@@ -3795,7 +3758,7 @@ def test_ds4_disk_kv_cache_skips_invalid_metadata_entries(
     )
     cache = _Ds4DiskKvCache(cache_dir, 1024, logger, "namespace")
 
-    assert cache._cache_entries() == []
+    assert cache._cache.evict(0) == ()
 
 
 def test_ds4_worker_dsml_replay_no_match_and_eviction_edges(

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -610,8 +610,6 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
         type[Any], overrides.get("Engine", FakeNativeEngine)
     )
     values: dict[str, object] = {
-        "__ds4_commit__": DS4_API_COMMIT,
-        "__ds4_symbols__": DS4_REQUIRED_C_SYMBOLS,
         "AsyncEngine": overrides.get(
             "AsyncEngine", _fake_async_engine_type(native_engine_type)
         ),
@@ -622,6 +620,7 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
         "SamplingOptions": FakeNativeSamplingOptions,
         "ThinkMode": NativeThinkMode,
         "TokenScoreMode": NativeTokenScoreMode,
+        "capabilities": lambda: _fake_capabilities(),
         "is_backend_available": (
             lambda backend: backend in {"metal", "cuda", "cpu"}
         ),
@@ -637,14 +636,14 @@ def _fake_capabilities(**overrides: object) -> SimpleNamespace:
         "backend": "metal",
         "ds4_api_version": DS4_API_VERSION,
         "ds4_commit": DS4_API_COMMIT,
-        "logprobs": False,
+        "logprobs": True,
         "mtp": True,
-        "payloads": False,
+        "payloads": True,
         "progress": True,
         "required_symbols": DS4_REQUIRED_C_SYMBOLS,
-        "snapshots": False,
+        "snapshots": True,
         "speculative_eval": False,
-        "top_logprobs": False,
+        "top_logprobs": True,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -2188,7 +2187,15 @@ def test_ds4_token_details_reject_invalid_top_k(
 def test_ds4_token_details_require_native_logprob_support(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    _install_binding(monkeypatch, _fake_binding())
+    _install_binding(
+        monkeypatch,
+        _fake_binding(
+            capabilities=lambda: _fake_capabilities(
+                logprobs=False,
+                top_logprobs=False,
+            ),
+        ),
+    )
     model = Ds4Model(str(_model_file(tmp_path)))
     fake = _latest_fake_engine()
     fake.argmax_script = [101]

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -83,6 +83,13 @@ class NativeThinkMode(StrEnum):
     MAX = "max"
 
 
+class NativeTokenScoreMode(StrEnum):
+    NONE = "none"
+    TOKEN_LOGPROB = "token_logprob"
+    TOP_LOGPROBS = "top_logprobs"
+    TOKEN_LOGPROB_AND_TOP_LOGPROBS = "token_logprob_and_top_logprobs"
+
+
 @dataclass(frozen=True, slots=True)
 class FakeNativeOptions:
     model_path: str
@@ -108,6 +115,12 @@ class FakeNativeSamplingOptions:
     seed: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class FakeNativeGenerationScoreOptions:
+    mode: NativeTokenScoreMode = NativeTokenScoreMode.NONE
+    top_k: int = 0
+
+
 class FakeNativeSession:
     def __init__(self, engine: "FakeNativeEngine", ctx_size: int) -> None:
         self.argmax_calls = 0
@@ -124,6 +137,9 @@ class FakeNativeSession:
         self.sample_options: list[FakeNativeSamplingOptions] = []
         self.save_payload_calls = 0
         self.save_snapshot_calls = 0
+        self.next_token_score_options: list[
+            FakeNativeGenerationScoreOptions | None
+        ] = []
         self.token_logprob_calls: list[int] = []
         self.tokens: list[int] = []
         self.top_logprobs_calls: list[int] = []
@@ -375,6 +391,7 @@ def _fake_async_engine_type(
             decode: bool = False,
             stop_on_eos: bool = True,
             exclude_token_id: int | None = None,
+            scores: FakeNativeGenerationScoreOptions | None = None,
         ) -> SimpleNamespace:
             def step() -> SimpleNamespace:
                 if options is not None and exclude_token_id is not None:
@@ -391,6 +408,23 @@ def _fake_async_engine_type(
 
                 is_eos = token_id == self._owner._native.eos_token_id
                 should_advance = advance and not (stop_on_eos and is_eos)
+                score_options = scores or FakeNativeGenerationScoreOptions()
+                top_logprobs: tuple[tuple[int, float], ...] = ()
+                token_logprob: float | None = None
+                self._native.next_token_score_options.append(scores)
+                if not (stop_on_eos and is_eos):
+                    if score_options.mode in {
+                        NativeTokenScoreMode.TOP_LOGPROBS,
+                        NativeTokenScoreMode.TOKEN_LOGPROB_AND_TOP_LOGPROBS,
+                    }:
+                        top_logprobs = tuple(
+                            self._native.top_logprobs(score_options.top_k)
+                        )
+                    if score_options.mode in {
+                        NativeTokenScoreMode.TOKEN_LOGPROB,
+                        NativeTokenScoreMode.TOKEN_LOGPROB_AND_TOP_LOGPROBS,
+                    }:
+                        token_logprob = self._native.token_logprob(token_id)
                 if should_advance:
                     try:
                         self._native.eval(token_id)
@@ -408,6 +442,8 @@ def _fake_async_engine_type(
                     is_eos=is_eos,
                     advanced=should_advance,
                     token_bytes=token_bytes,
+                    token_logprob=token_logprob,
+                    top_logprobs=top_logprobs,
                 )
 
             return cast(SimpleNamespace, await self._owner._call(step))
@@ -582,8 +618,10 @@ def _fake_binding(**overrides: object) -> SimpleNamespace:
         "Backend": NativeBackend,
         "Engine": native_engine_type,
         "EngineOptions": FakeNativeOptions,
+        "GenerationScoreOptions": FakeNativeGenerationScoreOptions,
         "SamplingOptions": FakeNativeSamplingOptions,
         "ThinkMode": NativeThinkMode,
+        "TokenScoreMode": NativeTokenScoreMode,
         "is_backend_available": (
             lambda backend: backend in {"metal", "cuda", "cpu"}
         ),
@@ -2062,6 +2100,12 @@ def test_ds4_generation_stream_returns_token_details_when_requested(
     assert detail.tokens == [
         Token(id=101, token="A", probability=exp(-0.1)),
         Token(id=102, token="B", probability=exp(-1.5)),
+    ]
+    assert fake.sessions[0].next_token_score_options == [
+        FakeNativeGenerationScoreOptions(
+            mode=NativeTokenScoreMode.TOKEN_LOGPROB_AND_TOP_LOGPROBS,
+            top_k=2,
+        )
     ]
     assert fake.sessions[0].top_logprobs_calls == [2]
     assert fake.sessions[0].token_logprob_calls == [101]

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -2112,6 +2112,61 @@ def test_ds4_generation_stream_returns_token_details_when_requested(
     assert fake.sessions[0].eval_calls == [101]
 
 
+def test_ds4_generation_stream_accepts_real_pyds4_score_types(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pyds4 = pytest.importorskip("pyds4")
+    fake_async_engine = _fake_async_engine_type(
+        FakeNativeEngine, logprobs=True
+    )
+    monkeypatch.setattr(pyds4, "AsyncEngine", fake_async_engine)
+    FakeNativeEngine.instances.clear()
+
+    async def run_case() -> tuple[list[object], FakeNativeEngine]:
+        model = Ds4Model(str(_model_file(tmp_path)))
+        fake = _latest_fake_engine()
+        fake.argmax_script = [101]
+        fake.token_logprobs = {101: -0.25}
+        fake.token_text_map = {101: b"A", 102: b"B"}
+        fake.top_logprobs = [
+            pyds4.TokenScore(token_id=101, logprob=-0.25),
+            pyds4.TokenScore(token_id=102, logprob=-1.25),
+        ]
+        response = await model(
+            "hello",
+            settings=GenerationSettings(
+                max_new_tokens=1,
+                temperature=0.0,
+                use_async_generator=True,
+            ),
+            manual_sampling=True,
+            pick=2,
+        )
+        chunks: list[object] = [chunk async for chunk in response]
+        model.close()
+        return chunks, fake
+
+    chunks, fake = run(run_case())
+
+    assert len(chunks) == 1
+    detail = chunks[0]
+    assert isinstance(detail, TokenDetail)
+    assert detail.id == 101
+    assert detail.token == "A"
+    assert detail.probability == pytest.approx(exp(-0.25))
+    assert detail.tokens == [
+        Token(id=101, token="A", probability=exp(-0.25)),
+        Token(id=102, token="B", probability=exp(-1.25)),
+    ]
+    score_options = fake.sessions[0].next_token_score_options
+    assert len(score_options) == 1
+    assert isinstance(score_options[0], pyds4.GenerationScoreOptions)
+    assert score_options[0].mode is (
+        pyds4.TokenScoreMode.TOKEN_LOGPROB_AND_TOP_LOGPROBS
+    )
+    assert score_options[0].top_k == 2
+
+
 def test_ds4_token_details_reject_invalid_top_k(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/model/ds4_model_test.py
+++ b/tests/model/ds4_model_test.py
@@ -722,6 +722,27 @@ def require_pyds4() -> None:
     pytest.importorskip("pyds4", reason=_PYDS4_SKIP_REASON)
 
 
+def _available_pyds4_backend(pyds4: object) -> str:
+    capabilities = getattr(pyds4, "capabilities")()
+    available_backends = getattr(capabilities, "available_backends", ())
+    available = {
+        str(getattr(backend, "value", backend))
+        for backend in available_backends
+    }
+    for backend in ("metal", "cuda", "cpu"):
+        if backend in available:
+            return backend
+    pytest.skip("pyds4 does not report an available DS4 backend.")
+
+
+def test_available_pyds4_backend_accepts_cpu_only_binding() -> None:
+    pyds4 = SimpleNamespace(
+        capabilities=lambda: SimpleNamespace(available_backends=("cpu",))
+    )
+
+    assert _available_pyds4_backend(pyds4) == "cpu"
+
+
 def _model_file(tmp_path: Path) -> Path:
     model_path = tmp_path / "ds4flash.gguf"
     model_path.write_bytes(b"gguf")
@@ -2216,7 +2237,14 @@ def test_ds4_generation_stream_accepts_real_pyds4_score_types(
     FakeNativeEngine.instances.clear()
 
     async def run_case() -> tuple[list[object], FakeNativeEngine]:
-        model = Ds4Model(str(_model_file(tmp_path)))
+        model = Ds4Model(
+            str(_model_file(tmp_path)),
+            TransformerEngineSettings(
+                backend_config={
+                    "native_backend": _available_pyds4_backend(pyds4)
+                }
+            ),
+        )
         fake = _latest_fake_engine()
         fake.argmax_script = [101]
         fake.token_logprobs = {101: -0.25}

--- a/tests/model/transformer_extra_test.py
+++ b/tests/model/transformer_extra_test.py
@@ -1,9 +1,9 @@
 from logging import Logger
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from avalan.entities import TransformerEngineSettings
-from avalan.model.transformer import TransformerModel
+from avalan.model.transformer import AutoTokenizer, TransformerModel
 
 
 class DummyTransformerModel(TransformerModel):
@@ -31,3 +31,22 @@ class TransformerModelPropertyTestCase(TestCase):
         self.assertTrue(model.uses_tokenizer)
         with self.assertRaises(NotImplementedError):
             model._tokenize_input("in")
+
+    def test_load_tokenizer_disables_tokenization_cleanup(self) -> None:
+        tokenizer = MagicMock()
+        tokenizer.clean_up_tokenization_spaces = True
+        model = DummyTransformerModel(
+            "id",
+            TransformerEngineSettings(
+                auto_load_model=False, auto_load_tokenizer=False
+            ),
+            logger=MagicMock(spec=Logger),
+        )
+
+        with patch.object(
+            AutoTokenizer, "from_pretrained", return_value=tokenizer
+        ):
+            loaded_tokenizer = model._load_tokenizer_with_tokens("tok")
+
+        self.assertIs(loaded_tokenizer, tokenizer)
+        self.assertFalse(tokenizer.clean_up_tokenization_spaces)

--- a/tests/project_metadata_test.py
+++ b/tests/project_metadata_test.py
@@ -62,7 +62,7 @@ def test_ds4_extra_declares_platform_scoped_pyds4_dependency() -> None:
         canonicalize_name(requirement.name) for requirement in requirements
     } == {"pyds4"}
     assert all(
-        requirement.specifier == SpecifierSet(">=1.0.0,<2.0.0")
+        requirement.specifier == SpecifierSet(">=1.0.1,<2.0.0")
         for requirement in requirements
     )
     assert all(requirement.url is None for requirement in requirements)
@@ -113,7 +113,7 @@ def test_test_group_installs_pyds4_for_ds4_bridge_tests() -> None:
     dependency = _test_group_dependencies()["pyds4"]
 
     assert isinstance(dependency, dict)
-    assert dependency["version"] == ">=1.0.0,<2.0.0"
+    assert dependency["version"] == ">=1.0.1,<2.0.0"
     assert "markers" in dependency
     marker = Marker(str(dependency["markers"]))
     assert marker.evaluate(

--- a/tests/project_metadata_test.py
+++ b/tests/project_metadata_test.py
@@ -1,15 +1,25 @@
 import tomllib
 from pathlib import Path
 
+from packaging.markers import Marker
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 
 
-def _optional_dependencies() -> dict[str, list[str]]:
+def _pyproject() -> dict[str, object]:
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+
+def _optional_dependencies() -> dict[str, list[str]]:
+    data = _pyproject()
     return data["project"]["optional-dependencies"]
+
+
+def _test_group_dependencies() -> dict[str, object]:
+    data = _pyproject()
+    return data["tool"]["poetry"]["group"]["test"]["dependencies"]
 
 
 def test_vendors_extra_includes_bedrock_runtime_dependencies() -> None:
@@ -52,12 +62,10 @@ def test_ds4_extra_declares_platform_scoped_pyds4_dependency() -> None:
         canonicalize_name(requirement.name) for requirement in requirements
     } == {"pyds4"}
     assert all(
-        requirement.specifier == SpecifierSet() for requirement in requirements
-    )
-    assert all(
-        requirement.url == "git+https://github.com/avalan-ai/pyds4.git@main"
+        requirement.specifier == SpecifierSet(">=1.0.0,<2.0.0")
         for requirement in requirements
     )
+    assert all(requirement.url is None for requirement in requirements)
     assert all(requirement.marker is not None for requirement in requirements)
     assert any(
         requirement.marker is not None
@@ -101,9 +109,41 @@ def test_ds4_extra_declares_platform_scoped_pyds4_dependency() -> None:
     )
 
 
+def test_test_group_installs_pyds4_for_ds4_bridge_tests() -> None:
+    dependency = _test_group_dependencies()["pyds4"]
+
+    assert isinstance(dependency, dict)
+    assert dependency["version"] == ">=1.0.0,<2.0.0"
+    assert "markers" in dependency
+    marker = Marker(str(dependency["markers"]))
+    assert marker.evaluate(
+        {
+            "platform_system": "Linux",
+            "platform_machine": "x86_64",
+        }
+    )
+    assert marker.evaluate(
+        {
+            "platform_system": "Darwin",
+            "platform_machine": "arm64",
+        }
+    )
+    assert not marker.evaluate(
+        {
+            "platform_system": "Darwin",
+            "platform_machine": "x86_64",
+        }
+    )
+    assert not marker.evaluate(
+        {
+            "platform_system": "Windows",
+            "platform_machine": "AMD64",
+        }
+    )
+
+
 def test_core_dependencies_omit_optional_ds4_binding() -> None:
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    data = _pyproject()
     dependencies = {
         canonicalize_name(Requirement(requirement).name)
         for requirement in data["project"]["dependencies"]

--- a/tests/project_metadata_test.py
+++ b/tests/project_metadata_test.py
@@ -62,7 +62,7 @@ def test_ds4_extra_declares_platform_scoped_pyds4_dependency() -> None:
         canonicalize_name(requirement.name) for requirement in requirements
     } == {"pyds4"}
     assert all(
-        requirement.specifier == SpecifierSet(">=1.0.1,<2.0.0")
+        requirement.specifier == SpecifierSet(">=1.0.2,<2.0.0")
         for requirement in requirements
     )
     assert all(requirement.url is None for requirement in requirements)
@@ -113,7 +113,7 @@ def test_test_group_installs_pyds4_for_ds4_bridge_tests() -> None:
     dependency = _test_group_dependencies()["pyds4"]
 
     assert isinstance(dependency, dict)
-    assert dependency["version"] == ">=1.0.1,<2.0.0"
+    assert dependency["version"] == ">=1.0.2,<2.0.0"
     assert "markers" in dependency
     marker = Marker(str(dependency["markers"]))
     assert marker.evaluate(

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -136,6 +136,51 @@ class DsmlToolsTestCase(TestCase):
         self.assertIsNone(DsmlTools.render_tool_schemas([]))
         self.assertEqual(DsmlTools.render_tool_calls(()), "")
 
+    def test_render_tool_result_escapes_content(self):
+        self.assertEqual(
+            DsmlTools.render_tool_result("value <4> & done"),
+            "<tool_result>value &lt;4&gt; &amp; done</tool_result>",
+        )
+
+    def test_split_reasoning_returns_visible_content(self):
+        self.assertEqual(
+            DsmlTools.split_reasoning("<think>hidden</think>visible"),
+            ("visible", "hidden"),
+        )
+
+    def test_tools_prompt_rejects_empty_schema_text(self):
+        with self.assertRaises(ValueError):
+            DsmlTools.tools_prompt("")
+
+    def test_tools_prompt_rejects_none_from_dsml_module(self):
+        fake_dsml = type(
+            "FakeDsml",
+            (),
+            {"tools_prompt": staticmethod(lambda _: None)},
+        )()
+
+        with patch.object(DsmlTools, "_pyds4_dsml", return_value=fake_dsml):
+            with self.assertRaises(ValueError):
+                DsmlTools.tools_prompt("schema")
+
+    def test_tools_prompt_returns_rendered_prompt(self):
+        fake_dsml = type(
+            "FakeDsml",
+            (),
+            {"tools_prompt": staticmethod(lambda _: "prompt")},
+        )()
+
+        with patch.object(DsmlTools, "_pyds4_dsml", return_value=fake_dsml):
+            self.assertEqual(DsmlTools.tools_prompt("schema"), "prompt")
+
+    def test_missing_pyds4_module_raises_runtime_error(self):
+        with patch(
+            "avalan.tool.dsml.import_module",
+            side_effect=ModuleNotFoundError("pyds4"),
+        ):
+            with self.assertRaises(RuntimeError):
+                DsmlTools.render_tool_result("content")
+
     def test_render_prompt_with_thinking_handles_intermediate_assistant(self):
         rendered = DsmlTools.render_prompt(
             None,
@@ -227,6 +272,24 @@ class DsmlToolsTestCase(TestCase):
         self.assertIsNone(
             DsmlTools.parse_generated_message("<｜DSML｜tool_calls>")
         )
+
+    def test_parse_tool_calls_returns_none_without_calls(self):
+        self.assertIsNone(DsmlTools.parse_tool_calls("visible content"))
+
+    def test_to_tool_call_defaults_non_dict_arguments(self):
+        call_id = _uuid4()
+        native_call = type(
+            "NativeCall",
+            (),
+            {"name": "math.calculator", "arguments": "bad"},
+        )()
+
+        with patch("avalan.tool.dsml.uuid4", return_value=call_id):
+            call = DsmlTools._to_tool_call(native_call)
+
+        self.assertEqual(call.id, f"ds4_tool_{call_id.hex}")
+        self.assertEqual(call.name, "math.calculator")
+        self.assertEqual(call.arguments, {})
 
     def test_tool_call_start_suffix_length_tracks_marker_variants(self):
         self.assertEqual(
@@ -386,6 +449,17 @@ class ToolCallParserDsmlTestCase(TestCase):
                 parser.message_tool_calls("mentions tool_calls only"),
                 [],
             )
+
+    def test_message_tool_calls_reraises_missing_pyds4_for_dsml_format(self):
+        parser = ToolCallParser(tool_format=ToolFormat.DSML)
+
+        with patch.object(
+            DsmlTools,
+            "tool_call_start_span",
+            side_effect=RuntimeError("pyds4 missing"),
+        ):
+            with self.assertRaises(RuntimeError):
+                parser.message_tool_calls("mentions tool_calls only")
 
     def test_dsml_tool_call_status_reports_prefix_open_and_closed(self):
         parser = ToolCallParser(tool_format=ToolFormat.DSML)

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -5,10 +5,17 @@ from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
 
+import pytest
+
 from avalan.backends.ds4_native import ThinkMode
 from avalan.entities import MessageRole, MessageToolCall, ToolCall, ToolFormat
 from avalan.tool.dsml import DsmlPromptMessage, DsmlTools
 from avalan.tool.parser import ToolCallParser
+
+pytest.importorskip(
+    "pyds4",
+    reason="pyds4 is not installed; install the test group to run DS4 tests.",
+)
 
 
 class DsmlToolsTestCase(TestCase):

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+from pathlib import Path
 from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
@@ -9,6 +12,29 @@ from avalan.tool.parser import ToolCallParser
 
 
 class DsmlToolsTestCase(TestCase):
+    def test_importing_dsml_module_does_not_import_pyds4(self):
+        env = {
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src"),
+        }
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "import avalan.tool.dsml as dsml; "
+                    "print(hasattr(dsml, 'DsmlTools')); "
+                    "print('pyds4' in sys.modules)"
+                ),
+            ],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.stdout.splitlines(), ["True", "False"])
+
     def test_render_tool_schemas_uses_function_payload(self):
         schemas = [
             {
@@ -195,16 +221,10 @@ class DsmlToolsTestCase(TestCase):
             DsmlTools.parse_generated_message("<｜DSML｜tool_calls>")
         )
 
-    def test_parse_generated_message_handles_unclosed_invoke_and_invalid_json(
+    def test_parse_generated_message_rejects_malformed_dsml(
         self,
     ):
         malformed = '<tool_calls><invoke name="broken"></tool_calls>'
-        parsed = DsmlTools.parse_generated_message(malformed)
-
-        self.assertIsNotNone(parsed)
-        assert parsed is not None
-        self.assertEqual(parsed.calls, ())
-
         invalid_json = (
             "<tool_calls>"
             '<invoke name="math.calculator">'
@@ -212,16 +232,15 @@ class DsmlToolsTestCase(TestCase):
             "</invoke>"
             "</tool_calls>"
         )
-        parsed = DsmlTools.parse_generated_message(invalid_json)
 
-        self.assertIsNotNone(parsed)
-        assert parsed is not None
-        self.assertEqual(parsed.calls[0].arguments, {"value": None})
+        self.assertIsNone(DsmlTools.parse_generated_message(malformed))
+        self.assertIsNone(DsmlTools.parse_generated_message(invalid_json))
 
-    def test_parameter_end_after_returns_original_index_for_unknown_marker(
+    def test_stream_argument_deltas_rejects_invalid_offsets(
         self,
     ):
-        self.assertEqual(DsmlTools._parameter_end_after("abc", 1), 1)
+        with self.assertRaises(ValueError):
+            DsmlTools.stream_argument_deltas("", -1)
 
     def test_stream_argument_deltas_omits_dsml_tags(self):
         raw = (

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -221,6 +221,32 @@ class DsmlToolsTestCase(TestCase):
             DsmlTools.parse_generated_message("<｜DSML｜tool_calls>")
         )
 
+    def test_tool_call_start_suffix_length_tracks_marker_variants(self):
+        self.assertEqual(
+            DsmlTools.tool_call_start_suffix_length(
+                "visible\n\n<｜DSML｜tool"
+            ),
+            len("\n\n<｜DSML｜tool"),
+        )
+        self.assertEqual(
+            DsmlTools.tool_call_start_suffix_length("visible\n<DSML｜tool"),
+            len("\n<DSML｜tool"),
+        )
+        self.assertEqual(
+            DsmlTools.tool_call_start_suffix_length("visible<tool_calls>"),
+            len("<tool_calls>"),
+        )
+        self.assertEqual(
+            DsmlTools.tool_call_start_suffix_length("visible only"),
+            0,
+        )
+
+    def test_tool_call_start_suffix_length_rejects_invalid_text(self):
+        with self.assertRaises(TypeError):
+            DsmlTools.tool_call_start_suffix_length(  # type: ignore[arg-type]
+                object()
+            )
+
     def test_parse_generated_message_rejects_malformed_dsml(
         self,
     ):

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -440,6 +440,24 @@ class ToolCallParserDsmlTestCase(TestCase):
     def test_message_tool_calls_ignores_missing_pyds4_auto_probe(self):
         parser = ToolCallParser()
 
+        with patch(
+            "avalan.tool.dsml.import_module",
+            side_effect=ModuleNotFoundError("pyds4"),
+        ):
+            self.assertEqual(
+                parser.message_tool_calls(
+                    "<tool_calls>"
+                    '<invoke name="math.calculator">'
+                    '<parameter name="expression">2 + 2</parameter>'
+                    "</invoke>"
+                    "</tool_calls>"
+                ),
+                [],
+            )
+
+    def test_message_tool_calls_ignores_dsml_probe_runtime_error(self):
+        parser = ToolCallParser()
+
         with patch.object(
             DsmlTools,
             "tool_call_start_span",
@@ -449,6 +467,20 @@ class ToolCallParserDsmlTestCase(TestCase):
                 parser.message_tool_calls("mentions tool_calls only"),
                 [],
             )
+
+    def test_message_tool_calls_detects_dsml_when_pyds4_available(self):
+        parser = ToolCallParser()
+
+        calls = parser.message_tool_calls(
+            "<tool_calls>"
+            '<invoke name="math.calculator">'
+            '<parameter name="expression">2 + 2</parameter>'
+            "</invoke>"
+            "</tool_calls>"
+        )
+
+        self.assertEqual(calls[0]["name"], "math.calculator")
+        self.assertEqual(calls[0]["arguments"], {"expression": "2 + 2"})
 
     def test_message_tool_calls_reraises_missing_pyds4_for_dsml_format(self):
         parser = ToolCallParser(tool_format=ToolFormat.DSML)

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -329,23 +329,86 @@ class ToolCallParserDsmlTestCase(TestCase):
             "math.calculator",
         )
 
+    def test_message_tool_calls_uses_dsml_start_helper(self):
+        parser = ToolCallParser()
+        text = "generated tool_calls message"
+        call = ToolCall(
+            id="call_1",
+            name="math.calculator",
+            arguments={"expression": "2 + 2"},
+        )
+
+        with (
+            patch.object(
+                DsmlTools,
+                "tool_call_start_span",
+                return_value=(0, len(text)),
+            ) as start_span,
+            patch.object(
+                DsmlTools,
+                "parse_tool_calls",
+                return_value=[call],
+            ) as parse_tool_calls,
+        ):
+            calls = parser.message_tool_calls(text)
+
+        start_span.assert_called_once_with(text)
+        parse_tool_calls.assert_called_once_with(text)
+        self.assertEqual(calls[0]["name"], "math.calculator")
+        self.assertEqual(calls[0]["arguments"], {"expression": "2 + 2"})
+
+    def test_message_tool_calls_skips_dsml_helper_for_plain_text(self):
+        parser = ToolCallParser()
+
+        with patch.object(
+            DsmlTools,
+            "tool_call_start_span",
+            side_effect=AssertionError("unexpected DSML import"),
+        ):
+            self.assertEqual(parser.message_tool_calls("plain text"), [])
+
+    def test_message_tool_calls_ignores_missing_pyds4_auto_probe(self):
+        parser = ToolCallParser()
+
+        with patch.object(
+            DsmlTools,
+            "tool_call_start_span",
+            side_effect=RuntimeError("pyds4 missing"),
+        ):
+            self.assertEqual(
+                parser.message_tool_calls("mentions tool_calls only"),
+                [],
+            )
+
     def test_dsml_tool_call_status_reports_prefix_open_and_closed(self):
         parser = ToolCallParser(tool_format=ToolFormat.DSML)
 
-        self.assertIs(
-            parser.tool_call_status("<｜DSM"),
-            ToolCallParser.ToolCallBufferStatus.PREFIX,
-        )
-        self.assertIs(
-            parser.tool_call_status("<｜DSML｜tool_calls>"),
-            ToolCallParser.ToolCallBufferStatus.OPEN,
-        )
-        self.assertIs(
-            parser.tool_call_status(
-                "<｜DSML｜tool_calls></｜DSML｜tool_calls>"
+        cases = (
+            ("plain text", ToolCallParser.ToolCallBufferStatus.NONE),
+            ("<｜DSM", ToolCallParser.ToolCallBufferStatus.PREFIX),
+            (
+                "<｜DSML｜tool_calls>",
+                ToolCallParser.ToolCallBufferStatus.OPEN,
             ),
-            ToolCallParser.ToolCallBufferStatus.CLOSED,
+            (
+                "<｜DSML｜tool_calls></｜DSML｜tool_calls>",
+                ToolCallParser.ToolCallBufferStatus.CLOSED,
+            ),
+            ("<DSML｜tool_calls>", ToolCallParser.ToolCallBufferStatus.OPEN),
+            (
+                "<DSML｜tool_calls></DSML｜tool_calls>",
+                ToolCallParser.ToolCallBufferStatus.CLOSED,
+            ),
+            ("<tool_calls>", ToolCallParser.ToolCallBufferStatus.OPEN),
+            (
+                "<tool_calls></tool_calls>",
+                ToolCallParser.ToolCallBufferStatus.CLOSED,
+            ),
         )
+
+        for text, expected in cases:
+            with self.subTest(text=text):
+                self.assertIs(parser.tool_call_status(text), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Delegate DS4 DSML rendering/parsing, stop-string buffering, and disk KV cache handling to pyds4.
- Require pyds4 capability metadata for DS4 API/version/backend compatibility checks.
- Add DS4 token score option support for native logprobs/top-logprobs when exposed by pyds4.
- Switch the DS4 dependency to released pyds4 wheels and add pyds4 to test dependencies.
- Expand CI to run Python 3.11-3.13 across Linux CUDA and macOS Metal targets, with wheel build artifacts.
- Update Python support docs and related dependency pins.