### PR TITLE
Add Codex MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1904,6 +1904,39 @@ You can customize the MCP tool identity with `--mcp-name` (defaults to `run`) an
 > [!TIP]
 > Use `--protocol mcp` (optionally along with other `--protocol` flags) to expose only the MCP interface when serving your agent.
 
+##### Example: Use an avalan agent from Codex CLI
+
+Start an avalan agent as a streamable HTTP MCP server:
+
+```sh
+avalan agent serve \
+    --engine-uri "ai://env:OPENAI_API_KEY@openai/gpt-4o-mini" \
+    --protocol mcp \
+    --mcp-name ask_avalan \
+    --mcp-description "Ask the avalan-hosted agent." \
+    --run-max-new-tokens 256 \
+    --developer "Answer concisely." \
+    --host 127.0.0.1 \
+    --port 9001 \
+    -vvv
+```
+
+In another terminal, point Codex CLI at that MCP endpoint:
+
+```sh
+codex mcp add avalan --url http://127.0.0.1:9001/mcp
+```
+
+Interactive Codex sessions will show the `ask_avalan` tool for approval when
+the model uses it. For non-interactive `codex exec`, approve that MCP server's
+tools in the command configuration:
+
+```sh
+codex exec \
+    -c 'mcp_servers.avalan.default_tools_approval_mode="approve"' \
+    'Use the ask_avalan MCP tool to ask: What is avalan?'
+```
+
 #### A2A server
 
 Avalan also embeds an A2A-compatible server alongside the OpenAI-compatible


### PR DESCRIPTION
## Summary

- Add a README example showing how to expose an avalan agent as a streamable HTTP MCP server with `avalan agent serve --protocol mcp`.
- Show how to register that endpoint in Codex CLI and set the MCP approval mode needed for non-interactive `codex exec`.

## Testing

- `printf '%s\n' 'Reply with exactly: avalan-openai-ok' | poetry run avalan model run 'ai://env:OPENAI_API_KEY@openai/gpt-4o-mini' --max-new-tokens 20 --quiet`
  - Output: `avalan-openai-ok`
- `poetry run avalan agent serve --engine-uri 'ai://env:OPENAI_API_KEY@openai/gpt-4o-mini' --protocol mcp --mcp-name ask_avalan --mcp-description 'Ask the avalan-hosted agent.' --run-max-new-tokens 80 --developer 'Answer concisely.' --host 127.0.0.1 --port 19093 -v`
  - Started MCP server at `http://127.0.0.1:19093/mcp`.
- Manual MCP `initialize`, `tools/list`, and `tools/call` requests against `http://127.0.0.1:19093/mcp`
  - `tools/list` returned `ask_avalan`.
  - `tools/call` returned `avalan-agent-serve-mcp-ok`.
- `codex exec --json --sandbox read-only -m gpt-5.5 -c 'approval_policy="never"' -c 'mcp_servers.avalan.url="http://127.0.0.1:19093/mcp"' -c 'mcp_servers.avalan.default_tools_approval_mode="approve"' "Use the ask_avalan MCP tool with input_string exactly 'Reply with exactly: codex-used-avalan-agent-serve'. Do not run shell commands. Reply with only the exact text returned by the MCP tool."`
  - MCP tool result: `codex-used-avalan-agent-serve`
