### PR TITLE
Add tool parsing descriptors

### DIFF
--- a/docs/FLOW_COMPATIBILITY.md
+++ b/docs/FLOW_COMPATIBILITY.md
@@ -16,16 +16,15 @@ Native flows are Python-constructed directed graphs:
   connects existing nodes.
 - `Flow.parse_mermaid(...)` imports a Mermaid edge diagram into plain nodes and
   unlabeled or labeled edges.
-- `Flow.execute(...)` runs synchronously from explicit or inferred start nodes.
-- `Flow.execute_async(...)` runs asynchronously with cancellation checkpoints,
+- `Flow.execute_async(...)` runs flows with cancellation checkpoints,
   `initial_data`, and `initial_inputs`.
 - `Node` can run a Python callable, pass through input values, or invoke a
   subgraph. Node input and output schemas are Python `type` checks.
 - `FlowManager` wraps async execution with timeout support and sanitized
   before/after events.
 
-Current flow execution infers start nodes from graph topology and returns the
-single terminal node value when exactly one terminal node exists. When multiple
+Flow execution infers start nodes from graph topology and returns the single
+terminal node value when exactly one terminal node exists. When multiple
 terminal nodes exist, execution returns a mapping keyed by terminal node name.
 Cycles and unknown node references are runtime errors.
 

--- a/src/avalan/agent/loader.py
+++ b/src/avalan/agent/loader.py
@@ -5,6 +5,7 @@ from ..entities import (
     EngineUri,
     OrchestratorSettings,
     PermanentMemoryStoreSettings,
+    ToolCallRecoveryFormat,
     ToolFormat,
     ToolManagerSettings,
     TransformerEngineSettings,
@@ -599,10 +600,30 @@ class OrchestratorLoader:
             if tool_format_str:
                 tool_format = ToolFormat(tool_format_str)
 
+            recovery_format_values = tool_section.get("recovery_formats", [])
+            assert isinstance(
+                recovery_format_values, list
+            ), "tool.recovery_formats must be a list"
+            tool_recovery_formats: list[ToolCallRecoveryFormat] = []
+            for value in recovery_format_values:
+                assert isinstance(
+                    value, str
+                ), "tool.recovery_formats entries must be strings"
+                tool_recovery_formats.append(ToolCallRecoveryFormat(value))
+
             _l("Loaded agent from %s", path, is_debug=False)
 
+            if tool_recovery_formats:
+                return await self.from_settings(
+                    settings,
+                    tool_settings=tool_settings,
+                    tool_format=tool_format,
+                    tool_recovery_formats=tool_recovery_formats,
+                )
             return await self.from_settings(
-                settings, tool_settings=tool_settings, tool_format=tool_format
+                settings,
+                tool_settings=tool_settings,
+                tool_format=tool_format,
             )
 
     async def from_settings(
@@ -611,6 +632,7 @@ class OrchestratorLoader:
         *,
         tool_settings: ToolSettingsContext | None = None,
         tool_format: ToolFormat | None = None,
+        tool_recovery_formats: list[ToolCallRecoveryFormat] | None = None,
     ) -> Orchestrator:
         _l = self._log_wrapper(self._logger)
 
@@ -730,7 +752,10 @@ class OrchestratorLoader:
         tool = ToolManager.create_instance(
             available_toolsets=available_toolsets,
             enable_tools=settings.tools,
-            settings=ToolManagerSettings(tool_format=tool_format),
+            settings=ToolManagerSettings(
+                tool_format=tool_format,
+                recovery_formats=tool_recovery_formats or [],
+            ),
         )
         tool = await self._stack.enter_async_context(tool)
 

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -9,6 +9,8 @@ from ....entities import (
     ToolCall,
     ToolCallContext,
     ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallOutcome,
     ToolCallResult,
@@ -31,11 +33,14 @@ from json import dumps, loads
 from queue import Queue
 from time import perf_counter
 from typing import Any, AsyncIterator, Awaitable, Callable, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 
 class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     """Async iterator handling tool execution during streaming."""
+
+    _MAXIMUM_TOOL_CYCLES = 8
+    _MAXIMUM_CONSECUTIVE_NON_EXECUTED_CYCLES = 2
 
     _response: TextGenerationResponse
     _response_iterator: AsyncIterator[Token | TokenDetail | str] | None
@@ -52,6 +57,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     _context: ModelCallContext
     _tool_context: ToolCallContext | None
     _call_history: list[ToolCall]
+    _attempted_call_signatures: set[str]
+    _tool_cycle_signatures: set[str]
+    _tool_cycle_count: int
+    _consecutive_non_executed_cycles: int
     _agent_id: UUID | None
     _participant_id: UUID | None
     _session_id: UUID | None
@@ -89,6 +98,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         self._step = 0
         self._tool_context = None
         self._call_history = []
+        self._attempted_call_signatures = set()
+        self._tool_cycle_signatures = set()
+        self._tool_cycle_count = 0
+        self._consecutive_non_executed_cycles = 0
         self._agent_id = agent_id
         self._participant_id = participant_id
         self._session_id = session_id
@@ -237,7 +250,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                 confirm=False,
             )
 
-            self._call_history.append(call)
+            self._record_tool_outcome(result)
             self._tool_context = context
 
             end = perf_counter()
@@ -267,6 +280,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                 result_events.append(result_event)
 
             tool_messages = []
+            outcomes = []
             for e in result_events:
                 assert e.payload is not None and "result" in e.payload
                 tool_result = e.payload["result"]
@@ -276,6 +290,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                     (ToolCallResult, ToolCallError, ToolCallDiagnostic),
                 ):
                     continue
+                outcomes.append(tool_result)
                 tool_messages.extend(
                     self._tool_observation_messages(
                         tool_result,
@@ -287,6 +302,17 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                         json_output=True,
                     )
                 )
+
+            if not self._should_continue_tool_cycle(
+                tool_messages,
+                outcomes,
+            ):
+                if self._event_manager and not self._finished:
+                    self._finished = True
+                    await self._event_manager.trigger(
+                        Event(type=EventType.END)
+                    )
+                raise StopAsyncIteration
 
             assert self._input and (
                 (
@@ -464,7 +490,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                     context,
                     confirm=True,
                 )
-                self._call_history.append(call)
+                self._record_tool_outcome(result)
                 self._tool_context = context
                 if result is not None:
                     results.append(result)
@@ -480,7 +506,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                     )
                     await self._event_manager.trigger(result_event)
 
-            current_response = await self._react_process(delta, results)
+            next_response = await self._react_process(delta, results)
+            if next_response is None:
+                break
+            current_response = next_response
             new_text, structured_calls = await self._response_text_and_calls(
                 current_response
             )
@@ -520,6 +549,11 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     ) -> ToolCallOutcome | None:
         if self._tool_manager is None:
             return None
+        repeated_diagnostic = self._repeated_call_diagnostic(call)
+        if repeated_diagnostic is not None:
+            return repeated_diagnostic
+
+        self._attempted_call_signatures.add(self._call_signature(call))
         if type(self._tool_manager) is ToolManager:
             confirmation = self._tool_confirm if confirm else None
             return await self._tool_manager.execute_call(
@@ -531,7 +565,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
 
     async def _react_process(
         self, output: str, results: list[ToolCallOutcome]
-    ) -> TextGenerationResponse:
+    ) -> TextGenerationResponse | None:
         tool_messages: list[Message] = []
         for result in results:
             tool_messages.extend(
@@ -540,6 +574,9 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                     json_output=False,
                 )
             )
+
+        if not self._should_continue_tool_cycle(tool_messages, results):
+            return None
 
         assert self._input and (
             (
@@ -583,6 +620,124 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         assert isinstance(response, TextGenerationResponse)
         self._model_responses.append(response)
         return response
+
+    def _should_continue_tool_cycle(
+        self,
+        tool_messages: list[Message],
+        outcomes: list[ToolCallOutcome],
+    ) -> bool:
+        if not tool_messages:
+            return False
+
+        cycle_signature = self._tool_cycle_signature(tool_messages)
+        if cycle_signature in self._tool_cycle_signatures:
+            return False
+
+        if self._tool_cycle_count >= self._MAXIMUM_TOOL_CYCLES:
+            return False
+
+        non_executed = bool(outcomes) and all(
+            isinstance(outcome, ToolCallDiagnostic) for outcome in outcomes
+        )
+        if non_executed:
+            self._consecutive_non_executed_cycles += 1
+        else:
+            self._consecutive_non_executed_cycles = 0
+
+        if (
+            self._consecutive_non_executed_cycles
+            > self._MAXIMUM_CONSECUTIVE_NON_EXECUTED_CYCLES
+        ):
+            return False
+
+        self._tool_cycle_signatures.add(cycle_signature)
+        self._tool_cycle_count += 1
+        return True
+
+    def _record_tool_outcome(self, result: ToolCallOutcome | None) -> None:
+        if isinstance(result, (ToolCallResult, ToolCallError)):
+            self._call_history.append(result.call)
+
+    def _repeated_call_diagnostic(
+        self, call: ToolCall
+    ) -> ToolCallDiagnostic | None:
+        if self._call_signature(call) not in self._attempted_call_signatures:
+            return None
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            call_id=call.id,
+            requested_name=call.name,
+            code=ToolCallDiagnosticCode.REPEATED_CALL,
+            stage=ToolCallDiagnosticStage.GUARD,
+            message="Tool call repeats a previous attempt.",
+        )
+
+    @staticmethod
+    def _call_signature(call: ToolCall) -> str:
+        return dumps(
+            {
+                "arguments": call.arguments,
+                "name": call.name,
+            },
+            default=str,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def _tool_cycle_signature(cls, messages: list[Message]) -> str:
+        payload = [
+            cls._tool_cycle_message_payload(message) for message in messages
+        ]
+        return dumps(
+            payload,
+            default=str,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def _tool_cycle_message_payload(cls, message: Message) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "arguments": message.arguments,
+            "content": message.content,
+            "name": message.name,
+            "role": message.role.value,
+            "thinking": message.thinking,
+            "tool_calls": (
+                [asdict(tool_call) for tool_call in message.tool_calls]
+                if message.tool_calls
+                else None
+            ),
+        }
+        if message.tool_call_result is not None:
+            result = message.tool_call_result
+            payload["tool_call_result"] = {
+                "arguments": result.arguments,
+                "call": cls._call_signature(result.call),
+                "name": result.name,
+                "result": cls._json_content(result.result),
+            }
+        if message.tool_call_error is not None:
+            error = message.tool_call_error
+            payload["tool_call_error"] = {
+                "arguments": error.arguments,
+                "call": cls._call_signature(error.call),
+                "message": error.message,
+                "name": error.name,
+            }
+        if message.tool_call_diagnostic is not None:
+            diagnostic = message.tool_call_diagnostic
+            payload["tool_call_diagnostic"] = {
+                "call_id": diagnostic.call_id,
+                "canonical_name": diagnostic.canonical_name,
+                "code": diagnostic.code.value,
+                "details": diagnostic.details,
+                "message": diagnostic.message,
+                "requested_name": diagnostic.requested_name,
+                "retryable": diagnostic.retryable,
+                "stage": diagnostic.stage.value,
+                "status": diagnostic.status.value,
+            }
+        return payload
 
     @classmethod
     def _tool_observation_messages(

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -8,7 +8,9 @@ from ....entities import (
     TokenDetail,
     ToolCall,
     ToolCallContext,
+    ToolCallDiagnostic,
     ToolCallError,
+    ToolCallOutcome,
     ToolCallResult,
     ToolCallToken,
 )
@@ -18,6 +20,7 @@ from ....model.call import ModelCallContext
 from ....model.response.parsers.tool import ToolCallResponseParser
 from ....model.response.text import TextGenerationResponse
 from ....tool.manager import ToolManager
+from ....utils import tool_call_diagnostic_payload
 from ... import AgentOperation
 from ...engine import EngineAgent
 
@@ -228,10 +231,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                 cancellation_checker=self._cancellation_checker,
             )
 
-            result = (
-                await self._tool_manager(call, context)
-                if self._tool_manager
-                else None
+            result = await self._execute_tool_call(
+                call,
+                context,
+                confirm=False,
             )
 
             self._call_history.append(call)
@@ -240,7 +243,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
             end = perf_counter()
             result_event = Event(
                 type=EventType.TOOL_RESULT,
-                payload={"result": result},
+                payload={"call": call, "result": result},
                 started=start,
                 finished=end,
                 elapsed=end - start,
@@ -267,51 +270,21 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
             for e in result_events:
                 assert e.payload is not None and "result" in e.payload
                 tool_result = e.payload["result"]
-                tool_output = (
-                    tool_result.message
-                    if isinstance(tool_result, ToolCallError)
-                    else tool_result.result
-                )
-                tool_messages.append(
-                    Message(
-                        role=MessageRole.ASSISTANT,
-                        tool_calls=[
-                            MessageToolCall(
-                                id=str(tool_result.call.id),
-                                name=tool_result.name,
-                                arguments=cast(Any, tool_result.arguments),
-                            )
-                        ],
-                    )
-                )
-                tool_result_output = dumps(
-                    (
-                        asdict(cast(Any, tool_output))
-                        if is_dataclass(tool_output)
-                        else tool_output
-                    ),
-                    default=lambda o: (
-                        b64encode(o).decode()
-                        if isinstance(o, (bytes, bytearray, memoryview))
-                        else str(o)
-                    ),
-                )
-                tool_messages.append(
-                    Message(
-                        role=MessageRole.TOOL,
-                        name=tool_result.name,
-                        arguments=tool_result.arguments,
-                        content=tool_result_output,
-                        tool_call_result=(
-                            tool_result
-                            if isinstance(tool_result, ToolCallResult)
+                event_call = e.payload.get("call")
+                if not isinstance(
+                    tool_result,
+                    (ToolCallResult, ToolCallError, ToolCallDiagnostic),
+                ):
+                    continue
+                tool_messages.extend(
+                    self._tool_observation_messages(
+                        tool_result,
+                        call=(
+                            event_call
+                            if isinstance(event_call, ToolCall)
                             else None
                         ),
-                        tool_call_error=(
-                            tool_result
-                            if isinstance(tool_result, ToolCallError)
-                            else None
-                        ),
+                        json_output=True,
                     )
                 )
 
@@ -466,7 +439,7 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
             if not calls:
                 break
 
-            results: list[ToolCallResult | ToolCallError] = []
+            results: list[ToolCallOutcome] = []
             for call in calls:
                 if self._event_manager:
                     start = perf_counter()
@@ -486,10 +459,10 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                     cancellation_checker=self._cancellation_checker,
                 )
 
-                result = (
-                    await self._tool_manager(call, context)
-                    if self._tool_manager
-                    else None
+                result = await self._execute_tool_call(
+                    call,
+                    context,
+                    confirm=True,
                 )
                 self._call_history.append(call)
                 self._tool_context = context
@@ -538,65 +511,33 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
             )
         return "".join(text_parts), calls
 
+    async def _execute_tool_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+        *,
+        confirm: bool,
+    ) -> ToolCallOutcome | None:
+        if self._tool_manager is None:
+            return None
+        if type(self._tool_manager) is ToolManager:
+            confirmation = self._tool_confirm if confirm else None
+            return await self._tool_manager.execute_call(
+                call,
+                context,
+                confirm=confirmation,
+            )
+        return await self._tool_manager(call, context)
+
     async def _react_process(
-        self, output: str, results: list[ToolCallResult | ToolCallError]
+        self, output: str, results: list[ToolCallOutcome]
     ) -> TextGenerationResponse:
         tool_messages: list[Message] = []
         for result in results:
-            tool_messages.append(
-                Message(
-                    role=MessageRole.ASSISTANT,
-                    tool_calls=[
-                        MessageToolCall(
-                            id=str(result.call.id),
-                            name=result.name,
-                            arguments=cast(Any, result.arguments),
-                        )
-                    ],
-                )
-            )
-            tool_messages.append(
-                Message(
-                    role=MessageRole.TOOL,
-                    name=result.name,
-                    arguments=result.arguments,
-                    content=(
-                        result.message
-                        if isinstance(result, ToolCallError)
-                        else (
-                            result.result
-                            if isinstance(result.result, str)
-                            else (
-                                dumps(
-                                    (
-                                        asdict(result.result)
-                                        if is_dataclass(result.result)
-                                        else result.result
-                                    ),
-                                    default=lambda o: (
-                                        b64encode(o).decode()
-                                        if isinstance(
-                                            o,
-                                            (
-                                                bytes,
-                                                bytearray,
-                                                memoryview,
-                                            ),
-                                        )
-                                        else str(o)
-                                    ),
-                                )
-                                if result.result is not None
-                                else ""
-                            )
-                        )
-                    ),
-                    tool_call_result=(
-                        result if isinstance(result, ToolCallResult) else None
-                    ),
-                    tool_call_error=(
-                        result if isinstance(result, ToolCallError) else None
-                    ),
+            tool_messages.extend(
+                self._tool_observation_messages(
+                    result,
+                    json_output=False,
                 )
             )
 
@@ -642,6 +583,131 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
         assert isinstance(response, TextGenerationResponse)
         self._model_responses.append(response)
         return response
+
+    @classmethod
+    def _tool_observation_messages(
+        cls,
+        outcome: ToolCallOutcome,
+        *,
+        call: ToolCall | None = None,
+        json_output: bool,
+    ) -> list[Message]:
+        if isinstance(outcome, ToolCallDiagnostic):
+            return cls._diagnostic_messages(
+                outcome,
+                call=call,
+                json_output=json_output,
+            )
+
+        return [
+            Message(
+                role=MessageRole.ASSISTANT,
+                tool_calls=[
+                    MessageToolCall(
+                        id=str(outcome.call.id),
+                        name=outcome.name,
+                        arguments=cast(Any, outcome.arguments),
+                    )
+                ],
+            ),
+            Message(
+                role=MessageRole.TOOL,
+                name=outcome.name,
+                arguments=outcome.arguments,
+                content=cls._outcome_content(
+                    outcome,
+                    json_output=json_output,
+                ),
+                tool_call_result=(
+                    outcome if isinstance(outcome, ToolCallResult) else None
+                ),
+                tool_call_error=(
+                    outcome if isinstance(outcome, ToolCallError) else None
+                ),
+            ),
+        ]
+
+    @classmethod
+    def _diagnostic_messages(
+        cls,
+        diagnostic: ToolCallDiagnostic,
+        *,
+        call: ToolCall | None,
+        json_output: bool,
+    ) -> list[Message]:
+        call_id = diagnostic.call_id or (call.id if call else None)
+        name = (
+            diagnostic.canonical_name
+            or diagnostic.requested_name
+            or (call.name if call else "tool")
+        )
+        arguments = call.arguments if call else None
+        content = cls._outcome_content(
+            diagnostic,
+            json_output=json_output,
+        )
+        if call_id is None:
+            return [
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    content=content,
+                    tool_call_diagnostic=diagnostic,
+                )
+            ]
+
+        return [
+            Message(
+                role=MessageRole.ASSISTANT,
+                tool_calls=[
+                    MessageToolCall(
+                        id=str(call_id),
+                        name=name,
+                        arguments=cast(Any, arguments),
+                    )
+                ],
+            ),
+            Message(
+                role=MessageRole.TOOL,
+                name=name,
+                arguments=arguments,
+                content=content,
+                tool_call_diagnostic=diagnostic,
+            ),
+        ]
+
+    @classmethod
+    def _outcome_content(
+        cls,
+        outcome: ToolCallOutcome,
+        *,
+        json_output: bool,
+    ) -> str:
+        if isinstance(outcome, ToolCallDiagnostic):
+            return cls._json_content(tool_call_diagnostic_payload(outcome))
+        if isinstance(outcome, ToolCallError):
+            return (
+                cls._json_content(outcome.message)
+                if json_output
+                else outcome.message
+            )
+
+        result = outcome.result
+        if not json_output and isinstance(result, str):
+            return result
+        if not json_output and result is None:
+            return ""
+        return cls._json_content(result)
+
+    @staticmethod
+    def _json_content(value: Any) -> str:
+        return dumps(
+            asdict(cast(Any, value)) if is_dataclass(value) else value,
+            default=lambda o: (
+                b64encode(o).decode()
+                if isinstance(o, (bytes, bytearray, memoryview))
+                else str(o)
+            ),
+        )
 
     async def _emit(
         self, item: Token | TokenDetail | Event | str

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -385,12 +385,23 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                 self._tool_process_events.put(event)
         except StopAsyncIteration:
             if self._tool_parser:
+                parser_items: list[Token | TokenDetail | Event] = []
+                parser_events: list[Event] = []
                 for item in await self._tool_parser.flush():
                     if isinstance(item, Event):
-                        self._tool_process_events.put(item)
+                        if item.type == EventType.TOOL_PROCESS:
+                            self._tool_process_events.put(item)
+                        elif item.type == EventType.TOOL_DIAGNOSTIC:
+                            parser_events.append(item)
+                        else:
+                            self._tool_process_events.put(item)
                     else:
-                        assert self._parser_queue
-                        self._parser_queue.put(item)
+                        parser_items.append(item)
+                assert self._parser_queue
+                for item in parser_items:
+                    self._parser_queue.put(item)
+                for event in parser_events:
+                    self._parser_queue.put(event)
                 if self._parser_queue and not self._parser_queue.empty():
                     return self._parser_queue.get()
                 if not self._tool_process_events.empty():

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -262,6 +262,13 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                 elapsed=end - start,
             )
             if self._event_manager:
+                await self._trigger_tool_diagnostic_event(
+                    call=call,
+                    result=result,
+                    started=start,
+                    finished=end,
+                    elapsed=end - start,
+                )
                 await self._event_manager.trigger(result_event)
 
             self._tool_result_events.put(result_event)
@@ -504,6 +511,13 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
                         finished=end,
                         elapsed=end - start,
                     )
+                    await self._trigger_tool_diagnostic_event(
+                        call=call,
+                        result=result,
+                        started=start,
+                        finished=end,
+                        elapsed=end - start,
+                    )
                     await self._event_manager.trigger(result_event)
 
             next_response = await self._react_process(delta, results)
@@ -657,6 +671,33 @@ class OrchestratorResponse(AsyncIterator[Token | TokenDetail | Event]):
     def _record_tool_outcome(self, result: ToolCallOutcome | None) -> None:
         if isinstance(result, (ToolCallResult, ToolCallError)):
             self._call_history.append(result.call)
+
+    async def _trigger_tool_diagnostic_event(
+        self,
+        *,
+        call: ToolCall,
+        result: ToolCallOutcome | None,
+        started: float,
+        finished: float,
+        elapsed: float,
+    ) -> None:
+        if not isinstance(result, ToolCallDiagnostic):
+            return
+        assert self._event_manager
+        await self._event_manager.trigger(
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={
+                    "call": call,
+                    "diagnostic": result,
+                    "diagnostics": [result],
+                    "result": result,
+                },
+                started=started,
+                finished=finished,
+                elapsed=elapsed,
+            )
+        )
 
     def _repeated_call_diagnostic(
         self, call: ToolCall

--- a/src/avalan/agent/templates/blueprint.toml
+++ b/src/avalan/agent/templates/blueprint.toml
@@ -95,9 +95,14 @@ cache_strategy = "{{ orchestrator.call_options['cache_strategy'] }}"
 {% endfor %}
 {% endif %}
 
-{% if orchestrator.tools or tool_format %}
+{% if orchestrator.tools or tool_format or tool_recovery_formats %}
 [tool]
 {% if tool_format %}format = "{{ tool_format }}"
+{% endif %}
+{% if tool_recovery_formats %}recovery_formats = [
+{% for recovery_format in tool_recovery_formats %}    "{{ recovery_format }}"{% if not loop.last %},{% endif %}
+{% endfor %}
+]
 {% endif %}
 {% if orchestrator.tools %}enable = [
 {% for tool in orchestrator.tools %}    "{{ tool }}"{% if not loop.last %},{% endif %}

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -13,6 +13,7 @@ from ..entities import (
     ReasoningTag,
     TextGenerationLoaderClass,
     TimestepSpacing,
+    ToolCallRecoveryFormat,
     ToolFormat,
     User,
     VisionColorModel,
@@ -1317,6 +1318,12 @@ class CLI:
             type=str,
             choices=[t.value for t in ToolFormat],
             help="Tool format",
+        )
+        agent_run_parser.add_argument(
+            "--tool-recovery-format",
+            action="append",
+            choices=[t.value for t in ToolCallRecoveryFormat],
+            help="Enable a tool-call recovery format",
         )
         agent_run_parser.add_argument(
             "--reasoning-tag",

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -14,6 +14,7 @@ from ...entities import (
     OrchestratorSettings,
     PermanentMemoryStoreSettings,
     ToolCall,
+    ToolCallRecoveryFormat,
     ToolFormat,
 )
 from ...event import Event, EventStats
@@ -579,9 +580,23 @@ async def agent_run(
             tool_format = (
                 ToolFormat(args.tool_format) if args.tool_format else None
             )
-            orchestrator = await loader.from_settings(
-                settings, tool_settings=tool_settings, tool_format=tool_format
-            )
+            tool_recovery_formats = [
+                ToolCallRecoveryFormat(value)
+                for value in getattr(args, "tool_recovery_format", None) or []
+            ]
+            if tool_recovery_formats:
+                orchestrator = await loader.from_settings(
+                    settings,
+                    tool_settings=tool_settings,
+                    tool_format=tool_format,
+                    tool_recovery_formats=tool_recovery_formats,
+                )
+            else:
+                orchestrator = await loader.from_settings(
+                    settings,
+                    tool_settings=tool_settings,
+                    tool_format=tool_format,
+                )
         orchestrator.event_manager.add_listener(_event_listener)
 
         orchestrator = await stack.enter_async_context(orchestrator)
@@ -948,11 +963,13 @@ async def agent_init(args: Namespace, console: Console, theme: Theme) -> None:
     )
     template = env.get_template("blueprint.toml")
     tool_format = getattr(args, "tool_format", None)
+    tool_recovery_formats = getattr(args, "tool_recovery_format", None) or []
     rendered = template.render(
         orchestrator=settings,
         browser_tool=browser_tool,
         database_tool=database_tool,
         graph_tool=graph_tool,
         tool_format=tool_format,
+        tool_recovery_formats=tool_recovery_formats,
     )
     console.print(Syntax(rendered, "toml"))

--- a/src/avalan/cli/commands/flow.py
+++ b/src/avalan/cli/commands/flow.py
@@ -6,6 +6,7 @@ from ...flow import (
     FlowLoadIssue,
     FlowLoadIssueCategory,
     FlowNodeDefinition,
+    FlowNodeMetadata,
     FlowOutputType,
     Node,
     default_flow_node_registry,
@@ -409,7 +410,14 @@ def _flow_schema_issue() -> TaskValidationIssue:
 def _flow_metadata_loader() -> FlowDefinitionLoader:
     registry = default_flow_node_registry()
     for node_type in ("agent", "file_convert", "pdf_to_images"):
-        registry.register(node_type, _flow_task_context_metadata_node)
+        registry.register(
+            node_type,
+            _flow_task_context_metadata_node,
+            metadata=FlowNodeMetadata(
+                supports_ref=node_type == "agent",
+                async_only=True,
+            ),
+        )
     return FlowDefinitionLoader(registry)
 
 

--- a/src/avalan/cli/commands/model.py
+++ b/src/avalan/cli/commands/model.py
@@ -750,7 +750,10 @@ async def _token_stream(
                     if next_input_token_count:
                         display_input_token_count += next_input_token_count
                         input_token_count = next_input_token_count
-                elif event.type == EventType.TOOL_RESULT:
+                elif event.type in (
+                    EventType.TOOL_DIAGNOSTIC,
+                    EventType.TOOL_RESULT,
+                ):
                     tool_event_results.append(event)
                     if event.payload and "call" in event.payload:
                         completed_call_ids.add(event.payload["call"].id)

--- a/src/avalan/cli/theme/fancy.py
+++ b/src/avalan/cli/theme/fancy.py
@@ -16,12 +16,19 @@ from ...entities import (
     Token,
     TokenDetail,
     TokenizerConfig,
+    ToolCallDiagnostic,
     ToolCallError,
     User,
 )
 from ...event import TOOL_TYPES, Event, EventStats, EventType
 from ...memory.permanent import PermanentMemoryPartition
-from ...utils import _j, _lf, to_json
+from ...utils import (
+    _j,
+    _lf,
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 
 from datetime import datetime, timedelta
 from locale import format_string
@@ -2333,12 +2340,25 @@ class FancyTheme(Theme):
                             + "[/gray78]",
                         )
                     )
+                elif event.type == EventType.TOOL_DIAGNOSTIC and payload:
+                    diagnostic = self._tool_diagnostic_from_payload(payload)
+                    if diagnostic is None:
+                        event_log.append(str(event.payload))
+                        continue
+                    event_log.append(
+                        self._tool_diagnostic_log(diagnostic, payload)
+                    )
                 elif (
                     event.type == EventType.TOOL_RESULT
                     and payload
                     and payload["result"]
                 ):
                     result = payload["result"]
+                    if isinstance(result, ToolCallDiagnostic):
+                        event_log.append(
+                            self._tool_diagnostic_log(result, payload)
+                        )
+                        continue
                     event_log.append(
                         _(
                             "Executed tool {tool} call #{call_id}"
@@ -2358,7 +2378,9 @@ class FancyTheme(Theme):
                             + "[/gray78]",
                             total_arguments=len(result.call.arguments or []),
                             result=(
-                                "[red]" + result.message + "[/red]"
+                                "[red]"
+                                + to_json(tool_call_error_payload(result))
+                                + "[/red]"
                                 if isinstance(result, ToolCallError)
                                 else (
                                     "[spring_green3]"
@@ -2396,6 +2418,54 @@ class FancyTheme(Theme):
             event_log = event_log[-events_limit:]
 
         return event_log
+
+    def _tool_diagnostic_from_payload(
+        self, payload: Any
+    ) -> ToolCallDiagnostic | None:
+        if not isinstance(payload, dict):
+            return None
+        diagnostic = payload.get("diagnostic")
+        if isinstance(diagnostic, ToolCallDiagnostic):
+            return diagnostic
+        result = payload.get("result")
+        if isinstance(result, ToolCallDiagnostic):
+            return result
+        diagnostics = payload.get("diagnostics")
+        if isinstance(diagnostics, list):
+            return next(
+                (
+                    item
+                    for item in diagnostics
+                    if isinstance(item, ToolCallDiagnostic)
+                ),
+                None,
+            )
+        return None
+
+    def _tool_diagnostic_log(
+        self, diagnostic: ToolCallDiagnostic, payload: Any
+    ) -> str:
+        call = payload.get("call") if isinstance(payload, dict) else None
+        tool_name = (
+            getattr(call, "name", None)
+            or diagnostic.canonical_name
+            or diagnostic.requested_name
+            or "tool"
+        )
+        call_id = (
+            getattr(call, "id", None) or diagnostic.call_id or diagnostic.id
+        )
+        diagnostic_payload = tool_call_diagnostic_payload(diagnostic)
+        return self._(
+            "Tool diagnostic {code} at {stage} for {tool} call #{call_id}:"
+            " {message}."
+        ).format(
+            code="[yellow]" + diagnostic_payload["code"] + "[/yellow]",
+            stage="[gray78]" + diagnostic_payload["stage"] + "[/gray78]",
+            tool="[gray78]" + str(tool_name) + "[/gray78]",
+            call_id="[gray78]" + str(call_id)[:8] + "[/gray78]",
+            message="[yellow]" + diagnostic.message + "[/yellow]",
+        )
 
     def _tokens_table(
         self,

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -613,9 +613,21 @@ class MessageToolCall:
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCall:
-    id: UUID | str
+    id: UUID | str | None
     name: str
     arguments: dict[str, ToolValue] | None = None
+    provider_name: str | None = None
+    provider_name_encoded: bool = False
+
+    def __post_init__(self) -> None:
+        if self.id is not None:
+            _assert_tool_identifier(self.id, "id")
+        assert isinstance(self.name, str)
+        _assert_optional_tool_name(self.provider_name, "provider_name")
+        assert isinstance(self.provider_name_encoded, bool)
+        assert (
+            self.provider_name is not None or not self.provider_name_encoded
+        ), "provider_name is required when provider_name_encoded is true"
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -189,6 +189,14 @@ class ToolCallDiagnosticStatus(StrEnum):
     NON_EXECUTED = "non_executed"
 
 
+class ToolNameResolutionStatus(StrEnum):
+    EXACT = "exact"
+    ALIAS = "alias"
+    AMBIGUOUS = "ambiguous"
+    UNKNOWN = "unknown"
+    DISABLED = "disabled"
+
+
 class ToolManagerExecutionMode(StrEnum):
     LEGACY = "legacy"
     OUTCOMES = "outcomes"
@@ -682,6 +690,42 @@ ToolCallOutcome: TypeAlias = (
 
 @final
 @dataclass(frozen=True, kw_only=True, slots=True)
+class ToolDescriptor:
+    name: str
+    aliases: list[str] = field(default_factory=list)
+    schema: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _assert_optional_tool_name(self.name, "name")
+        assert isinstance(self.aliases, list)
+        for alias in self.aliases:
+            _assert_optional_tool_name(alias, "alias")
+        if self.schema is not None:
+            assert isinstance(self.schema, dict)
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ToolNameResolution:
+    requested_name: str
+    status: ToolNameResolutionStatus
+    canonical_name: str | None = None
+    candidates: list[str] = field(default_factory=list)
+    diagnostic_code: ToolCallDiagnosticCode | None = None
+
+    def __post_init__(self) -> None:
+        _assert_optional_tool_name(self.requested_name, "requested_name")
+        _assert_optional_tool_name(self.canonical_name, "canonical_name")
+        assert isinstance(self.status, ToolNameResolutionStatus)
+        assert isinstance(self.candidates, list)
+        for candidate in self.candidates:
+            _assert_optional_tool_name(candidate, "candidate")
+        if self.diagnostic_code is not None:
+            assert isinstance(self.diagnostic_code, ToolCallDiagnosticCode)
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Message:
     role: MessageRole
     thinking: str | None = ""
@@ -991,6 +1035,7 @@ class ReasoningToken(Token):
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ToolCallToken(Token):
     call: ToolCall | None = None
+    provider_name: str | None = None
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -692,16 +692,34 @@ ToolCallOutcome: TypeAlias = (
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ToolDescriptor:
     name: str
+    callable: Callable[..., Any] | None = None
     aliases: list[str] = field(default_factory=list)
     schema: dict[str, Any] | None = None
+    parameter_schema: dict[str, Any] | None = None
+    return_schema: dict[str, Any] | None = None
+    provider_safe_schema: dict[str, Any] | None = None
+    namespace: str | None = None
+    policy: dict[str, ToolValue] = field(default_factory=dict)
+    metadata: dict[str, ToolValue] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _assert_optional_tool_name(self.name, "name")
+        if self.callable is not None:
+            assert callable(self.callable)
         assert isinstance(self.aliases, list)
         for alias in self.aliases:
             _assert_optional_tool_name(alias, "alias")
         if self.schema is not None:
             assert isinstance(self.schema, dict)
+        if self.parameter_schema is not None:
+            assert isinstance(self.parameter_schema, dict)
+        if self.return_schema is not None:
+            assert isinstance(self.return_schema, dict)
+        if self.provider_safe_schema is not None:
+            assert isinstance(self.provider_safe_schema, dict)
+        _assert_optional_tool_name(self.namespace, "namespace")
+        assert isinstance(self.policy, dict)
+        assert isinstance(self.metadata, dict)
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -808,6 +808,7 @@ class Message:
     tool_calls: list[MessageToolCall] | None = None
     tool_call_result: ToolCallResult | None = None
     tool_call_error: ToolCallError | None = None
+    tool_call_diagnostic: ToolCallDiagnostic | None = None
 
 
 Input = str | list[str] | Message | list[Message]

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -618,6 +618,7 @@ class ToolCall:
     arguments: dict[str, ToolValue] | None = None
     provider_name: str | None = None
     provider_name_encoded: bool = False
+    provider_arguments_malformed: bool = False
 
     def __post_init__(self) -> None:
         if self.id is not None:
@@ -625,9 +626,14 @@ class ToolCall:
         assert isinstance(self.name, str)
         _assert_optional_tool_name(self.provider_name, "provider_name")
         assert isinstance(self.provider_name_encoded, bool)
+        assert isinstance(self.provider_arguments_malformed, bool)
         assert (
             self.provider_name is not None or not self.provider_name_encoded
         ), "provider_name is required when provider_name_encoded is true"
+        assert (
+            self.provider_name is not None
+            or not self.provider_arguments_malformed
+        ), "provider_name is required when provider arguments are malformed"
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -690,6 +690,26 @@ ToolCallOutcome: TypeAlias = (
 
 @final
 @dataclass(frozen=True, kw_only=True, slots=True)
+class PreparedToolCall:
+    call: ToolCall
+    callable: Callable[..., Any]
+    descriptor: "ToolDescriptor"
+    arguments: dict[str, ToolValue]
+    context: "ToolCallContext"
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.call, ToolCall)
+        assert callable(self.callable)
+        assert isinstance(self.descriptor, ToolDescriptor)
+        assert isinstance(self.arguments, dict)
+        assert isinstance(self.context, ToolCallContext)
+        assert self.call.name == self.descriptor.name
+        assert self.callable is self.descriptor.callable
+        assert (self.call.arguments or {}) == self.arguments
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolDescriptor:
     name: str
     callable: Callable[..., Any] | None = None

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -156,6 +156,39 @@ class ToolFormat(StrEnum):
     DSML = "dsml"
 
 
+class ToolCallDiagnosticCode(StrEnum):
+    UNKNOWN_TOOL = "tool.unknown"
+    DISABLED_TOOL = "tool.disabled"
+    AMBIGUOUS_TOOL_NAME = "tool.ambiguous_name"
+    MALFORMED_CALL = "tool_call.malformed"
+    MALFORMED_ARGUMENTS = "tool_call.arguments_malformed"
+    ARGUMENT_VALIDATION_FAILED = "tool_call.arguments_invalid"
+    POLICY_SUPPRESSED = "tool_call.policy_suppressed"
+    FILTER_SUPPRESSED = "tool_call.filter_suppressed"
+    USER_REJECTED = "tool_call.user_rejected"
+    REPEATED_CALL = "tool_call.repeated"
+    MAXIMUM_DEPTH = "tool_call.maximum_depth"
+    CANCELLED = "tool_call.cancelled"
+    TIMEOUT = "tool_call.timeout"
+    LOOP_GUARD = "tool_call.loop_guard"
+    RUNAWAY_GUARD = "tool_call.runaway_guard"
+
+
+class ToolCallDiagnosticStage(StrEnum):
+    PARSE = "parse"
+    RESOLVE = "resolve"
+    VALIDATE = "validate"
+    POLICY = "policy"
+    FILTER = "filter"
+    CONFIRM = "confirm"
+    DISPATCH = "dispatch"
+    GUARD = "guard"
+
+
+class ToolCallDiagnosticStatus(StrEnum):
+    NON_EXECUTED = "non_executed"
+
+
 class VisionColorModel(StrEnum):
     ONE = "1"
     L = "L"
@@ -569,6 +602,66 @@ class ToolCallError(ToolCall):
 
 @final
 @dataclass(frozen=True, kw_only=True, slots=True)
+class ToolCallDiagnostic:
+    id: UUID | str
+    call_id: UUID | str | None = None
+    requested_name: str | None = None
+    canonical_name: str | None = None
+    status: ToolCallDiagnosticStatus = ToolCallDiagnosticStatus.NON_EXECUTED
+    code: ToolCallDiagnosticCode
+    stage: ToolCallDiagnosticStage
+    message: str
+    retryable: bool = False
+    details: dict[str, ToolValue] = field(default_factory=dict)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    duration_ms: int | float | None = None
+
+    def __post_init__(self) -> None:
+        _assert_tool_identifier(self.id, "id")
+        if self.call_id is not None:
+            _assert_tool_identifier(self.call_id, "call_id")
+        _assert_optional_tool_name(self.requested_name, "requested_name")
+        _assert_optional_tool_name(self.canonical_name, "canonical_name")
+        assert isinstance(self.code, ToolCallDiagnosticCode)
+        assert isinstance(self.stage, ToolCallDiagnosticStage)
+        assert isinstance(self.status, ToolCallDiagnosticStatus)
+        assert isinstance(self.message, str)
+        assert self.message.strip(), "message must not be empty"
+        assert isinstance(self.retryable, bool)
+        assert isinstance(self.details, dict)
+        if self.started_at is not None:
+            assert isinstance(self.started_at, datetime)
+        if self.finished_at is not None:
+            assert isinstance(self.finished_at, datetime)
+        if self.duration_ms is not None:
+            assert isinstance(self.duration_ms, int | float)
+            assert not isinstance(self.duration_ms, bool)
+            assert self.duration_ms >= 0
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ToolCallParseOutcome:
+    calls: list[ToolCall] = field(default_factory=list)
+    diagnostics: list[ToolCallDiagnostic] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.calls, list)
+        assert isinstance(self.diagnostics, list)
+        for call in self.calls:
+            assert isinstance(call, ToolCall)
+        for diagnostic in self.diagnostics:
+            assert isinstance(diagnostic, ToolCallDiagnostic)
+
+
+ToolCallOutcome: TypeAlias = (
+    ToolCallResult | ToolCallError | ToolCallDiagnostic
+)
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Message:
     role: MessageRole
     thinking: str | None = ""
@@ -935,6 +1028,19 @@ class ToolManagerSettings:
         ]
         | None
     ) = None
+
+
+def _assert_tool_identifier(value: UUID | str, field_name: str) -> None:
+    assert isinstance(value, (UUID, str)), f"{field_name} is invalid"
+    if isinstance(value, str):
+        assert value.strip(), f"{field_name} must not be empty"
+
+
+def _assert_optional_tool_name(value: str | None, field_name: str) -> None:
+    if value is None:
+        return
+    assert isinstance(value, str), f"{field_name} must be a string"
+    assert value.strip(), f"{field_name} must not be empty"
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -630,8 +630,18 @@ class ToolCallResult(ToolCall):
 class ToolCallError(ToolCall):
     id: UUID | str
     call: ToolCall
-    error: BaseException
+    error: ToolValue | BaseException
     message: str
+
+    @property
+    def error_type(self) -> str:
+        if isinstance(self.error, BaseException):
+            return self.error.__class__.__name__
+        if isinstance(self.error, dict):
+            error_type = self.error.get("type")
+            if isinstance(error_type, str) and error_type.strip():
+                return error_type
+        return "ToolCallError"
 
 
 @final
@@ -1132,9 +1142,16 @@ class ToolFilter:
 
 @final
 @dataclass(frozen=True, kw_only=True, slots=True)
+class ToolTransformerResult:
+    result: ToolValue | None = None
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ToolTransformer:
     func: Callable[
-        [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
+        [ToolCall, ToolCallContext, ToolValue | None],
+        ToolValue | ToolTransformerResult | None,
     ]
     namespace: str | None = None
 
@@ -1167,7 +1184,8 @@ class ToolManagerSettings:
     transformers: (
         list[
             Callable[
-                [ToolCall, ToolCallContext, ToolValue | None], ToolValue | None
+                [ToolCall, ToolCallContext, ToolValue | None],
+                ToolValue | ToolTransformerResult | None,
             ]
             | ToolTransformer
         ]

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -156,6 +156,15 @@ class ToolFormat(StrEnum):
     DSML = "dsml"
 
 
+class ToolCallRecoveryFormat(StrEnum):
+    TOOL_CALL_BLOCK = "tool_call_block"
+    MINIMAX_XML = "minimax_xml"
+    TOOL_CODE = "tool_code"
+    BROAD_XML = "broad_xml"
+    DSML_LEAKAGE = "dsml_leakage"
+    FENCED = "fenced"
+
+
 class ToolCallDiagnosticCode(StrEnum):
     UNKNOWN_TOOL = "tool.unknown"
     DISABLED_TOOL = "tool.disabled"
@@ -1181,6 +1190,9 @@ class ToolTransformer:
 class ToolManagerSettings:
     eos_token: str | None = None
     tool_format: ToolFormat | None = None
+    recovery_formats: list[ToolCallRecoveryFormat] = field(
+        default_factory=list
+    )
     avoid_repetition: bool = False
     maximum_depth: int | None = None
     maximum_argument_depth: int | None = None
@@ -1231,6 +1243,9 @@ class ToolManagerSettings:
                 and not isinstance(limit, bool)
                 and limit > 0
             )
+        assert isinstance(self.recovery_formats, list)
+        for recovery_format in self.recovery_formats:
+            assert isinstance(recovery_format, ToolCallRecoveryFormat)
         assert isinstance(self.execution_mode, ToolManagerExecutionMode)
         assert isinstance(self.missing_call_mode, ToolManagerMissingCallMode)
         assert isinstance(self.parser_return_mode, ToolParserReturnMode)

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -167,6 +167,7 @@ class ToolCallDiagnosticCode(StrEnum):
     FILTER_SUPPRESSED = "tool_call.filter_suppressed"
     USER_REJECTED = "tool_call.user_rejected"
     REPEATED_CALL = "tool_call.repeated"
+    MAXIMUM_SIZE = "tool_call.maximum_size"
     MAXIMUM_DEPTH = "tool_call.maximum_depth"
     CANCELLED = "tool_call.cancelled"
     TIMEOUT = "tool_call.timeout"
@@ -1163,6 +1164,11 @@ class ToolManagerSettings:
     tool_format: ToolFormat | None = None
     avoid_repetition: bool = False
     maximum_depth: int | None = None
+    maximum_argument_depth: int | None = None
+    maximum_argument_size: int | None = None
+    maximum_parser_input_size: int | None = None
+    maximum_parser_payload_depth: int | None = None
+    maximum_parser_payload_size: int | None = None
     execution_mode: ToolManagerExecutionMode = ToolManagerExecutionMode.LEGACY
     missing_call_mode: ToolManagerMissingCallMode = (
         ToolManagerMissingCallMode.LEGACY_NONE
@@ -1193,6 +1199,19 @@ class ToolManagerSettings:
     ) = None
 
     def __post_init__(self) -> None:
+        for limit in (
+            self.maximum_depth,
+            self.maximum_argument_depth,
+            self.maximum_argument_size,
+            self.maximum_parser_input_size,
+            self.maximum_parser_payload_depth,
+            self.maximum_parser_payload_size,
+        ):
+            assert limit is None or (
+                isinstance(limit, int)
+                and not isinstance(limit, bool)
+                and limit > 0
+            )
         assert isinstance(self.execution_mode, ToolManagerExecutionMode)
         assert isinstance(self.missing_call_mode, ToolManagerMissingCallMode)
         assert isinstance(self.parser_return_mode, ToolParserReturnMode)

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -189,6 +189,26 @@ class ToolCallDiagnosticStatus(StrEnum):
     NON_EXECUTED = "non_executed"
 
 
+class ToolManagerExecutionMode(StrEnum):
+    LEGACY = "legacy"
+    OUTCOMES = "outcomes"
+
+
+class ToolManagerMissingCallMode(StrEnum):
+    LEGACY_NONE = "legacy_none"
+    DIAGNOSTIC = "diagnostic"
+
+
+class ToolParserReturnMode(StrEnum):
+    LEGACY = "legacy"
+    OUTCOME = "outcome"
+
+
+class ToolProviderArgumentsMode(StrEnum):
+    EMPTY_ON_MALFORMED = "empty_on_malformed"
+    DIAGNOSTIC_ON_MALFORMED = "diagnostic_on_malformed"
+
+
 class VisionColorModel(StrEnum):
     ONE = "1"
     L = "L"
@@ -1009,6 +1029,14 @@ class ToolManagerSettings:
     tool_format: ToolFormat | None = None
     avoid_repetition: bool = False
     maximum_depth: int | None = None
+    execution_mode: ToolManagerExecutionMode = ToolManagerExecutionMode.LEGACY
+    missing_call_mode: ToolManagerMissingCallMode = (
+        ToolManagerMissingCallMode.LEGACY_NONE
+    )
+    parser_return_mode: ToolParserReturnMode = ToolParserReturnMode.LEGACY
+    provider_arguments_mode: ToolProviderArgumentsMode = (
+        ToolProviderArgumentsMode.EMPTY_ON_MALFORMED
+    )
     filters: (
         list[
             Callable[
@@ -1028,6 +1056,14 @@ class ToolManagerSettings:
         ]
         | None
     ) = None
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.execution_mode, ToolManagerExecutionMode)
+        assert isinstance(self.missing_call_mode, ToolManagerMissingCallMode)
+        assert isinstance(self.parser_return_mode, ToolParserReturnMode)
+        assert isinstance(
+            self.provider_arguments_mode, ToolProviderArgumentsMode
+        )
 
 
 def _assert_tool_identifier(value: UUID | str, field_name: str) -> None:

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -189,6 +189,12 @@ class ToolCallDiagnosticStatus(StrEnum):
     NON_EXECUTED = "non_executed"
 
 
+class ToolFilterResultStatus(StrEnum):
+    PASS = "pass"
+    MODIFY = "modify"
+    SUPPRESS = "suppress"
+
+
 class ToolNameResolutionStatus(StrEnum):
     EXACT = "exact"
     ALIAS = "alias"
@@ -1085,13 +1091,41 @@ class ToolCallContext:
     session_id: UUID | None = None
     calls: list[ToolCall] | None = None
     cancellation_checker: Callable[[], Awaitable[None]] | None = None
+    flow_tool_node: bool = False
+
+
+@final
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ToolFilterResult:
+    status: ToolFilterResultStatus
+    call: ToolCall | None = None
+    context: ToolCallContext | None = None
+    code: ToolCallDiagnosticCode = ToolCallDiagnosticCode.FILTER_SUPPRESSED
+    message: str | None = None
+    details: dict[str, ToolValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.status, ToolFilterResultStatus)
+        if self.call is not None:
+            assert isinstance(self.call, ToolCall)
+        if self.context is not None:
+            assert isinstance(self.context, ToolCallContext)
+        assert isinstance(self.code, ToolCallDiagnosticCode)
+        if self.message is not None:
+            assert isinstance(self.message, str)
+            assert self.message.strip(), "message must not be empty"
+        assert isinstance(self.details, dict)
+        if self.status is ToolFilterResultStatus.MODIFY:
+            assert self.call is not None
+            assert self.context is not None
 
 
 @final
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ToolFilter:
     func: Callable[
-        [ToolCall, ToolCallContext], tuple[ToolCall, ToolCallContext] | None
+        [ToolCall, ToolCallContext],
+        tuple[ToolCall, ToolCallContext] | ToolFilterResult | None,
     ]
     namespace: str | None = None
 
@@ -1124,7 +1158,7 @@ class ToolManagerSettings:
         list[
             Callable[
                 [ToolCall, ToolCallContext],
-                tuple[ToolCall, ToolCallContext] | None,
+                tuple[ToolCall, ToolCallContext] | ToolFilterResult | None,
             ]
             | ToolFilter
         ]

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -39,6 +39,7 @@ class EventType(StrEnum):
     STREAM_END = "stream_end"
     TOKEN_GENERATED = "token_generated"
     TOOL_DETECT = "tool_detect"
+    TOOL_DIAGNOSTIC = "tool_diagnostic"
     TOOL_EXECUTE = "tool_execute"
     TOOL_MODEL_RUN = "tool_model_run"
     TOOL_MODEL_RESPONSE = "tool_model_response"

--- a/src/avalan/event/__init__.py
+++ b/src/avalan/event/__init__.py
@@ -44,6 +44,7 @@ class EventType(StrEnum):
     TOOL_MODEL_RUN = "tool_model_run"
     TOOL_MODEL_RESPONSE = "tool_model_response"
     TOOL_PROCESS = "tool_process"
+    TOOL_PROGRESS = "tool_progress"
     TOOL_RESULT = "tool_result"
 
 

--- a/src/avalan/flow/__init__.py
+++ b/src/avalan/flow/__init__.py
@@ -3,7 +3,9 @@ from .definition import FlowDefinition as FlowDefinition
 from .definition import FlowEdgeDefinition as FlowEdgeDefinition
 from .definition import FlowInputDefinition as FlowInputDefinition
 from .definition import FlowInputType as FlowInputType
+from .definition import FlowNodeContract as FlowNodeContract
 from .definition import FlowNodeDefinition as FlowNodeDefinition
+from .definition import FlowNodeMetadata as FlowNodeMetadata
 from .definition import FlowOutputDefinition as FlowOutputDefinition
 from .definition import FlowOutputType as FlowOutputType
 from .flow import Flow as Flow

--- a/src/avalan/flow/__init__.py
+++ b/src/avalan/flow/__init__.py
@@ -26,7 +26,10 @@ from .manager import FlowManager as FlowManager
 from .node import CancellationChecker as CancellationChecker
 from .node import Node as Node
 from .registry import FLOW_INPUT_KEY as FLOW_INPUT_KEY
+from .registry import FLOW_TOOL_NODE_TYPE as FLOW_TOOL_NODE_TYPE
 from .registry import FlowNodeFactory as FlowNodeFactory
 from .registry import FlowNodeRegistry as FlowNodeRegistry
+from .registry import FlowToolResolver as FlowToolResolver
 from .registry import default_flow_node_registry as default_flow_node_registry
 from .registry import flow_input_binding as flow_input_binding
+from .registry import tool_flow_node_registry as tool_flow_node_registry

--- a/src/avalan/flow/connection.py
+++ b/src/avalan/flow/connection.py
@@ -26,19 +26,6 @@ class Connection:
             filters or []
         )
 
-    def check_conditions(self, data: Any) -> bool:
-        for condition in self.conditions:
-            result = condition(data)
-            if isawaitable(result):
-                _close_awaitable(result)
-                raise TypeError(
-                    "Connection condition produced awaitable output; "
-                    "use check_conditions_async"
-                )
-            if not result:
-                return False
-        return True
-
     async def check_conditions_async(self, data: Any) -> bool:
         for condition in self.conditions:
             result = condition(data)
@@ -47,17 +34,6 @@ class Connection:
             if not result:
                 return False
         return True
-
-    def apply_filters(self, data: Any) -> Any:
-        for filter_function in self.filters:
-            data = filter_function(data)
-            if isawaitable(data):
-                _close_awaitable(data)
-                raise TypeError(
-                    "Connection filter produced awaitable output; "
-                    "use apply_filters_async"
-                )
-        return data
 
     async def apply_filters_async(self, data: Any) -> Any:
         for filter_function in self.filters:
@@ -68,9 +44,3 @@ class Connection:
 
     def __repr__(self) -> str:
         return f"<Conn {self.src.name}->{self.dest.name}>"
-
-
-def _close_awaitable(value: object) -> None:
-    close = getattr(value, "close", None)
-    if callable(close):
-        close()

--- a/src/avalan/flow/definition.py
+++ b/src/avalan/flow/definition.py
@@ -96,6 +96,46 @@ class FlowOutputDefinition:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class FlowNodeContract:
+    name: str | None = None
+    type: FlowInputType | FlowOutputType | str | None = None
+    schema: FlowMetadata | None = None
+    schema_ref: str | None = None
+    metadata: FlowMetadata = field(default_factory=_empty_mapping)
+
+    def __post_init__(self) -> None:
+        if self.name is not None:
+            _assert_non_empty_string(self.name, "name")
+        if self.type is not None:
+            assert isinstance(self.type, FlowInputType | FlowOutputType | str)
+            if isinstance(self.type, str):
+                _assert_non_empty_string(self.type, "type")
+        if self.schema is not None:
+            object.__setattr__(self, "schema", _freeze_mapping(self.schema))
+        if self.schema_ref is not None:
+            _assert_non_empty_string(self.schema_ref, "schema_ref")
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FlowNodeMetadata:
+    supports_ref: bool = False
+    async_only: bool = False
+    input_contract: FlowNodeContract | None = None
+    output_contract: FlowNodeContract | None = None
+    metadata: FlowMetadata = field(default_factory=_empty_mapping)
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.supports_ref, bool)
+        assert isinstance(self.async_only, bool)
+        if self.input_contract is not None:
+            assert isinstance(self.input_contract, FlowNodeContract)
+        if self.output_contract is not None:
+            assert isinstance(self.output_contract, FlowNodeContract)
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class FlowNodeDefinition:
     name: str
     type: str

--- a/src/avalan/flow/flow.py
+++ b/src/avalan/flow/flow.py
@@ -134,11 +134,24 @@ class Flow:
                 "Flow has no valid starting node; graph may contain a cycle"
             )
 
+        reachable = self._collect_reachable(start_nodes)
+        cycle_nodes = self._detect_cycle_nodes(start_nodes)
+        if cycle_nodes:
+            remaining = sorted(cycle_nodes)
+            raise ValueError(
+                "Flow contains a cycle involving: " + ", ".join(remaining)
+            )
+
         incoming_counts = {
-            name: len(self.incoming.get(name, [])) for name in self.nodes
+            name: sum(
+                1
+                for connection in self.incoming.get(name, [])
+                if connection.src.name in reachable
+            )
+            for name in reachable
         }
         indegree = dict(incoming_counts)
-        buffers: dict[str, dict[str, Any]] = {name: {} for name in self.nodes}
+        buffers: dict[str, dict[str, Any]] = {name: {} for name in reachable}
         if initial_inputs is not None and len(start_nodes) == 1:
             buffers[start_nodes[0].name] = dict(initial_inputs)
         elif initial_data is not None and len(start_nodes) == 1:
@@ -151,7 +164,6 @@ class Flow:
 
         outputs: dict[str, Any] = {}
         processed: set[str] = set()
-        reachable = self._collect_reachable(start_nodes)
         await _check_cancelled(cancellation_checker)
         while queue:
             await _check_cancelled(cancellation_checker)
@@ -184,17 +196,10 @@ class Flow:
                 "Flow contains a cycle involving: " + ", ".join(remaining)
             )
 
-        cycle_nodes = self._detect_cycle_nodes(start_nodes)
-        if cycle_nodes:
-            remaining = sorted(cycle_nodes)
-            raise ValueError(
-                "Flow contains a cycle involving: " + ", ".join(remaining)
-            )
-
         terminal = {
             name: _flow_output(outputs[name])
             for name, outs in self.outgoing.items()
-            if not outs
+            if name in reachable and not outs
         }
         await _check_cancelled(cancellation_checker)
         if len(terminal) == 1:
@@ -232,24 +237,23 @@ class Flow:
 
     def _detect_cycle_nodes(self, start_nodes: list[Node]) -> set[str]:
         visited: set[str] = set()
-        recursion_stack: set[str] = set()
+        path: list[str] = []
+        path_indexes: dict[str, int] = {}
         cycle_nodes: set[str] = set()
 
-        def dfs(name: str) -> bool:
-            if name in recursion_stack:
-                cycle_nodes.add(name)
-                return True
+        def dfs(name: str) -> None:
+            if name in path_indexes:
+                cycle_nodes.update(path[path_indexes[name] :])
+                return
             if name in visited:
-                return False
+                return
             visited.add(name)
-            recursion_stack.add(name)
-            found_cycle = False
+            path_indexes[name] = len(path)
+            path.append(name)
             for connection in self.outgoing.get(name, []):
-                if dfs(connection.dest.name):
-                    cycle_nodes.add(name)
-                    found_cycle = True
-            recursion_stack.remove(name)
-            return found_cycle
+                dfs(connection.dest.name)
+            path.pop()
+            path_indexes.pop(name)
 
         for node in start_nodes:
             dfs(node.name)
@@ -261,7 +265,11 @@ class Flow:
         processed: set[str],
         reachable: set[str],
     ) -> None:
-        if node.name in processed or len(processed) >= len(reachable):
+        if (
+            node.name not in reachable
+            or node.name in processed
+            or len(processed) >= len(reachable)
+        ):
             raise ValueError("Flow traversal revisited node: " + node.name)
 
 

--- a/src/avalan/flow/flow.py
+++ b/src/avalan/flow/flow.py
@@ -6,6 +6,8 @@ from collections import deque
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
+_SKIPPED = object()
+
 
 class Flow:
     """Directed graph of nodes and connections."""
@@ -126,6 +128,8 @@ class Flow:
             raise ValueError(
                 "Flow has no valid starting node; graph may contain a cycle"
             )
+        reachable = self._collect_reachable(start_nodes)
+        self._assert_sync_supported(reachable)
 
         incoming_counts = {
             name: len(self.incoming.get(name, [])) for name in self.nodes
@@ -142,20 +146,19 @@ class Flow:
 
         outputs: dict[str, Any] = {}
         processed: set[str] = set()
-        reachable = self._collect_reachable(start_nodes)
         while queue:
             node = queue.popleft()
             self._assert_unprocessed_queue_node(node, processed, reachable)
             processed.add(node.name)
             inputs = buffers[node.name]
             if incoming_counts[node.name] > 0 and not inputs:
-                outputs[node.name] = None
+                outputs[node.name] = _SKIPPED
             else:
                 outputs[node.name] = node.execute(inputs)
             out_value = outputs[node.name]
             for connection in self.outgoing.get(node.name, []):
                 indegree[connection.dest.name] -= 1
-                if out_value is not None and connection.check_conditions(
+                if out_value is not _SKIPPED and connection.check_conditions(
                     out_value
                 ):
                     forwarded = connection.apply_filters(out_value)
@@ -177,7 +180,7 @@ class Flow:
             )
 
         terminal = {
-            name: outputs[name]
+            name: _flow_output(outputs[name])
             for name, outs in self.outgoing.items()
             if not outs
         }
@@ -227,7 +230,7 @@ class Flow:
             processed.add(node.name)
             inputs = buffers[node.name]
             if incoming_counts[node.name] > 0 and not inputs:
-                outputs[node.name] = None
+                outputs[node.name] = _SKIPPED
             else:
                 outputs[node.name] = await node.execute_async(
                     inputs,
@@ -237,7 +240,7 @@ class Flow:
             out_value = outputs[node.name]
             for connection in self.outgoing.get(node.name, []):
                 indegree[connection.dest.name] -= 1
-                if out_value is not None and (
+                if out_value is not _SKIPPED and (
                     await connection.check_conditions_async(out_value)
                 ):
                     forwarded = await connection.apply_filters_async(out_value)
@@ -259,7 +262,7 @@ class Flow:
             )
 
         terminal = {
-            name: outputs[name]
+            name: _flow_output(outputs[name])
             for name, outs in self.outgoing.items()
             if not outs
         }
@@ -296,6 +299,28 @@ class Flow:
             for connection in self.outgoing.get(name, []):
                 stack.append(connection.dest.name)
         return reachable
+
+    def _assert_sync_supported(self, reachable: set[str]) -> None:
+        async_only = sorted(
+            name
+            for name in reachable
+            if self._node_requires_async(self.nodes[name])
+        )
+        if async_only:
+            raise TypeError(
+                "Flow contains async-only node(s); use execute_async: "
+                + ", ".join(async_only)
+            )
+
+    def _node_requires_async(self, node: Node) -> bool:
+        if node.async_only:
+            return True
+        if node.subgraph is None:
+            return False
+        return any(
+            node.subgraph._node_requires_async(subgraph_node)
+            for subgraph_node in node.subgraph.nodes.values()
+        )
 
     def _detect_cycle_nodes(self, start_nodes: list[Node]) -> set[str]:
         visited: set[str] = set()
@@ -337,3 +362,9 @@ async def _check_cancelled(
 ) -> None:
     if cancellation_checker is not None:
         await cancellation_checker()
+
+
+def _flow_output(value: Any) -> Any:
+    if value is _SKIPPED:
+        return None
+    return value

--- a/src/avalan/flow/flow.py
+++ b/src/avalan/flow/flow.py
@@ -118,76 +118,6 @@ class Flow:
             edges.append((left, label, right))
         return edges
 
-    def execute(
-        self,
-        initial_node: str | Node | None = None,
-        initial_data: Any = None,
-    ) -> Any:
-        start_nodes = self._resolve_start_nodes(initial_node)
-        if not start_nodes:
-            raise ValueError(
-                "Flow has no valid starting node; graph may contain a cycle"
-            )
-        reachable = self._collect_reachable(start_nodes)
-        self._assert_sync_supported(reachable)
-
-        incoming_counts = {
-            name: len(self.incoming.get(name, [])) for name in self.nodes
-        }
-        indegree = dict(incoming_counts)
-        buffers: dict[str, dict[str, Any]] = {name: {} for name in self.nodes}
-        if initial_data is not None and len(start_nodes) == 1:
-            buffers[start_nodes[0].name] = {"__init__": initial_data}
-
-        queue: deque[Node] = deque()
-        for node in start_nodes:
-            indegree[node.name] = 0
-            queue.append(node)
-
-        outputs: dict[str, Any] = {}
-        processed: set[str] = set()
-        while queue:
-            node = queue.popleft()
-            self._assert_unprocessed_queue_node(node, processed, reachable)
-            processed.add(node.name)
-            inputs = buffers[node.name]
-            if incoming_counts[node.name] > 0 and not inputs:
-                outputs[node.name] = _SKIPPED
-            else:
-                outputs[node.name] = node.execute(inputs)
-            out_value = outputs[node.name]
-            for connection in self.outgoing.get(node.name, []):
-                indegree[connection.dest.name] -= 1
-                if out_value is not _SKIPPED and connection.check_conditions(
-                    out_value
-                ):
-                    forwarded = connection.apply_filters(out_value)
-                    buffers[connection.dest.name][node.name] = forwarded
-                if indegree[connection.dest.name] == 0:
-                    queue.append(connection.dest)
-
-        if processed != reachable:
-            remaining = sorted(reachable - processed)
-            raise ValueError(
-                "Flow contains a cycle involving: " + ", ".join(remaining)
-            )
-
-        cycle_nodes = self._detect_cycle_nodes(start_nodes)
-        if cycle_nodes:
-            remaining = sorted(cycle_nodes)
-            raise ValueError(
-                "Flow contains a cycle involving: " + ", ".join(remaining)
-            )
-
-        terminal = {
-            name: _flow_output(outputs[name])
-            for name, outs in self.outgoing.items()
-            if not outs
-        }
-        if len(terminal) == 1:
-            return next(iter(terminal.values()))
-        return terminal
-
     async def execute_async(
         self,
         initial_node: str | Node | None = None,
@@ -299,28 +229,6 @@ class Flow:
             for connection in self.outgoing.get(name, []):
                 stack.append(connection.dest.name)
         return reachable
-
-    def _assert_sync_supported(self, reachable: set[str]) -> None:
-        async_only = sorted(
-            name
-            for name in reachable
-            if self._node_requires_async(self.nodes[name])
-        )
-        if async_only:
-            raise TypeError(
-                "Flow contains async-only node(s); use execute_async: "
-                + ", ".join(async_only)
-            )
-
-    def _node_requires_async(self, node: Node) -> bool:
-        if node.async_only:
-            return True
-        if node.subgraph is None:
-            return False
-        return any(
-            node.subgraph._node_requires_async(subgraph_node)
-            for subgraph_node in node.subgraph.nodes.values()
-        )
 
     def _detect_cycle_nodes(self, start_nodes: list[Node]) -> set[str]:
         visited: set[str] = set()

--- a/src/avalan/flow/loader.py
+++ b/src/avalan/flow/loader.py
@@ -621,7 +621,7 @@ def _validate_node_type(
     if ref is not None and _is_path_escape(ref):
         issues.append(_path_escape_issue(f"nodes.{name}.ref"))
     if registry.supports(node_type):
-        if ref is not None and node_type != "agent":
+        if ref is not None and not registry.supports_ref(node_type):
             issues.append(
                 _issue(
                     code="flow.untrusted_callable",

--- a/src/avalan/flow/node.py
+++ b/src/avalan/flow/node.py
@@ -18,7 +18,11 @@ class Node:
         output_schema: type | None = None,
         func: Callable[..., Any] | None = None,
         subgraph: "Flow | None" = None,
+        async_only: bool = False,
+        receives_cancellation_checker: bool = False,
     ) -> None:
+        assert isinstance(async_only, bool)
+        assert isinstance(receives_cancellation_checker, bool)
         self.name: str = name
         self.label: str = label or name
         self.shape: str | None = shape
@@ -26,6 +30,10 @@ class Node:
         self.output_schema: type | None = output_schema
         self.func: Callable[..., Any] | None = func
         self.subgraph: "Flow | None" = subgraph
+        self.async_only: bool = async_only
+        self.receives_cancellation_checker: bool = (
+            receives_cancellation_checker
+        )
 
     def execute(self, inputs: dict[str, Any]) -> Any:
         if self.subgraph is not None:
@@ -68,7 +76,10 @@ class Node:
 
         self._validate_input(inputs)
         await _check_cancelled(cancellation_checker)
-        output = self._compute_output(inputs)
+        output = self._compute_output_async(
+            inputs,
+            cancellation_checker=cancellation_checker,
+        )
         if isawaitable(output):
             output = await output
         self._validate_output(output)
@@ -86,6 +97,19 @@ class Node:
             return self.func(inputs)
         except TypeError:
             return self.func(*inputs.values())
+
+    def _compute_output_async(
+        self,
+        inputs: dict[str, Any],
+        *,
+        cancellation_checker: CancellationChecker | None,
+    ) -> Any:
+        if callable(self.func) and self.receives_cancellation_checker:
+            return self.func(
+                inputs,
+                cancellation_checker=cancellation_checker,
+            )
+        return self._compute_output(inputs)
 
     def _subgraph_initial(self, inputs: dict[str, Any]) -> Any:
         return next(iter(inputs.values())) if len(inputs) == 1 else inputs

--- a/src/avalan/flow/node.py
+++ b/src/avalan/flow/node.py
@@ -35,28 +35,6 @@ class Node:
             receives_cancellation_checker
         )
 
-    def execute(self, inputs: dict[str, Any]) -> Any:
-        if self.subgraph is not None:
-            initial = self._subgraph_initial(inputs)
-            result = self.subgraph.execute(
-                initial_node=None, initial_data=initial
-            )
-            self._validate_output(result)
-            return result
-
-        self._validate_input(inputs)
-        output = self._compute_output(inputs)
-        if isawaitable(output):
-            close = getattr(output, "close", None)
-            if callable(close):
-                close()
-            raise TypeError(
-                f"{self.name} produced awaitable output; use execute_async"
-            )
-        self._validate_output(output)
-
-        return output
-
     async def execute_async(
         self,
         inputs: dict[str, Any],

--- a/src/avalan/flow/registry.py
+++ b/src/avalan/flow/registry.py
@@ -2,6 +2,7 @@ from ..entities import (
     ToolCall,
     ToolCallContext,
     ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallOutcome,
@@ -22,6 +23,7 @@ from .definition import (
 )
 from .node import Node
 
+from asyncio import CancelledError
 from collections.abc import Awaitable, Iterable, Mapping
 from typing import Any, Protocol, cast
 from uuid import uuid4
@@ -327,6 +329,9 @@ def _tool_node_factory(
                 name=descriptor.name,
                 arguments=arguments,
             )
+            diagnostic = resolver.validate_tool_call(call)
+            if diagnostic is not None:
+                return _tool_node_output(definition, diagnostic)
             outcome = await resolver.execute_call(
                 call,
                 context=ToolCallContext(
@@ -484,6 +489,11 @@ def _tool_node_output(
     definition: FlowNodeDefinition,
     outcome: ToolCallOutcome,
 ) -> object:
+    if (
+        isinstance(outcome, ToolCallDiagnostic)
+        and outcome.code is ToolCallDiagnosticCode.CANCELLED
+    ):
+        raise CancelledError()
     mode = cast(str, definition.config.get("output_mode", "raw"))
     if mode == "envelope":
         return _tool_node_envelope(outcome)
@@ -555,7 +565,13 @@ def _tool_node_arguments(
             if isinstance(name, str) and isinstance(selector, str)
         }
 
-    parameters = _tool_parameter_names(descriptor)
+    properties = _tool_parameter_properties(descriptor)
+    parameters = (
+        frozenset(properties) if properties is not None else frozenset()
+    )
+    if properties is not None and not parameters:
+        return {}
+
     if isinstance(source, Mapping):
         matched = {
             name: _copy_flow_value(source[name])

--- a/src/avalan/flow/registry.py
+++ b/src/avalan/flow/registry.py
@@ -1,3 +1,8 @@
+from ..entities import (
+    ToolDescriptor,
+    ToolNameResolution,
+    ToolNameResolutionStatus,
+)
 from .definition import (
     FlowInputDefinition,
     FlowInputType,
@@ -8,14 +13,23 @@ from .definition import (
 )
 from .node import Node
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Protocol
 
 FLOW_INPUT_KEY = "__flow_input__"
+FLOW_TOOL_NODE_TYPE = "tool"
 
 
 class FlowNodeFactory(Protocol):
     def __call__(self, definition: FlowNodeDefinition) -> Node: ...
+
+
+class FlowToolResolver(Protocol):
+    def list_tools(self) -> list[ToolDescriptor]: ...
+
+    def resolve_tool_name(
+        self, name: str, *, provider_originated: bool = False
+    ) -> ToolNameResolution: ...
 
 
 class FlowNodeConfigurationError(ValueError):
@@ -160,6 +174,40 @@ def default_flow_node_registry() -> FlowNodeRegistry:
     )
 
 
+def tool_flow_node_registry(
+    resolver: FlowToolResolver,
+    *,
+    base_registry: FlowNodeRegistry | None = None,
+) -> FlowNodeRegistry:
+    assert _is_flow_tool_resolver(resolver)
+    if base_registry is not None:
+        assert isinstance(base_registry, FlowNodeRegistry)
+    registry = base_registry or default_flow_node_registry()
+    descriptors = {
+        descriptor.name: descriptor for descriptor in resolver.list_tools()
+    }
+    registry.register(
+        FLOW_TOOL_NODE_TYPE,
+        _tool_node_factory(resolver, descriptors),
+        metadata=FlowNodeMetadata(
+            supports_ref=True,
+            async_only=True,
+            input_contract=FlowNodeContract(
+                name="arguments",
+                type=FlowInputType.OBJECT,
+                metadata={"dynamic": True},
+            ),
+            output_contract=FlowNodeContract(
+                name="result",
+                type=FlowOutputType.JSON,
+                metadata={"dynamic": True},
+            ),
+            metadata={"tools": _tool_contracts(descriptors.values())},
+        ),
+    )
+    return registry
+
+
 def flow_input_binding(
     input_definition: FlowInputDefinition | None,
     value: object,
@@ -206,6 +254,57 @@ def _select_node(definition: FlowNodeDefinition) -> Node:
     return Node(definition.name, func=run)
 
 
+def _tool_node_factory(
+    resolver: FlowToolResolver,
+    descriptors: Mapping[str, ToolDescriptor],
+) -> FlowNodeFactory:
+    def factory(definition: FlowNodeDefinition) -> Node:
+        path = f"nodes.{definition.name}.ref"
+        requested_name = definition.ref
+        if requested_name is None:
+            raise FlowNodeConfigurationError(
+                code="flow.missing_ref",
+                path=path,
+                message="Tool flow nodes must declare a tool ref.",
+                hint="Set ref to an enabled avalan tool name.",
+            )
+        if _is_ref_import_like(requested_name):
+            raise FlowNodeConfigurationError(
+                code="flow.invalid_ref",
+                path=path,
+                message="Tool flow node ref must be a tool name.",
+                hint="Use an enabled avalan tool name, not a path or URI.",
+            )
+        resolution = resolver.resolve_tool_name(requested_name)
+        if resolution.status not in {
+            ToolNameResolutionStatus.EXACT,
+            ToolNameResolutionStatus.ALIAS,
+        }:
+            raise FlowNodeConfigurationError(
+                code=f"flow.tool_{resolution.status.value}",
+                path=path,
+                message=(
+                    "Tool flow node ref does not resolve to one enabled tool."
+                ),
+                hint="Use an enabled avalan tool name or unambiguous alias.",
+            )
+        assert resolution.canonical_name is not None
+        descriptor = descriptors[resolution.canonical_name]
+
+        async def run(_: dict[str, object]) -> object:
+            raise NotImplementedError(
+                "Flow tool node execution is unavailable."
+            )
+
+        return Node(
+            definition.name,
+            label=descriptor.name,
+            func=run,
+        )
+
+    return factory
+
+
 def _node_input_value(
     definition: FlowNodeDefinition,
     inputs: Mapping[str, object],
@@ -240,3 +339,31 @@ def _copy_flow_value(value: object) -> object:
     if isinstance(value, list | tuple):
         return [_copy_flow_value(item) for item in value]
     return value
+
+
+def _is_flow_tool_resolver(value: object) -> bool:
+    return (
+        hasattr(value, "list_tools")
+        and callable(getattr(value, "list_tools"))
+        and hasattr(value, "resolve_tool_name")
+        and callable(getattr(value, "resolve_tool_name"))
+    )
+
+
+def _tool_contracts(
+    descriptors: Iterable[ToolDescriptor],
+) -> dict[str, dict[str, object]]:
+    contracts: dict[str, dict[str, object]] = {}
+    for descriptor in descriptors:
+        assert isinstance(descriptor, ToolDescriptor)
+        contract: dict[str, object] = {"aliases": tuple(descriptor.aliases)}
+        if descriptor.parameter_schema is not None:
+            contract["parameter_schema"] = descriptor.parameter_schema
+        if descriptor.return_schema is not None:
+            contract["return_schema"] = descriptor.return_schema
+        contracts[descriptor.name] = contract
+    return contracts
+
+
+def _is_ref_import_like(ref: str) -> bool:
+    return "://" in ref or "/" in ref or "\\" in ref or ":" in ref

--- a/src/avalan/flow/registry.py
+++ b/src/avalan/flow/registry.py
@@ -1,11 +1,17 @@
 from ..entities import (
     ToolCall,
+    ToolCallContext,
     ToolCallDiagnostic,
+    ToolCallDiagnosticStage,
+    ToolCallError,
+    ToolCallOutcome,
+    ToolCallResult,
     ToolDescriptor,
     ToolNameResolution,
     ToolNameResolutionStatus,
     ToolValue,
 )
+from ..utils import tool_call_diagnostic_payload, tool_call_error_payload
 from .definition import (
     FlowInputDefinition,
     FlowInputType,
@@ -16,8 +22,8 @@ from .definition import (
 )
 from .node import Node
 
-from collections.abc import Iterable, Mapping
-from typing import Protocol, cast
+from collections.abc import Awaitable, Iterable, Mapping
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 FLOW_INPUT_KEY = "__flow_input__"
@@ -38,6 +44,12 @@ class FlowToolResolver(Protocol):
     def validate_tool_call(
         self, call: ToolCall
     ) -> ToolCallDiagnostic | None: ...
+
+    def execute_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> Awaitable[ToolCallOutcome]: ...
 
 
 class FlowNodeConfigurationError(ValueError):
@@ -299,36 +311,37 @@ def _tool_node_factory(
         assert resolution.canonical_name is not None
         descriptor = descriptors[resolution.canonical_name]
         _validate_tool_node_bindings(definition, descriptor)
+        _validate_tool_node_output_mode(definition)
 
-        async def run(inputs: dict[str, object]) -> object:
+        async def run(
+            inputs: dict[str, object],
+            *,
+            cancellation_checker: Any = None,
+        ) -> object:
             arguments = cast(
                 dict[str, ToolValue],
                 _tool_node_arguments(definition, descriptor, inputs),
             )
-            diagnostic = resolver.validate_tool_call(
-                ToolCall(
-                    id=str(uuid4()),
-                    name=descriptor.name,
-                    arguments=arguments,
-                )
+            call = ToolCall(
+                id=str(uuid4()),
+                name=descriptor.name,
+                arguments=arguments,
             )
-            if diagnostic is not None:
-                raise FlowNodeConfigurationError(
-                    code="flow.invalid_arguments",
-                    path=f"nodes.{definition.name}.config.arguments",
-                    message="Tool node arguments are invalid.",
-                    hint=(
-                        "Provide arguments matching the tool parameter schema."
-                    ),
-                )
-            raise NotImplementedError(
-                "Flow tool node execution is unavailable."
+            outcome = await resolver.execute_call(
+                call,
+                context=ToolCallContext(
+                    cancellation_checker=cancellation_checker,
+                    flow_tool_node=True,
+                ),
             )
+            return _tool_node_output(definition, outcome)
 
         return Node(
             definition.name,
             label=descriptor.name,
             func=run,
+            async_only=True,
+            receives_cancellation_checker=True,
         )
 
     return factory
@@ -378,6 +391,8 @@ def _is_flow_tool_resolver(value: object) -> bool:
         and callable(getattr(value, "resolve_tool_name"))
         and hasattr(value, "validate_tool_call")
         and callable(getattr(value, "validate_tool_call"))
+        and hasattr(value, "execute_call")
+        and callable(getattr(value, "execute_call"))
     )
 
 
@@ -451,6 +466,76 @@ def _validate_tool_node_bindings(
             message="Tool node argument binding is missing.",
             hint="Bind every required tool parameter.",
         )
+
+
+def _validate_tool_node_output_mode(definition: FlowNodeDefinition) -> None:
+    mode = definition.config.get("output_mode", "raw")
+    if mode in {"raw", "envelope"}:
+        return
+    raise FlowNodeConfigurationError(
+        code="flow.invalid_output_mode",
+        path=f"nodes.{definition.name}.config.output_mode",
+        message="Tool node output mode is invalid.",
+        hint="Use raw or envelope.",
+    )
+
+
+def _tool_node_output(
+    definition: FlowNodeDefinition,
+    outcome: ToolCallOutcome,
+) -> object:
+    mode = cast(str, definition.config.get("output_mode", "raw"))
+    if mode == "envelope":
+        return _tool_node_envelope(outcome)
+    if isinstance(outcome, ToolCallResult):
+        return outcome.result
+    if isinstance(outcome, ToolCallDiagnostic):
+        if outcome.stage is ToolCallDiagnosticStage.VALIDATE:
+            raise FlowNodeConfigurationError(
+                code="flow.invalid_arguments",
+                path=f"nodes.{definition.name}.config.arguments",
+                message="Tool node arguments are invalid.",
+                hint="Provide arguments matching the tool parameter schema.",
+            )
+        raise FlowNodeConfigurationError(
+            code="flow.tool_diagnostic",
+            path=f"nodes.{definition.name}",
+            message="Tool node did not execute.",
+            hint="Use envelope output mode to compose diagnostic outcomes.",
+        )
+    assert isinstance(outcome, ToolCallError)
+    raise RuntimeError(
+        f"Tool node execution failed: {outcome.error_type}: {outcome.message}"
+    )
+
+
+def _tool_node_envelope(outcome: ToolCallOutcome) -> dict[str, object]:
+    if isinstance(outcome, ToolCallResult):
+        return {
+            "status": "result",
+            "call_id": outcome.call.id,
+            "canonical_name": outcome.name,
+            "result": outcome.result,
+            "error": None,
+            "diagnostic": None,
+        }
+    if isinstance(outcome, ToolCallError):
+        return {
+            "status": "error",
+            "call_id": outcome.call.id,
+            "canonical_name": outcome.name,
+            "result": None,
+            "error": tool_call_error_payload(outcome),
+            "diagnostic": None,
+        }
+    return {
+        "status": "diagnostic",
+        "call_id": outcome.call_id,
+        "canonical_name": outcome.canonical_name,
+        "result": None,
+        "error": None,
+        "diagnostic": tool_call_diagnostic_payload(outcome),
+    }
 
 
 def _tool_node_arguments(

--- a/src/avalan/flow/registry.py
+++ b/src/avalan/flow/registry.py
@@ -1,7 +1,10 @@
 from ..entities import (
+    ToolCall,
+    ToolCallDiagnostic,
     ToolDescriptor,
     ToolNameResolution,
     ToolNameResolutionStatus,
+    ToolValue,
 )
 from .definition import (
     FlowInputDefinition,
@@ -14,7 +17,8 @@ from .definition import (
 from .node import Node
 
 from collections.abc import Iterable, Mapping
-from typing import Protocol
+from typing import Protocol, cast
+from uuid import uuid4
 
 FLOW_INPUT_KEY = "__flow_input__"
 FLOW_TOOL_NODE_TYPE = "tool"
@@ -30,6 +34,10 @@ class FlowToolResolver(Protocol):
     def resolve_tool_name(
         self, name: str, *, provider_originated: bool = False
     ) -> ToolNameResolution: ...
+
+    def validate_tool_call(
+        self, call: ToolCall
+    ) -> ToolCallDiagnostic | None: ...
 
 
 class FlowNodeConfigurationError(ValueError):
@@ -290,8 +298,29 @@ def _tool_node_factory(
             )
         assert resolution.canonical_name is not None
         descriptor = descriptors[resolution.canonical_name]
+        _validate_tool_node_bindings(definition, descriptor)
 
-        async def run(_: dict[str, object]) -> object:
+        async def run(inputs: dict[str, object]) -> object:
+            arguments = cast(
+                dict[str, ToolValue],
+                _tool_node_arguments(definition, descriptor, inputs),
+            )
+            diagnostic = resolver.validate_tool_call(
+                ToolCall(
+                    id=str(uuid4()),
+                    name=descriptor.name,
+                    arguments=arguments,
+                )
+            )
+            if diagnostic is not None:
+                raise FlowNodeConfigurationError(
+                    code="flow.invalid_arguments",
+                    path=f"nodes.{definition.name}.config.arguments",
+                    message="Tool node arguments are invalid.",
+                    hint=(
+                        "Provide arguments matching the tool parameter schema."
+                    ),
+                )
             raise NotImplementedError(
                 "Flow tool node execution is unavailable."
             )
@@ -347,6 +376,8 @@ def _is_flow_tool_resolver(value: object) -> bool:
         and callable(getattr(value, "list_tools"))
         and hasattr(value, "resolve_tool_name")
         and callable(getattr(value, "resolve_tool_name"))
+        and hasattr(value, "validate_tool_call")
+        and callable(getattr(value, "validate_tool_call"))
     )
 
 
@@ -359,11 +390,149 @@ def _tool_contracts(
         contract: dict[str, object] = {"aliases": tuple(descriptor.aliases)}
         if descriptor.parameter_schema is not None:
             contract["parameter_schema"] = descriptor.parameter_schema
+            contract["input_contract"] = FlowNodeContract(
+                name="arguments",
+                type=FlowInputType.OBJECT,
+                schema=descriptor.parameter_schema,
+            )
         if descriptor.return_schema is not None:
             contract["return_schema"] = descriptor.return_schema
+            contract["output_contract"] = FlowNodeContract(
+                name="result",
+                type=FlowOutputType.JSON,
+                schema=descriptor.return_schema,
+            )
         contracts[descriptor.name] = contract
     return contracts
 
 
 def _is_ref_import_like(ref: str) -> bool:
     return "://" in ref or "/" in ref or "\\" in ref or ":" in ref
+
+
+def _validate_tool_node_bindings(
+    definition: FlowNodeDefinition,
+    descriptor: ToolDescriptor,
+) -> None:
+    bindings = definition.config.get("arguments")
+    if bindings is None:
+        return
+    path = f"nodes.{definition.name}.config.arguments"
+    if not isinstance(bindings, Mapping):
+        raise FlowNodeConfigurationError(
+            code="flow.invalid_arguments",
+            path=path,
+            message="Tool node argument bindings are invalid.",
+            hint="Use a TOML table mapping parameter names to selectors.",
+        )
+
+    parameters = _tool_parameter_names(descriptor)
+    required = _tool_required_parameters(descriptor)
+    for name, selector in bindings.items():
+        if not isinstance(name, str) or name not in parameters:
+            raise FlowNodeConfigurationError(
+                code="flow.unknown_argument_binding",
+                path=f"{path}.{name}",
+                message="Tool node argument binding is unknown.",
+                hint="Bind only declared tool parameters.",
+            )
+        if not isinstance(selector, str) or not selector.strip():
+            raise FlowNodeConfigurationError(
+                code="flow.invalid_argument_selector",
+                path=f"{path}.{name}",
+                message="Tool node argument selector is invalid.",
+                hint="Use a non-empty dotted input selector.",
+            )
+    missing = sorted(required - set(bindings))
+    if missing:
+        raise FlowNodeConfigurationError(
+            code="flow.missing_argument_binding",
+            path=f"{path}.{missing[0]}",
+            message="Tool node argument binding is missing.",
+            hint="Bind every required tool parameter.",
+        )
+
+
+def _tool_node_arguments(
+    definition: FlowNodeDefinition,
+    descriptor: ToolDescriptor,
+    inputs: Mapping[str, object],
+) -> dict[str, object]:
+    bindings = definition.config.get("arguments")
+    source = _node_input_value(definition, inputs)
+    if bindings is not None:
+        assert isinstance(bindings, Mapping)
+        return {
+            str(name): _select_argument(
+                source, str(selector), definition, name
+            )
+            for name, selector in bindings.items()
+            if isinstance(name, str) and isinstance(selector, str)
+        }
+
+    parameters = _tool_parameter_names(descriptor)
+    if isinstance(source, Mapping):
+        matched = {
+            name: _copy_flow_value(source[name])
+            for name in sorted(parameters)
+            if name in source
+        }
+        if matched:
+            return matched
+
+    if len(parameters) == 1:
+        parameter = next(iter(parameters))
+        return {parameter: source}
+
+    raise FlowNodeConfigurationError(
+        code="flow.ambiguous_argument_binding",
+        path=f"nodes.{definition.name}.config.arguments",
+        message="Tool node arguments are ambiguous.",
+        hint="Add explicit argument selectors for this tool node.",
+    )
+
+
+def _select_argument(
+    source: object,
+    selector: str,
+    definition: FlowNodeDefinition,
+    name: object,
+) -> object:
+    try:
+        return _select_path(source, selector)
+    except (IndexError, KeyError, ValueError):
+        raise FlowNodeConfigurationError(
+            code="flow.unresolved_argument_selector",
+            path=f"nodes.{definition.name}.config.arguments.{name}",
+            message="Tool node argument selector cannot be resolved.",
+            hint="Reference a value available on the node input.",
+        ) from None
+
+
+def _tool_parameter_names(descriptor: ToolDescriptor) -> frozenset[str]:
+    properties = _tool_parameter_properties(descriptor)
+    if properties is None:
+        return frozenset()
+    return frozenset(properties)
+
+
+def _tool_required_parameters(descriptor: ToolDescriptor) -> frozenset[str]:
+    schema = descriptor.parameter_schema
+    if schema is None:
+        return frozenset()
+    required = schema.get("required", [])
+    if not isinstance(required, list | tuple):
+        return frozenset()
+    return frozenset(name for name in required if isinstance(name, str))
+
+
+def _tool_parameter_properties(
+    descriptor: ToolDescriptor,
+) -> Mapping[str, object] | None:
+    schema = descriptor.parameter_schema
+    if schema is None:
+        return None
+    properties = schema.get("properties", {})
+    if not isinstance(properties, Mapping):
+        return None
+    return properties

--- a/src/avalan/flow/registry.py
+++ b/src/avalan/flow/registry.py
@@ -1,4 +1,11 @@
-from .definition import FlowInputDefinition, FlowNodeDefinition
+from .definition import (
+    FlowInputDefinition,
+    FlowInputType,
+    FlowNodeContract,
+    FlowNodeDefinition,
+    FlowNodeMetadata,
+    FlowOutputType,
+)
 from .node import Node
 
 from collections.abc import Mapping
@@ -35,22 +42,60 @@ class FlowNodeRegistry:
     def __init__(
         self,
         factories: Mapping[str, FlowNodeFactory] | None = None,
+        metadata: Mapping[str, FlowNodeMetadata] | None = None,
     ) -> None:
-        self._factories: dict[str, FlowNodeFactory] = dict(factories or {})
+        self._factories: dict[str, FlowNodeFactory] = {}
+        self._metadata: dict[str, FlowNodeMetadata] = {}
+        node_metadata = metadata or {}
+        for node_type, factory in (factories or {}).items():
+            self.register(
+                node_type,
+                factory,
+                metadata=node_metadata.get(node_type),
+            )
 
     def register(
         self,
         node_type: str,
         factory: FlowNodeFactory,
+        *,
+        metadata: FlowNodeMetadata | None = None,
     ) -> "FlowNodeRegistry":
         assert isinstance(node_type, str) and node_type.strip()
         assert callable(factory)
+        if metadata is not None:
+            assert isinstance(metadata, FlowNodeMetadata)
         self._factories[node_type] = factory
+        self._metadata[node_type] = metadata or FlowNodeMetadata()
         return self
 
     def supports(self, node_type: str) -> bool:
         assert isinstance(node_type, str) and node_type.strip()
         return node_type in self._factories
+
+    def metadata(self, node_type: str) -> FlowNodeMetadata | None:
+        assert isinstance(node_type, str) and node_type.strip()
+        return self._metadata.get(node_type)
+
+    def supports_ref(self, node_type: str) -> bool:
+        assert isinstance(node_type, str) and node_type.strip()
+        metadata = self.metadata(node_type)
+        return metadata.supports_ref if metadata is not None else False
+
+    def is_async_only(self, node_type: str) -> bool:
+        assert isinstance(node_type, str) and node_type.strip()
+        metadata = self.metadata(node_type)
+        return metadata.async_only if metadata is not None else False
+
+    def input_contract(self, node_type: str) -> FlowNodeContract | None:
+        assert isinstance(node_type, str) and node_type.strip()
+        metadata = self.metadata(node_type)
+        return metadata.input_contract if metadata is not None else None
+
+    def output_contract(self, node_type: str) -> FlowNodeContract | None:
+        assert isinstance(node_type, str) and node_type.strip()
+        metadata = self.metadata(node_type)
+        return metadata.output_contract if metadata is not None else None
 
     def build(self, definition: FlowNodeDefinition) -> Node:
         assert isinstance(definition, FlowNodeDefinition)
@@ -65,7 +110,53 @@ def default_flow_node_registry() -> FlowNodeRegistry:
             "input": _input_node,
             "passthrough": _echo_node,
             "select": _select_node,
-        }
+        },
+        {
+            "constant": FlowNodeMetadata(
+                output_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+            ),
+            "echo": FlowNodeMetadata(
+                input_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+                output_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+            ),
+            "input": FlowNodeMetadata(
+                output_contract=FlowNodeContract(
+                    name="value",
+                    type=FlowOutputType.OBJECT,
+                    metadata={"dynamic": True},
+                ),
+            ),
+            "passthrough": FlowNodeMetadata(
+                input_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+                output_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+            ),
+            "select": FlowNodeMetadata(
+                input_contract=FlowNodeContract(
+                    name="value",
+                    type=FlowInputType.OBJECT,
+                    metadata={"dynamic": True},
+                ),
+                output_contract=FlowNodeContract(
+                    name="value",
+                    metadata={"dynamic": True},
+                ),
+            ),
+        },
     )
 
 

--- a/src/avalan/model/nlp/text/ds4.py
+++ b/src/avalan/model/nlp/text/ds4.py
@@ -1676,6 +1676,7 @@ class Ds4Model(TextGenerationModel):
             message.tool_calls
             or message.tool_call_result
             or message.tool_call_error
+            or message.tool_call_diagnostic
         )
 
     @staticmethod

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -608,6 +608,8 @@ class TextGenerationModel(BaseNLPModel):
         template_messages = []
         for message in messages:
             message_dict = asdict(message)
+            if message_dict.get("tool_call_diagnostic") is None:
+                message_dict.pop("tool_call_diagnostic", None)
             prepared = _TOOL_MESSAGE_PARSER.prepare_message_for_template(
                 message, message_dict
             )

--- a/src/avalan/model/nlp/text/vendor/anthropic.py
+++ b/src/avalan/model/nlp/text/vendor/anthropic.py
@@ -10,6 +10,7 @@ from .....entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallDiagnostic,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -17,7 +18,7 @@ from .....entities import (
 from .....model.provider import ProviderFamily
 from .....model.stream import TextGenerationSingleStream
 from .....tool.manager import ToolManager
-from .....utils import to_json
+from .....utils import to_json, tool_call_diagnostic_payload
 from ....message import TemplateMessage, TemplateMessageRole
 from ....vendor import TextGenerationVendor, TextGenerationVendorStream
 from . import (
@@ -269,8 +270,15 @@ class AnthropicClient(TextGenerationVendor):
                 continue
 
             if message.role == MessageRole.TOOL:
-                result = message.tool_call_result or message.tool_call_error
-                if not isinstance(result, (ToolCallResult, ToolCallError)):
+                result = (
+                    message.tool_call_result
+                    or message.tool_call_error
+                    or message.tool_call_diagnostic
+                )
+                if not isinstance(
+                    result,
+                    (ToolCallResult, ToolCallError, ToolCallDiagnostic),
+                ):
                     if not isinstance(message, Message):
                         fallback_messages = self._message_templates(
                             message, [*excluded_roles, "tool"]
@@ -283,11 +291,35 @@ class AnthropicClient(TextGenerationVendor):
                             )
                         template_messages.extend(fallback_messages)
                     continue
-                call_id = str(result.call.id)
-                if call_id not in tool_call_ids:
-                    tool_use_block = AnthropicClient._tool_use_block(
-                        result.call
+                call: ToolCall | MessageToolCall
+                if isinstance(result, ToolCallDiagnostic):
+                    if result.call_id is None:
+                        template_messages.append(
+                            {
+                                "role": str(MessageRole.ASSISTANT),
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": to_json(
+                                            tool_call_diagnostic_payload(
+                                                result
+                                            )
+                                        ),
+                                    }
+                                ],
+                            }
+                        )
+                        continue
+                    call = AnthropicClient._diagnostic_tool_call(
+                        message,
+                        result,
                     )
+                    call_id = str(result.call_id)
+                else:
+                    call = result.call
+                    call_id = str(result.call.id)
+                if call_id not in tool_call_ids:
+                    tool_use_block = AnthropicClient._tool_use_block(call)
                     if last_assistant_index is not None:
                         assistant_message = template_messages[
                             last_assistant_index
@@ -384,9 +416,42 @@ class AnthropicClient(TextGenerationVendor):
         }
 
     @staticmethod
+    def _diagnostic_tool_call(
+        message: Message,
+        diagnostic: ToolCallDiagnostic,
+    ) -> MessageToolCall:
+        assert diagnostic.call_id is not None
+        return MessageToolCall(
+            id=str(diagnostic.call_id),
+            name=(
+                message.name
+                or diagnostic.canonical_name
+                or diagnostic.requested_name
+                or "tool"
+            ),
+            arguments=cast(Any, message.arguments or {}),
+        )
+
+    @staticmethod
     def _tool_result_message(
-        result: ToolCallResult | ToolCallError,
+        result: ToolCallResult | ToolCallError | ToolCallDiagnostic,
     ) -> dict[str, Any]:
+        if isinstance(result, ToolCallDiagnostic):
+            assert result.call_id is not None
+            return {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": str(result.call_id),
+                        "content": to_json(
+                            tool_call_diagnostic_payload(result)
+                        ),
+                        "is_error": True,
+                    }
+                ],
+            }
+
         tool_result_content: dict[str, Any] = {
             "type": "tool_result",
             "tool_use_id": str(result.call.id),

--- a/src/avalan/model/nlp/text/vendor/bedrock.py
+++ b/src/avalan/model/nlp/text/vendor/bedrock.py
@@ -734,7 +734,7 @@ class BedrockClient(TextGenerationVendor):
         }
         if isinstance(result, ToolCallError):
             content["error"] = {
-                "name": result.error.__class__.__name__,
+                "name": result.error_type,
                 "message": result.message,
             }
         return {

--- a/src/avalan/model/nlp/text/vendor/bedrock.py
+++ b/src/avalan/model/nlp/text/vendor/bedrock.py
@@ -9,6 +9,7 @@ from .....entities import (
     ReasoningToken,
     Token,
     TokenDetail,
+    ToolCallDiagnostic,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -16,7 +17,7 @@ from .....entities import (
 from .....model.provider import ProviderFamily
 from .....model.stream import TextGenerationSingleStream
 from .....tool.manager import ToolManager
-from .....utils import to_json
+from .....utils import to_json, tool_call_diagnostic_payload
 from ....message import TemplateMessageRole
 from ....vendor import TextGenerationVendor, TextGenerationVendorStream
 from . import (
@@ -530,7 +531,28 @@ class BedrockClient(TextGenerationVendor):
             if exclude_roles and str(message.role) in exclude_roles:
                 continue
             if message.role == MessageRole.TOOL:
-                result = message.tool_call_result or message.tool_call_error
+                result = (
+                    message.tool_call_result
+                    or message.tool_call_error
+                    or message.tool_call_diagnostic
+                )
+                if (
+                    isinstance(result, ToolCallDiagnostic)
+                    and result.call_id is None
+                ):
+                    templated.append(
+                        {
+                            "role": str(MessageRole.ASSISTANT),
+                            "content": [
+                                {
+                                    "text": to_json(
+                                        tool_call_diagnostic_payload(result)
+                                    )
+                                }
+                            ],
+                        }
+                    )
+                    continue
                 if result:
                     templated.append(self._tool_result_message(result))
                 continue
@@ -715,8 +737,29 @@ class BedrockClient(TextGenerationVendor):
         return {"type": "url", "url": image_url.get("uri", "")}
 
     def _tool_result_message(
-        self, result: ToolCallResult | ToolCallError
+        self, result: ToolCallResult | ToolCallError | ToolCallDiagnostic
     ) -> dict[str, Any]:
+        if isinstance(result, ToolCallDiagnostic):
+            assert result.call_id is not None
+            return {
+                "role": str(MessageRole.USER),
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": str(result.call_id),
+                            "content": [
+                                {
+                                    "text": to_json(
+                                        tool_call_diagnostic_payload(result)
+                                    )
+                                }
+                            ],
+                            "status": "error",
+                        }
+                    }
+                ],
+            }
+
         content: dict[str, Any] = {
             "toolUseId": result.call.id,
             "content": [

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -8,6 +8,7 @@ from .....entities import (
     ReasoningToken,
     Token,
     TokenDetail,
+    ToolCallDiagnostic,
     ToolCallResult,
     ToolCallToken,
 )
@@ -15,7 +16,7 @@ from .....model.provider import ProviderFamily, provider_string_option
 from .....model.response.text import TextGenerationResponse
 from .....model.stream import TextGenerationSingleStream
 from .....tool.manager import ToolManager
-from .....utils import to_json
+from .....utils import to_json, tool_call_diagnostic_payload
 from ....message import TemplateMessage, TemplateMessageRole
 from ....vendor import TextGenerationVendor, TextGenerationVendorStream
 from . import (
@@ -282,11 +283,15 @@ class OpenAIClient(TextGenerationVendor):
         messages: list[Message],
         exclude_roles: list[TemplateMessageRole] | None = None,
     ) -> list[TemplateMessage] | list[dict[str, Any]]:
-        tool_results = [
-            message.tool_call_result or message.tool_call_error
+        tool_messages = [
+            message
             for message in messages
             if message.role == MessageRole.TOOL
-            and (message.tool_call_result or message.tool_call_error)
+            and (
+                message.tool_call_result
+                or message.tool_call_error
+                or message.tool_call_diagnostic
+            )
         ]
         do_exclude_roles = [*(exclude_roles or []), "tool"]
         template_messages = super()._template_messages(
@@ -303,27 +308,58 @@ class OpenAIClient(TextGenerationVendor):
                     for block in content
                     if isinstance(block, dict)
                 ]
-        for result in tool_results:
-            assert result is not None
-            call_id = str(result.call.id)
+        for tool_message in tool_messages:
+            outcome = (
+                tool_message.tool_call_result
+                or tool_message.tool_call_error
+                or tool_message.tool_call_diagnostic
+            )
+            assert outcome is not None
+
+            output: Any
+            if isinstance(outcome, ToolCallDiagnostic):
+                call_id_value = outcome.call_id
+                if call_id_value is None:
+                    messages_out.append(
+                        {
+                            "role": str(MessageRole.ASSISTANT),
+                            "content": to_json(
+                                tool_call_diagnostic_payload(outcome)
+                            ),
+                        }
+                    )
+                    continue
+                call_id = str(call_id_value)
+                name = (
+                    tool_message.name
+                    or outcome.canonical_name
+                    or outcome.requested_name
+                    or "tool"
+                )
+                arguments = tool_message.arguments
+                output = tool_call_diagnostic_payload(outcome)
+            else:
+                call_id = str(outcome.call.id)
+                name = outcome.call.name
+                arguments = outcome.call.arguments
+                output = (
+                    outcome.result
+                    if isinstance(outcome, ToolCallResult)
+                    else {"error": outcome.message}
+                )
+
             call_message = {
                 "type": "function_call",
-                "name": TextGenerationVendor.encode_tool_name(
-                    result.call.name
-                ),
+                "name": TextGenerationVendor.encode_tool_name(name),
                 "call_id": call_id,
-                "arguments": to_json(result.call.arguments),
+                "arguments": to_json(arguments),
             }
             messages_out.append(call_message)
 
             result_message = {
                 "type": "function_call_output",
                 "call_id": call_id,
-                "output": to_json(
-                    result.result
-                    if isinstance(result, ToolCallResult)
-                    else {"error": result.message}
-                ),
+                "output": to_json(output),
             }
             messages_out.append(result_message)
         return messages_out

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -1,6 +1,6 @@
 """Parser emitting events for detected tool calls."""
 
-from ....entities import ToolCallToken, ToolFormat
+from ....entities import ToolCallDiagnostic, ToolCallToken, ToolFormat
 from ....event import Event, EventType
 from ....event.manager import EventManager
 from ....tool.manager import ToolManager
@@ -37,6 +37,7 @@ class ToolCallResponseParser:
             self._tag_buffer = self._tag_buffer[-64:]
 
         result: list[Any] = []
+        terminal_status: ToolCallParser.ToolCallBufferStatus | None = None
 
         if not self._inside_call:
             candidate = self._pending_str + token_str
@@ -58,6 +59,8 @@ class ToolCallResponseParser:
                 self._inside_call = (
                     status is ToolCallParser.ToolCallBufferStatus.OPEN
                 )
+                if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+                    terminal_status = status
             else:
                 if self._pending_tokens:
                     result.extend(self._pending_tokens)
@@ -73,6 +76,7 @@ class ToolCallResponseParser:
                 )
             if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
                 self._inside_call = False
+                terminal_status = status
 
         if not result:
             return result
@@ -85,30 +89,49 @@ class ToolCallResponseParser:
                 Event(type=EventType.TOOL_DETECT)
             )
 
-        calls = self._tool_manager.get_calls(self._buffer.getvalue())
-        if not calls:
+        buffer_text = self._buffer.getvalue()
+        calls, diagnostics = self._parse_buffer(buffer_text)
+        if calls:
+            event = Event(
+                type=EventType.TOOL_PROCESS,
+                payload=cast(dict[str, Any], calls),
+                started=perf_counter(),
+            )
+
+            self._clear_buffers()
+            return result + [event]
+
+        if terminal_status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+            if not diagnostics:
+                diagnostics = self._stream_buffer_diagnostics(buffer_text)
+            if diagnostics:
+                event = await self._diagnostic_event(diagnostics)
+                self._clear_buffers()
+                return result + [event]
+
             return result
 
+        return result
+
+    async def _diagnostic_event(
+        self, diagnostics: list[ToolCallDiagnostic]
+    ) -> Event:
         event = Event(
-            type=EventType.TOOL_PROCESS,
-            payload=cast(dict[str, Any], calls),
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"diagnostics": cast(Any, diagnostics)},
             started=perf_counter(),
         )
-
-        self._buffer = StringIO()
-        self._tag_buffer = ""
-        self._inside_call = False
-        return result + [event]
+        if self._event_manager:
+            await self._event_manager.trigger(event)
+        return event
 
     async def flush(self) -> Iterable[Any]:
         result: list[Any] = []
-        if (
-            self._inside_call
-            and self._tool_manager.tool_format is ToolFormat.HARMONY
-        ):
-            calls = self._tool_manager.get_calls(
-                self._buffer.getvalue() + "<|call|>"
-            )
+        if self._inside_call:
+            buffer_text = self._buffer.getvalue()
+            calls: list[Any] | None = None
+            if self._tool_manager.tool_format is ToolFormat.HARMONY:
+                calls, _ = self._parse_buffer(f"{buffer_text}<|call|>")
             if calls:
                 if self._event_manager:
                     await self._event_manager.trigger(
@@ -120,13 +143,36 @@ class ToolCallResponseParser:
                     payload=cast(dict[str, Any], calls),
                     started=perf_counter(),
                 )
-                self._buffer = StringIO()
-                self._tag_buffer = ""
-                self._inside_call = False
+                self._clear_buffers()
                 result.append(event)
+            else:
+                diagnostics = self._stream_buffer_diagnostics(buffer_text)
+                if diagnostics:
+                    result.append(await self._diagnostic_event(diagnostics))
+                    self._clear_buffers()
 
         if self._pending_tokens:
             result.extend(self._pending_tokens)
             self._pending_tokens.clear()
             self._pending_str = ""
         return result
+
+    def _parse_buffer(
+        self, text: str
+    ) -> tuple[list[Any] | None, list[ToolCallDiagnostic]]:
+        if type(self._tool_manager) is ToolManager:
+            outcome = self._tool_manager.parse_calls(text)
+            return outcome.calls or None, outcome.diagnostics
+        return self._tool_manager.get_calls(text), []
+
+    def _stream_buffer_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        if type(self._tool_manager) is ToolManager:
+            return self._tool_manager.stream_buffer_diagnostics(text)
+        return []
+
+    def _clear_buffers(self) -> None:
+        self._buffer = StringIO()
+        self._tag_buffer = ""
+        self._inside_call = False

--- a/src/avalan/model/response/parsers/tool.py
+++ b/src/avalan/model/response/parsers/tool.py
@@ -20,6 +20,7 @@ class ToolCallResponseParser:
         self._tool_manager = tool_manager
         self._event_manager = event_manager
         self._buffer = StringIO()
+        self._tool_buffer = StringIO()
         self._tag_buffer = ""
         self._inside_call = False
         self._pending_tokens: list[str] = []
@@ -30,6 +31,12 @@ class ToolCallResponseParser:
         should_check = self._tool_manager.is_potential_tool_call(
             buffer_value, token_str
         )
+        if (
+            should_check
+            and self._markdown_fence_is_open(buffer_value)
+            and not self._has_unfenced_tool_marker(buffer_value, token_str)
+        ):
+            should_check = False
 
         self._buffer.write(token_str)
         self._tag_buffer += token_str
@@ -38,19 +45,51 @@ class ToolCallResponseParser:
 
         result: list[Any] = []
         terminal_status: ToolCallParser.ToolCallBufferStatus | None = None
+        visible_suffix = ""
 
         if not self._inside_call:
             candidate = self._pending_str + token_str
             status = self._tool_manager.tool_call_status(candidate)
+            if (
+                not self._pending_tokens
+                and self._has_tool_marker(token_str)
+                and not self._has_executable_tool_marker(
+                    buffer_value, token_str
+                )
+            ):
+                status = ToolCallParser.ToolCallBufferStatus.NONE
+                should_check = False
+            pending_split = self._split_pending_candidate(candidate)
+            if pending_split is not None:
+                pending_prefix, tool_token, status = pending_split
+                result.append(pending_prefix)
+                candidate = tool_token
+                self._pending_tokens.clear()
+                self._pending_str = ""
+                self._tool_buffer = StringIO()
+            else:
+                split_prefix, tool_token = self._split_visible_prefix(
+                    token_str, status, buffer_value
+                )
+                if split_prefix is not None:
+                    result.append(split_prefix)
+                    candidate = tool_token
+                    status = self._tool_manager.tool_call_status(candidate)
             if status is ToolCallParser.ToolCallBufferStatus.PREFIX:
-                self._pending_tokens.append(token_str)
+                self._pending_tokens.append(tool_token)
                 self._pending_str = candidate
+                self._tool_buffer.write(tool_token)
                 return result
             if status in (
                 ToolCallParser.ToolCallBufferStatus.OPEN,
                 ToolCallParser.ToolCallBufferStatus.CLOSED,
             ):
-                self._pending_tokens.append(token_str)
+                if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+                    tool_token, visible_suffix = (
+                        self._split_closed_visible_suffix(tool_token)
+                    )
+                self._pending_tokens.append(tool_token)
+                self._tool_buffer.write(tool_token)
                 result.extend(
                     ToolCallToken(token=t) for t in self._pending_tokens
                 )
@@ -66,19 +105,34 @@ class ToolCallResponseParser:
                     result.extend(self._pending_tokens)
                     self._pending_tokens.clear()
                     self._pending_str = ""
+                    self._tool_buffer = StringIO()
                 result.append(token_str)
         else:
-            result.append(ToolCallToken(token=token_str))
-            status = self._tool_manager.tool_call_status(self._tag_buffer)
-            if status is not ToolCallParser.ToolCallBufferStatus.CLOSED:
-                status = self._tool_manager.tool_call_status(
-                    f"<tool_call>{self._tag_buffer}"
+            tool_token = token_str
+            current_tool_text = self._tool_buffer.getvalue()
+            combined_tool_text = current_tool_text + token_str
+            closed_split = self._split_current_call_close(
+                combined_tool_text, len(current_tool_text)
+            )
+            if (
+                closed_split is None
+                and self._tool_manager.tool_call_status(combined_tool_text)
+                is ToolCallParser.ToolCallBufferStatus.CLOSED
+            ):
+                closed_split = self._split_closed_visible_suffix(
+                    combined_tool_text
                 )
-            if status is ToolCallParser.ToolCallBufferStatus.CLOSED:
+            if closed_split is not None:
+                tool_text, visible_suffix = closed_split
+                token_length = max(0, len(tool_text) - len(current_tool_text))
+                tool_token = token_str[:token_length]
                 self._inside_call = False
-                terminal_status = status
+                terminal_status = ToolCallParser.ToolCallBufferStatus.CLOSED
+            if tool_token:
+                result.append(ToolCallToken(token=tool_token))
+            self._tool_buffer.write(tool_token)
 
-        if not result:
+        if not result and terminal_status is None:
             return result
 
         if not should_check:
@@ -89,27 +143,38 @@ class ToolCallResponseParser:
                 Event(type=EventType.TOOL_DETECT)
             )
 
-        buffer_text = self._buffer.getvalue()
-        calls, diagnostics = self._parse_buffer(buffer_text)
+        buffer_text = self._parse_text()
+        if self._inside_call and terminal_status is None:
+            status = self._tool_manager.tool_call_status(buffer_text)
+            if status is not ToolCallParser.ToolCallBufferStatus.CLOSED:
+                return result
+            self._inside_call = False
+            terminal_status = status
+
+        parse_text = self._closed_parse_text(buffer_text, visible_suffix)
+        calls, diagnostics = self._parse_buffer(parse_text)
         if calls:
-            event = Event(
-                type=EventType.TOOL_PROCESS,
-                payload=cast(dict[str, Any], calls),
-                started=perf_counter(),
+            events = await self._events_for_parse(calls, diagnostics)
+            return await self._finish_closed_segment(
+                result + events, visible_suffix
             )
 
-            self._clear_buffers()
-            return result + [event]
-
         if terminal_status is ToolCallParser.ToolCallBufferStatus.CLOSED:
-            if not diagnostics:
-                diagnostics = self._stream_buffer_diagnostics(buffer_text)
+            if diagnostics:
+                stream_diagnostics = self._stream_buffer_diagnostics(
+                    parse_text
+                )
+                if stream_diagnostics:
+                    diagnostics = stream_diagnostics
+            else:
+                diagnostics = self._stream_buffer_diagnostics(parse_text)
             if diagnostics:
                 event = await self._diagnostic_event(diagnostics)
-                self._clear_buffers()
-                return result + [event]
+                return await self._finish_closed_segment(
+                    result + [event], visible_suffix
+                )
 
-            return result
+            return await self._finish_closed_segment(result, visible_suffix)
 
         return result
 
@@ -125,42 +190,474 @@ class ToolCallResponseParser:
             await self._event_manager.trigger(event)
         return event
 
+    async def _events_for_parse(
+        self,
+        calls: list[Any],
+        diagnostics: list[ToolCallDiagnostic],
+    ) -> list[Event]:
+        events: list[Event] = []
+        if diagnostics:
+            events.append(await self._diagnostic_event(diagnostics))
+        events.append(
+            Event(
+                type=EventType.TOOL_PROCESS,
+                payload=cast(Any, calls),
+                started=perf_counter(),
+            )
+        )
+        return events
+
+    async def _finish_closed_segment(
+        self, items: list[Any], visible_suffix: str
+    ) -> list[Any]:
+        if not visible_suffix or not self._has_unfenced_tool_marker(
+            "", visible_suffix
+        ):
+            self._clear_buffers(visible_suffix)
+            return self._append_visible_suffix(items, visible_suffix)
+
+        self._clear_buffers()
+        suffix_items = await self.push(visible_suffix)
+        return items + list(suffix_items)
+
     async def flush(self) -> Iterable[Any]:
         result: list[Any] = []
         if self._inside_call:
-            buffer_text = self._buffer.getvalue()
+            buffer_text = self._parse_text()
             calls: list[Any] | None = None
+            diagnostics: list[ToolCallDiagnostic] = []
             if self._tool_manager.tool_format is ToolFormat.HARMONY:
-                calls, _ = self._parse_buffer(f"{buffer_text}<|call|>")
+                calls, diagnostics = self._parse_buffer(
+                    f"{buffer_text}<|call|>"
+                )
             if calls:
                 if self._event_manager:
                     await self._event_manager.trigger(
                         Event(type=EventType.TOOL_DETECT)
                     )
 
-                event = Event(
-                    type=EventType.TOOL_PROCESS,
-                    payload=cast(dict[str, Any], calls),
-                    started=perf_counter(),
-                )
+                events = await self._events_for_parse(calls, diagnostics)
                 self._clear_buffers()
-                result.append(event)
+                result.extend(events)
             else:
                 diagnostics = self._stream_buffer_diagnostics(buffer_text)
                 if diagnostics:
                     result.append(await self._diagnostic_event(diagnostics))
                     self._clear_buffers()
+        elif self._pending_tokens:
+            diagnostics = self._stream_buffer_diagnostics(self._pending_str)
+            if diagnostics:
+                result.append(await self._diagnostic_event(diagnostics))
+                self._clear_buffers()
+                return result
 
         if self._pending_tokens:
             result.extend(self._pending_tokens)
             self._pending_tokens.clear()
             self._pending_str = ""
+            self._tool_buffer = StringIO()
         return result
+
+    def _split_pending_candidate(
+        self, candidate: str
+    ) -> tuple[str, str, ToolCallParser.ToolCallBufferStatus] | None:
+        if not self._pending_tokens:
+            return None
+
+        for index in self._tool_marker_start_indexes(candidate):
+            if index == 0:
+                return None
+            suffix = candidate[index:]
+            suffix_status = self._tool_manager.tool_call_status(suffix)
+            if suffix_status is not ToolCallParser.ToolCallBufferStatus.NONE:
+                return candidate[:index], suffix, suffix_status
+
+        return None
+
+    def _split_visible_prefix(
+        self,
+        token_str: str,
+        status: ToolCallParser.ToolCallBufferStatus,
+        buffer_prefix: str = "",
+    ) -> tuple[str | None, str]:
+        if (
+            self._pending_tokens
+            or status is ToolCallParser.ToolCallBufferStatus.PREFIX
+            or "<" not in token_str
+        ):
+            return None, token_str
+
+        marker_indexes = [
+            index
+            for index in self._tool_marker_start_indexes(token_str)
+            if self._is_executable_tool_marker(
+                buffer_prefix + token_str, len(buffer_prefix) + index
+            )
+        ]
+        if not marker_indexes or marker_indexes[0] == 0:
+            return None, token_str
+
+        for index in marker_indexes:
+            suffix = token_str[index:]
+            suffix_status = self._tool_manager.tool_call_status(suffix)
+            if suffix_status is not ToolCallParser.ToolCallBufferStatus.NONE:
+                return token_str[:index], suffix
+
+        return None, token_str
+
+    def _has_unfenced_tool_marker(
+        self, buffer_prefix: str, token_str: str
+    ) -> bool:
+        return self._has_executable_tool_marker(buffer_prefix, token_str)
+
+    def _has_executable_tool_marker(
+        self, buffer_prefix: str, token_str: str
+    ) -> bool:
+        text = buffer_prefix + token_str
+        return any(
+            self._is_executable_tool_marker(text, len(buffer_prefix) + index)
+            for index in self._tool_marker_start_indexes(token_str)
+        )
+
+    def _has_tool_marker(self, text: str) -> bool:
+        return any(True for _ in self._tool_marker_start_indexes(text))
+
+    @staticmethod
+    def _markdown_fence_is_open(text: str) -> bool:
+        open_fence: tuple[str, int] | None = None
+        for line in text.splitlines():
+            stripped = line.lstrip(" \t")
+            if not stripped.startswith(("```", "~~~")):
+                continue
+            character = stripped[0]
+            length = 0
+            for current in stripped:
+                if current != character:
+                    break
+                length += 1
+            if open_fence is None:
+                open_fence = (character, length)
+            elif character == open_fence[0] and length >= open_fence[1]:
+                open_fence = None
+        return open_fence is not None
+
+    @classmethod
+    def _is_executable_tool_marker(cls, text: str, index: int) -> bool:
+        return not (
+            cls._markdown_fence_is_open(text[:index])
+            or cls._index_is_inside_visible_quote(text, index)
+        )
+
+    @staticmethod
+    def _index_is_inside_visible_quote(text: str, index: int) -> bool:
+        quote: str | None = None
+        escaped = False
+        for position, character in enumerate(text[:index]):
+            if escaped:
+                escaped = False
+                continue
+            if character in ("\n", "\r"):
+                quote = None
+                continue
+            if quote is not None:
+                if character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+                continue
+            if character == '"':
+                quote = character
+                continue
+            if character == "'" and ToolCallParser._is_quote_delimiter(
+                text, position
+            ):
+                quote = character
+        return quote is not None
+
+    def _tool_marker_start_indexes(self, text: str) -> Iterable[int]:
+        markers = self._tool_marker_starts()
+        for index, character in enumerate(text):
+            if character != "<":
+                continue
+            suffix = text[index:]
+            if any(
+                marker.startswith(suffix) or suffix.startswith(marker)
+                for marker in markers
+            ):
+                yield index
+
+    def _tool_marker_starts(self) -> tuple[str, ...]:
+        markers = ["<tool_call", "<tool ", "<tool>"]
+        tool_format = getattr(self._tool_manager, "tool_format", None)
+        if tool_format is ToolFormat.HARMONY:
+            markers.extend(
+                [
+                    "<|channel|>commentary",
+                    "<|start|>assistant<|channel|>commentary",
+                    "<|channel|>analysis",
+                    "<|start|>assistant<|channel|>analysis",
+                ]
+            )
+        if tool_format is ToolFormat.DSML:
+            markers.extend(
+                [
+                    "<｜DSML｜tool_calls",
+                    "<DSML｜tool_calls",
+                    "<tool_calls",
+                ]
+            )
+        return tuple(markers)
+
+    def _split_closed_visible_suffix(self, text: str) -> tuple[str, str]:
+        active = False
+        close_index = 0
+        escaped = False
+        index = 0
+        quote: str | None = None
+        while index < len(text):
+            character = text[index]
+            if escaped:
+                escaped = False
+                index += 1
+                continue
+            if quote is not None:
+                if character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+                index += 1
+                continue
+            if character in ("'", '"'):
+                quote = character
+                index += 1
+                continue
+
+            self_closing_span = self._self_closing_tool_close_span_at(
+                text, index
+            )
+            if (
+                self_closing_span is not None
+                and not self._markdown_fence_is_open(text[:index])
+            ):
+                active = False
+                close_index = self_closing_span[1]
+                index = close_index
+                continue
+
+            start_marker = self._tool_marker_at(
+                text, index, self._tool_marker_starts()
+            )
+            if start_marker is not None and not self._markdown_fence_is_open(
+                text[:index]
+            ):
+                active = True
+                index += len(start_marker)
+                continue
+
+            end_marker = self._tool_marker_at(
+                text, index, self._tool_marker_ends()
+            )
+            if (
+                end_marker is not None
+                and active
+                and not self._markdown_fence_is_open(text[:index])
+            ):
+                active = False
+                close_index = index + len(end_marker)
+                index = close_index
+                continue
+
+            visible_end_marker = self._tool_marker_at(
+                text, index, self._visible_tool_marker_ends()
+            )
+            if (
+                visible_end_marker is not None
+                and active
+                and not self._markdown_fence_is_open(text[:index])
+            ):
+                return text[:index], text[index:]
+
+            index += 1
+
+        if active or not close_index:
+            return text, ""
+
+        suffix = text[close_index:]
+        if not suffix:
+            return text, ""
+        return text[:close_index], suffix
+
+    def _split_current_call_close(
+        self, text: str, token_start: int
+    ) -> tuple[str, str] | None:
+        active = False
+        escaped = False
+        index = 0
+        quote: str | None = None
+        while index < len(text):
+            character = text[index]
+            if escaped:
+                escaped = False
+                index += 1
+                continue
+            if quote is not None:
+                if character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+                index += 1
+                continue
+            if character in ("'", '"'):
+                quote = character
+                index += 1
+                continue
+
+            if self._markdown_fence_is_open(text[:index]):
+                index += 1
+                continue
+
+            self_closing_span = self._self_closing_tool_close_span_at(
+                text, index
+            )
+            if self_closing_span is not None:
+                active = False
+                close_index = self_closing_span[1]
+                if close_index >= token_start:
+                    return text[:close_index], text[close_index:]
+                index = close_index
+                continue
+
+            start_marker = self._tool_marker_at(
+                text, index, self._tool_marker_starts()
+            )
+            if start_marker is not None:
+                active = True
+                index += len(start_marker)
+                continue
+
+            end_marker = self._tool_marker_at(
+                text, index, self._tool_marker_ends()
+            )
+            if end_marker is not None and active:
+                active = False
+                close_index = index + len(end_marker)
+                if close_index >= token_start:
+                    return text[:close_index], text[close_index:]
+                index = close_index
+                continue
+
+            visible_end_marker = self._tool_marker_at(
+                text, index, self._visible_tool_marker_ends()
+            )
+            if visible_end_marker is not None and active:
+                active = False
+                if index >= token_start:
+                    return text[:index], text[index:]
+                index += len(visible_end_marker)
+                continue
+
+            index += 1
+
+        return None
+
+    def _self_closing_tool_end_indexes(self, text: str) -> Iterable[int]:
+        for _, close_index in self._self_closing_tool_close_spans(text):
+            yield close_index
+
+    def _self_closing_tool_close_spans(
+        self, text: str
+    ) -> Iterable[tuple[int, int]]:
+        for marker in ("<tool_call", "<tool "):
+            index = text.find(marker)
+            while index != -1:
+                tag_end = ToolCallParser._tag_end_index(
+                    text, index + len(marker)
+                )
+                if tag_end == -1:
+                    break
+                if text[index : tag_end + 1].rstrip().endswith("/>"):
+                    yield index, tag_end + 1
+                index = text.find(marker, index + 1)
+
+    @staticmethod
+    def _self_closing_tool_close_span_at(
+        text: str, index: int
+    ) -> tuple[int, int] | None:
+        if not text.startswith(("<tool_call", "<tool "), index):
+            return None
+
+        tag_end = ToolCallParser._tag_end_index(text, index)
+        if tag_end == -1:
+            return None
+
+        if not text[index : tag_end + 1].rstrip().endswith("/>"):
+            return None
+
+        return index, tag_end + 1
+
+    @staticmethod
+    def _tool_marker_at(
+        text: str, index: int, markers: Iterable[str]
+    ) -> str | None:
+        for marker in sorted(markers, key=len, reverse=True):
+            if text.startswith(marker, index):
+                return marker
+        return None
+
+    @staticmethod
+    def _marker_indexes(text: str, marker: str) -> Iterable[int]:
+        index = text.find(marker)
+        while index != -1:
+            yield index
+            index = text.find(marker, index + 1)
+
+    def _tool_marker_ends(self) -> tuple[str, ...]:
+        markers = ["</tool_call>", "</tool>"]
+        tool_format = getattr(self._tool_manager, "tool_format", None)
+        if tool_format is ToolFormat.HARMONY:
+            markers.append("<|call|>")
+        if tool_format is ToolFormat.DSML:
+            markers.extend(
+                [
+                    "</｜DSML｜tool_calls>",
+                    "</DSML｜tool_calls>",
+                    "</tool_calls>",
+                ]
+            )
+        return tuple(markers)
+
+    def _visible_tool_marker_ends(self) -> tuple[str, ...]:
+        tool_format = getattr(self._tool_manager, "tool_format", None)
+        if tool_format is ToolFormat.HARMONY:
+            return ("<|channel|>final<|message|>",)
+        return ()
+
+    @staticmethod
+    def _append_visible_suffix(
+        items: list[Any], visible_suffix: str
+    ) -> list[Any]:
+        if visible_suffix:
+            items.append(visible_suffix)
+        return items
+
+    def _parse_text(self) -> str:
+        tool_text = self._tool_buffer.getvalue()
+        return tool_text or self._buffer.getvalue()
+
+    def _closed_parse_text(self, text: str, visible_suffix: str) -> str:
+        if (
+            getattr(self._tool_manager, "tool_format", None)
+            is ToolFormat.HARMONY
+            and visible_suffix.startswith("<|channel|>final<|message|>")
+            and "<|call|>" not in text
+        ):
+            return text + "<|call|>"
+        return text
 
     def _parse_buffer(
         self, text: str
     ) -> tuple[list[Any] | None, list[ToolCallDiagnostic]]:
-        if type(self._tool_manager) is ToolManager:
+        if issubclass(type(self._tool_manager), ToolManager):
             outcome = self._tool_manager.parse_calls(text)
             return outcome.calls or None, outcome.diagnostics
         return self._tool_manager.get_calls(text), []
@@ -168,11 +665,16 @@ class ToolCallResponseParser:
     def _stream_buffer_diagnostics(
         self, text: str
     ) -> list[ToolCallDiagnostic]:
-        if type(self._tool_manager) is ToolManager:
+        if issubclass(type(self._tool_manager), ToolManager):
             return self._tool_manager.stream_buffer_diagnostics(text)
         return []
 
-    def _clear_buffers(self) -> None:
+    def _clear_buffers(self, visible_text: str = "") -> None:
         self._buffer = StringIO()
-        self._tag_buffer = ""
+        self._tool_buffer = StringIO()
+        self._tag_buffer = visible_text[-64:]
         self._inside_call = False
+        self._pending_tokens.clear()
+        self._pending_str = ""
+        if visible_text:
+            self._buffer.write(visible_text)

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -154,14 +154,17 @@ class TextGenerationVendor(ABC):
         tool_name_text = (
             tool_name if isinstance(tool_name, str) else str(tool_name or "")
         )
-        name = (
-            TextGenerationVendor.decode_tool_name(tool_name_text)
-            if tool_name_text
-            else ""
-        )
         provider_name_encoded = tool_name_text.startswith(
             TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX
         )
+        if tool_name_text:
+            try:
+                name = TextGenerationVendor.decode_tool_name(tool_name_text)
+            except AssertionError:
+                assert provider_name_encoded
+                name = tool_name_text
+        else:
+            name = ""
         provider_arguments_malformed = False
         if isinstance(arguments, str):
             try:

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -162,11 +162,19 @@ class TextGenerationVendor(ABC):
         provider_name_encoded = tool_name_text.startswith(
             TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX
         )
+        provider_arguments_malformed = False
         if isinstance(arguments, str):
             try:
-                args = cast(dict[str, Any], loads(arguments))
+                parsed_arguments = loads(arguments)
             except JSONDecodeError:
+                provider_arguments_malformed = True
                 args = {}
+            else:
+                if isinstance(parsed_arguments, dict):
+                    args = parsed_arguments
+                else:
+                    provider_arguments_malformed = True
+                    args = {}
         else:
             args = (
                 arguments
@@ -184,6 +192,7 @@ class TextGenerationVendor(ABC):
             arguments=cast(dict[str, ToolValue], args),
             provider_name=tool_name_text or None,
             provider_name_encoded=provider_name_encoded,
+            provider_arguments_malformed=provider_arguments_malformed,
         )
         token_payload: dict[str, Any] = {
             "name": name,

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -21,11 +21,17 @@ from .provider import ProviderFamily, provider_family_value
 from .stream import TextGenerationStream
 
 from abc import ABC
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from binascii import Error as BinasciiError
 from json import JSONDecodeError, dumps, loads
+from re import compile as compile_regex
 from typing import Any, AsyncIterator, cast
 
 
 class TextGenerationVendor(ABC):
+    _PROVIDER_TOOL_NAME_PATTERN = compile_regex(r"^[A-Za-z0-9_-]+$")
+    _PROVIDER_TOOL_NAME_PREFIX = "avl_"
+
     async def __call__(
         self,
         model_id: str,
@@ -103,11 +109,41 @@ class TextGenerationVendor(ABC):
 
     @staticmethod
     def encode_tool_name(tool_name: str) -> str:
-        return tool_name.replace(".", "__")
+        assert isinstance(tool_name, str)
+        assert tool_name.strip(), "tool name must not be empty"
+        if TextGenerationVendor._PROVIDER_TOOL_NAME_PATTERN.fullmatch(
+            tool_name
+        ) and not tool_name.startswith(
+            TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX
+        ):
+            return tool_name
+        encoded = urlsafe_b64encode(tool_name.encode()).decode().rstrip("=")
+        return f"{TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX}{encoded}"
 
     @staticmethod
     def decode_tool_name(tool_name: str) -> str:
-        return tool_name.replace("__", ".")
+        assert isinstance(tool_name, str)
+        assert tool_name.strip(), "tool name must not be empty"
+        assert TextGenerationVendor._PROVIDER_TOOL_NAME_PATTERN.fullmatch(
+            tool_name
+        ), "provider tool name is invalid"
+
+        prefix = TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX
+        if not tool_name.startswith(prefix):
+            return tool_name
+
+        payload = tool_name[len(prefix) :]
+        assert payload, "provider tool name is missing encoded content"
+        padding = "=" * (-len(payload) % 4)
+        try:
+            decoded = urlsafe_b64decode(f"{payload}{padding}").decode()
+        except (BinasciiError, UnicodeDecodeError) as exc:
+            raise AssertionError("provider tool name is malformed") from exc
+        assert decoded.strip(), "decoded tool name must not be empty"
+        assert (
+            TextGenerationVendor.encode_tool_name(decoded) == tool_name
+        ), "provider tool name is malformed"
+        return decoded
 
     @staticmethod
     def build_tool_call_token(
@@ -118,7 +154,11 @@ class TextGenerationVendor(ABC):
         tool_name_text = (
             tool_name if isinstance(tool_name, str) else str(tool_name or "")
         )
-        name = TextGenerationVendor.decode_tool_name(tool_name_text)
+        name = (
+            TextGenerationVendor.decode_tool_name(tool_name_text)
+            if tool_name_text
+            else ""
+        )
         if isinstance(arguments, str):
             try:
                 args = cast(dict[str, Any], loads(arguments))
@@ -148,7 +188,9 @@ class TextGenerationVendor(ABC):
             token_payload["id"] = call_id_value
         token_json = dumps(token_payload)
         return ToolCallToken(
-            token=f"<tool_call>{token_json}</tool_call>", call=call
+            token=f"<tool_call>{token_json}</tool_call>",
+            call=call,
+            provider_name=tool_name_text or None,
         )
 
 

--- a/src/avalan/model/vendor.py
+++ b/src/avalan/model/vendor.py
@@ -159,6 +159,9 @@ class TextGenerationVendor(ABC):
             if tool_name_text
             else ""
         )
+        provider_name_encoded = tool_name_text.startswith(
+            TextGenerationVendor._PROVIDER_TOOL_NAME_PREFIX
+        )
         if isinstance(arguments, str):
             try:
                 args = cast(dict[str, Any], loads(arguments))
@@ -179,6 +182,8 @@ class TextGenerationVendor(ABC):
             id=cast(Any, call_id_value),
             name=name,
             arguments=cast(dict[str, ToolValue], args),
+            provider_name=tool_name_text or None,
+            provider_name_encoded=provider_name_encoded,
         )
         token_payload: dict[str, Any] = {
             "name": name,

--- a/src/avalan/server/a2a/router.py
+++ b/src/avalan/server/a2a/router.py
@@ -5,12 +5,17 @@ from ...entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallDiagnostic,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
 )
 from ...event import Event, EventType
-from ...utils import to_json
+from ...utils import (
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 from ..entities import ChatCompletionRequest, ChatMessage
 from ..routers import orchestrate
 from ..sse import sse_message
@@ -505,7 +510,10 @@ class A2AResponseTranslator:
             if item.type is EventType.TOOL_PROCESS:
                 events.extend(await self._handle_tool_process(item))
                 return events
-            if item.type is EventType.TOOL_RESULT:
+            if item.type in (
+                EventType.TOOL_DIAGNOSTIC,
+                EventType.TOOL_RESULT,
+            ):
                 events.extend(await self._handle_tool_result(item))
                 return events
             return events
@@ -692,6 +700,8 @@ class A2AResponseTranslator:
         events: list[dict[str, Any]] = []
         payload = event.payload or {}
         result = payload.get("result") if isinstance(payload, dict) else None
+        if event.type is EventType.TOOL_DIAGNOSTIC:
+            result = result or _payload_diagnostic(payload)
         call = payload.get("call") if isinstance(payload, dict) else None
         artifact_id: str | None = None
         artifact_name: str | None = None
@@ -708,9 +718,21 @@ class A2AResponseTranslator:
             artifact_name = result.call.name
             content = {
                 "type": "data",
-                "data": {"error": result.message},
+                "data": {"error": tool_call_error_payload(result)},
             }
             metadata["status"] = "error"
+        elif isinstance(result, ToolCallDiagnostic):
+            artifact_id = str(result.call_id or result.id)
+            artifact_name = (
+                result.canonical_name or result.requested_name or "tool"
+            )
+            content = {
+                "type": "data",
+                "data": {"diagnostic": _diagnostic_payload(result)},
+            }
+            metadata["status"] = "diagnostic"
+            metadata["diagnostic_code"] = result.code.value
+            metadata["diagnostic_stage"] = result.stage.value
         elif isinstance(payload, ToolCall):
             artifact_id = str(payload.id)
             artifact_name = payload.name
@@ -1302,6 +1324,7 @@ def _state_for_item(
         return StreamState.REASONING
     if isinstance(item, (ToolCallToken, Event)):
         if isinstance(item, Event) and item.type not in (
+            EventType.TOOL_DIAGNOSTIC,
             EventType.TOOL_PROCESS,
             EventType.TOOL_RESULT,
         ):
@@ -1326,8 +1349,19 @@ def _call_identifier(item: Token | TokenDetail | Event | str) -> str | None:
                 call = candidates[0]
                 if isinstance(call, ToolCall):
                     return str(call.id)
-        if item.type is EventType.TOOL_RESULT and item.payload:
+        if (
+            item.type
+            in (
+                EventType.TOOL_DIAGNOSTIC,
+                EventType.TOOL_RESULT,
+            )
+            and item.payload
+        ):
             result = item.payload.get("result")
+            if item.type is EventType.TOOL_DIAGNOSTIC:
+                result = result or _payload_diagnostic(item.payload)
+            if isinstance(result, ToolCallDiagnostic):
+                return str(result.call_id or result.id)
             if isinstance(result, (ToolCallResult, ToolCallError)):
                 return str(result.call.id)
             call = item.payload.get("call")
@@ -1342,6 +1376,37 @@ def _token_text(item: Token | TokenDetail | Event | str) -> str:
     if isinstance(item, Token):
         return item.token
     return ""
+
+
+def _payload_diagnostic(
+    payload: dict[str, Any],
+) -> ToolCallDiagnostic | None:
+    diagnostic = payload.get("diagnostic")
+    if isinstance(diagnostic, ToolCallDiagnostic):
+        return diagnostic
+    diagnostics = payload.get("diagnostics")
+    if isinstance(diagnostics, list):
+        return next(
+            (
+                item
+                for item in diagnostics
+                if isinstance(item, ToolCallDiagnostic)
+            ),
+            None,
+        )
+    return None
+
+
+def _diagnostic_payload(
+    diagnostic: ToolCallDiagnostic,
+) -> dict[str, Any]:
+    payload = {
+        "id": str(diagnostic.id),
+        **tool_call_diagnostic_payload(diagnostic),
+    }
+    if diagnostic.call_id is not None:
+        payload["call_id"] = str(diagnostic.call_id)
+    return payload
 
 
 def _enum_value(value: Any) -> str | None:

--- a/src/avalan/server/routers/chat.py
+++ b/src/avalan/server/routers/chat.py
@@ -1,6 +1,12 @@
 from ...agent.orchestrator import Orchestrator
-from ...entities import MessageRole, ReasoningToken, ToolCallToken
-from ...event import Event
+from ...entities import (
+    MessageRole,
+    ReasoningToken,
+    ToolCallDiagnostic,
+    ToolCallError,
+    ToolCallToken,
+)
+from ...event import Event, EventType
 from ...server.entities import (
     ChatCompletionChoice,
     ChatCompletionChunk,
@@ -11,12 +17,17 @@ from ...server.entities import (
     ChatCompletionUsage,
     ChatMessage,
 )
+from ...utils import (
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 from .. import di_get_logger, di_get_orchestrator
 from ..sse import sse_headers, sse_message
 from . import orchestrate, resolve_model_id
 
 from logging import Logger
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
@@ -61,8 +72,10 @@ async def create_chat_completion(
         async def generate_chunks() -> AsyncIterator[str]:
             async for token in response:
                 if isinstance(token, Event):
-                    continue
-                if isinstance(token, (ReasoningToken, ToolCallToken)):
+                    token_text = _event_text(token)
+                    if not token_text:
+                        continue
+                elif isinstance(token, (ReasoningToken, ToolCallToken)):
                     token_text = token.token
                 else:
                     token_text = str(token)
@@ -118,3 +131,67 @@ async def create_chat_completion(
     await orchestrator.sync_messages()
 
     return final_response
+
+
+def _event_text(event: Event) -> str:
+    payload = event.payload if isinstance(event.payload, dict) else {}
+    if event.type is EventType.TOOL_DIAGNOSTIC:
+        diagnostic = _payload_diagnostic(payload)
+        if diagnostic is None:
+            return ""
+        return to_json(
+            {
+                "type": "tool_diagnostic",
+                "diagnostic": _diagnostic_payload(diagnostic),
+            }
+        )
+    if event.type is EventType.TOOL_RESULT:
+        result = payload.get("result")
+        if isinstance(result, ToolCallDiagnostic):
+            return to_json(
+                {
+                    "type": "tool_diagnostic",
+                    "diagnostic": _diagnostic_payload(result),
+                }
+            )
+        if isinstance(result, ToolCallError):
+            return to_json(
+                {
+                    "type": "tool_error",
+                    "toolCallId": str(result.call.id),
+                    "name": result.call.name,
+                    "error": tool_call_error_payload(result),
+                }
+            )
+    return ""
+
+
+def _payload_diagnostic(
+    payload: dict[str, Any],
+) -> ToolCallDiagnostic | None:
+    diagnostic = payload.get("diagnostic")
+    if isinstance(diagnostic, ToolCallDiagnostic):
+        return diagnostic
+    diagnostics = payload.get("diagnostics")
+    if isinstance(diagnostics, list):
+        return next(
+            (
+                item
+                for item in diagnostics
+                if isinstance(item, ToolCallDiagnostic)
+            ),
+            None,
+        )
+    return None
+
+
+def _diagnostic_payload(
+    diagnostic: ToolCallDiagnostic,
+) -> dict[str, Any]:
+    payload = {
+        "id": str(diagnostic.id),
+        **tool_call_diagnostic_payload(diagnostic),
+    }
+    if diagnostic.call_id is not None:
+        payload["call_id"] = str(diagnostic.call_id)
+    return payload

--- a/src/avalan/server/routers/mcp.py
+++ b/src/avalan/server/routers/mcp.py
@@ -4,6 +4,8 @@ from ...entities import (
     ReasoningToken,
     Token,
     TokenDetail,
+    ToolCall,
+    ToolCallDiagnostic,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -15,7 +17,11 @@ from ...server.entities import (
     MCPToolRequest,
 )
 from ...types import JsonObject, JsonScalar, MutableJsonValue
-from ...utils import to_json
+from ...utils import (
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 from ..sse import sse_bytes, sse_headers
 from . import (
     MODEL_FALLBACK as DEFAULT_MODEL_FALLBACK,
@@ -32,6 +38,7 @@ from dataclasses import dataclass, replace
 from json import JSONDecodeError, dumps, loads
 from logging import Logger
 from typing import (
+    Any,
     AsyncGenerator,
     AsyncIterator,
     Final,
@@ -701,6 +708,7 @@ async def _stream_mcp_response(
                 continue
 
             if isinstance(item, Event) and item.type in (
+                EventType.TOOL_DIAGNOSTIC,
                 EventType.TOOL_PROCESS,
                 EventType.TOOL_RESULT,
             ):
@@ -931,6 +939,38 @@ async def _tool_event_notifications(
         }
         return
 
+    if "diagnostic" in item:
+        diagnostic_payload = item["diagnostic"]
+        tool_summary = tool_summaries.setdefault(
+            tool_call_id,
+            {
+                "id": tool_call_id,
+                "name": item.get("name"),
+                "arguments": item.get("arguments"),
+            },
+        )
+        tool_summary["diagnostic"] = diagnostic_payload
+        yield {
+            "jsonrpc": "2.0",
+            "method": "notifications/message",
+            "params": {
+                "level": "warning",
+                "message": {
+                    "type": "tool.diagnostic",
+                    "toolCallId": tool_call_id,
+                    "name": item.get("name"),
+                    "arguments": item.get("arguments"),
+                    "diagnostic": diagnostic_payload,
+                    "timings": {
+                        "started": event.started,
+                        "finished": event.finished,
+                        "elapsed": event.elapsed,
+                    },
+                },
+            },
+        }
+        return
+
     tool_summary = tool_summaries.setdefault(
         tool_call_id,
         {
@@ -1038,12 +1078,22 @@ def _tool_call_event_item(event: Event) -> dict[str, JSONValue] | None:
             if isinstance(event.payload, dict)
             else None
         )
+        if isinstance(tool_result, ToolCallDiagnostic):
+            call = (
+                event.payload.get("call")
+                if isinstance(event.payload, dict)
+                else None
+            )
+            return _tool_call_diagnostic_item(
+                tool_result,
+                call if isinstance(call, ToolCall) else None,
+            )
         if isinstance(tool_result, ToolCallError):
             return {
                 "id": str(tool_result.call.id),
                 "name": tool_result.name,
                 "arguments": cast(JSONValue, tool_result.arguments),
-                "error": tool_result.message,
+                "error": cast(JSONValue, tool_call_error_payload(tool_result)),
             }
         if isinstance(tool_result, ToolCallResult):
             result: JSONValue = (
@@ -1059,6 +1109,16 @@ def _tool_call_event_item(event: Event) -> dict[str, JSONValue] | None:
                 "arguments": cast(JSONValue, tool_result.arguments),
                 "result": result,
             }
+    if event.type is EventType.TOOL_DIAGNOSTIC:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        diagnostic = _payload_diagnostic(payload)
+        if diagnostic is None:
+            return None
+        call = payload.get("call")
+        return _tool_call_diagnostic_item(
+            diagnostic,
+            call if isinstance(call, ToolCall) else None,
+        )
     if isinstance(event.payload, list) and event.payload:
         call = event.payload[0]
     else:
@@ -1073,6 +1133,48 @@ def _tool_call_event_item(event: Event) -> dict[str, JSONValue] | None:
         "id": str(call.id),
         "name": call.name,
         "arguments": cast(JSONValue, call.arguments),
+    }
+
+
+def _payload_diagnostic(
+    payload: dict[str, Any],
+) -> ToolCallDiagnostic | None:
+    diagnostic = payload.get("diagnostic")
+    if isinstance(diagnostic, ToolCallDiagnostic):
+        return diagnostic
+    diagnostics = payload.get("diagnostics")
+    if isinstance(diagnostics, list):
+        return next(
+            (
+                item
+                for item in diagnostics
+                if isinstance(item, ToolCallDiagnostic)
+            ),
+            None,
+        )
+    return None
+
+
+def _tool_call_diagnostic_item(
+    diagnostic: ToolCallDiagnostic, call: ToolCall | None
+) -> dict[str, JSONValue]:
+    diagnostic_payload = {
+        "id": str(diagnostic.id),
+        **tool_call_diagnostic_payload(diagnostic),
+    }
+    if diagnostic.call_id is not None:
+        diagnostic_payload["call_id"] = str(diagnostic.call_id)
+    return {
+        "id": str(call.id if call else diagnostic.call_id or diagnostic.id),
+        "name": (
+            call.name
+            if call
+            else diagnostic.canonical_name
+            or diagnostic.requested_name
+            or "tool"
+        ),
+        "arguments": cast(JSONValue, call.arguments if call else None),
+        "diagnostic": cast(JSONValue, diagnostic_payload),
     }
 
 

--- a/src/avalan/server/routers/responses.py
+++ b/src/avalan/server/routers/responses.py
@@ -3,13 +3,19 @@ from ...entities import (
     ReasoningToken,
     Token,
     TokenDetail,
+    ToolCall,
+    ToolCallDiagnostic,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
 )
 from ...event import Event, EventType
 from ...server.entities import ResponsesRequest
-from ...utils import to_json
+from ...utils import (
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 from .. import di_get_logger, di_get_orchestrator
 from ..sse import sse_headers, sse_message
 from . import orchestrate, resolve_model_id
@@ -74,11 +80,16 @@ async def create_response(
                 call_id: str | None = None
                 if isinstance(token, Event):
                     if token.type not in (
+                        EventType.TOOL_DIAGNOSTIC,
                         EventType.TOOL_PROCESS,
                         EventType.TOOL_RESULT,
                     ):
                         continue
-                    call_id = _tool_call_event_item(token)["id"]
+                    item = _tool_call_event_item(token)
+                    if item is None:
+                        continue
+                    item_id = item.get("id")
+                    call_id = item_id if isinstance(item_id, str) else None
                 elif (
                     isinstance(token, ToolCallToken) and token.call is not None
                 ):
@@ -159,28 +170,38 @@ def _token_to_sse(
             )
         )
     elif isinstance(token, Event) and token.type in (
+        EventType.TOOL_DIAGNOSTIC,
         EventType.TOOL_PROCESS,
         EventType.TOOL_RESULT,
     ):
         item = _tool_call_event_item(token)
+        if item is None:
+            return events
         delta_obj = {
             "id": item["id"],
             "name": item["name"],
             "arguments": item.get("arguments"),
         }
-        if token.type is EventType.TOOL_RESULT:
+        if "diagnostic" in item:
+            delta_obj["diagnostic"] = item["diagnostic"]
+        elif token.type is EventType.TOOL_RESULT:
             if "error" in item:
-                delta_obj["error"] = to_json(item.get("error"))
+                delta_obj["error"] = item.get("error")
             else:
                 result = item.get("result", None)
                 delta_obj["result"] = to_json(result) if result else None
 
+        event_type = (
+            "response.tool_call_diagnostic.delta"
+            if "diagnostic" in item
+            else "response.function_call_arguments.delta"
+        )
         events.append(
             sse_message(
                 to_json(
                     {
                         **delta_obj,
-                        "type": "response.function_call_arguments.delta",
+                        "type": event_type,
                         "delta": to_json(delta_obj),
                         "id": item["id"],
                         "output_index": 0,
@@ -188,7 +209,7 @@ def _token_to_sse(
                         "sequence_number": seq,
                     }
                 ),
-                event="response.function_call_arguments.delta",
+                event=event_type,
             )
         )
     elif isinstance(token, ToolCallToken):
@@ -304,7 +325,12 @@ def _new_state(
         new_state = ResponseState.REASONING
     elif isinstance(token, (ToolCallToken, Event)) and (
         not isinstance(token, Event)
-        or token.type in (EventType.TOOL_PROCESS, EventType.TOOL_RESULT)
+        or token.type
+        in (
+            EventType.TOOL_DIAGNOSTIC,
+            EventType.TOOL_PROCESS,
+            EventType.TOOL_RESULT,
+        )
     ):
         new_state = ResponseState.TOOL_CALLING
     elif token is not None:
@@ -410,7 +436,7 @@ def _content_part_done(id: str | None = None) -> str:
     return sse_message(to_json(data), event="response.content_part.done")
 
 
-def _tool_call_event_item(event: Event) -> dict[str, Any]:
+def _tool_call_event_item(event: Event) -> dict[str, Any] | None:
     payload = cast(Any, event.payload)
     tool_result = (
         payload["result"]
@@ -419,12 +445,48 @@ def _tool_call_event_item(event: Event) -> dict[str, Any]:
         and "result" in payload
         else None
     )
+    if isinstance(tool_result, ToolCallDiagnostic):
+        call = payload.get("call") if isinstance(payload, dict) else None
+        return _tool_call_diagnostic_item(
+            tool_result,
+            call if isinstance(call, ToolCall) else None,
+        )
+    if event.type is EventType.TOOL_DIAGNOSTIC:
+        diagnostic = (
+            payload.get("diagnostic") if isinstance(payload, dict) else None
+        )
+        if not isinstance(diagnostic, ToolCallDiagnostic):
+            diagnostics = (
+                payload.get("diagnostics")
+                if isinstance(payload, dict)
+                else None
+            )
+            if isinstance(diagnostics, list):
+                diagnostic = next(
+                    (
+                        item
+                        for item in diagnostics
+                        if isinstance(item, ToolCallDiagnostic)
+                    ),
+                    None,
+                )
+        if not isinstance(diagnostic, ToolCallDiagnostic):
+            return None
+        call = payload.get("call") if isinstance(payload, dict) else None
+        return _tool_call_diagnostic_item(
+            diagnostic,
+            call if isinstance(call, ToolCall) else None,
+        )
     if tool_result is not None:
         tool_call = tool_result.call
     elif isinstance(payload, list):
         tool_call = payload[0]
+    elif isinstance(payload, dict):
+        tool_call = payload.get("call") or payload.get(0)
     else:
-        tool_call = cast(dict[Any, Any], payload)[0]
+        tool_call = None
+    if tool_call is None:
+        return None
     item = {
         "type": "function_call",
         "id": str(tool_call.id),
@@ -433,9 +495,39 @@ def _tool_call_event_item(event: Event) -> dict[str, Any]:
     }
     if tool_result is not None:
         if isinstance(tool_result, ToolCallError):
-            item["error"] = tool_result.message
+            item["error"] = tool_call_error_payload(tool_result)
         elif isinstance(tool_result, ToolCallResult):
             item["result"] = tool_result.result
         else:
             item["result"] = tool_result
     return item
+
+
+def _tool_call_diagnostic_item(
+    diagnostic: ToolCallDiagnostic, call: ToolCall | None
+) -> dict[str, Any]:
+    diagnostic_payload = {
+        "id": str(diagnostic.id),
+        **tool_call_diagnostic_payload(diagnostic),
+    }
+    if diagnostic.call_id is not None:
+        diagnostic_payload["call_id"] = str(diagnostic.call_id)
+    if diagnostic.started_at is not None:
+        diagnostic_payload["started_at"] = diagnostic.started_at.isoformat()
+    if diagnostic.finished_at is not None:
+        diagnostic_payload["finished_at"] = diagnostic.finished_at.isoformat()
+    if diagnostic.duration_ms is not None:
+        diagnostic_payload["duration_ms"] = diagnostic.duration_ms
+    return {
+        "type": "function_call",
+        "id": str(call.id if call else diagnostic.call_id or diagnostic.id),
+        "name": (
+            call.name
+            if call
+            else diagnostic.canonical_name
+            or diagnostic.requested_name
+            or "tool"
+        ),
+        "arguments": call.arguments if call else None,
+        "diagnostic": diagnostic_payload,
+    }

--- a/src/avalan/task/targets/flow.py
+++ b/src/avalan/task/targets/flow.py
@@ -1,5 +1,5 @@
 from ...event import Event, EventType
-from ...flow.definition import FlowNodeDefinition
+from ...flow.definition import FlowNodeDefinition, FlowNodeMetadata
 from ...flow.flow import Flow
 from ...flow.node import Node
 from ...flow.registry import (
@@ -240,10 +240,12 @@ def task_flow_node_registry(
     registry.register(
         "file_convert",
         _file_convert_node_factory(context),
+        metadata=FlowNodeMetadata(async_only=True),
     )
     registry.register(
         "pdf_to_images",
         _file_convert_node_factory(context, default_converter="pdf_image"),
+        metadata=FlowNodeMetadata(async_only=True),
     )
     if agent_runner is not None:
         registry.register(
@@ -253,6 +255,7 @@ def task_flow_node_registry(
                 agent_runner=agent_runner,
                 execution_roots=execution_roots,
             ),
+            metadata=FlowNodeMetadata(supports_ref=True, async_only=True),
         )
     return registry
 

--- a/src/avalan/tool/__init__.py
+++ b/src/avalan/tool/__init__.py
@@ -1,4 +1,5 @@
 from .json_schema import get_json_schema
+from .names import matches_tool_namespace
 
 from abc import ABC
 from collections.abc import Callable, Sequence
@@ -137,9 +138,7 @@ class ToolSet:
             name = getattr(tool, "__name__", tool.__class__.__name__)
             canonical_name = f"{namespace}.{name}" if namespace else name
             for enabled in enable_tools:
-                if canonical_name == enabled or canonical_name.startswith(
-                    f"{enabled}."
-                ):
+                if matches_tool_namespace(canonical_name, enabled):
                     tools.append(tool)
                     break
 

--- a/src/avalan/tool/__init__.py
+++ b/src/avalan/tool/__init__.py
@@ -114,20 +114,36 @@ class ToolSet:
                 self.tools[i] = tool
 
     def with_enabled_tools(self, enable_tools: list[str]) -> "ToolSet":
-        prefix = f"{self.namespace}." if self.namespace else ""
+        self._filter_enabled_tools(enable_tools)
+        return self
 
-        tools = []
+    def _filter_enabled_tools(
+        self, enable_tools: list[str], prefix: str | None = None
+    ) -> None:
+        namespace = (
+            f"{prefix}.{self.namespace}"
+            if prefix and self.namespace
+            else prefix or self.namespace
+        )
+
+        tools: list[Callable[..., Any] | Tool | ToolSet] = []
         for tool in self._tools:
-            name = (
-                f"{prefix}{getattr(tool, '__name__', tool.__class__.__name__)}"
-            )
+            if isinstance(tool, ToolSet):
+                tool._filter_enabled_tools(enable_tools, namespace)
+                if tool.tools:
+                    tools.append(tool)
+                continue
+
+            name = getattr(tool, "__name__", tool.__class__.__name__)
+            canonical_name = f"{namespace}.{name}" if namespace else name
             for enabled in enable_tools:
-                if name == enabled or name.startswith(f"{enabled}."):
+                if canonical_name == enabled or canonical_name.startswith(
+                    f"{enabled}."
+                ):
                     tools.append(tool)
                     break
 
         self._tools = tools
-        return self
 
     async def __aenter__(self) -> "ToolSet":
         for tool in self.tools:
@@ -153,20 +169,21 @@ class ToolSet:
         self, prefix: str | None = None
     ) -> list[dict[str, Any]] | None:
         schemas: list[dict[str, Any]] = []
-        prefix = (
-            f"{prefix}."
-            if prefix
-            else f"{self.namespace}." if self.namespace else ""
+        namespace = (
+            f"{prefix}.{self.namespace}"
+            if prefix and self.namespace
+            else prefix or self.namespace
         )
+        schema_prefix = f"{namespace}." if namespace else ""
         for tool in self.tools:
             if isinstance(tool, ToolSet):
-                tool_schemas = tool.json_schemas(prefix)
+                tool_schemas = tool.json_schemas(namespace)
                 if tool_schemas:
                     schemas.extend(tool_schemas)
                 continue
 
             schema = (
-                tool.json_schema(prefix)
+                tool.json_schema(schema_prefix)
                 if isinstance(tool, Tool)
                 else get_json_schema(tool)
             )
@@ -178,7 +195,7 @@ class ToolSet:
                 and "name" in schema["function"]
             ):
                 schema["function"]["name"] = (
-                    prefix + schema["function"]["name"]
+                    schema_prefix + schema["function"]["name"]
                 )
             schemas.append(schema)
         return schemas

--- a/src/avalan/tool/json_schema.py
+++ b/src/avalan/tool/json_schema.py
@@ -234,9 +234,20 @@ def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
 
     properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
+    additional_properties: bool | dict[str, Any] = False
     function_signature = signature(function)
     for name, parameter in function_signature.parameters.items():
         if name == "context":
+            continue
+        if parameter.kind is Parameter.VAR_KEYWORD:
+            annotation = (
+                parameter.annotation
+                if parameter.annotation is not Parameter.empty
+                else Any
+            )
+            additional_properties = (
+                True if annotation is Any else _annotation_schema(annotation)
+            )
             continue
         if parameter.kind not in {
             Parameter.POSITIONAL_OR_KEYWORD,
@@ -275,7 +286,7 @@ def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
                 "type": "object",
                 "properties": properties,
                 "required": required,
-                "additionalProperties": False,
+                "additionalProperties": additional_properties,
             },
             "return": return_schema,
         },

--- a/src/avalan/tool/json_schema.py
+++ b/src/avalan/tool/json_schema.py
@@ -1,6 +1,12 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import MISSING, fields, is_dataclass
+from enum import Enum
 from inspect import Parameter, signature
-from typing import Any, Literal, get_args, get_origin
+from json import dumps
+from types import NoneType, UnionType
+from typing import Any, Literal, get_args, get_origin, is_typeddict
+
+_JSON_DEFAULT_MISSING = object()
 
 
 def _parse_docstring_sections(docstring: str | None) -> dict[str, str]:
@@ -34,41 +40,189 @@ def _literal_schema(annotation: object) -> dict[str, Any] | None:
 
     value_types = {type(value) for value in values}
     if len(value_types) != 1:
-        return {"type": "object"}
+        return {"enum": values}
 
     base_type = _json_type(next(iter(value_types)))
     return {"type": base_type, "enum": values}
 
 
 def _json_type(annotation: object) -> str:
+    schema = _annotation_schema(annotation)
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        return schema_type
+    if isinstance(schema_type, list):
+        types = [value for value in schema_type if value != "null"]
+        if len(types) == 1:
+            return str(types[0])
+    return "object"
+
+
+def _annotation_schema(annotation: object) -> dict[str, Any]:
+    literal_schema = _literal_schema(annotation)
+    if literal_schema is not None:
+        return literal_schema
+
+    enum_schema = _enum_schema(annotation)
+    if enum_schema is not None:
+        return enum_schema
+
     if annotation is str:
-        return "string"
+        return {"type": "string"}
     if annotation is int:
-        return "integer"
+        return {"type": "integer"}
     if annotation is float:
-        return "number"
+        return {"type": "number"}
     if annotation is bool:
-        return "boolean"
+        return {"type": "boolean"}
+    if annotation is None or annotation is NoneType:
+        return {"type": "null"}
     if annotation is dict:
-        return "object"
-    if annotation in {list, tuple, set}:
-        return "array"
+        return {"type": "object"}
+    if annotation in {list, tuple, set, frozenset}:
+        return {"type": "array"}
+    if annotation in {Any, object}:
+        return {"type": "object"}
+
+    if isinstance(annotation, type) and is_typeddict(annotation):
+        return _typeddict_schema(annotation)
+    if isinstance(annotation, type) and is_dataclass(annotation):
+        return _dataclass_schema(annotation)
 
     origin = get_origin(annotation)
     args = get_args(annotation)
-    if origin in {list, tuple, set}:
-        return "array"
-    if origin is dict:
-        return "object"
-    if origin is None and annotation in {Any, object}:
-        return "object"
-    if origin is None:
-        return "object"
 
-    non_none_args = [arg for arg in args if arg is not type(None)]
-    if len(non_none_args) == 1:
-        return _json_type(non_none_args[0])
-    return "object"
+    if origin in {UnionType} or str(origin) == "typing.Union":
+        return _union_schema(args)
+    if origin in {list, set, frozenset, Sequence}:
+        return _array_schema(args)
+    if origin is tuple:
+        return _tuple_schema(args)
+    if origin in {dict, Mapping, MutableMapping}:
+        return _mapping_schema(args)
+
+    return {"type": "object"}
+
+
+def _enum_schema(annotation: object) -> dict[str, Any] | None:
+    if not isinstance(annotation, type) or not issubclass(annotation, Enum):
+        return None
+
+    values = [member.value for member in annotation]
+    if not values:
+        return {"type": "object"}
+
+    value_types = {type(value) for value in values}
+    if len(value_types) == 1:
+        return {"type": _json_type(next(iter(value_types))), "enum": values}
+    return {"enum": values}
+
+
+def _union_schema(args: tuple[object, ...]) -> dict[str, Any]:
+    if not args:
+        return {"type": "object"}
+
+    schemas = [_annotation_schema(arg) for arg in args]
+    non_null_schemas = [
+        schema for schema in schemas if schema.get("type") != "null"
+    ]
+    has_null = len(non_null_schemas) < len(schemas)
+
+    if has_null and len(non_null_schemas) == 1:
+        schema = dict(non_null_schemas[0])
+        schema_type = schema.get("type")
+        if isinstance(schema_type, str):
+            schema["type"] = [schema_type, "null"]
+        else:
+            schema = {"anyOf": [schema, {"type": "null"}]}
+        return schema
+
+    return {"anyOf": _unique_schemas(schemas)}
+
+
+def _array_schema(args: tuple[object, ...]) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "array"}
+    if args:
+        schema["items"] = _annotation_schema(args[0])
+    return schema
+
+
+def _tuple_schema(args: tuple[object, ...]) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "array"}
+    if not args:
+        return schema
+    if len(args) == 2 and args[1] is Ellipsis:
+        schema["items"] = _annotation_schema(args[0])
+        return schema
+    schema["prefixItems"] = [_annotation_schema(arg) for arg in args]
+    schema["minItems"] = len(args)
+    schema["maxItems"] = len(args)
+    return schema
+
+
+def _mapping_schema(args: tuple[object, ...]) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "object"}
+    if len(args) != 2:
+        return schema
+
+    value_annotation = args[1]
+    if value_annotation not in {Any, object}:
+        schema["additionalProperties"] = _annotation_schema(value_annotation)
+    return schema
+
+
+def _typeddict_schema(annotation: type) -> dict[str, Any]:
+    properties: dict[str, dict[str, Any]] = {}
+    annotations = getattr(annotation, "__annotations__", {})
+    for name, field_annotation in annotations.items():
+        properties[name] = _annotation_schema(field_annotation)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": sorted(getattr(annotation, "__required_keys__", set())),
+        "additionalProperties": False,
+    }
+
+
+def _dataclass_schema(annotation: type) -> dict[str, Any]:
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
+    annotations = getattr(annotation, "__annotations__", {})
+    for field in fields(annotation):
+        field_annotation = annotations.get(field.name, field.type)
+        properties[field.name] = _annotation_schema(field_annotation)
+        if field.default is MISSING and field.default_factory is MISSING:
+            required.append(field.name)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, Enum):
+        value = value.value
+    try:
+        dumps(value)
+    except TypeError:
+        return _JSON_DEFAULT_MISSING
+    return value
+
+
+def _unique_schemas(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for schema in schemas:
+        key = dumps(schema, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(schema)
+    return unique
 
 
 def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
@@ -78,10 +232,12 @@ def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
     summary = function_doc.splitlines()[0].strip() if function_doc else ""
     docs = _parse_docstring_sections(function_doc)
 
-    properties: dict[str, dict[str, str]] = {}
+    properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
     function_signature = signature(function)
     for name, parameter in function_signature.parameters.items():
+        if name == "context":
+            continue
         if parameter.kind not in {
             Parameter.POSITIONAL_OR_KEYWORD,
             Parameter.KEYWORD_ONLY,
@@ -93,21 +249,22 @@ def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
             if parameter.annotation is not Parameter.empty
             else Any
         )
-        literal_schema = _literal_schema(annotation)
-        properties[name] = (
-            literal_schema
-            if literal_schema
-            else {"type": _json_type(annotation)}
-        )
+        properties[name] = _annotation_schema(annotation)
         properties[name]["description"] = docs.get(f"arg:{name}", "")
         if parameter.default is Parameter.empty:
             required.append(name)
+        else:
+            default = _json_default(parameter.default)
+            if default is not _JSON_DEFAULT_MISSING:
+                properties[name]["default"] = default
 
     return_annotation = (
         function_signature.return_annotation
         if function_signature.return_annotation is not Parameter.empty
         else Any
     )
+    return_schema = _annotation_schema(return_annotation)
+    return_schema["description"] = docs.get("return", "")
 
     return {
         "type": "function",
@@ -118,10 +275,8 @@ def get_json_schema(function: Callable[..., Any]) -> dict[str, Any]:
                 "type": "object",
                 "properties": properties,
                 "required": required,
+                "additionalProperties": False,
             },
-            "return": {
-                "type": _json_type(return_annotation),
-                "description": docs.get("return", ""),
-            },
+            "return": return_schema,
         },
     }

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -310,8 +310,8 @@ class ToolManager:
         return self._parser.tool_call_status(buffer)
 
     def get_calls(self, text: str) -> list[ToolCall] | None:
-        calls = self._parser(text)
-        return calls if isinstance(calls, list) else None
+        calls = self._parser.parse(text).calls
+        return calls or None
 
     async def __aenter__(self) -> "ToolManager":
         if self._toolsets:

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -19,9 +19,12 @@ from .json_schema import get_json_schema
 from .parser import ToolCallParser
 
 from asyncio import CancelledError, wait_for
+from base64 import urlsafe_b64encode
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
+from copy import deepcopy
 from inspect import signature
+from re import compile as compile_regex
 from types import TracebackType
 from typing import Any, cast
 from uuid import uuid4
@@ -29,6 +32,8 @@ from uuid import uuid4
 
 class ToolManager:
     _INTERRUPT_CLOSE_TIMEOUT = 0.5
+    _PROVIDER_TOOL_NAME_PATTERN = compile_regex(r"^[A-Za-z0-9_-]+$")
+    _PROVIDER_TOOL_NAME_PREFIX = "avl_"
 
     _parser: ToolCallParser
     _stack: AsyncExitStack
@@ -218,23 +223,8 @@ class ToolManager:
 
         self._tools = {}
         if enabled_toolsets:
-            for i, toolset in enumerate(enabled_toolsets):
-                prefix = f"{toolset.namespace}." if toolset.namespace else ""
-                for tool in toolset.tools:
-                    if isinstance(tool, ToolSet):
-                        continue
-                    name = getattr(tool, "__name__", tool.__class__.__name__)
-                    canonical_name = f"{prefix}{name}"
-                    self._tools[canonical_name] = cast(
-                        Callable[..., Any], tool
-                    )
-                    aliases = self._tool_aliases(tool)
-                    self._add_aliases(self._aliases, canonical_name, aliases)
-                    self._descriptors[canonical_name] = ToolDescriptor(
-                        name=canonical_name,
-                        aliases=aliases,
-                        schema=self._tool_schema(tool, prefix),
-                    )
+            for toolset in enabled_toolsets:
+                self._register_toolset(toolset)
 
         self._toolsets = enabled_toolsets
 
@@ -283,6 +273,35 @@ class ToolManager:
             names.append((f"{tool_prefix}{name}", cls._tool_aliases(tool)))
         return names
 
+    def _register_toolset(
+        self, toolset: ToolSet, prefix: str | None = None
+    ) -> None:
+        namespace = (
+            f"{prefix}.{toolset.namespace}"
+            if prefix and toolset.namespace
+            else prefix or toolset.namespace
+        )
+        tool_prefix = f"{namespace}." if namespace else ""
+        for tool in toolset.tools:
+            if isinstance(tool, ToolSet):
+                self._register_toolset(tool, namespace)
+                continue
+
+            assert self._tools is not None
+            name = getattr(tool, "__name__", tool.__class__.__name__)
+            canonical_name = f"{tool_prefix}{name}"
+            self._tools[canonical_name] = cast(Callable[..., Any], tool)
+            aliases = self._tool_aliases(tool)
+            self._add_aliases(self._aliases, canonical_name, aliases)
+            schema = self._tool_schema(tool, tool_prefix)
+            self._descriptors[canonical_name] = self._tool_descriptor(
+                canonical_name=canonical_name,
+                tool=tool,
+                aliases=aliases,
+                namespace=namespace,
+                schema=schema,
+            )
+
     @staticmethod
     def _tool_schema(
         tool: Callable[..., Any] | Tool, prefix: str
@@ -298,6 +317,76 @@ class ToolManager:
         ):
             schema["function"]["name"] = prefix + schema["function"]["name"]
         return schema
+
+    @classmethod
+    def _tool_descriptor(
+        cls,
+        *,
+        canonical_name: str,
+        tool: Callable[..., Any] | Tool,
+        aliases: list[str],
+        namespace: str | None,
+        schema: dict[str, Any] | None,
+    ) -> ToolDescriptor:
+        function_schema = (
+            schema.get("function")
+            if schema and schema.get("type") == "function"
+            else None
+        )
+        parameters = (
+            function_schema.get("parameters")
+            if isinstance(function_schema, dict)
+            else None
+        )
+        returns = (
+            function_schema.get("return")
+            if isinstance(function_schema, dict)
+            else None
+        )
+        return ToolDescriptor(
+            name=canonical_name,
+            callable=cast(Callable[..., Any], tool),
+            aliases=aliases,
+            schema=schema,
+            parameter_schema=(
+                cast(dict[str, Any], parameters)
+                if isinstance(parameters, dict)
+                else None
+            ),
+            return_schema=(
+                cast(dict[str, Any], returns)
+                if isinstance(returns, dict)
+                else None
+            ),
+            provider_safe_schema=cls._provider_safe_schema(schema),
+            namespace=namespace,
+        )
+
+    @classmethod
+    def _provider_safe_schema(
+        cls, schema: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if not schema:
+            return None
+        provider_schema = deepcopy(schema)
+        function = provider_schema.get("function")
+        if (
+            provider_schema.get("type") == "function"
+            and isinstance(function, dict)
+            and isinstance(function.get("name"), str)
+        ):
+            function["name"] = cls._encode_provider_tool_name(function["name"])
+        return provider_schema
+
+    @classmethod
+    def _encode_provider_tool_name(cls, tool_name: str) -> str:
+        assert tool_name.strip(), "tool name must not be empty"
+        if cls._PROVIDER_TOOL_NAME_PATTERN.fullmatch(
+            tool_name
+        ) and not tool_name.startswith(cls._PROVIDER_TOOL_NAME_PREFIX):
+            return tool_name
+        encoded = urlsafe_b64encode(tool_name.encode()).decode().rstrip("=")
+        return f"{cls._PROVIDER_TOOL_NAME_PREFIX}{encoded}"
 
     def is_potential_tool_call(self, buffer: str, token_str: str) -> bool:
         """Proxy :meth:`ToolCallParser.is_potential_tool_call`."""

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -16,6 +16,7 @@ from ..entities import (
     ToolManagerSettings,
     ToolNameResolution,
     ToolNameResolutionStatus,
+    ToolProviderArgumentsMode,
     ToolTransformer,
     ToolTransformerResult,
 )
@@ -185,6 +186,14 @@ class ToolManager:
                 ),
                 details={"candidates": cast(Any, resolution.candidates)},
             )
+
+        assert resolution.canonical_name is not None
+        provider_diagnostic = self._provider_arguments_diagnostic(
+            call=call,
+            canonical_name=resolution.canonical_name,
+        )
+        if provider_diagnostic is not None:
+            return provider_diagnostic
 
         arguments = call.arguments if call.arguments is not None else {}
         if not isinstance(arguments, dict):
@@ -641,6 +650,13 @@ class ToolManager:
             return self._resolution_diagnostic(call, resolution)
         assert resolution.canonical_name is not None
 
+        provider_diagnostic = self._provider_arguments_diagnostic(
+            call=call,
+            canonical_name=resolution.canonical_name,
+        )
+        if provider_diagnostic is not None:
+            return provider_diagnostic
+
         arguments = call.arguments if call.arguments is not None else {}
         if not isinstance(arguments, dict):
             return self._diagnostic(
@@ -668,6 +684,7 @@ class ToolManager:
             arguments=arguments,
             provider_name=call.provider_name,
             provider_name_encoded=call.provider_name_encoded,
+            provider_arguments_malformed=call.provider_arguments_malformed,
         )
         if validate:
             diagnostic = self._validate_tool_arguments(
@@ -747,6 +764,26 @@ class ToolManager:
             code=ToolCallDiagnosticCode.CANCELLED,
             stage=ToolCallDiagnosticStage.GUARD,
             message="Tool call was cancelled before execution.",
+        )
+
+    def _provider_arguments_diagnostic(
+        self,
+        *,
+        call: ToolCall,
+        canonical_name: str,
+    ) -> ToolCallDiagnostic | None:
+        if (
+            self._settings.provider_arguments_mode
+            is not ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+            or not call.provider_arguments_malformed
+        ):
+            return None
+        return self._diagnostic(
+            call=call,
+            canonical_name=canonical_name,
+            code=ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            message="Provider tool call arguments are malformed.",
         )
 
     def _validate_tool_arguments(
@@ -1069,6 +1106,9 @@ class ToolManager:
                 arguments=call.arguments,
                 provider_name=call.provider_name,
                 provider_name_encoded=call.provider_name_encoded,
+                provider_arguments_malformed=(
+                    call.provider_arguments_malformed
+                ),
                 result=result,
             )
         except Exception as exc:
@@ -1079,6 +1119,9 @@ class ToolManager:
                 arguments=call.arguments,
                 provider_name=call.provider_name,
                 provider_name_encoded=call.provider_name_encoded,
+                provider_arguments_malformed=(
+                    call.provider_arguments_malformed
+                ),
                 error=self._project_error(exc),
                 message=str(exc),
             )

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -16,6 +16,7 @@ from ..entities import (
 )
 from . import Tool, ToolSet
 from .json_schema import get_json_schema
+from .names import matches_tool_namespace
 from .parser import ToolCallParser
 
 from asyncio import CancelledError, wait_for
@@ -44,12 +45,6 @@ class ToolManager:
     _descriptors: dict[str, ToolDescriptor]
     _tools: dict[str, Callable[..., Any]] | None = None
     _toolsets: list[ToolSet] | None = None
-
-    @staticmethod
-    def _matches_namespace(tool_name: str, namespace: str | None) -> bool:
-        if not namespace:
-            return True
-        return tool_name == namespace or tool_name.startswith(f"{namespace}.")
 
     @classmethod
     def create_instance(
@@ -512,7 +507,7 @@ class ToolManager:
                     filter_namespace = f.namespace
                 else:
                     filter_func = f
-                if not self._matches_namespace(call.name, filter_namespace):
+                if not matches_tool_namespace(call.name, filter_namespace):
                     continue
                 modified = filter_func(call, context)
                 if modified is not None:
@@ -546,8 +541,9 @@ class ToolManager:
                         transformer_namespace = t.namespace
                     else:
                         transformer_func = t
-                    if not self._matches_namespace(
-                        call.name, transformer_namespace
+                    if not matches_tool_namespace(
+                        call.name,
+                        transformer_namespace,
                     ):
                         continue
                     transformed = transformer_func(call, context, result)

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -17,6 +17,7 @@ from ..entities import (
     ToolNameResolution,
     ToolNameResolutionStatus,
     ToolTransformer,
+    ToolTransformerResult,
 )
 from . import Tool, ToolSet
 from .json_schema import get_json_schema
@@ -29,7 +30,7 @@ from binascii import Error as BinasciiError
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import deepcopy
-from inspect import signature
+from inspect import Parameter, signature
 from re import compile as compile_regex
 from types import TracebackType
 from typing import Any, cast
@@ -722,7 +723,7 @@ class ToolManager:
                     context=context or ToolCallContext(),
                 )
             else:
-                signature(tool).bind(**arguments)
+                self._bind_callable_arguments(tool, arguments)
         except TypeError as exc:
             return ToolCallDiagnostic(
                 id=uuid4(),
@@ -809,7 +810,7 @@ class ToolManager:
                 call=call,
                 name=call.name,
                 arguments=call.arguments,
-                error=exc,
+                error=self._project_error(exc),
                 message=str(exc),
             )
 
@@ -825,9 +826,28 @@ class ToolManager:
             return await tool(**arguments, context=context)
         if is_native_tool:
             return await tool(context=context)
-        if arguments:
-            return await tool(*arguments.values())
-        return tool()
+        call_args, call_kwargs = self._bind_callable_arguments(tool, arguments)
+        result = tool(*call_args, **call_kwargs)
+        if isinstance(result, Awaitable):
+            return await result
+        return result
+
+    @staticmethod
+    def _bind_callable_arguments(
+        tool: Callable[..., Any],
+        arguments: dict[str, Any],
+    ) -> tuple[list[Any], dict[str, Any]]:
+        function_signature = signature(tool)
+        call_args: list[Any] = []
+        call_kwargs = dict(arguments)
+        for parameter in function_signature.parameters.values():
+            if (
+                parameter.kind is Parameter.POSITIONAL_ONLY
+                and parameter.name in call_kwargs
+            ):
+                call_args.append(call_kwargs.pop(parameter.name))
+        function_signature.bind(*call_args, **call_kwargs)
+        return call_args, call_kwargs
 
     def _apply_transformers(
         self,
@@ -850,9 +870,15 @@ class ToolManager:
             ):
                 continue
             transformed = transformer_func(call, context, result)
-            if transformed is not None:
+            if isinstance(transformed, ToolTransformerResult):
+                result = transformed.result
+            elif transformed is not None:
                 result = transformed
         return result
+
+    @staticmethod
+    def _project_error(exc: Exception) -> dict[str, object]:
+        return {"type": exc.__class__.__name__}
 
 
 async def _check_cancelled(context: ToolCallContext) -> None:

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -493,35 +493,15 @@ class ToolManager:
         """Return a prepared execution plan or a diagnostic."""
         assert call
 
-        history = context.calls or []
-
-        if self._settings.avoid_repetition and history:
-            last = history[-1]
-            if last.name == call.name and last.arguments == call.arguments:
-                return self._diagnostic(
-                    call=call,
-                    code=ToolCallDiagnosticCode.REPEATED_CALL,
-                    stage=ToolCallDiagnosticStage.GUARD,
-                    message="Tool call repeats the previous call.",
-                )
-
-        if (
-            self._settings.maximum_depth is not None
-            and len(history) + 1 > self._settings.maximum_depth
-        ):
-            return self._diagnostic(
-                call=call,
-                code=ToolCallDiagnosticCode.MAXIMUM_DEPTH,
-                stage=ToolCallDiagnosticStage.GUARD,
-                message="Tool call exceeds the maximum depth.",
-            )
+        diagnostic = self._guard_diagnostic(call, context)
+        if diagnostic is not None:
+            return diagnostic
 
         await _check_cancelled(context)
 
         prepared = self._prepare_resolved_call(
             call,
             context,
-            validate=False,
         )
         if isinstance(prepared, ToolCallDiagnostic):
             return prepared
@@ -532,7 +512,21 @@ class ToolManager:
         call, context = filtered
         await _check_cancelled(context)
 
-        return self._prepare_resolved_call(call, context)
+        prepared = self._prepare_resolved_call(
+            call,
+            context,
+        )
+        if isinstance(prepared, ToolCallDiagnostic):
+            return prepared
+
+        diagnostic = self._guard_diagnostic(prepared.call, prepared.context)
+        if diagnostic is not None:
+            return diagnostic
+
+        validation = self._validate_prepared_call(prepared)
+        if validation is not None:
+            return validation
+        return prepared
 
     async def execute_prepared_call(
         self, prepared: PreparedToolCall
@@ -622,17 +616,7 @@ class ToolManager:
         if self._settings.execution_mode is ToolManagerExecutionMode.OUTCOMES:
             return await self.execute_call(call, context)
 
-        history = context.calls or []
-
-        if self._settings.avoid_repetition and history:
-            last = history[-1]
-            if last.name == call.name and last.arguments == call.arguments:
-                return None
-
-        if (
-            self._settings.maximum_depth is not None
-            and len(history) + 1 > self._settings.maximum_depth
-        ):
+        if self._guard_diagnostic(call, context) is not None:
             return None
 
         if not self._tools or call.name not in self._tools:
@@ -650,9 +634,10 @@ class ToolManager:
         prepared = self._prepare_resolved_call(
             call,
             context,
-            validate=False,
         )
         if isinstance(prepared, ToolCallDiagnostic):
+            return None
+        if self._guard_diagnostic(prepared.call, prepared.context) is not None:
             return None
         return await self._execute_prepared_call(prepared)
 
@@ -660,8 +645,6 @@ class ToolManager:
         self,
         call: ToolCall,
         context: ToolCallContext,
-        *,
-        validate: bool = True,
     ) -> PreparedToolCall | ToolCallDiagnostic:
         resolution = self._resolve_call_name(call)
         if resolution.diagnostic_code is not None:
@@ -704,22 +687,50 @@ class ToolManager:
             provider_name_encoded=call.provider_name_encoded,
             provider_arguments_malformed=call.provider_arguments_malformed,
         )
-        if validate:
-            diagnostic = self._validate_tool_arguments(
-                call=prepared_call,
-                canonical_name=resolution.canonical_name,
-                tool=tool,
-                arguments=arguments,
-                context=context,
-            )
-            if diagnostic is not None:
-                return diagnostic
         return PreparedToolCall(
             call=prepared_call,
             callable=tool,
             descriptor=descriptor,
             arguments=arguments,
             context=context,
+        )
+
+    def _guard_diagnostic(
+        self, call: ToolCall, context: ToolCallContext
+    ) -> ToolCallDiagnostic | None:
+        history = context.calls or []
+
+        if self._settings.avoid_repetition and history:
+            last = history[-1]
+            if last.name == call.name and last.arguments == call.arguments:
+                return self._diagnostic(
+                    call=call,
+                    code=ToolCallDiagnosticCode.REPEATED_CALL,
+                    stage=ToolCallDiagnosticStage.GUARD,
+                    message="Tool call repeats the previous call.",
+                )
+
+        if (
+            self._settings.maximum_depth is not None
+            and len(history) + 1 > self._settings.maximum_depth
+        ):
+            return self._diagnostic(
+                call=call,
+                code=ToolCallDiagnosticCode.MAXIMUM_DEPTH,
+                stage=ToolCallDiagnosticStage.GUARD,
+                message="Tool call exceeds the maximum depth.",
+            )
+        return None
+
+    def _validate_prepared_call(
+        self, prepared: PreparedToolCall
+    ) -> ToolCallDiagnostic | None:
+        return self._validate_tool_arguments(
+            call=prepared.call,
+            canonical_name=prepared.call.name,
+            tool=prepared.callable,
+            arguments=prepared.arguments,
+            context=prepared.context,
         )
 
     def _resolution_diagnostic(

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -9,6 +9,8 @@ from ..entities import (
     ToolCallResult,
     ToolDescriptor,
     ToolFilter,
+    ToolFilterResult,
+    ToolFilterResultStatus,
     ToolFormat,
     ToolManagerSettings,
     ToolNameResolution,
@@ -478,7 +480,10 @@ class ToolManager:
         if isinstance(prepared, ToolCallDiagnostic):
             return prepared
 
-        call, context = self._apply_filters(prepared.call, prepared.context)
+        filtered = self._apply_filters(prepared.call, prepared.context)
+        if isinstance(filtered, ToolCallDiagnostic):
+            return filtered
+        call, context = filtered
         await _check_cancelled(context)
 
         return self._prepare_resolved_call(call, context)
@@ -538,24 +543,25 @@ class ToolManager:
         ):
             return None
 
-        tool = self._tools.get(call.name, None) if self._tools else None
-
-        if not tool:
+        if not self._tools or call.name not in self._tools:
             return None
 
         await _check_cancelled(context)
 
-        call, context = self._apply_filters(call, context)
+        filtered = self._apply_filters(call, context)
+        if isinstance(filtered, ToolCallDiagnostic):
+            return None
+        call, context = filtered
 
         await _check_cancelled(context)
 
-        prepared = PreparedToolCall(
-            call=call,
-            callable=tool,
-            descriptor=self._legacy_descriptor(call.name, tool),
-            arguments=call.arguments or {},
-            context=context,
+        prepared = self._prepare_resolved_call(
+            call,
+            context,
+            validate=False,
         )
+        if isinstance(prepared, ToolCallDiagnostic):
+            return None
         return await self._execute_prepared_call(prepared)
 
     def _prepare_resolved_call(
@@ -629,6 +635,7 @@ class ToolManager:
         stage: ToolCallDiagnosticStage,
         message: str,
         canonical_name: str | None = None,
+        details: dict[str, Any] | None = None,
     ) -> ToolCallDiagnostic:
         return ToolCallDiagnostic(
             id=uuid4(),
@@ -638,6 +645,7 @@ class ToolManager:
             code=code,
             stage=stage,
             message=message,
+            details=details or {},
         )
 
     def _validate_tool_arguments(
@@ -671,7 +679,7 @@ class ToolManager:
 
     def _apply_filters(
         self, call: ToolCall, context: ToolCallContext
-    ) -> tuple[ToolCall, ToolCallContext]:
+    ) -> tuple[ToolCall, ToolCallContext] | ToolCallDiagnostic:
         if not self._settings.filters:
             return call, context
 
@@ -685,22 +693,40 @@ class ToolManager:
             if not matches_tool_namespace(call.name, filter_namespace):
                 continue
             modified = filter_func(call, context)
-            if modified is not None:
-                assert isinstance(modified, tuple) and len(modified) == 2
-                call, context = modified
+            if modified is None:
+                continue
+            if isinstance(modified, ToolFilterResult):
+                if modified.status is ToolFilterResultStatus.PASS:
+                    continue
+                if modified.status is ToolFilterResultStatus.SUPPRESS:
+                    return self._diagnostic(
+                        call=call,
+                        code=modified.code,
+                        stage=ToolCallDiagnosticStage.FILTER,
+                        message=(
+                            modified.message
+                            or "Tool call was suppressed by a filter."
+                        ),
+                        details=modified.details,
+                    )
+                assert modified.status is ToolFilterResultStatus.MODIFY
+                assert modified.call is not None
+                assert modified.context is not None
+                modified = (modified.call, modified.context)
+            assert isinstance(modified, tuple) and len(modified) == 2
+            next_call, next_context = modified
+            assert isinstance(next_call, ToolCall)
+            assert isinstance(next_context, ToolCallContext)
+            if context.flow_tool_node and next_call.name != call.name:
+                return self._diagnostic(
+                    call=call,
+                    code=ToolCallDiagnosticCode.FILTER_SUPPRESSED,
+                    stage=ToolCallDiagnosticStage.FILTER,
+                    message="Tool filter name rewrites are disabled.",
+                    details={"filtered_name": next_call.name},
+                )
+            call, context = next_call, next_context
         return call, context
-
-    def _legacy_descriptor(
-        self, name: str, tool: Callable[..., Any]
-    ) -> ToolDescriptor:
-        descriptor = self._descriptors.get(name)
-        if descriptor is not None and descriptor.callable is tool:
-            return descriptor
-        return ToolDescriptor(
-            name=name,
-            callable=tool,
-            aliases=[],
-        )
 
     async def _execute_prepared_call(
         self, prepared: PreparedToolCall

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -170,16 +170,19 @@ class ToolManager:
 
     def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
         """Return a diagnostic when a tool call is not executable."""
-        resolution = self.resolve_tool_name(call.name)
+        resolution = self._resolve_call_name(call)
         if resolution.diagnostic_code is not None:
             return ToolCallDiagnostic(
                 id=uuid4(),
                 call_id=call.id,
-                requested_name=call.name,
+                requested_name=resolution.requested_name,
                 canonical_name=resolution.canonical_name,
                 code=resolution.diagnostic_code,
                 stage=ToolCallDiagnosticStage.RESOLVE,
-                message=f"Tool '{call.name}' is {resolution.status.value}.",
+                message=(
+                    f"Tool '{resolution.requested_name}' is "
+                    f"{resolution.status.value}."
+                ),
                 details={"candidates": cast(Any, resolution.candidates)},
             )
 
@@ -633,7 +636,7 @@ class ToolManager:
         *,
         validate: bool = True,
     ) -> PreparedToolCall | ToolCallDiagnostic:
-        resolution = self.resolve_tool_name(call.name)
+        resolution = self._resolve_call_name(call)
         if resolution.diagnostic_code is not None:
             return self._resolution_diagnostic(call, resolution)
         assert resolution.canonical_name is not None
@@ -663,6 +666,8 @@ class ToolManager:
             id=call.id,
             name=resolution.canonical_name,
             arguments=arguments,
+            provider_name=call.provider_name,
+            provider_name_encoded=call.provider_name_encoded,
         )
         if validate:
             diagnostic = self._validate_tool_arguments(
@@ -689,12 +694,24 @@ class ToolManager:
         return ToolCallDiagnostic(
             id=uuid4(),
             call_id=call.id,
-            requested_name=call.name,
+            requested_name=resolution.requested_name,
             canonical_name=resolution.canonical_name,
             code=resolution.diagnostic_code,
             stage=ToolCallDiagnosticStage.RESOLVE,
-            message=f"Tool '{call.name}' is {resolution.status.value}.",
+            message=(
+                f"Tool '{resolution.requested_name}' is "
+                f"{resolution.status.value}."
+            ),
             details={"candidates": cast(Any, resolution.candidates)},
+        )
+
+    def _resolve_call_name(self, call: ToolCall) -> ToolNameResolution:
+        provider_name = call.provider_name
+        if provider_name is None:
+            return self.resolve_tool_name(call.name)
+        return self.resolve_tool_name(
+            provider_name,
+            provider_originated=True,
         )
 
     def _diagnostic(
@@ -1050,6 +1067,8 @@ class ToolManager:
                 call=call,
                 name=call.name,
                 arguments=call.arguments,
+                provider_name=call.provider_name,
+                provider_name_encoded=call.provider_name_encoded,
                 result=result,
             )
         except Exception as exc:
@@ -1058,6 +1077,8 @@ class ToolManager:
                 call=call,
                 name=call.name,
                 arguments=call.arguments,
+                provider_name=call.provider_name,
+                provider_name_encoded=call.provider_name_encoded,
                 error=self._project_error(exc),
                 message=str(exc),
             )

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -1,19 +1,27 @@
 from ..entities import (
     ToolCall,
     ToolCallContext,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
+    ToolDescriptor,
     ToolFilter,
     ToolFormat,
     ToolManagerSettings,
+    ToolNameResolution,
+    ToolNameResolutionStatus,
     ToolTransformer,
 )
 from . import Tool, ToolSet
+from .json_schema import get_json_schema
 from .parser import ToolCallParser
 
 from asyncio import CancelledError, wait_for
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
+from inspect import signature
 from types import TracebackType
 from typing import Any, cast
 from uuid import uuid4
@@ -24,6 +32,10 @@ class ToolManager:
 
     _parser: ToolCallParser
     _stack: AsyncExitStack
+    _aliases: dict[str, list[str]]
+    _available_aliases: dict[str, list[str]]
+    _available_tool_names: set[str]
+    _descriptors: dict[str, ToolDescriptor]
     _tools: dict[str, Callable[..., Any]] | None = None
     _toolsets: list[ToolSet] | None = None
 
@@ -73,6 +85,107 @@ class ToolManager:
                 schemas.extend(toolset_schemas)
         return schemas
 
+    def list_tools(self) -> list[ToolDescriptor]:
+        """Return descriptors for enabled tools."""
+        return list(self._descriptors.values())
+
+    def describe_tool(self, name: str) -> ToolDescriptor | None:
+        """Return the descriptor for an enabled tool."""
+        resolution = self.resolve_tool_name(name)
+        if resolution.canonical_name is None:
+            return None
+        return self._descriptors.get(resolution.canonical_name)
+
+    def resolve_tool_name(self, name: str) -> ToolNameResolution:
+        """Resolve a requested tool name against enabled tools."""
+        assert isinstance(name, str)
+        assert name.strip(), "name must not be empty"
+        if self._tools and name in self._tools:
+            return ToolNameResolution(
+                requested_name=name,
+                status=ToolNameResolutionStatus.EXACT,
+                canonical_name=name,
+                candidates=[name],
+            )
+
+        aliases = self._aliases.get(name, [])
+        if len(aliases) == 1:
+            return ToolNameResolution(
+                requested_name=name,
+                status=ToolNameResolutionStatus.ALIAS,
+                canonical_name=aliases[0],
+                candidates=aliases,
+            )
+        if len(aliases) > 1:
+            return ToolNameResolution(
+                requested_name=name,
+                status=ToolNameResolutionStatus.AMBIGUOUS,
+                candidates=aliases,
+                diagnostic_code=ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME,
+            )
+
+        if (
+            name in self._available_tool_names
+            or name in self._available_aliases
+        ):
+            return ToolNameResolution(
+                requested_name=name,
+                status=ToolNameResolutionStatus.DISABLED,
+                diagnostic_code=ToolCallDiagnosticCode.DISABLED_TOOL,
+            )
+
+        return ToolNameResolution(
+            requested_name=name,
+            status=ToolNameResolutionStatus.UNKNOWN,
+            diagnostic_code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        )
+
+    def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
+        """Return a diagnostic when a tool call is not executable."""
+        resolution = self.resolve_tool_name(call.name)
+        if resolution.diagnostic_code is not None:
+            return ToolCallDiagnostic(
+                id=uuid4(),
+                call_id=call.id,
+                requested_name=call.name,
+                canonical_name=resolution.canonical_name,
+                code=resolution.diagnostic_code,
+                stage=ToolCallDiagnosticStage.RESOLVE,
+                message=f"Tool '{call.name}' is {resolution.status.value}.",
+                details={"candidates": cast(Any, resolution.candidates)},
+            )
+
+        arguments = call.arguments or {}
+        if not isinstance(arguments, dict):
+            return ToolCallDiagnostic(
+                id=uuid4(),
+                call_id=call.id,
+                requested_name=call.name,
+                canonical_name=resolution.canonical_name,
+                code=ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                stage=ToolCallDiagnosticStage.VALIDATE,
+                message="Tool call arguments must be an object.",
+            )
+
+        assert resolution.canonical_name is not None
+        tool = (
+            self._tools.get(resolution.canonical_name) if self._tools else None
+        )
+        assert tool is not None
+        try:
+            signature(tool).bind(**arguments)
+        except TypeError as exc:
+            return ToolCallDiagnostic(
+                id=uuid4(),
+                call_id=call.id,
+                requested_name=call.name,
+                canonical_name=resolution.canonical_name,
+                code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+                stage=ToolCallDiagnosticStage.VALIDATE,
+                message=str(exc),
+            )
+        return None
+
     def __init__(
         self,
         *,
@@ -84,6 +197,16 @@ class ToolManager:
         self._parser = parser
         self._settings = settings or ToolManagerSettings()
         self._stack = AsyncExitStack()
+        self._aliases = {}
+        self._available_aliases = {}
+        self._available_tool_names = set()
+        self._descriptors = {}
+
+        if available_toolsets:
+            for toolset in available_toolsets:
+                for name, aliases in self._toolset_tool_names(toolset):
+                    self._available_tool_names.add(name)
+                    self._add_aliases(self._available_aliases, name, aliases)
 
         enabled_toolsets = []
         if available_toolsets:
@@ -101,14 +224,80 @@ class ToolManager:
                     if isinstance(tool, ToolSet):
                         continue
                     name = getattr(tool, "__name__", tool.__class__.__name__)
-                    self._tools[f"{prefix}{name}"] = cast(
+                    canonical_name = f"{prefix}{name}"
+                    self._tools[canonical_name] = cast(
                         Callable[..., Any], tool
+                    )
+                    aliases = self._tool_aliases(tool)
+                    self._add_aliases(self._aliases, canonical_name, aliases)
+                    self._descriptors[canonical_name] = ToolDescriptor(
+                        name=canonical_name,
+                        aliases=aliases,
+                        schema=self._tool_schema(tool, prefix),
                     )
 
         self._toolsets = enabled_toolsets
 
     def set_eos_token(self, eos_token: str) -> None:
         self._parser.set_eos_token(eos_token)
+
+    @classmethod
+    def _add_aliases(
+        cls,
+        registry: dict[str, list[str]],
+        canonical_name: str,
+        aliases: list[str],
+    ) -> None:
+        for alias in aliases:
+            registry.setdefault(alias, []).append(canonical_name)
+
+    @classmethod
+    def _tool_aliases(cls, tool: Callable[..., Any] | Tool) -> list[str]:
+        aliases = getattr(tool, "aliases", [])
+        assert isinstance(aliases, Sequence)
+        assert not isinstance(aliases, str)
+        return [cls._valid_tool_alias(alias) for alias in aliases]
+
+    @staticmethod
+    def _valid_tool_alias(alias: object) -> str:
+        assert isinstance(alias, str), "tool aliases must be strings"
+        assert alias.strip(), "tool aliases must not be empty"
+        return alias
+
+    @classmethod
+    def _toolset_tool_names(
+        cls, toolset: ToolSet, prefix: str | None = None
+    ) -> list[tuple[str, list[str]]]:
+        namespace_prefix = (
+            f"{prefix}.{toolset.namespace}"
+            if prefix and toolset.namespace
+            else prefix or toolset.namespace
+        )
+        tool_prefix = f"{namespace_prefix}." if namespace_prefix else ""
+        names: list[tuple[str, list[str]]] = []
+        for tool in toolset.tools:
+            if isinstance(tool, ToolSet):
+                names.extend(cls._toolset_tool_names(tool, namespace_prefix))
+                continue
+            name = getattr(tool, "__name__", tool.__class__.__name__)
+            names.append((f"{tool_prefix}{name}", cls._tool_aliases(tool)))
+        return names
+
+    @staticmethod
+    def _tool_schema(
+        tool: Callable[..., Any] | Tool, prefix: str
+    ) -> dict[str, Any] | None:
+        if isinstance(tool, Tool):
+            return tool.json_schema(prefix)
+        schema = get_json_schema(tool)
+        if (
+            prefix
+            and schema.get("type") == "function"
+            and "function" in schema
+            and "name" in schema["function"]
+        ):
+            schema["function"]["name"] = prefix + schema["function"]["name"]
+        return schema
 
     def is_potential_tool_call(self, buffer: str, token_str: str) -> bool:
         """Proxy :meth:`ToolCallParser.is_potential_tool_call`."""

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -174,7 +174,7 @@ class ToolManager:
                 details={"candidates": cast(Any, resolution.candidates)},
             )
 
-        arguments = call.arguments or {}
+        arguments = call.arguments if call.arguments is not None else {}
         if not isinstance(arguments, dict):
             return ToolCallDiagnostic(
                 id=uuid4(),
@@ -621,7 +621,7 @@ class ToolManager:
             return self._resolution_diagnostic(call, resolution)
         assert resolution.canonical_name is not None
 
-        arguments = call.arguments or {}
+        arguments = call.arguments if call.arguments is not None else {}
         if not isinstance(arguments, dict):
             return self._diagnostic(
                 call=call,
@@ -716,6 +716,16 @@ class ToolManager:
         arguments: dict[str, Any],
         context: ToolCallContext | None = None,
     ) -> ToolCallDiagnostic | None:
+        descriptor = self._descriptors[canonical_name]
+        schema_diagnostic = self._validate_arguments_schema(
+            call=call,
+            canonical_name=canonical_name,
+            arguments=arguments,
+            schema=descriptor.parameter_schema,
+        )
+        if schema_diagnostic is not None:
+            return schema_diagnostic
+
         try:
             if isinstance(tool, Tool):
                 signature(tool.__call__).bind(
@@ -735,6 +745,202 @@ class ToolManager:
                 message=str(exc),
             )
         return None
+
+    def _validate_arguments_schema(
+        self,
+        *,
+        call: ToolCall,
+        canonical_name: str,
+        arguments: dict[str, Any],
+        schema: dict[str, Any] | None,
+    ) -> ToolCallDiagnostic | None:
+        if schema is None:
+            return None
+
+        error = self._schema_validation_error(arguments, schema, "$")
+        if error is None:
+            return None
+        return self._diagnostic(
+            call=call,
+            canonical_name=canonical_name,
+            code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            message=error,
+        )
+
+    @classmethod
+    def _schema_validation_error(
+        cls,
+        value: Any,
+        schema: dict[str, Any],
+        path: str,
+    ) -> str | None:
+        if "anyOf" in schema:
+            any_of = schema["anyOf"]
+            assert isinstance(any_of, list)
+            if any(
+                isinstance(candidate, dict)
+                and cls._schema_validation_error(value, candidate, path)
+                is None
+                for candidate in any_of
+            ):
+                return None
+            return f"{path} does not match any allowed schema."
+
+        expected_type = schema.get("type")
+        if expected_type is not None and not cls._matches_schema_type(
+            value,
+            expected_type,
+        ):
+            return (
+                f"{path} must be {cls._format_expected_type(expected_type)}."
+            )
+
+        if "enum" in schema:
+            enum_values = schema["enum"]
+            assert isinstance(enum_values, list)
+            if value not in enum_values:
+                return f"{path} must be one of {enum_values!r}."
+
+        if value is None:
+            return None
+
+        schema_type = schema.get("type")
+        if schema_type == "object" or (
+            isinstance(schema_type, list) and "object" in schema_type
+        ):
+            return cls._object_schema_validation_error(value, schema, path)
+        if schema_type == "array" or (
+            isinstance(schema_type, list) and "array" in schema_type
+        ):
+            return cls._array_schema_validation_error(value, schema, path)
+        return None
+
+    @classmethod
+    def _object_schema_validation_error(
+        cls,
+        value: Any,
+        schema: dict[str, Any],
+        path: str,
+    ) -> str | None:
+        if not isinstance(value, dict):
+            return None
+
+        properties = schema.get("properties", {})
+        assert isinstance(properties, dict)
+        required = schema.get("required", [])
+        assert isinstance(required, list)
+        for name in required:
+            assert isinstance(name, str)
+            if name not in value:
+                return f"{path}.{name} is required."
+
+        additional_properties = schema.get("additionalProperties", True)
+        for name, field_value in value.items():
+            field_path = f"{path}.{name}"
+            field_schema = properties.get(name)
+            if isinstance(field_schema, dict):
+                error = cls._schema_validation_error(
+                    field_value,
+                    field_schema,
+                    field_path,
+                )
+                if error is not None:
+                    return error
+                continue
+            if additional_properties is False:
+                return f"{field_path} is not allowed."
+            if isinstance(additional_properties, dict):
+                error = cls._schema_validation_error(
+                    field_value,
+                    additional_properties,
+                    field_path,
+                )
+                if error is not None:
+                    return error
+        return None
+
+    @classmethod
+    def _array_schema_validation_error(
+        cls,
+        value: Any,
+        schema: dict[str, Any],
+        path: str,
+    ) -> str | None:
+        if not isinstance(value, list):
+            return None
+
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            return f"{path} must contain at least {min_items} item(s)."
+
+        max_items = schema.get("maxItems")
+        if isinstance(max_items, int) and len(value) > max_items:
+            return f"{path} must contain at most {max_items} item(s)."
+
+        prefix_items = schema.get("prefixItems")
+        if isinstance(prefix_items, list):
+            for index, item_schema in enumerate(prefix_items):
+                if index >= len(value) or not isinstance(item_schema, dict):
+                    continue
+                error = cls._schema_validation_error(
+                    value[index],
+                    item_schema,
+                    f"{path}[{index}]",
+                )
+                if error is not None:
+                    return error
+            return None
+
+        items = schema.get("items")
+        if isinstance(items, dict):
+            for index, item in enumerate(value):
+                error = cls._schema_validation_error(
+                    item,
+                    items,
+                    f"{path}[{index}]",
+                )
+                if error is not None:
+                    return error
+        return None
+
+    @classmethod
+    def _matches_schema_type(
+        cls,
+        value: Any,
+        expected_type: str | list[str],
+    ) -> bool:
+        if isinstance(expected_type, list):
+            return any(
+                cls._matches_schema_type(value, t) for t in expected_type
+            )
+
+        match expected_type:
+            case "null":
+                return value is None
+            case "boolean":
+                return isinstance(value, bool)
+            case "integer":
+                return isinstance(value, int) and not isinstance(value, bool)
+            case "number":
+                return isinstance(value, int | float) and not isinstance(
+                    value,
+                    bool,
+                )
+            case "string":
+                return isinstance(value, str)
+            case "array":
+                return isinstance(value, list)
+            case "object":
+                return isinstance(value, dict)
+            case _:
+                return True
+
+    @staticmethod
+    def _format_expected_type(expected_type: str | list[str]) -> str:
+        if isinstance(expected_type, list):
+            return " or ".join(expected_type)
+        return expected_type
 
     def _apply_filters(
         self, call: ToolCall, context: ToolCallContext

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -62,6 +62,15 @@ class ToolManager:
         parser = ToolCallParser(
             eos_token=settings.eos_token if settings else None,
             tool_format=settings.tool_format if settings else None,
+            maximum_payload_depth=(
+                settings.maximum_parser_payload_depth if settings else None
+            ),
+            maximum_payload_size=(
+                settings.maximum_parser_payload_size if settings else None
+            ),
+            maximum_text_size=(
+                settings.maximum_parser_input_size if settings else None
+            ),
         )
         return cls(
             available_toolsets=available_toolsets,
@@ -185,6 +194,14 @@ class ToolManager:
                 stage=ToolCallDiagnosticStage.VALIDATE,
                 message="Tool call arguments must be an object.",
             )
+
+        diagnostic = self._validate_argument_limits(
+            call=call,
+            canonical_name=resolution.canonical_name,
+            arguments=arguments,
+        )
+        if diagnostic is not None:
+            return diagnostic
 
         assert resolution.canonical_name is not None
         tool = (
@@ -631,6 +648,14 @@ class ToolManager:
                 message="Tool call arguments must be an object.",
             )
 
+        diagnostic = self._validate_argument_limits(
+            call=call,
+            canonical_name=resolution.canonical_name,
+            arguments=arguments,
+        )
+        if diagnostic is not None:
+            return diagnostic
+
         descriptor = self._descriptors[resolution.canonical_name]
         tool = descriptor.callable
         assert tool is not None
@@ -745,6 +770,23 @@ class ToolManager:
                 message=str(exc),
             )
         return None
+
+    def _validate_argument_limits(
+        self,
+        *,
+        call: ToolCall,
+        canonical_name: str | None,
+        arguments: dict[str, Any],
+    ) -> ToolCallDiagnostic | None:
+        return ToolCallParser.resource_limit_diagnostic(
+            value=arguments,
+            maximum_depth=self._settings.maximum_argument_depth,
+            maximum_size=self._settings.maximum_argument_size,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            call_id=call.id,
+            requested_name=call.name,
+            canonical_name=canonical_name,
+        )
 
     def _validate_arguments_schema(
         self,

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -33,6 +33,7 @@ from binascii import Error as BinasciiError
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import deepcopy
+from dataclasses import replace
 from inspect import Parameter, signature
 from re import compile as compile_regex
 from types import TracebackType
@@ -768,7 +769,7 @@ class ToolManager:
         return ToolCallDiagnostic(
             id=uuid4(),
             call_id=call.id,
-            requested_name=call.name,
+            requested_name=call.name if call.name.strip() else None,
             canonical_name=canonical_name,
             code=code,
             stage=stage,
@@ -1068,6 +1069,7 @@ class ToolManager:
         if not self._settings.filters:
             return call, context
 
+        flow_tool_node = context.flow_tool_node
         for f in self._settings.filters:
             filter_namespace: str | None = None
             if isinstance(f, ToolFilter):
@@ -1075,7 +1077,10 @@ class ToolManager:
                 filter_namespace = f.namespace
             else:
                 filter_func = f
-            if not matches_tool_namespace(call.name, filter_namespace):
+            if not matches_tool_namespace(
+                self._filtered_tool_name(call),
+                filter_namespace,
+            ):
                 continue
             modified = filter_func(call, context)
             if modified is None:
@@ -1086,6 +1091,7 @@ class ToolManager:
                 if modified.status is ToolFilterResultStatus.SUPPRESS:
                     return self._diagnostic(
                         call=call,
+                        canonical_name=self._diagnostic_canonical_name(call),
                         code=modified.code,
                         stage=ToolCallDiagnosticStage.FILTER,
                         message=(
@@ -1102,16 +1108,71 @@ class ToolManager:
             next_call, next_context = modified
             assert isinstance(next_call, ToolCall)
             assert isinstance(next_context, ToolCallContext)
-            if context.flow_tool_node and next_call.name != call.name:
+            next_context = self._preserve_flow_context(
+                context,
+                next_context,
+                flow_tool_node=flow_tool_node,
+            )
+            flow_tool_node = flow_tool_node or next_context.flow_tool_node
+            filtered_name = self._filtered_tool_name(next_call)
+            if flow_tool_node and filtered_name != self._filtered_tool_name(
+                call
+            ):
                 return self._diagnostic(
                     call=call,
+                    canonical_name=self._diagnostic_canonical_name(call),
                     code=ToolCallDiagnosticCode.FILTER_SUPPRESSED,
                     stage=ToolCallDiagnosticStage.FILTER,
                     message="Tool filter name rewrites are disabled.",
-                    details={"filtered_name": next_call.name},
+                    details={"filtered_name": filtered_name},
                 )
             call, context = next_call, next_context
         return call, context
+
+    def _filtered_tool_name(self, call: ToolCall) -> str:
+        if call.provider_name is None:
+            try:
+                resolution = self.resolve_tool_name(call.name)
+            except AssertionError:
+                return call.name
+            return resolution.canonical_name or resolution.requested_name
+        try:
+            resolution = self.resolve_tool_name(
+                call.provider_name,
+                provider_originated=True,
+            )
+        except AssertionError:
+            return call.provider_name
+        return resolution.canonical_name or resolution.requested_name
+
+    def _diagnostic_canonical_name(self, call: ToolCall) -> str | None:
+        try:
+            resolution = self._resolve_call_name(call)
+        except AssertionError:
+            return None
+        return resolution.canonical_name
+
+    @staticmethod
+    def _preserve_flow_context(
+        current: ToolCallContext,
+        next_context: ToolCallContext,
+        *,
+        flow_tool_node: bool,
+    ) -> ToolCallContext:
+        if not flow_tool_node and not next_context.flow_tool_node:
+            return next_context
+
+        changes: dict[str, Any] = {}
+        if not next_context.flow_tool_node:
+            changes["flow_tool_node"] = True
+        if (
+            next_context.cancellation_checker is None
+            and current.cancellation_checker is not None
+        ):
+            changes["cancellation_checker"] = current.cancellation_checker
+        if not changes:
+            return next_context
+        return replace(next_context, **changes)
 
     async def _execute_prepared_call(
         self, prepared: PreparedToolCall

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -63,6 +63,7 @@ class ToolManager:
     ) -> "ToolManager":
         parser = ToolCallParser(
             eos_token=settings.eos_token if settings else None,
+            recovery_formats=settings.recovery_formats if settings else None,
             tool_format=settings.tool_format if settings else None,
             maximum_payload_depth=(
                 settings.maximum_parser_payload_depth if settings else None

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -6,6 +6,7 @@ from ..entities import (
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
     ToolCallError,
+    ToolCallOutcome,
     ToolCallResult,
     ToolDescriptor,
     ToolFilter,
@@ -25,7 +26,7 @@ from .parser import ToolCallParser
 from asyncio import CancelledError, wait_for
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from binascii import Error as BinasciiError
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import deepcopy
 from inspect import signature
@@ -496,6 +497,49 @@ class ToolManager:
         await _check_cancelled(prepared.context)
         return await self._execute_prepared_call(prepared)
 
+    async def execute_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+        *,
+        confirm: (
+            Callable[
+                [ToolCall], Awaitable[str | bool | None] | str | bool | None
+            ]
+            | None
+        ) = None,
+    ) -> ToolCallOutcome:
+        """Execute a call and return result, error, or diagnostic."""
+        assert call
+
+        try:
+            prepared = await self.prepare_call(call, context)
+        except CancelledError:
+            return self._cancelled_diagnostic(call)
+        if isinstance(prepared, ToolCallDiagnostic):
+            return prepared
+
+        if confirm is not None:
+            action = confirm(prepared.call)
+            if isinstance(action, Awaitable):
+                action = await action
+            if action not in (True, "y", "a"):
+                return self._diagnostic(
+                    call=prepared.call,
+                    canonical_name=prepared.call.name,
+                    code=ToolCallDiagnosticCode.USER_REJECTED,
+                    stage=ToolCallDiagnosticStage.CONFIRM,
+                    message="Tool call was rejected before execution.",
+                )
+
+        try:
+            return await self.execute_prepared_call(prepared)
+        except CancelledError:
+            return self._cancelled_diagnostic(
+                prepared.call,
+                canonical_name=prepared.call.name,
+            )
+
     async def __aenter__(self) -> "ToolManager":
         if self._toolsets:
             for i, toolset in enumerate(self._toolsets):
@@ -646,6 +690,20 @@ class ToolManager:
             stage=stage,
             message=message,
             details=details or {},
+        )
+
+    def _cancelled_diagnostic(
+        self,
+        call: ToolCall,
+        *,
+        canonical_name: str | None = None,
+    ) -> ToolCallDiagnostic:
+        return self._diagnostic(
+            call=call,
+            canonical_name=canonical_name,
+            code=ToolCallDiagnosticCode.CANCELLED,
+            stage=ToolCallDiagnosticStage.GUARD,
+            message="Tool call was cancelled before execution.",
         )
 
     def _validate_tool_arguments(

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -7,6 +7,7 @@ from ..entities import (
     ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallOutcome,
+    ToolCallParseOutcome,
     ToolCallResult,
     ToolDescriptor,
     ToolFilter,
@@ -463,13 +464,23 @@ class ToolManager:
         return self._parser.is_potential_tool_call(buffer, token_str)
 
     def tool_call_status(
-        self, buffer: str
+        self, buffer: str, *, final: bool = False
     ) -> ToolCallParser.ToolCallBufferStatus:
         """Proxy :meth:`ToolCallParser.tool_call_status`."""
-        return self._parser.tool_call_status(buffer)
+        return self._parser.tool_call_status(buffer, final=final)
+
+    def parse_calls(self, text: str) -> ToolCallParseOutcome:
+        """Return parsed calls and diagnostics for ``text``."""
+        return self._parser.parse(text)
+
+    def stream_buffer_diagnostics(
+        self, buffer: str
+    ) -> list[ToolCallDiagnostic]:
+        """Return diagnostics for a terminal streaming buffer."""
+        return self._parser.stream_buffer_diagnostics(buffer)
 
     def get_calls(self, text: str) -> list[ToolCall] | None:
-        calls = self._parser.parse(text).calls
+        calls = self.parse_calls(text).calls
         return calls or None
 
     async def prepare_call(

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -14,6 +14,7 @@ from ..entities import (
     ToolFilterResult,
     ToolFilterResultStatus,
     ToolFormat,
+    ToolManagerExecutionMode,
     ToolManagerSettings,
     ToolNameResolution,
     ToolNameResolutionStatus,
@@ -134,6 +135,14 @@ class ToolManager:
                 candidates=[canonical_request],
             )
 
+        if canonical_request in self._available_tool_names:
+            return ToolNameResolution(
+                requested_name=name,
+                status=ToolNameResolutionStatus.DISABLED,
+                candidates=[canonical_request],
+                diagnostic_code=ToolCallDiagnosticCode.DISABLED_TOOL,
+            )
+
         aliases = self._aliases.get(canonical_request, [])
         if len(aliases) == 1:
             return ToolNameResolution(
@@ -150,18 +159,11 @@ class ToolManager:
                 diagnostic_code=ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME,
             )
 
-        if (
-            canonical_request in self._available_tool_names
-            or canonical_request in self._available_aliases
-        ):
-            candidates = self._available_aliases.get(
-                canonical_request,
-                [canonical_request],
-            )
+        if canonical_request in self._available_aliases:
             return ToolNameResolution(
                 requested_name=name,
                 status=ToolNameResolutionStatus.DISABLED,
-                candidates=candidates,
+                candidates=self._available_aliases[canonical_request],
                 diagnostic_code=ToolCallDiagnosticCode.DISABLED_TOOL,
             )
 
@@ -612,9 +614,12 @@ class ToolManager:
 
     async def __call__(
         self, call: ToolCall, context: ToolCallContext
-    ) -> ToolCallResult | ToolCallError | None:
+    ) -> ToolCallOutcome | None:
         """Execute a single tool call and return the result."""
         assert call
+
+        if self._settings.execution_mode is ToolManagerExecutionMode.OUTCOMES:
+            return await self.execute_call(call, context)
 
         history = context.calls or []
 
@@ -738,10 +743,17 @@ class ToolManager:
         provider_name = call.provider_name
         if provider_name is None:
             return self.resolve_tool_name(call.name)
-        return self.resolve_tool_name(
-            provider_name,
-            provider_originated=True,
-        )
+        try:
+            return self.resolve_tool_name(
+                provider_name,
+                provider_originated=True,
+            )
+        except AssertionError:
+            return ToolNameResolution(
+                requested_name=provider_name,
+                status=ToolNameResolutionStatus.UNKNOWN,
+                diagnostic_code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            )
 
     def _diagnostic(
         self,

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -19,7 +19,8 @@ from .json_schema import get_json_schema
 from .parser import ToolCallParser
 
 from asyncio import CancelledError, wait_for
-from base64 import urlsafe_b64encode
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from binascii import Error as BinasciiError
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import deepcopy
@@ -101,19 +102,27 @@ class ToolManager:
             return None
         return self._descriptors.get(resolution.canonical_name)
 
-    def resolve_tool_name(self, name: str) -> ToolNameResolution:
+    def resolve_tool_name(
+        self, name: str, *, provider_originated: bool = False
+    ) -> ToolNameResolution:
         """Resolve a requested tool name against enabled tools."""
         assert isinstance(name, str)
         assert name.strip(), "name must not be empty"
-        if self._tools and name in self._tools:
+        assert isinstance(provider_originated, bool)
+
+        canonical_request = self._canonical_requested_name(
+            name,
+            provider_originated=provider_originated,
+        )
+        if self._tools and canonical_request in self._tools:
             return ToolNameResolution(
                 requested_name=name,
                 status=ToolNameResolutionStatus.EXACT,
-                canonical_name=name,
-                candidates=[name],
+                canonical_name=canonical_request,
+                candidates=[canonical_request],
             )
 
-        aliases = self._aliases.get(name, [])
+        aliases = self._aliases.get(canonical_request, [])
         if len(aliases) == 1:
             return ToolNameResolution(
                 requested_name=name,
@@ -130,12 +139,17 @@ class ToolManager:
             )
 
         if (
-            name in self._available_tool_names
-            or name in self._available_aliases
+            canonical_request in self._available_tool_names
+            or canonical_request in self._available_aliases
         ):
+            candidates = self._available_aliases.get(
+                canonical_request,
+                [canonical_request],
+            )
             return ToolNameResolution(
                 requested_name=name,
                 status=ToolNameResolutionStatus.DISABLED,
+                candidates=candidates,
                 diagnostic_code=ToolCallDiagnosticCode.DISABLED_TOOL,
             )
 
@@ -387,6 +401,40 @@ class ToolManager:
             return tool_name
         encoded = urlsafe_b64encode(tool_name.encode()).decode().rstrip("=")
         return f"{cls._PROVIDER_TOOL_NAME_PREFIX}{encoded}"
+
+    @classmethod
+    def _canonical_requested_name(
+        cls, name: str, *, provider_originated: bool
+    ) -> str:
+        requested_name = (
+            cls._decode_provider_tool_name(name)
+            if provider_originated
+            else name
+        )
+        return requested_name.removeprefix("functions.")
+
+    @classmethod
+    def _decode_provider_tool_name(cls, tool_name: str) -> str:
+        assert tool_name.strip(), "tool name must not be empty"
+        assert cls._PROVIDER_TOOL_NAME_PATTERN.fullmatch(
+            tool_name
+        ), "provider tool name is invalid"
+
+        if not tool_name.startswith(cls._PROVIDER_TOOL_NAME_PREFIX):
+            return tool_name
+
+        payload = tool_name[len(cls._PROVIDER_TOOL_NAME_PREFIX) :]
+        assert payload, "provider tool name is missing encoded content"
+        padding = "=" * (-len(payload) % 4)
+        try:
+            decoded = urlsafe_b64decode(f"{payload}{padding}").decode()
+        except (BinasciiError, UnicodeDecodeError) as exc:
+            raise AssertionError("provider tool name is malformed") from exc
+        assert decoded.strip(), "decoded tool name must not be empty"
+        assert (
+            cls._encode_provider_tool_name(decoded) == tool_name
+        ), "provider tool name is malformed"
+        return decoded
 
     def is_potential_tool_call(self, buffer: str, token_str: str) -> bool:
         """Proxy :meth:`ToolCallParser.is_potential_tool_call`."""

--- a/src/avalan/tool/manager.py
+++ b/src/avalan/tool/manager.py
@@ -1,4 +1,5 @@
 from ..entities import (
+    PreparedToolCall,
     ToolCall,
     ToolCallContext,
     ToolCallDiagnostic,
@@ -186,19 +187,12 @@ class ToolManager:
             self._tools.get(resolution.canonical_name) if self._tools else None
         )
         assert tool is not None
-        try:
-            signature(tool).bind(**arguments)
-        except TypeError as exc:
-            return ToolCallDiagnostic(
-                id=uuid4(),
-                call_id=call.id,
-                requested_name=call.name,
-                canonical_name=resolution.canonical_name,
-                code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
-                stage=ToolCallDiagnosticStage.VALIDATE,
-                message=str(exc),
-            )
-        return None
+        return self._validate_tool_arguments(
+            call=call,
+            canonical_name=resolution.canonical_name,
+            tool=tool,
+            arguments=arguments,
+        )
 
     def __init__(
         self,
@@ -445,6 +439,58 @@ class ToolManager:
         calls = self._parser.parse(text).calls
         return calls or None
 
+    async def prepare_call(
+        self, call: ToolCall, context: ToolCallContext
+    ) -> PreparedToolCall | ToolCallDiagnostic:
+        """Return a prepared execution plan or a diagnostic."""
+        assert call
+
+        history = context.calls or []
+
+        if self._settings.avoid_repetition and history:
+            last = history[-1]
+            if last.name == call.name and last.arguments == call.arguments:
+                return self._diagnostic(
+                    call=call,
+                    code=ToolCallDiagnosticCode.REPEATED_CALL,
+                    stage=ToolCallDiagnosticStage.GUARD,
+                    message="Tool call repeats the previous call.",
+                )
+
+        if (
+            self._settings.maximum_depth is not None
+            and len(history) + 1 > self._settings.maximum_depth
+        ):
+            return self._diagnostic(
+                call=call,
+                code=ToolCallDiagnosticCode.MAXIMUM_DEPTH,
+                stage=ToolCallDiagnosticStage.GUARD,
+                message="Tool call exceeds the maximum depth.",
+            )
+
+        await _check_cancelled(context)
+
+        prepared = self._prepare_resolved_call(
+            call,
+            context,
+            validate=False,
+        )
+        if isinstance(prepared, ToolCallDiagnostic):
+            return prepared
+
+        call, context = self._apply_filters(prepared.call, prepared.context)
+        await _check_cancelled(context)
+
+        return self._prepare_resolved_call(call, context)
+
+    async def execute_prepared_call(
+        self, prepared: PreparedToolCall
+    ) -> ToolCallResult | ToolCallError:
+        """Execute a prepared call without rerunning preparation."""
+        assert isinstance(prepared, PreparedToolCall)
+        await _check_cancelled(prepared.context)
+        return await self._execute_prepared_call(prepared)
+
     async def __aenter__(self) -> "ToolManager":
         if self._toolsets:
             for i, toolset in enumerate(self._toolsets):
@@ -499,56 +545,172 @@ class ToolManager:
 
         await _check_cancelled(context)
 
-        if self._settings.filters:
-            for f in self._settings.filters:
-                filter_namespace: str | None = None
-                if isinstance(f, ToolFilter):
-                    filter_func = f.func
-                    filter_namespace = f.namespace
-                else:
-                    filter_func = f
-                if not matches_tool_namespace(call.name, filter_namespace):
-                    continue
-                modified = filter_func(call, context)
-                if modified is not None:
-                    assert isinstance(modified, tuple) and len(modified) == 2
-                    call, context = modified
+        call, context = self._apply_filters(call, context)
 
         await _check_cancelled(context)
 
-        is_native_tool = isinstance(tool, Tool)
+        prepared = PreparedToolCall(
+            call=call,
+            callable=tool,
+            descriptor=self._legacy_descriptor(call.name, tool),
+            arguments=call.arguments or {},
+            context=context,
+        )
+        return await self._execute_prepared_call(prepared)
 
-        try:
-            result = (
-                await tool(**call.arguments, context=context)
-                if is_native_tool and call.arguments
-                else (
-                    await tool(context=context)
-                    if is_native_tool
-                    else (
-                        await tool(*call.arguments.values())
-                        if call.arguments
-                        else tool()
-                    )
-                )
+    def _prepare_resolved_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+        *,
+        validate: bool = True,
+    ) -> PreparedToolCall | ToolCallDiagnostic:
+        resolution = self.resolve_tool_name(call.name)
+        if resolution.diagnostic_code is not None:
+            return self._resolution_diagnostic(call, resolution)
+        assert resolution.canonical_name is not None
+
+        arguments = call.arguments or {}
+        if not isinstance(arguments, dict):
+            return self._diagnostic(
+                call=call,
+                canonical_name=resolution.canonical_name,
+                code=ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                stage=ToolCallDiagnosticStage.VALIDATE,
+                message="Tool call arguments must be an object.",
             )
 
-            if self._settings.transformers:
-                for t in self._settings.transformers:
-                    transformer_namespace: str | None = None
-                    if isinstance(t, ToolTransformer):
-                        transformer_func = t.func
-                        transformer_namespace = t.namespace
-                    else:
-                        transformer_func = t
-                    if not matches_tool_namespace(
-                        call.name,
-                        transformer_namespace,
-                    ):
-                        continue
-                    transformed = transformer_func(call, context, result)
-                    if transformed is not None:
-                        result = transformed
+        descriptor = self._descriptors[resolution.canonical_name]
+        tool = descriptor.callable
+        assert tool is not None
+        prepared_call = ToolCall(
+            id=call.id,
+            name=resolution.canonical_name,
+            arguments=arguments,
+        )
+        if validate:
+            diagnostic = self._validate_tool_arguments(
+                call=prepared_call,
+                canonical_name=resolution.canonical_name,
+                tool=tool,
+                arguments=arguments,
+                context=context,
+            )
+            if diagnostic is not None:
+                return diagnostic
+        return PreparedToolCall(
+            call=prepared_call,
+            callable=tool,
+            descriptor=descriptor,
+            arguments=arguments,
+            context=context,
+        )
+
+    def _resolution_diagnostic(
+        self, call: ToolCall, resolution: ToolNameResolution
+    ) -> ToolCallDiagnostic:
+        assert resolution.diagnostic_code is not None
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            call_id=call.id,
+            requested_name=call.name,
+            canonical_name=resolution.canonical_name,
+            code=resolution.diagnostic_code,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message=f"Tool '{call.name}' is {resolution.status.value}.",
+            details={"candidates": cast(Any, resolution.candidates)},
+        )
+
+    def _diagnostic(
+        self,
+        *,
+        call: ToolCall,
+        code: ToolCallDiagnosticCode,
+        stage: ToolCallDiagnosticStage,
+        message: str,
+        canonical_name: str | None = None,
+    ) -> ToolCallDiagnostic:
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            call_id=call.id,
+            requested_name=call.name,
+            canonical_name=canonical_name,
+            code=code,
+            stage=stage,
+            message=message,
+        )
+
+    def _validate_tool_arguments(
+        self,
+        *,
+        call: ToolCall,
+        canonical_name: str,
+        tool: Callable[..., Any],
+        arguments: dict[str, Any],
+        context: ToolCallContext | None = None,
+    ) -> ToolCallDiagnostic | None:
+        try:
+            if isinstance(tool, Tool):
+                signature(tool.__call__).bind(
+                    **arguments,
+                    context=context or ToolCallContext(),
+                )
+            else:
+                signature(tool).bind(**arguments)
+        except TypeError as exc:
+            return ToolCallDiagnostic(
+                id=uuid4(),
+                call_id=call.id,
+                requested_name=call.name,
+                canonical_name=canonical_name,
+                code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+                stage=ToolCallDiagnosticStage.VALIDATE,
+                message=str(exc),
+            )
+        return None
+
+    def _apply_filters(
+        self, call: ToolCall, context: ToolCallContext
+    ) -> tuple[ToolCall, ToolCallContext]:
+        if not self._settings.filters:
+            return call, context
+
+        for f in self._settings.filters:
+            filter_namespace: str | None = None
+            if isinstance(f, ToolFilter):
+                filter_func = f.func
+                filter_namespace = f.namespace
+            else:
+                filter_func = f
+            if not matches_tool_namespace(call.name, filter_namespace):
+                continue
+            modified = filter_func(call, context)
+            if modified is not None:
+                assert isinstance(modified, tuple) and len(modified) == 2
+                call, context = modified
+        return call, context
+
+    def _legacy_descriptor(
+        self, name: str, tool: Callable[..., Any]
+    ) -> ToolDescriptor:
+        descriptor = self._descriptors.get(name)
+        if descriptor is not None and descriptor.callable is tool:
+            return descriptor
+        return ToolDescriptor(
+            name=name,
+            callable=tool,
+            aliases=[],
+        )
+
+    async def _execute_prepared_call(
+        self, prepared: PreparedToolCall
+    ) -> ToolCallResult | ToolCallError:
+        call = prepared.call
+        context = prepared.context
+        tool = prepared.callable
+        try:
+            result = await self._dispatch_tool(tool, call, context)
+            result = self._apply_transformers(call, context, result)
 
             return ToolCallResult(
                 id=uuid4(),
@@ -566,6 +728,47 @@ class ToolManager:
                 error=exc,
                 message=str(exc),
             )
+
+    async def _dispatch_tool(
+        self,
+        tool: Callable[..., Any],
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> Any:
+        is_native_tool = isinstance(tool, Tool)
+        arguments = call.arguments or {}
+        if is_native_tool and arguments:
+            return await tool(**arguments, context=context)
+        if is_native_tool:
+            return await tool(context=context)
+        if arguments:
+            return await tool(*arguments.values())
+        return tool()
+
+    def _apply_transformers(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+        result: Any,
+    ) -> Any:
+        if not self._settings.transformers:
+            return result
+        for t in self._settings.transformers:
+            transformer_namespace: str | None = None
+            if isinstance(t, ToolTransformer):
+                transformer_func = t.func
+                transformer_namespace = t.namespace
+            else:
+                transformer_func = t
+            if not matches_tool_namespace(
+                call.name,
+                transformer_namespace,
+            ):
+                continue
+            transformed = transformer_func(call, context, result)
+            if transformed is not None:
+                result = transformed
+        return result
 
 
 async def _check_cancelled(context: ToolCallContext) -> None:

--- a/src/avalan/tool/names.py
+++ b/src/avalan/tool/names.py
@@ -1,0 +1,5 @@
+def matches_tool_namespace(tool_name: str, namespace: str | None) -> bool:
+    """Return whether a tool name belongs to a namespace."""
+    if not namespace:
+        return True
+    return tool_name == namespace or tool_name.startswith(f"{namespace}.")

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -3,7 +3,12 @@ from ..entities import (
     MessageContent,
     MessageContentText,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallParseOutcome,
     ToolFormat,
+    ToolValue,
 )
 from .dsml import DsmlTools
 
@@ -12,7 +17,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from json import JSONDecodeError, loads
 from re import DOTALL, compile, finditer, search, sub
-from typing import Any, final
+from typing import Any, cast, final
 from uuid import UUID, uuid4
 from xml.etree import ElementTree
 
@@ -62,6 +67,30 @@ class ToolCallParser:
         if not calls:
             calls = self._parse_tag(text)
         return calls
+
+    def parse(self, text: str) -> ToolCallParseOutcome:
+        """Return normalized tool calls and parse diagnostics."""
+        parsed = self(text)
+        calls: list[ToolCall] = []
+        diagnostics: list[ToolCallDiagnostic] = []
+
+        if isinstance(parsed, list):
+            for call in parsed:
+                normalized, diagnostic = self._normalize_tool_call(call)
+                if normalized is not None:
+                    calls.append(normalized)
+                if diagnostic is not None:
+                    diagnostics.append(diagnostic)
+        elif isinstance(parsed, tuple) and len(parsed) == 2:
+            normalized, diagnostic = self._normalize_tuple_call(parsed)
+            if normalized is not None:
+                calls.append(normalized)
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+        else:
+            diagnostics.extend(self._parse_failure_diagnostics(text))
+
+        return ToolCallParseOutcome(calls=calls, diagnostics=diagnostics)
 
     def set_eos_token(self, eos_token: str) -> None:
         self._eos_token = eos_token
@@ -510,6 +539,247 @@ class ToolCallParser:
                 pass
 
         return tool_calls if tool_calls else None
+
+    def _normalize_tool_call(
+        self, call: ToolCall
+    ) -> tuple[ToolCall | None, ToolCallDiagnostic | None]:
+        if call.arguments is not None and not isinstance(call.arguments, dict):
+            return None, self._arguments_diagnostic(
+                call_id=call.id,
+                requested_name=call.name,
+            )
+        return call, None
+
+    def _normalize_tuple_call(
+        self, parsed: tuple[Any, Any]
+    ) -> tuple[ToolCall | None, ToolCallDiagnostic | None]:
+        name, arguments = parsed
+        if not isinstance(name, str) or not name.strip():
+            return None, self._malformed_call_diagnostic()
+        if not isinstance(arguments, dict):
+            return None, self._arguments_diagnostic(requested_name=name)
+        return (
+            ToolCall(
+                id=uuid4(),
+                name=name,
+                arguments=cast(dict[str, ToolValue], arguments),
+            ),
+            None,
+        )
+
+    def _parse_failure_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        match self._tool_format:
+            case ToolFormat.JSON:
+                diagnostics = self._json_failure_diagnostics(
+                    text,
+                    name_field="tool",
+                )
+            case ToolFormat.REACT:
+                diagnostics = self._react_failure_diagnostics(text)
+            case ToolFormat.OPENAI:
+                diagnostics = self._json_failure_diagnostics(
+                    text,
+                    name_field="name",
+                )
+            case ToolFormat.HARMONY:
+                diagnostics = self._harmony_failure_diagnostics(text)
+            case _:
+                diagnostics = []
+
+        if not diagnostics:
+            diagnostics = self._tag_failure_diagnostics(text)
+        return diagnostics
+
+    def _json_failure_diagnostics(
+        self,
+        text: str,
+        *,
+        name_field: str,
+    ) -> list[ToolCallDiagnostic]:
+        stripped = text.strip()
+        if not stripped or stripped[0] not in "[{":
+            return []
+        try:
+            payload = loads(stripped)
+        except JSONDecodeError:
+            return [self._malformed_call_diagnostic()]
+
+        if not isinstance(payload, dict):
+            return [self._malformed_call_diagnostic()]
+
+        name = payload.get(name_field)
+        requested_name = name if isinstance(name, str) else None
+        if not isinstance(name, str) or not name.strip():
+            return [self._malformed_call_diagnostic()]
+
+        arguments = payload.get("arguments", {})
+        if not isinstance(arguments, dict):
+            return [self._arguments_diagnostic(requested_name=requested_name)]
+        return []
+
+    def _react_failure_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        act = search(r"Action:\s*(\w+)", text)
+        inp = search(r"Action Input:\s*({.*}|\[.*\])", text, DOTALL)
+        if not act and not inp:
+            return []
+        if not act or not inp:
+            return [self._malformed_call_diagnostic()]
+        try:
+            arguments = loads(inp.group(1))
+        except JSONDecodeError:
+            return [
+                self._malformed_call_diagnostic(requested_name=act.group(1))
+            ]
+        if not isinstance(arguments, dict):
+            return [self._arguments_diagnostic(requested_name=act.group(1))]
+        return []
+
+    def _harmony_failure_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        if "<|channel|>" not in text or " to=" not in text:
+            return []
+
+        diagnostics: list[ToolCallDiagnostic] = []
+        pattern = (
+            r"(?:<\|start\|>assistant)?"
+            r"<\|channel\|>(?:commentary|analysis)"
+            r" to=(?:functions\.)?([\w\.]+)"
+            r"(?:<\|channel\|>(?:commentary|analysis))?"
+            r"[^<]*"
+            r"(?:<\|constrain\|>json)?"
+            r"<\|message\|>\s*(.*?)\s*<\|call\|>"
+        )
+        for match in finditer(pattern, text, DOTALL):
+            requested_name = match.group(1)
+            args_text = match.group(2)
+            if not args_text:
+                continue
+            try:
+                arguments = loads(args_text)
+            except JSONDecodeError:
+                diagnostics.append(
+                    self._malformed_call_diagnostic(
+                        requested_name=requested_name
+                    )
+                )
+                continue
+            if not isinstance(arguments, dict):
+                diagnostics.append(
+                    self._arguments_diagnostic(requested_name=requested_name)
+                )
+        return diagnostics
+
+    def _tag_failure_diagnostics(self, text: str) -> list[ToolCallDiagnostic]:
+        if "<tool_call" not in text and "<tool " not in text:
+            return []
+
+        diagnostics: list[ToolCallDiagnostic] = []
+        payloads = self._tag_payloads(text)
+        for payload in payloads:
+            diagnostic = self._payload_diagnostic(payload)
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+        return diagnostics
+
+    def _tag_payloads(self, text: str) -> list[Any]:
+        payloads: list[Any] = []
+        try:
+            root = ElementTree.fromstring(f"<root>{text}</root>")
+            for element in root.findall(".//tool_call"):
+                if element.text is not None:
+                    payload = self._deserialize_payload(element.text)
+                    name = element.attrib.get("name")
+                    if name is not None:
+                        payload = {"name": name, "arguments": payload}
+                    payloads.append(payload)
+            for element in root.findall(".//tool"):
+                if element.text is not None:
+                    payload = self._deserialize_payload(element.text)
+                    name = element.attrib.get("name")
+                    if name is not None:
+                        payload = {"name": name, "arguments": payload}
+                    payloads.append(payload)
+            return payloads
+        except ElementTree.ParseError:
+            pass
+
+        payload_patterns = (
+            r"<tool_call>\s*(\{.*?\})\s*</tool_call>",
+            r"<tool_call\s+name=\"([^\"]+)\"\s*>(.*?)</tool_call>",
+            r"<tool\s+name=\"([^\"]+)\"\s*>(.*?)</tool>",
+            r"<tool_call\s+name=\"([^\"]+)\"\s+arguments='([^']*)'\s*/>",
+        )
+        for pattern in payload_patterns:
+            for match in finditer(pattern, text, DOTALL):
+                if match.lastindex == 1:
+                    payloads.append(self._deserialize_payload(match.group(1)))
+                    continue
+                name = match.group(1)
+                arguments = self._deserialize_payload(match.group(2))
+                payloads.append({"name": name, "arguments": arguments})
+        return payloads
+
+    @staticmethod
+    def _deserialize_payload(text: str) -> Any:
+        json_text = text.strip()
+        try:
+            return loads(json_text)
+        except JSONDecodeError:
+            try:
+                return literal_eval(json_text)
+            except (SyntaxError, ValueError):
+                return None
+
+    def _payload_diagnostic(self, payload: Any) -> ToolCallDiagnostic | None:
+        if not isinstance(payload, dict):
+            return self._malformed_call_diagnostic()
+
+        name = payload.get("name")
+        requested_name = name if isinstance(name, str) else None
+        if not isinstance(name, str) or not name.strip():
+            return self._malformed_call_diagnostic()
+
+        arguments = payload.get("arguments")
+        if not isinstance(arguments, dict):
+            call_id = payload.get("id")
+            return self._arguments_diagnostic(
+                call_id=call_id if isinstance(call_id, (UUID, str)) else None,
+                requested_name=requested_name,
+            )
+        return None
+
+    @staticmethod
+    def _arguments_diagnostic(
+        *,
+        call_id: UUID | str | None = None,
+        requested_name: str | None = None,
+    ) -> ToolCallDiagnostic:
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            call_id=call_id,
+            requested_name=requested_name,
+            code=ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Tool call arguments must be an object.",
+        )
+
+    @staticmethod
+    def _malformed_call_diagnostic(
+        *,
+        requested_name: str | None = None,
+    ) -> ToolCallDiagnostic:
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            requested_name=requested_name,
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Tool call could not be parsed.",
+        )
 
     @staticmethod
     def _tool_call_from_payload(payload: Any) -> ToolCall | None:

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -36,15 +36,34 @@ _MARKDOWN_FENCED_BLOCK_PATTERN = compile(
 
 class ToolCallParser:
     _eos_token: str | None
+    _maximum_payload_depth: int | None
+    _maximum_payload_size: int | None
+    _maximum_text_size: int | None
     _tool_format: ToolFormat | None
 
     def __init__(
         self,
         tool_format: ToolFormat | None = None,
         eos_token: str | None = None,
+        maximum_text_size: int | None = None,
+        maximum_payload_depth: int | None = None,
+        maximum_payload_size: int | None = None,
     ) -> None:
+        for limit in (
+            maximum_text_size,
+            maximum_payload_depth,
+            maximum_payload_size,
+        ):
+            assert limit is None or (
+                isinstance(limit, int)
+                and not isinstance(limit, bool)
+                and limit > 0
+            )
         self._tool_format = tool_format
         self._eos_token = eos_token
+        self._maximum_text_size = maximum_text_size
+        self._maximum_payload_depth = maximum_payload_depth
+        self._maximum_payload_size = maximum_payload_size
 
     @property
     def tool_format(self) -> ToolFormat | None:
@@ -54,6 +73,9 @@ class ToolCallParser:
     def __call__(
         self, text: str
     ) -> tuple[str, dict[str, Any]] | list[ToolCall] | None:
+        if self._text_exceeds_limit(text):
+            return None
+
         calls: tuple[str, dict[str, Any]] | list[ToolCall] | None
         match self._tool_format:
             case ToolFormat.JSON:
@@ -76,6 +98,10 @@ class ToolCallParser:
 
     def parse(self, text: str) -> ToolCallParseOutcome:
         """Return normalized tool calls and parse diagnostics."""
+        text_diagnostic = self._text_limit_diagnostic(text)
+        if text_diagnostic is not None:
+            return ToolCallParseOutcome(diagnostics=[text_diagnostic])
+
         parsed = self(text)
         calls: list[ToolCall] = []
         diagnostics: list[ToolCallDiagnostic] = []
@@ -558,6 +584,16 @@ class ToolCallParser:
                 call_id=call.id,
                 requested_name=call.name,
             )
+        diagnostic = self.resource_limit_diagnostic(
+            value=call.arguments or {},
+            maximum_depth=self._maximum_payload_depth,
+            maximum_size=self._maximum_payload_size,
+            stage=ToolCallDiagnosticStage.PARSE,
+            call_id=call.id,
+            requested_name=call.name,
+        )
+        if diagnostic is not None:
+            return None, diagnostic
         return call, None
 
     def _normalize_tuple_call(
@@ -568,6 +604,15 @@ class ToolCallParser:
             return None, self._malformed_call_diagnostic()
         if not isinstance(arguments, dict):
             return None, self._arguments_diagnostic(requested_name=name)
+        diagnostic = self.resource_limit_diagnostic(
+            value=arguments,
+            maximum_depth=self._maximum_payload_depth,
+            maximum_size=self._maximum_payload_size,
+            stage=ToolCallDiagnosticStage.PARSE,
+            requested_name=name,
+        )
+        if diagnostic is not None:
+            return None, diagnostic
         return (
             ToolCall(
                 id=uuid4(),
@@ -601,6 +646,26 @@ class ToolCallParser:
         if not diagnostics:
             diagnostics = self._tag_failure_diagnostics(text)
         return diagnostics
+
+    def _text_exceeds_limit(self, text: str) -> bool:
+        return (
+            self._maximum_text_size is not None
+            and self._text_size(text) > self._maximum_text_size
+        )
+
+    def _text_limit_diagnostic(self, text: str) -> ToolCallDiagnostic | None:
+        if not self._text_exceeds_limit(text):
+            return None
+        assert self._maximum_text_size is not None
+        return self._resource_limit_diagnostic(
+            code=ToolCallDiagnosticCode.MAXIMUM_SIZE,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Tool parser input exceeds the maximum size.",
+            details={
+                "limit": self._maximum_text_size,
+                "size": self._text_size(text),
+            },
+        )
 
     def _json_failure_diagnostics(
         self,
@@ -759,14 +824,21 @@ class ToolCallParser:
         if not isinstance(name, str) or not name.strip():
             return self._malformed_call_diagnostic()
 
+        call_id = payload.get("id")
         arguments = payload.get("arguments")
         if not isinstance(arguments, dict):
-            call_id = payload.get("id")
             return self._arguments_diagnostic(
                 call_id=call_id if isinstance(call_id, (UUID, str)) else None,
                 requested_name=requested_name,
             )
-        return None
+        return self.resource_limit_diagnostic(
+            value=arguments,
+            maximum_depth=self._maximum_payload_depth,
+            maximum_size=self._maximum_payload_size,
+            stage=ToolCallDiagnosticStage.PARSE,
+            call_id=call_id if isinstance(call_id, (UUID, str)) else None,
+            requested_name=requested_name,
+        )
 
     @staticmethod
     def _arguments_diagnostic(
@@ -782,6 +854,107 @@ class ToolCallParser:
             stage=ToolCallDiagnosticStage.PARSE,
             message="Tool call arguments must be an object.",
         )
+
+    @classmethod
+    def resource_limit_diagnostic(
+        cls,
+        *,
+        value: Any,
+        maximum_depth: int | None,
+        maximum_size: int | None,
+        stage: ToolCallDiagnosticStage,
+        call_id: UUID | str | None = None,
+        requested_name: str | None = None,
+        canonical_name: str | None = None,
+    ) -> ToolCallDiagnostic | None:
+        assert isinstance(stage, ToolCallDiagnosticStage)
+        if maximum_depth is not None:
+            assert isinstance(maximum_depth, int)
+            assert not isinstance(maximum_depth, bool)
+            assert maximum_depth > 0
+            depth = cls._value_depth(value)
+            if depth > maximum_depth:
+                return cls._resource_limit_diagnostic(
+                    code=ToolCallDiagnosticCode.MAXIMUM_DEPTH,
+                    stage=stage,
+                    message="Tool call arguments exceed the maximum depth.",
+                    call_id=call_id,
+                    requested_name=requested_name,
+                    canonical_name=canonical_name,
+                    details={"limit": maximum_depth, "depth": depth},
+                )
+
+        if maximum_size is not None:
+            assert isinstance(maximum_size, int)
+            assert not isinstance(maximum_size, bool)
+            assert maximum_size > 0
+            size = cls._value_size(value)
+            if size > maximum_size:
+                return cls._resource_limit_diagnostic(
+                    code=ToolCallDiagnosticCode.MAXIMUM_SIZE,
+                    stage=stage,
+                    message="Tool call arguments exceed the maximum size.",
+                    call_id=call_id,
+                    requested_name=requested_name,
+                    canonical_name=canonical_name,
+                    details={"limit": maximum_size, "size": size},
+                )
+        return None
+
+    @staticmethod
+    def _resource_limit_diagnostic(
+        *,
+        code: ToolCallDiagnosticCode,
+        stage: ToolCallDiagnosticStage,
+        message: str,
+        call_id: UUID | str | None = None,
+        requested_name: str | None = None,
+        canonical_name: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> ToolCallDiagnostic:
+        return ToolCallDiagnostic(
+            id=uuid4(),
+            call_id=call_id,
+            requested_name=requested_name,
+            canonical_name=canonical_name,
+            code=code,
+            stage=stage,
+            message=message,
+            details=details or {},
+        )
+
+    @classmethod
+    def _value_depth(cls, value: Any) -> int:
+        if isinstance(value, dict):
+            if not value:
+                return 1
+            return 1 + max(cls._value_depth(v) for v in value.values())
+        if isinstance(value, list):
+            if not value:
+                return 1
+            return 1 + max(cls._value_depth(v) for v in value)
+        return 0
+
+    @classmethod
+    def _value_size(cls, value: Any) -> int:
+        if isinstance(value, dict):
+            return sum(
+                cls._text_size(k) + cls._value_size(v)
+                for k, v in value.items()
+            )
+        if isinstance(value, list):
+            return sum(cls._value_size(v) for v in value)
+        if isinstance(value, str):
+            return cls._text_size(value)
+        if value is None:
+            return 4
+        if isinstance(value, bool):
+            return 4 if value else 5
+        return cls._text_size(str(value))
+
+    @staticmethod
+    def _text_size(text: str) -> int:
+        return len(text.encode())
 
     @staticmethod
     def _malformed_call_diagnostic(

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -7,12 +7,14 @@ from ..entities import (
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
     ToolCallParseOutcome,
+    ToolCallRecoveryFormat,
     ToolFormat,
     ToolValue,
 )
 from .dsml import DsmlTools
 
 from ast import literal_eval
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from json import JSONDecodeError, loads
@@ -39,12 +41,14 @@ class ToolCallParser:
     _maximum_payload_depth: int | None
     _maximum_payload_size: int | None
     _maximum_text_size: int | None
+    _recovery_formats: tuple[ToolCallRecoveryFormat, ...]
     _tool_format: ToolFormat | None
 
     def __init__(
         self,
         tool_format: ToolFormat | None = None,
         eos_token: str | None = None,
+        recovery_formats: Sequence[ToolCallRecoveryFormat] | None = None,
         maximum_text_size: int | None = None,
         maximum_payload_depth: int | None = None,
         maximum_payload_size: int | None = None,
@@ -59,8 +63,12 @@ class ToolCallParser:
                 and not isinstance(limit, bool)
                 and limit > 0
             )
+        if recovery_formats is not None:
+            for recovery_format in recovery_formats:
+                assert isinstance(recovery_format, ToolCallRecoveryFormat)
         self._tool_format = tool_format
         self._eos_token = eos_token
+        self._recovery_formats = tuple(recovery_formats or ())
         self._maximum_text_size = maximum_text_size
         self._maximum_payload_depth = maximum_payload_depth
         self._maximum_payload_size = maximum_payload_size
@@ -69,6 +77,11 @@ class ToolCallParser:
     def tool_format(self) -> ToolFormat | None:
         """Return the tool format used by the parser."""
         return self._tool_format
+
+    @property
+    def recovery_formats(self) -> tuple[ToolCallRecoveryFormat, ...]:
+        """Return explicitly enabled recovery formats."""
+        return self._recovery_formats
 
     def __call__(
         self, text: str
@@ -1014,14 +1027,18 @@ class ToolCallParser:
         requested_name: str | None = None,
         message: str = "Tool call could not be parsed.",
         details: dict[str, ToolValue] | None = None,
+        recovery_format: ToolCallRecoveryFormat | None = None,
     ) -> ToolCallDiagnostic:
+        diagnostic_details = details.copy() if details is not None else {}
+        if recovery_format is not None:
+            diagnostic_details["source_format"] = recovery_format.value
         return ToolCallDiagnostic(
             id=uuid4(),
             requested_name=requested_name,
             code=ToolCallDiagnosticCode.MALFORMED_CALL,
             stage=ToolCallDiagnosticStage.PARSE,
             message=message,
-            details=details or {},
+            details=diagnostic_details,
         )
 
     @staticmethod

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -360,14 +360,18 @@ class ToolCallParser:
         PREFIX = 1
         OPEN = 2
         CLOSED = 3
+        MALFORMED = 4
+        UNTERMINATED = 5
 
     def tool_call_status(
-        self, buffer: str
+        self, buffer: str, *, final: bool = False
     ) -> "ToolCallParser.ToolCallBufferStatus":
+        status: ToolCallParser.ToolCallBufferStatus
         if self._tool_format is ToolFormat.DSML:
             dsml_status = self._dsml_tool_call_status(buffer)
             if dsml_status is not self.ToolCallBufferStatus.NONE:
-                return dsml_status
+                status = dsml_status
+                return self._final_tool_call_status(buffer, status, final)
 
         start = ["<tool_call", "<tool ", "<tool>"]
         end = ["</tool_call>", "</tool>", "/>", "<|call|>"]
@@ -385,15 +389,63 @@ class ToolCallParser:
         tail = buffer[-max_len:]
         for s in start:
             if s.startswith(tail) and tail != s:
-                return self.ToolCallBufferStatus.PREFIX
+                status = self.ToolCallBufferStatus.PREFIX
+                return self._final_tool_call_status(buffer, status, final)
         for s in start:
             idx = buffer.rfind(s)
             if idx != -1:
                 after = buffer[idx + len(s) :]
                 if any(e in after for e in end):
-                    return self.ToolCallBufferStatus.CLOSED
-                return self.ToolCallBufferStatus.OPEN
+                    status = self.ToolCallBufferStatus.CLOSED
+                    return self._final_tool_call_status(buffer, status, final)
+                status = self.ToolCallBufferStatus.OPEN
+                return self._final_tool_call_status(buffer, status, final)
         return self.ToolCallBufferStatus.NONE
+
+    def stream_buffer_diagnostics(
+        self, buffer: str
+    ) -> list[ToolCallDiagnostic]:
+        """Return diagnostics for a terminal streaming buffer."""
+        status = self.tool_call_status(buffer, final=True)
+        if status is self.ToolCallBufferStatus.UNTERMINATED:
+            return [
+                self._malformed_call_diagnostic(
+                    message=(
+                        "Tool call stream ended before the call was complete."
+                    ),
+                    details={"stream_status": status.name.lower()},
+                )
+            ]
+
+        outcome = self.parse(buffer)
+        if outcome.diagnostics:
+            return outcome.diagnostics
+        if status is self.ToolCallBufferStatus.MALFORMED:
+            return [
+                self._malformed_call_diagnostic(
+                    details={"stream_status": status.name.lower()}
+                )
+            ]
+        return []
+
+    def _final_tool_call_status(
+        self,
+        buffer: str,
+        status: "ToolCallParser.ToolCallBufferStatus",
+        final: bool,
+    ) -> "ToolCallParser.ToolCallBufferStatus":
+        if not final:
+            return status
+        if status in (
+            self.ToolCallBufferStatus.PREFIX,
+            self.ToolCallBufferStatus.OPEN,
+        ):
+            return self.ToolCallBufferStatus.UNTERMINATED
+        if status is self.ToolCallBufferStatus.CLOSED:
+            outcome = self.parse(buffer)
+            if not outcome.calls:
+                return self.ToolCallBufferStatus.MALFORMED
+        return status
 
     def _dsml_tool_call_status(
         self, buffer: str
@@ -960,13 +1012,16 @@ class ToolCallParser:
     def _malformed_call_diagnostic(
         *,
         requested_name: str | None = None,
+        message: str = "Tool call could not be parsed.",
+        details: dict[str, ToolValue] | None = None,
     ) -> ToolCallDiagnostic:
         return ToolCallDiagnostic(
             id=uuid4(),
             requested_name=requested_name,
             code=ToolCallDiagnosticCode.MALFORMED_CALL,
             stage=ToolCallDiagnosticStage.PARSE,
-            message="Tool call could not be parsed.",
+            message=message,
+            details=details or {},
         )
 
     @staticmethod

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -34,6 +34,20 @@ _MARKDOWN_FENCED_BLOCK_PATTERN = compile(
     r"^[ \t]*(?P=fence)[ \t]*$",
     DOTALL | MULTILINE,
 )
+_MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN = compile(
+    r"^[ \t]*(?P<fence>`{3,}|~{3,})[^\n\r]*(?:\r?\n)"
+    r"(?P<content>.*?)"
+    r"^[ \t]*(?P=fence)[ \t]*$",
+    DOTALL | MULTILINE,
+)
+_XML_NAME_PREFIX_PATTERN = compile(r"<(/?)([A-Za-z_][\w.-]*):")
+
+
+@dataclass(frozen=True, slots=True)
+class _RecoveryPayload:
+    span: tuple[int, int]
+    payload: Any
+    recovery_format: ToolCallRecoveryFormat
 
 
 class ToolCallParser:
@@ -107,6 +121,8 @@ class ToolCallParser:
                 calls = None
         if not calls:
             calls = self._parse_tag(text)
+        if not calls:
+            calls = self._parse_recovery(text)
         return calls
 
     def parse(self, text: str) -> ToolCallParseOutcome:
@@ -710,6 +726,7 @@ class ToolCallParser:
 
         if not diagnostics:
             diagnostics = self._tag_failure_diagnostics(text)
+        diagnostics.extend(self._recovery_failure_diagnostics(text))
         return diagnostics
 
     def _text_exceeds_limit(self, text: str) -> bool:
@@ -830,6 +847,360 @@ class ToolCallParser:
     @staticmethod
     def _without_markdown_fenced_blocks(text: str) -> str:
         return _MARKDOWN_FENCED_BLOCK_PATTERN.sub("", text)
+
+    def _parse_recovery(self, text: str) -> list[ToolCall] | None:
+        tool_calls: list[ToolCall] = []
+        for recovered in self._recovery_payloads(text):
+            parsed = self._tool_call_from_payload(recovered.payload)
+            if parsed is not None:
+                tool_calls.append(parsed)
+        return tool_calls if tool_calls else None
+
+    def _recovery_failure_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        diagnostics: list[ToolCallDiagnostic] = []
+        candidates = self._recovery_payloads(text)
+        for recovered in candidates:
+            diagnostic = self._payload_recovery_diagnostic(
+                recovered.payload, recovered.recovery_format
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+
+        if not candidates:
+            for recovery_format in self._recovery_formats:
+                if self._has_recovery_marker(text, recovery_format):
+                    diagnostics.append(
+                        self._malformed_call_diagnostic(
+                            recovery_format=recovery_format
+                        )
+                    )
+        return diagnostics
+
+    def _recovery_payloads(self, text: str) -> list[_RecoveryPayload]:
+        recovered: list[_RecoveryPayload] = []
+        seen_payloads: set[tuple[tuple[int, int], str]] = set()
+        for recovery_format in self._recovery_formats:
+            for payload in self._recovery_payloads_for_format(
+                text, recovery_format
+            ):
+                key = (payload.span, repr(payload.payload))
+                if key in seen_payloads:
+                    continue
+                seen_payloads.add(key)
+                recovered.append(payload)
+        return sorted(recovered, key=lambda payload: payload.span)
+
+    def _recovery_payloads_for_format(
+        self,
+        text: str,
+        recovery_format: ToolCallRecoveryFormat,
+    ) -> list[_RecoveryPayload]:
+        match recovery_format:
+            case ToolCallRecoveryFormat.TOOL_CALL_BLOCK:
+                return self._tool_call_block_payloads(
+                    text, recovery_format=recovery_format
+                )
+            case ToolCallRecoveryFormat.MINIMAX_XML:
+                return self._xml_recovery_payloads(
+                    text,
+                    recovery_format=recovery_format,
+                    names={"invoke", "tool_call"},
+                )
+            case ToolCallRecoveryFormat.TOOL_CODE:
+                return self._tool_code_payloads(
+                    text, recovery_format=recovery_format
+                )
+            case ToolCallRecoveryFormat.BROAD_XML:
+                return self._xml_recovery_payloads(
+                    text,
+                    recovery_format=recovery_format,
+                    names={"function", "function_call", "invoke"},
+                )
+            case ToolCallRecoveryFormat.DSML_LEAKAGE:
+                return self._xml_recovery_payloads(
+                    text,
+                    recovery_format=recovery_format,
+                    names={"invoke"},
+                )
+            case ToolCallRecoveryFormat.FENCED:
+                return self._fenced_recovery_payloads(text)
+
+    @staticmethod
+    def _has_recovery_marker(
+        text: str, recovery_format: ToolCallRecoveryFormat
+    ) -> bool:
+        match recovery_format:
+            case ToolCallRecoveryFormat.TOOL_CALL_BLOCK:
+                return "[TOOL_CALL]" in text
+            case ToolCallRecoveryFormat.MINIMAX_XML:
+                return any(
+                    marker in text
+                    for marker in ("<invoke", ":invoke", "<tool_call")
+                )
+            case ToolCallRecoveryFormat.TOOL_CODE:
+                return "<tool_code" in text
+            case ToolCallRecoveryFormat.BROAD_XML:
+                return any(
+                    marker in text
+                    for marker in ("<function", "<invoke", ":invoke")
+                )
+            case ToolCallRecoveryFormat.DSML_LEAKAGE:
+                return "DSML" in text and "invoke" in text
+            case ToolCallRecoveryFormat.FENCED:
+                return (
+                    _MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN.search(text)
+                    is not None
+                )
+
+    def _tool_call_block_payloads(
+        self,
+        text: str,
+        *,
+        recovery_format: ToolCallRecoveryFormat,
+    ) -> list[_RecoveryPayload]:
+        payloads: list[_RecoveryPayload] = []
+        pattern = compile(
+            r"\[TOOL_CALL\](?P<payload>.*?)\[/TOOL_CALL\]",
+            DOTALL,
+        )
+        for match in pattern.finditer(text):
+            payloads.append(
+                _RecoveryPayload(
+                    span=match.span(),
+                    payload=self._deserialize_payload(match.group("payload")),
+                    recovery_format=recovery_format,
+                )
+            )
+        return payloads
+
+    def _tool_code_payloads(
+        self,
+        text: str,
+        *,
+        recovery_format: ToolCallRecoveryFormat,
+    ) -> list[_RecoveryPayload]:
+        payloads: list[_RecoveryPayload] = []
+        pattern = compile(
+            r"<tool_code[^>]*>(?P<payload>.*?)</tool_code>",
+            DOTALL,
+        )
+        for match in pattern.finditer(text):
+            payload = self._deserialize_payload(match.group("payload"))
+            if payload is None:
+                payload = self._function_call_payload(match.group("payload"))
+            payloads.append(
+                _RecoveryPayload(
+                    span=match.span(),
+                    payload=payload,
+                    recovery_format=recovery_format,
+                )
+            )
+        return payloads
+
+    def _fenced_recovery_payloads(self, text: str) -> list[_RecoveryPayload]:
+        payloads: list[_RecoveryPayload] = []
+        for match in _MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN.finditer(text):
+            content = match.group("content")
+            direct_payload = self._deserialize_payload(content)
+            if direct_payload is not None:
+                payloads.append(
+                    _RecoveryPayload(
+                        span=match.span(),
+                        payload=direct_payload,
+                        recovery_format=ToolCallRecoveryFormat.FENCED,
+                    )
+                )
+                continue
+            nested_payloads = (
+                self._tool_call_block_payloads(
+                    content,
+                    recovery_format=ToolCallRecoveryFormat.FENCED,
+                )
+                + self._tool_code_payloads(
+                    content,
+                    recovery_format=ToolCallRecoveryFormat.FENCED,
+                )
+                + self._xml_recovery_payloads(
+                    content,
+                    recovery_format=ToolCallRecoveryFormat.FENCED,
+                    names={
+                        "function",
+                        "function_call",
+                        "invoke",
+                        "tool_call",
+                    },
+                )
+            )
+            if nested_payloads:
+                payloads.extend(
+                    _RecoveryPayload(
+                        span=match.span(),
+                        payload=nested.payload,
+                        recovery_format=ToolCallRecoveryFormat.FENCED,
+                    )
+                    for nested in nested_payloads
+                )
+                continue
+            payloads.append(
+                _RecoveryPayload(
+                    span=match.span(),
+                    payload=None,
+                    recovery_format=ToolCallRecoveryFormat.FENCED,
+                )
+            )
+        return payloads
+
+    def _xml_recovery_payloads(
+        self,
+        text: str,
+        *,
+        recovery_format: ToolCallRecoveryFormat,
+        names: set[str],
+    ) -> list[_RecoveryPayload]:
+        payloads: list[_RecoveryPayload] = []
+        name_pattern = "|".join(sorted(names))
+        pattern = compile(
+            rf"<(?:[A-Za-z_][\w.-]*:)?(?P<tag>{name_pattern})\b[^>]*>"
+            rf".*?</(?:[A-Za-z_][\w.-]*:)?(?P=tag)>",
+            DOTALL,
+        )
+        for match in pattern.finditer(text):
+            payloads.append(
+                _RecoveryPayload(
+                    span=match.span(),
+                    payload=self._xml_payload(match.group(0)),
+                    recovery_format=recovery_format,
+                )
+            )
+        return payloads
+
+    def _xml_payload(self, text: str) -> Any:
+        xml_text = _XML_NAME_PREFIX_PATTERN.sub(r"<\1", text)
+        try:
+            root = ElementTree.fromstring(xml_text)
+        except ElementTree.ParseError:
+            return None
+
+        tag = self._xml_local_name(root.tag)
+        if tag in {"function", "function_call", "invoke"}:
+            return self._xml_named_payload(root)
+        if tag == "tool_call":
+            return self._xml_tool_call_payload(root)
+        return None
+
+    def _xml_named_payload(self, element: ElementTree.Element) -> Any:
+        name = element.attrib.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return None
+
+        arguments = self._xml_arguments(element)
+        if arguments is None:
+            return None
+        return {"name": name, "arguments": arguments}
+
+    def _xml_tool_call_payload(self, element: ElementTree.Element) -> Any:
+        name = element.attrib.get("name")
+        if isinstance(name, str) and name.strip():
+            arguments = None
+            raw_payload = self._deserialize_payload(element.text or "")
+            if isinstance(raw_payload, dict):
+                arguments = raw_payload
+            else:
+                arguments = self._xml_arguments(element)
+            if arguments is None:
+                return None
+            return {"name": name, "arguments": arguments}
+
+        raw_payload = self._deserialize_payload(element.text or "")
+        if isinstance(raw_payload, dict):
+            return raw_payload
+
+        child_name = self._xml_child_text(element, "name")
+        if child_name is None:
+            return None
+        arguments = self._xml_arguments(element)
+        if arguments is None:
+            return None
+        return {"name": child_name, "arguments": arguments}
+
+    def _xml_arguments(
+        self, element: ElementTree.Element
+    ) -> dict[str, ToolValue] | None:
+        arguments_text = self._xml_child_text(element, "arguments")
+        if arguments_text is not None:
+            arguments = self._deserialize_payload(arguments_text)
+            if isinstance(arguments, dict):
+                return cast(dict[str, ToolValue], arguments)
+            return None
+
+        parameters: dict[str, ToolValue] = {}
+        for child in element:
+            if self._xml_local_name(child.tag) != "parameter":
+                continue
+            name = child.attrib.get("name")
+            if not isinstance(name, str) or not name.strip():
+                return None
+            parameters[name] = self._xml_parameter_value(child)
+        return parameters
+
+    def _xml_parameter_value(self, element: ElementTree.Element) -> ToolValue:
+        text = (element.text or "").strip()
+        if element.attrib.get("string") == "false":
+            try:
+                return cast(ToolValue, loads(text))
+            except JSONDecodeError:
+                return text
+        return text
+
+    @classmethod
+    def _xml_child_text(
+        cls, element: ElementTree.Element, name: str
+    ) -> str | None:
+        for child in element:
+            if cls._xml_local_name(child.tag) == name:
+                return child.text or ""
+        return None
+
+    @staticmethod
+    def _xml_local_name(name: str) -> str:
+        return name.rsplit("}", 1)[-1].rsplit(":", 1)[-1]
+
+    def _function_call_payload(self, text: str) -> Any:
+        match = search(r"([\w.]+)\s*\((\{.*\})\)", text.strip(), DOTALL)
+        if not match:
+            return None
+        arguments = self._deserialize_payload(match.group(2))
+        if not isinstance(arguments, dict):
+            return None
+        return {"name": match.group(1), "arguments": arguments}
+
+    def _payload_recovery_diagnostic(
+        self,
+        payload: Any,
+        recovery_format: ToolCallRecoveryFormat,
+    ) -> ToolCallDiagnostic | None:
+        diagnostic = self._payload_diagnostic(payload)
+        if diagnostic is None:
+            return None
+
+        details = diagnostic.details.copy()
+        details["source_format"] = recovery_format.value
+        return ToolCallDiagnostic(
+            id=diagnostic.id,
+            call_id=diagnostic.call_id,
+            requested_name=diagnostic.requested_name,
+            canonical_name=diagnostic.canonical_name,
+            code=diagnostic.code,
+            stage=diagnostic.stage,
+            message=diagnostic.message,
+            retryable=diagnostic.retryable,
+            details=details,
+            started_at=diagnostic.started_at,
+            finished_at=diagnostic.finished_at,
+            duration_ms=diagnostic.duration_ms,
+        )
 
     def _tag_payloads(self, text: str) -> list[Any]:
         payloads: list[Any] = []

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -17,7 +17,7 @@ from ast import literal_eval
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from json import JSONDecodeError, loads
+from json import JSONDecodeError, JSONDecoder, loads
 from re import DOTALL, MULTILINE, compile, finditer, search, sub
 from typing import Any, cast, final
 from uuid import UUID, uuid4
@@ -40,7 +40,24 @@ _MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN = compile(
     r"^[ \t]*(?P=fence)[ \t]*$",
     DOTALL | MULTILINE,
 )
+_MARKDOWN_FENCE_LINE_PATTERN = compile(r"^[ \t]*(?P<fence>`{3,}|~{3,})")
 _XML_NAME_PREFIX_PATTERN = compile(r"<(/?)([A-Za-z_][\w.-]*):")
+_TOOL_NAME_PATTERN_TEXT = r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*"
+_TOOL_NAME_PATTERN = compile(rf"^{_TOOL_NAME_PATTERN_TEXT}$")
+_BRACKET_CALL_PATTERN = compile(r"\[([^\]\r\n]*)\]\(([^)\r\n]*)\)")
+_BRACKET_CALL_START_PATTERN = compile(r"\[[^\]\r\n]*\]\(")
+_REACT_CALL_PATTERN = compile(
+    r"^[ \t]*Action:\s*(?P<name>[^\r\n]*)\s*(?:\r?\n)+"
+    r"[ \t]*Action Input:\s*(?P<arguments>.*?)(?=^[ \t]*Action:\s*|\Z)",
+    DOTALL | MULTILINE,
+)
+_REACT_ACTION_PATTERN = compile(
+    r"^[ \t]*Action:\s*(?P<name>[^\r\n]*)\s*$",
+    MULTILINE,
+)
+_REACT_INPUT_PATTERN = compile(r"^[ \t]*Action Input:\s*", MULTILINE)
+_REACT_JSON_DECODER = JSONDecoder()
+_NO_TAG_PAYLOAD = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +147,18 @@ class ToolCallParser:
         text_diagnostic = self._text_limit_diagnostic(text)
         if text_diagnostic is not None:
             return ToolCallParseOutcome(diagnostics=[text_diagnostic])
+
+        if self._tool_format is ToolFormat.REACT:
+            react_outcome = self._parse_react_outcome(text)
+            if react_outcome.calls:
+                if not react_outcome.diagnostics:
+                    react_outcome.diagnostics.extend(
+                        self._tag_failure_diagnostics(text)
+                    )
+                    react_outcome.diagnostics.extend(
+                        self._recovery_failure_diagnostics(text)
+                    )
+                return react_outcome
 
         parsed = self(text)
         calls: list[ToolCall] = []
@@ -263,16 +292,20 @@ class ToolCallParser:
                     "content_type": "json",
                 }
                 for call in parsed
+                if self._is_valid_tool_name(call.name)
+                and (
+                    call.arguments is None or isinstance(call.arguments, dict)
+                )
             ]
 
         if isinstance(parsed, tuple) and len(parsed) == 2:
             name, arguments = parsed
-            if isinstance(name, str):
+            if self._is_valid_tool_name(name) and isinstance(arguments, dict):
                 return [
                     {
                         "id": None,
                         "name": name,
-                        "arguments": arguments or {},
+                        "arguments": arguments,
                         "content_type": "json",
                     }
                 ]
@@ -498,17 +531,84 @@ class ToolCallParser:
             return None
 
     def _parse_react(self, text: str) -> tuple[str, dict[str, Any]] | None:
-        act = search(r"Action:\s*(\w+)", text)
-        inp = search(r"Action Input:\s*({.*})", text, DOTALL)
-        if act and inp:
-            try:
-                return act.group(1), loads(inp.group(1))
-            except JSONDecodeError:
-                pass
+        for name, arguments, malformed in self._react_payloads(text):
+            if (
+                not malformed
+                and _TOOL_NAME_PATTERN.fullmatch(name)
+                and isinstance(arguments, dict)
+            ):
+                return name, arguments
         return None
 
+    def _parse_react_outcome(self, text: str) -> ToolCallParseOutcome:
+        calls: list[ToolCall] = []
+        diagnostics: list[ToolCallDiagnostic] = []
+        for name, arguments, malformed in self._react_payloads(text):
+            requested_name = (
+                name if _TOOL_NAME_PATTERN.fullmatch(name) else None
+            )
+            if requested_name is None:
+                diagnostics.append(self._malformed_call_diagnostic())
+                continue
+            if malformed:
+                diagnostics.append(
+                    self._malformed_call_diagnostic(
+                        requested_name=requested_name
+                    )
+                )
+                continue
+            if not isinstance(arguments, dict):
+                diagnostics.append(
+                    self._arguments_diagnostic(requested_name=requested_name)
+                )
+                continue
+            diagnostic = self.resource_limit_diagnostic(
+                value=arguments,
+                maximum_depth=self._maximum_payload_depth,
+                maximum_size=self._maximum_payload_size,
+                stage=ToolCallDiagnosticStage.PARSE,
+                requested_name=requested_name,
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+                continue
+            calls.append(
+                ToolCall(
+                    id=uuid4(),
+                    name=requested_name,
+                    arguments=cast(dict[str, ToolValue], arguments),
+                )
+            )
+        return ToolCallParseOutcome(calls=calls, diagnostics=diagnostics)
+
+    def _react_payloads(self, text: str) -> list[tuple[str, Any, bool]]:
+        payloads: list[tuple[str, Any, bool]] = []
+        for match in _REACT_CALL_PATTERN.finditer(text):
+            arguments, malformed = self._decode_react_arguments(
+                match.group("arguments")
+            )
+            payloads.append(
+                (
+                    match.group("name").strip(),
+                    arguments,
+                    malformed,
+                )
+            )
+        return payloads
+
+    @staticmethod
+    def _decode_react_arguments(text: str) -> tuple[Any, bool]:
+        stripped = text.strip()
+        if not stripped:
+            return None, True
+        try:
+            arguments, _ = _REACT_JSON_DECODER.raw_decode(stripped)
+        except JSONDecodeError:
+            return None, True
+        return arguments, False
+
     def _parse_bracket(self, text: str) -> tuple[str, dict[str, Any]] | None:
-        m = search(r"\[(\w+)\]\(([^)]+)\)", text)
+        m = search(rf"\[({_TOOL_NAME_PATTERN_TEXT})\]\(([^)]+)\)", text)
         if m:
             return m.group(1), {"input": m.group(2)}
         return None
@@ -518,6 +618,8 @@ class ToolCallParser:
     ) -> tuple[str, dict[str, Any]] | None:
         try:
             payload = loads(text)
+            if not isinstance(payload, dict):
+                return None
             name = payload.get("name")
             args = payload.get("arguments", {})
             if isinstance(name, str) and isinstance(args, dict):
@@ -559,107 +661,21 @@ class ToolCallParser:
         if self._eos_token:
             text = text.strip().removesuffix(self._eos_token)
         text = self._without_markdown_fenced_blocks(text)
-        try:
-            root = ElementTree.fromstring(f"<root>{text}</root>")
-            for element in root.findall(".//tool_call"):
-                tool_call = None
-                try:
-                    if element.text is None:
-                        continue
-                    json_text = element.text.strip()
-
-                    try:
-                        tool_call = loads(json_text)
-                    except JSONDecodeError:
-                        try:
-                            tool_call = literal_eval(json_text)
-                        except (SyntaxError, ValueError):
-                            continue
-                except Exception:
-                    pass
-
-                if (
-                    tool_call is not None
-                    and "name" in tool_call
-                    and "arguments" in tool_call
-                ):
-                    parsed = self._tool_call_from_payload(tool_call)
-                    if parsed is not None:
-                        tool_calls.append(parsed)
-        except ElementTree.ParseError:
-            pass
-
-        if tool_calls:
-            return tool_calls
-
-        m = search(
-            r"<tool_call>\s*(\{.*?\})\s*</tool_call>", text, flags=DOTALL
-        )
-        if m:
-            tool_call_payload = m.group(1)
-            try:
-                tool_call = loads(tool_call_payload)
-                parsed = self._tool_call_from_payload(tool_call)
-                if parsed is not None:
-                    tool_calls.append(parsed)
-            except JSONDecodeError:
-                pass
-
-        m = search(
-            r"<tool_call\s+name=\"([^\"]+)\"\s*>(\{.*?\})</tool_call>",
-            text,
-            DOTALL,
-        )
-        if m:
-            try:
-                tool_calls.append(
-                    ToolCall(
-                        id=uuid4(),
-                        name=m.group(1),
-                        arguments=loads(m.group(2)),
-                    )
-                )
-            except JSONDecodeError:
-                pass
-
-        m = search(
-            r"<tool\s+name=\"([^\"]+)\"\s*>(\{.*?\})</tool>",
-            text,
-            DOTALL,
-        )
-        if m:
-            try:
-                tool_calls.append(
-                    ToolCall(
-                        id=uuid4(),
-                        name=m.group(1),
-                        arguments=loads(m.group(2)),
-                    )
-                )
-            except JSONDecodeError:
-                pass
-
-        m = search(
-            r"<tool_call\s+name=\"([^\"]+)\"\s+arguments='(\{.*?\})'\s*/>",
-            text,
-        )
-        if m:
-            try:
-                tool_calls.append(
-                    ToolCall(
-                        id=uuid4(),
-                        name=m.group(1),
-                        arguments=loads(m.group(2)),
-                    )
-                )
-            except JSONDecodeError:
-                pass
+        for payload in self._tag_payloads(text):
+            parsed = self._tool_call_from_payload(payload)
+            if parsed is not None:
+                tool_calls.append(parsed)
 
         return tool_calls if tool_calls else None
 
     def _normalize_tool_call(
         self, call: ToolCall
     ) -> tuple[ToolCall | None, ToolCallDiagnostic | None]:
+        if not self._is_valid_tool_name(call.name):
+            return None, self._malformed_call_diagnostic(
+                call_id=call.id,
+                requested_name=call.name if call.name.strip() else None,
+            )
         if call.arguments is not None and not isinstance(call.arguments, dict):
             return None, self._arguments_diagnostic(
                 call_id=call.id,
@@ -681,8 +697,12 @@ class ToolCallParser:
         self, parsed: tuple[Any, Any]
     ) -> tuple[ToolCall | None, ToolCallDiagnostic | None]:
         name, arguments = parsed
-        if not isinstance(name, str) or not name.strip():
-            return None, self._malformed_call_diagnostic()
+        if not self._is_valid_tool_name(name):
+            return None, self._malformed_call_diagnostic(
+                requested_name=(
+                    name if isinstance(name, str) and name.strip() else None
+                )
+            )
         if not isinstance(arguments, dict):
             return None, self._arguments_diagnostic(requested_name=name)
         diagnostic = self.resource_limit_diagnostic(
@@ -714,6 +734,8 @@ class ToolCallParser:
                 )
             case ToolFormat.REACT:
                 diagnostics = self._react_failure_diagnostics(text)
+            case ToolFormat.BRACKET:
+                diagnostics = self._bracket_failure_diagnostics(text)
             case ToolFormat.OPENAI:
                 diagnostics = self._json_failure_diagnostics(
                     text,
@@ -768,8 +790,16 @@ class ToolCallParser:
 
         name = payload.get(name_field)
         requested_name = name if isinstance(name, str) else None
-        if not isinstance(name, str) or not name.strip():
-            return [self._malformed_call_diagnostic()]
+        if not self._is_valid_tool_name(name):
+            return [
+                self._malformed_call_diagnostic(
+                    requested_name=(
+                        name
+                        if isinstance(name, str) and name.strip()
+                        else None
+                    )
+                )
+            ]
 
         arguments = payload.get("arguments", {})
         if not isinstance(arguments, dict):
@@ -779,20 +809,43 @@ class ToolCallParser:
     def _react_failure_diagnostics(
         self, text: str
     ) -> list[ToolCallDiagnostic]:
-        act = search(r"Action:\s*(\w+)", text)
-        inp = search(r"Action Input:\s*({.*}|\[.*\])", text, DOTALL)
-        if not act and not inp:
+        outcome = self._parse_react_outcome(text)
+        if outcome.diagnostics:
+            return outcome.diagnostics
+        if outcome.calls:
             return []
-        if not act or not inp:
+
+        has_action = _REACT_ACTION_PATTERN.search(text) is not None
+        has_input = _REACT_INPUT_PATTERN.search(text) is not None
+        if not has_action and not has_input:
+            return []
+        return [self._malformed_call_diagnostic()]
+
+    def _bracket_failure_diagnostics(
+        self, text: str
+    ) -> list[ToolCallDiagnostic]:
+        malformed = False
+        complete_call_starts: set[int] = set()
+        for match in _BRACKET_CALL_PATTERN.finditer(text):
+            complete_call_starts.add(match.start())
+            name = match.group(1).strip()
+            argument = match.group(2)
+            if (
+                not name
+                or not _TOOL_NAME_PATTERN.fullmatch(name)
+                or not argument
+            ):
+                malformed = True
+                break
+
+        if not malformed:
+            for match in _BRACKET_CALL_START_PATTERN.finditer(text):
+                if match.start() not in complete_call_starts:
+                    malformed = True
+                    break
+
+        if malformed:
             return [self._malformed_call_diagnostic()]
-        try:
-            arguments = loads(inp.group(1))
-        except JSONDecodeError:
-            return [
-                self._malformed_call_diagnostic(requested_name=act.group(1))
-            ]
-        if not isinstance(arguments, dict):
-            return [self._arguments_diagnostic(requested_name=act.group(1))]
         return []
 
     def _harmony_failure_diagnostics(
@@ -846,7 +899,26 @@ class ToolCallParser:
 
     @staticmethod
     def _without_markdown_fenced_blocks(text: str) -> str:
-        return _MARKDOWN_FENCED_BLOCK_PATTERN.sub("", text)
+        stripped_text = _MARKDOWN_FENCED_BLOCK_PATTERN.sub("", text)
+        lines = stripped_text.splitlines(keepends=True)
+        output: list[str] = []
+        open_fence: str | None = None
+        for line in lines:
+            match = _MARKDOWN_FENCE_LINE_PATTERN.match(line)
+            if open_fence is None:
+                if match is None:
+                    output.append(line)
+                    continue
+                open_fence = match.group("fence")
+                continue
+
+            if match is None:
+                continue
+            fence = match.group("fence")
+            if fence[0] == open_fence[0] and len(fence) >= len(open_fence):
+                open_fence = None
+
+        return "".join(output)
 
     def _parse_recovery(self, text: str) -> list[ToolCall] | None:
         tool_calls: list[ToolCall] = []
@@ -861,25 +933,44 @@ class ToolCallParser:
     ) -> list[ToolCallDiagnostic]:
         diagnostics: list[ToolCallDiagnostic] = []
         candidates = self._recovery_payloads(text)
+        candidates_by_format: dict[
+            ToolCallRecoveryFormat, list[_RecoveryPayload]
+        ] = {}
         for recovered in candidates:
+            candidates_by_format.setdefault(
+                recovered.recovery_format, []
+            ).append(recovered)
             diagnostic = self._payload_recovery_diagnostic(
                 recovered.payload, recovered.recovery_format
             )
             if diagnostic is not None:
                 diagnostics.append(diagnostic)
 
-        if not candidates:
-            for recovery_format in self._recovery_formats:
-                if self._has_recovery_marker(text, recovery_format):
-                    diagnostics.append(
-                        self._malformed_call_diagnostic(
-                            recovery_format=recovery_format
-                        )
+        reported_marker_starts: set[int] = set()
+        for recovery_format in self._recovery_formats:
+            candidate_starts = {
+                candidate.span[0]
+                for candidate in candidates_by_format.get(recovery_format, [])
+            }
+            for marker_start in self._recovery_marker_starts(
+                text, recovery_format
+            ):
+                if (
+                    marker_start in candidate_starts
+                    or marker_start in reported_marker_starts
+                ):
+                    continue
+                diagnostics.append(
+                    self._malformed_call_diagnostic(
+                        recovery_format=recovery_format
                     )
+                )
+                reported_marker_starts.add(marker_start)
+                break
         return diagnostics
 
     def _recovery_payloads(self, text: str) -> list[_RecoveryPayload]:
-        recovered: list[_RecoveryPayload] = []
+        candidates: list[_RecoveryPayload] = []
         seen_payloads: set[tuple[tuple[int, int], str]] = set()
         for recovery_format in self._recovery_formats:
             for payload in self._recovery_payloads_for_format(
@@ -889,8 +980,27 @@ class ToolCallParser:
                 if key in seen_payloads:
                     continue
                 seen_payloads.add(key)
-                recovered.append(payload)
-        return sorted(recovered, key=lambda payload: payload.span)
+                candidates.append(payload)
+
+        recovered: list[_RecoveryPayload] = []
+        for candidate in sorted(candidates, key=lambda payload: payload.span):
+            if any(
+                self._equivalent_recovery_payload(existing, candidate)
+                for existing in recovered
+            ):
+                continue
+            recovered.append(candidate)
+        return recovered
+
+    @staticmethod
+    def _equivalent_recovery_payload(
+        left: _RecoveryPayload, right: _RecoveryPayload
+    ) -> bool:
+        return (
+            repr(left.payload) == repr(right.payload)
+            and left.span[0] < right.span[1]
+            and right.span[0] < left.span[1]
+        )
 
     def _recovery_payloads_for_format(
         self,
@@ -927,32 +1037,61 @@ class ToolCallParser:
             case ToolCallRecoveryFormat.FENCED:
                 return self._fenced_recovery_payloads(text)
 
-    @staticmethod
+    @classmethod
     def _has_recovery_marker(
-        text: str, recovery_format: ToolCallRecoveryFormat
+        cls, text: str, recovery_format: ToolCallRecoveryFormat
     ) -> bool:
+        return bool(cls._recovery_marker_starts(text, recovery_format))
+
+    @classmethod
+    def _recovery_marker_starts(
+        cls, text: str, recovery_format: ToolCallRecoveryFormat
+    ) -> list[int]:
         match recovery_format:
             case ToolCallRecoveryFormat.TOOL_CALL_BLOCK:
-                return "[TOOL_CALL]" in text
+                return [
+                    match.start() for match in finditer(r"\[TOOL_CALL\]", text)
+                ]
             case ToolCallRecoveryFormat.MINIMAX_XML:
-                return any(
-                    marker in text
-                    for marker in ("<invoke", ":invoke", "<tool_call")
+                return cls._xml_recovery_marker_starts(
+                    text, {"invoke", "tool_call"}
                 )
             case ToolCallRecoveryFormat.TOOL_CODE:
-                return "<tool_code" in text
+                return [
+                    match.start() for match in finditer(r"<tool_code\b", text)
+                ]
             case ToolCallRecoveryFormat.BROAD_XML:
-                return any(
-                    marker in text
-                    for marker in ("<function", "<invoke", ":invoke")
+                return cls._xml_recovery_marker_starts(
+                    text, {"function", "function_call", "invoke"}
                 )
             case ToolCallRecoveryFormat.DSML_LEAKAGE:
-                return "DSML" in text and "invoke" in text
+                return [
+                    match.start()
+                    for match in finditer(r"<[A-Za-z_][\w.-]*:invoke\b", text)
+                ]
             case ToolCallRecoveryFormat.FENCED:
-                return (
-                    _MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN.search(text)
-                    is not None
-                )
+                closed_block_spans = [
+                    match.span()
+                    for match in (
+                        _MARKDOWN_FENCED_BLOCK_CAPTURE_PATTERN.finditer(text)
+                    )
+                ]
+                return [
+                    match.start()
+                    for match in compile(
+                        r"^[ \t]*(?:`{3,}|~{3,})", MULTILINE
+                    ).finditer(text)
+                    if not any(
+                        start < match.start() < end
+                        for start, end in closed_block_spans
+                    )
+                ]
+
+    @staticmethod
+    def _xml_recovery_marker_starts(text: str, names: set[str]) -> list[int]:
+        name_pattern = "|".join(sorted(names))
+        pattern = compile(rf"<(?:[A-Za-z_][\w.-]*:)?(?:{name_pattern})\b")
+        return [match.start() for match in pattern.finditer(text)]
 
     def _tool_call_block_payloads(
         self,
@@ -1207,18 +1346,12 @@ class ToolCallParser:
         try:
             root = ElementTree.fromstring(f"<root>{text}</root>")
             for element in root.findall(".//tool_call"):
-                if element.text is not None:
-                    payload = self._deserialize_payload(element.text)
-                    name = element.attrib.get("name")
-                    if name is not None:
-                        payload = {"name": name, "arguments": payload}
+                payload = self._tag_payload_from_element(element)
+                if payload is not _NO_TAG_PAYLOAD:
                     payloads.append(payload)
             for element in root.findall(".//tool"):
-                if element.text is not None:
-                    payload = self._deserialize_payload(element.text)
-                    name = element.attrib.get("name")
-                    if name is not None:
-                        payload = {"name": name, "arguments": payload}
+                payload = self._tag_payload_from_element(element)
+                if payload is not _NO_TAG_PAYLOAD:
                     payloads.append(payload)
             return payloads
         except ElementTree.ParseError:
@@ -1240,6 +1373,37 @@ class ToolCallParser:
                 payloads.append({"name": name, "arguments": arguments})
         return payloads
 
+    def _tag_payload_from_element(self, element: ElementTree.Element) -> Any:
+        name = element.attrib.get("name")
+        arguments_text = element.attrib.get("arguments")
+        if arguments_text is not None:
+            arguments = self._deserialize_json_payload(arguments_text)
+            if name is None:
+                return None
+            return {"name": name, "arguments": arguments}
+
+        if element.text is None:
+            if name is not None:
+                return {"name": name, "arguments": None}
+            return _NO_TAG_PAYLOAD
+
+        if name is not None:
+            payload = self._deserialize_json_payload(element.text)
+            payload = {"name": name, "arguments": payload}
+            return payload
+
+        try:
+            return self._deserialize_payload(element.text)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _deserialize_json_payload(text: str) -> Any:
+        try:
+            return loads(text.strip())
+        except Exception:
+            return None
+
     @staticmethod
     def _deserialize_payload(text: str) -> Any:
         json_text = text.strip()
@@ -1257,8 +1421,12 @@ class ToolCallParser:
 
         name = payload.get("name")
         requested_name = name if isinstance(name, str) else None
-        if not isinstance(name, str) or not name.strip():
-            return self._malformed_call_diagnostic()
+        if not self._is_valid_tool_name(name):
+            return self._malformed_call_diagnostic(
+                requested_name=(
+                    name if isinstance(name, str) and name.strip() else None
+                )
+            )
 
         call_id = payload.get("id")
         arguments = payload.get("arguments")
@@ -1395,6 +1563,7 @@ class ToolCallParser:
     @staticmethod
     def _malformed_call_diagnostic(
         *,
+        call_id: UUID | str | None = None,
         requested_name: str | None = None,
         message: str = "Tool call could not be parsed.",
         details: dict[str, ToolValue] | None = None,
@@ -1405,11 +1574,18 @@ class ToolCallParser:
             diagnostic_details["source_format"] = recovery_format.value
         return ToolCallDiagnostic(
             id=uuid4(),
+            call_id=call_id,
             requested_name=requested_name,
             code=ToolCallDiagnosticCode.MALFORMED_CALL,
             stage=ToolCallDiagnosticStage.PARSE,
             message=message,
             details=diagnostic_details,
+        )
+
+    @staticmethod
+    def _is_valid_tool_name(name: Any) -> bool:
+        return isinstance(name, str) and bool(
+            _TOOL_NAME_PATTERN.fullmatch(name)
         )
 
     @staticmethod
@@ -1419,8 +1595,11 @@ class ToolCallParser:
 
         name = payload.get("name")
         arguments = payload.get("arguments")
-        if not isinstance(name, str) or not isinstance(arguments, dict):
+        if not ToolCallParser._is_valid_tool_name(name) or not isinstance(
+            arguments, dict
+        ):
             return None
+        assert isinstance(name, str)
 
         call_id = payload.get("id")
         identifier: UUID | str = (

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -16,7 +16,7 @@ from ast import literal_eval
 from dataclasses import dataclass, field
 from enum import Enum
 from json import JSONDecodeError, loads
-from re import DOTALL, compile, finditer, search, sub
+from re import DOTALL, MULTILINE, compile, finditer, search, sub
 from typing import Any, cast, final
 from uuid import UUID, uuid4
 from xml.etree import ElementTree
@@ -26,6 +26,12 @@ _HARMONY_SEGMENT_PATTERN = compile(
     DOTALL,
 )
 _SPECIAL_TOKEN_PATTERN = compile(r"<\|[^>]+?\|>")
+_MARKDOWN_FENCED_BLOCK_PATTERN = compile(
+    r"^[ \t]*(?P<fence>`{3,}|~{3,})[^\n\r]*(?:\r?\n)"
+    r".*?"
+    r"^[ \t]*(?P=fence)[ \t]*$",
+    DOTALL | MULTILINE,
+)
 
 
 class ToolCallParser:
@@ -88,6 +94,9 @@ class ToolCallParser:
             if diagnostic is not None:
                 diagnostics.append(diagnostic)
         else:
+            diagnostics.extend(self._parse_failure_diagnostics(text))
+
+        if calls and not diagnostics:
             diagnostics.extend(self._parse_failure_diagnostics(text))
 
         return ToolCallParseOutcome(calls=calls, diagnostics=diagnostics)
@@ -442,6 +451,7 @@ class ToolCallParser:
 
         if self._eos_token:
             text = text.strip().removesuffix(self._eos_token)
+        text = self._without_markdown_fenced_blocks(text)
         try:
             root = ElementTree.fromstring(f"<root>{text}</root>")
             for element in root.findall(".//tool_call"):
@@ -675,6 +685,7 @@ class ToolCallParser:
         return diagnostics
 
     def _tag_failure_diagnostics(self, text: str) -> list[ToolCallDiagnostic]:
+        text = self._without_markdown_fenced_blocks(text)
         if "<tool_call" not in text and "<tool " not in text:
             return []
 
@@ -685,6 +696,10 @@ class ToolCallParser:
             if diagnostic is not None:
                 diagnostics.append(diagnostic)
         return diagnostics
+
+    @staticmethod
+    def _without_markdown_fenced_blocks(text: str) -> str:
+        return _MARKDOWN_FENCED_BLOCK_PATTERN.sub("", text)
 
     def _tag_payloads(self, text: str) -> list[Any]:
         payloads: list[Any] = []

--- a/src/avalan/tool/parser.py
+++ b/src/avalan/tool/parser.py
@@ -428,15 +428,18 @@ class ToolCallParser:
     def tool_call_status(
         self, buffer: str, *, final: bool = False
     ) -> "ToolCallParser.ToolCallBufferStatus":
+        status_buffer = self._without_markdown_fenced_blocks(buffer)
         status: ToolCallParser.ToolCallBufferStatus
         if self._tool_format is ToolFormat.DSML:
-            dsml_status = self._dsml_tool_call_status(buffer)
+            dsml_status = self._dsml_tool_call_status(status_buffer)
             if dsml_status is not self.ToolCallBufferStatus.NONE:
                 status = dsml_status
                 return self._final_tool_call_status(buffer, status, final)
+        if not status_buffer:
+            return self.ToolCallBufferStatus.NONE
 
         start = ["<tool_call", "<tool ", "<tool>"]
-        end = ["</tool_call>", "</tool>", "/>", "<|call|>"]
+        end = ["</tool_call>", "</tool>", "<|call|>"]
         if self._tool_format is ToolFormat.HARMONY:
             start.extend(
                 [
@@ -448,21 +451,161 @@ class ToolCallParser:
             )
             end.append("<|channel|>final<|message|>")
         max_len = max(len(s) for s in start)
-        tail = buffer[-max_len:]
+        tail = status_buffer[-max_len:]
         for s in start:
             if s.startswith(tail) and tail != s:
                 status = self.ToolCallBufferStatus.PREFIX
                 return self._final_tool_call_status(buffer, status, final)
-        for s in start:
-            idx = buffer.rfind(s)
-            if idx != -1:
-                after = buffer[idx + len(s) :]
-                if any(e in after for e in end):
-                    status = self.ToolCallBufferStatus.CLOSED
-                    return self._final_tool_call_status(buffer, status, final)
-                status = self.ToolCallBufferStatus.OPEN
+        latest_start = self._latest_tool_start(status_buffer, start)
+        if latest_start is not None:
+            idx, marker = latest_start
+            after = status_buffer[idx + len(marker) :]
+            if self._has_unquoted_tool_end(after, end) or (
+                self._opening_tool_tag_is_self_closing(marker, after)
+                and not self._has_unclosed_tool_start_before(
+                    status_buffer, idx, start, end
+                )
+            ):
+                status = self.ToolCallBufferStatus.CLOSED
                 return self._final_tool_call_status(buffer, status, final)
+            status = self.ToolCallBufferStatus.OPEN
+            return self._final_tool_call_status(buffer, status, final)
         return self.ToolCallBufferStatus.NONE
+
+    @classmethod
+    def _latest_tool_start(
+        cls, text: str, start_markers: list[str]
+    ) -> tuple[int, str] | None:
+        latest: tuple[int, str] | None = None
+        for marker in start_markers:
+            index = text.rfind(marker)
+            while index != -1:
+                if not cls._index_is_inside_quoted_text(text, index) and (
+                    latest is None
+                    or index > latest[0]
+                    or (index == latest[0] and len(marker) > len(latest[1]))
+                ):
+                    latest = (index, marker)
+                    break
+                index = text.rfind(marker, 0, index)
+        return latest
+
+    @classmethod
+    def _has_unquoted_tool_end(cls, text: str, end_markers: list[str]) -> bool:
+        for marker in end_markers:
+            index = text.find(marker)
+            while index != -1:
+                if not cls._index_is_inside_quoted_text(text, index):
+                    return True
+                index = text.find(marker, index + 1)
+        return False
+
+    @staticmethod
+    def _index_is_inside_quoted_text(text: str, index: int) -> bool:
+        quote: str | None = None
+        escaped = False
+        for position, character in enumerate(text[:index]):
+            if escaped:
+                escaped = False
+                continue
+            if quote is not None and character == "\\":
+                escaped = True
+                continue
+            if character not in ("'", '"'):
+                continue
+            if character == "'" and not ToolCallParser._is_quote_delimiter(
+                text, position
+            ):
+                continue
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+        return quote is not None
+
+    @staticmethod
+    def _is_quote_delimiter(text: str, position: int) -> bool:
+        return (
+            position == 0
+            or not text[position - 1].isalnum()
+            or position + 1 == len(text)
+            or not text[position + 1].isalnum()
+        )
+
+    @staticmethod
+    def _opening_tool_tag_is_self_closing(
+        start_marker: str, after_start: str
+    ) -> bool:
+        if start_marker not in {"<tool_call", "<tool "}:
+            return False
+
+        tag_end = ToolCallParser._tag_end_index(after_start, 0)
+        if tag_end == -1:
+            return False
+
+        return after_start[: tag_end + 1].rstrip().endswith("/>")
+
+    @staticmethod
+    def _tag_end_index(text: str, start: int) -> int:
+        quote: str | None = None
+        escaped = False
+        for index, character in enumerate(text[start:], start=start):
+            if escaped:
+                escaped = False
+                continue
+            if quote is not None:
+                if character == "\\":
+                    escaped = True
+                elif (
+                    character == quote
+                    and ToolCallParser._attribute_tail_is_valid(
+                        text, index + 1
+                    )
+                ):
+                    quote = None
+                continue
+            if character in ("'", '"'):
+                quote = character
+                continue
+            if character == ">":
+                return index
+        return -1
+
+    def _has_unclosed_tool_start_before(
+        self,
+        buffer: str,
+        index: int,
+        start_markers: list[str],
+        end_markers: list[str],
+    ) -> bool:
+        last_end = self._last_tool_end_before(buffer, index, end_markers)
+        for marker in start_markers:
+            start_index = buffer.find(marker, last_end + 1)
+            while start_index != -1 and start_index < index:
+                if not self._index_is_inside_quoted_text(buffer, start_index):
+                    after_start = buffer[start_index + len(marker) :]
+                    if not self._opening_tool_tag_is_self_closing(
+                        marker, after_start
+                    ):
+                        return True
+                start_index = buffer.find(marker, start_index + 1)
+        return False
+
+    @staticmethod
+    def _last_tool_end_before(
+        buffer: str, index: int, end_markers: list[str]
+    ) -> int:
+        last_end = -1
+        for marker in end_markers:
+            marker_index = buffer.rfind(marker, 0, index)
+            while marker_index != -1:
+                if not ToolCallParser._index_is_inside_quoted_text(
+                    buffer, marker_index
+                ):
+                    last_end = max(last_end, marker_index + len(marker))
+                    break
+                marker_index = buffer.rfind(marker, 0, marker_index)
+        return last_end
 
     def stream_buffer_diagnostics(
         self, buffer: str
@@ -481,6 +624,11 @@ class ToolCallParser:
 
         outcome = self.parse(buffer)
         if outcome.diagnostics:
+            if status is self.ToolCallBufferStatus.MALFORMED:
+                return [
+                    self._diagnostic_with_stream_status(diagnostic, status)
+                    for diagnostic in outcome.diagnostics
+                ]
             return outcome.diagnostics
         if status is self.ToolCallBufferStatus.MALFORMED:
             return [
@@ -508,6 +656,29 @@ class ToolCallParser:
             if not outcome.calls:
                 return self.ToolCallBufferStatus.MALFORMED
         return status
+
+    @staticmethod
+    def _diagnostic_with_stream_status(
+        diagnostic: ToolCallDiagnostic,
+        status: "ToolCallParser.ToolCallBufferStatus",
+    ) -> ToolCallDiagnostic:
+        details = diagnostic.details.copy()
+        details.setdefault("stream_status", status.name.lower())
+        return ToolCallDiagnostic(
+            id=diagnostic.id,
+            call_id=diagnostic.call_id,
+            requested_name=diagnostic.requested_name,
+            canonical_name=diagnostic.canonical_name,
+            status=diagnostic.status,
+            code=diagnostic.code,
+            stage=diagnostic.stage,
+            message=diagnostic.message,
+            retryable=diagnostic.retryable,
+            details=details,
+            started_at=diagnostic.started_at,
+            finished_at=diagnostic.finished_at,
+            duration_ms=diagnostic.duration_ms,
+        )
 
     def _dsml_tool_call_status(
         self, buffer: str
@@ -886,11 +1057,18 @@ class ToolCallParser:
 
     def _tag_failure_diagnostics(self, text: str) -> list[ToolCallDiagnostic]:
         text = self._without_markdown_fenced_blocks(text)
-        if "<tool_call" not in text and "<tool " not in text:
+        if (
+            self._find_unquoted_marker(text, "<tool_call", 0) == -1
+            and self._find_unquoted_marker(text, "<tool ", 0) == -1
+            and self._find_unquoted_marker(text, "<tool>", 0) == -1
+        ):
             return []
 
         diagnostics: list[ToolCallDiagnostic] = []
         payloads = self._tag_payloads(text)
+        if not payloads:
+            return [self._malformed_call_diagnostic()]
+
         for payload in payloads:
             diagnostic = self._payload_diagnostic(payload)
             if diagnostic is not None:
@@ -1342,6 +1520,11 @@ class ToolCallParser:
         )
 
     def _tag_payloads(self, text: str) -> list[Any]:
+        body_payloads = self._tag_body_payloads(text)
+        self_closing_payloads = self._self_closing_tag_payloads(text)
+        if body_payloads:
+            return body_payloads + self_closing_payloads
+
         payloads: list[Any] = []
         try:
             root = ElementTree.fromstring(f"<root>{text}</root>")
@@ -1357,21 +1540,166 @@ class ToolCallParser:
         except ElementTree.ParseError:
             pass
 
-        payload_patterns = (
-            r"<tool_call>\s*(\{.*?\})\s*</tool_call>",
-            r"<tool_call\s+name=\"([^\"]+)\"\s*>(.*?)</tool_call>",
-            r"<tool\s+name=\"([^\"]+)\"\s*>(.*?)</tool>",
-            r"<tool_call\s+name=\"([^\"]+)\"\s+arguments='([^']*)'\s*/>",
-        )
-        for pattern in payload_patterns:
-            for match in finditer(pattern, text, DOTALL):
-                if match.lastindex == 1:
-                    payloads.append(self._deserialize_payload(match.group(1)))
+        return self_closing_payloads
+
+    def _tag_body_payloads(self, text: str) -> list[Any]:
+        payloads: list[Any] = []
+        for start_marker, end_marker in (
+            ("<tool_call", "</tool_call>"),
+            ("<tool ", "</tool>"),
+            ("<tool>", "</tool>"),
+        ):
+            index = self._find_unquoted_marker(text, start_marker, 0)
+            while index != -1:
+                tag_end = self._tag_end_index(text, index)
+                if tag_end == -1:
+                    break
+                opening = text[index : tag_end + 1]
+                close_index = self._find_unquoted_marker(
+                    text, end_marker, tag_end + 1
+                )
+                if close_index == -1:
+                    index = text.find(start_marker, tag_end + 1)
                     continue
-                name = match.group(1)
-                arguments = self._deserialize_payload(match.group(2))
-                payloads.append({"name": name, "arguments": arguments})
+                if not opening.rstrip().endswith("/>"):
+                    payloads.append(
+                        self._tag_body_payload(
+                            opening,
+                            text[tag_end + 1 : close_index],
+                        )
+                    )
+                index = self._find_unquoted_marker(
+                    text, start_marker, close_index + len(end_marker)
+                )
         return payloads
+
+    def _tag_body_payload(self, opening: str, body: str) -> Any:
+        name = self._tag_attribute(opening, "name")
+        if name is not None:
+            arguments = self._deserialize_json_payload(body)
+            return {"name": name, "arguments": arguments}
+        try:
+            return self._deserialize_payload(body)
+        except Exception:
+            return None
+
+    def _self_closing_tag_payloads(self, text: str) -> list[Any]:
+        payloads: list[Any] = []
+        for start_marker in ("<tool_call", "<tool "):
+            index = self._find_unquoted_marker(text, start_marker, 0)
+            while index != -1:
+                tag_end = self._tag_end_index(text, index)
+                if tag_end == -1:
+                    break
+                opening = text[index : tag_end + 1]
+                if opening.rstrip().endswith("/>"):
+                    name = self._tag_attribute(opening, "name")
+                    if name is not None:
+                        arguments_text = self._tag_attribute(
+                            opening, "arguments"
+                        )
+                        arguments = (
+                            self._deserialize_tag_payload(arguments_text)
+                            if arguments_text is not None
+                            else None
+                        )
+                        payloads.append({"name": name, "arguments": arguments})
+                index = self._find_unquoted_marker(
+                    text, start_marker, tag_end + 1
+                )
+        return payloads
+
+    def _deserialize_tag_payload(self, text: str) -> Any:
+        try:
+            return self._deserialize_payload(text)
+        except Exception:
+            return None
+
+    @classmethod
+    def _tag_attribute(cls, opening: str, name: str) -> str | None:
+        index = opening.find(name)
+        while index != -1:
+            after_name = index + len(name)
+            if cls._tag_attribute_name_matches(opening, index, after_name):
+                equals_index = cls._skip_spaces(opening, after_name)
+                if (
+                    equals_index < len(opening)
+                    and opening[equals_index] == "="
+                ):
+                    value_index = cls._skip_spaces(opening, equals_index + 1)
+                    if value_index < len(opening) and opening[value_index] in (
+                        "'",
+                        '"',
+                    ):
+                        close_index = cls._tag_attribute_close_index(
+                            opening,
+                            value_index + 1,
+                            opening[value_index],
+                        )
+                        if close_index != -1:
+                            return opening[value_index + 1 : close_index]
+            index = opening.find(name, after_name)
+        return None
+
+    @staticmethod
+    def _tag_attribute_name_matches(
+        opening: str,
+        index: int,
+        after_name: int,
+    ) -> bool:
+        before_ok = index == 0 or opening[index - 1].isspace()
+        after_ok = after_name == len(opening) or (
+            opening[after_name].isspace() or opening[after_name] == "="
+        )
+        return before_ok and after_ok
+
+    @staticmethod
+    def _skip_spaces(text: str, index: int) -> int:
+        while index < len(text) and text[index].isspace():
+            index += 1
+        return index
+
+    @staticmethod
+    def _tag_attribute_close_index(
+        opening: str, start: int, quote: str
+    ) -> int:
+        escaped = False
+        for index, character in enumerate(opening[start:], start=start):
+            if escaped:
+                escaped = False
+                continue
+            if character == "\\":
+                escaped = True
+                continue
+            if character == quote and ToolCallParser._attribute_tail_is_valid(
+                opening, index + 1
+            ):
+                return index
+        return -1
+
+    @staticmethod
+    def _attribute_tail_is_valid(text: str, index: int) -> bool:
+        index = ToolCallParser._skip_spaces(text, index)
+        if index >= len(text) or text.startswith((">", "/>"), index):
+            return True
+        if not (text[index].isalpha() or text[index] in {"_", ":"}):
+            return False
+        index += 1
+        while index < len(text) and (
+            text[index].isalnum() or text[index] in {"_", ":", ".", "-"}
+        ):
+            index += 1
+        index = ToolCallParser._skip_spaces(text, index)
+        return index < len(text) and text[index] == "="
+
+    @classmethod
+    def _find_unquoted_marker(cls, text: str, marker: str, start: int) -> int:
+        index = text.find(marker, start)
+        while index != -1:
+            if not cls._index_is_inside_quoted_text(text, index):
+                return index
+            index = text.find(marker, index + 1)
+        return -1
 
     def _tag_payload_from_element(self, element: ElementTree.Element) -> Any:
         name = element.attrib.get("name")

--- a/src/avalan/utils.py
+++ b/src/avalan/utils.py
@@ -1,4 +1,4 @@
-from .entities import ToolCallDiagnostic
+from .entities import ToolCallDiagnostic, ToolCallError
 
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, time
@@ -64,4 +64,12 @@ def tool_call_diagnostic_payload(
         payload["canonical_name"] = diagnostic.canonical_name
     if diagnostic.details:
         payload["details"] = diagnostic.details
+    return payload
+
+
+def tool_call_error_payload(error: ToolCallError) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": error.error_type,
+        "message": error.message,
+    }
     return payload

--- a/src/avalan/utils.py
+++ b/src/avalan/utils.py
@@ -1,3 +1,5 @@
+from .entities import ToolCallDiagnostic
+
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -44,3 +46,22 @@ def to_json(item: Any) -> str:
         )
 
     return dumps(item, default=_default)
+
+
+def tool_call_diagnostic_payload(
+    diagnostic: ToolCallDiagnostic,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": diagnostic.status.value,
+        "code": diagnostic.code.value,
+        "stage": diagnostic.stage.value,
+        "message": diagnostic.message,
+        "retryable": diagnostic.retryable,
+    }
+    if diagnostic.requested_name is not None:
+        payload["requested_name"] = diagnostic.requested_name
+    if diagnostic.canonical_name is not None:
+        payload["canonical_name"] = diagnostic.canonical_name
+    if diagnostic.details:
+        payload["details"] = diagnostic.details
+    return payload

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -12,6 +12,7 @@ from avalan.agent.loader import OrchestratorLoader
 from avalan.entities import (
     OrchestratorSettings,
     PermanentMemoryStoreSettings,
+    ToolCallRecoveryFormat,
     ToolFormat,
 )
 from avalan.event import Event, EventType
@@ -743,6 +744,108 @@ format = \"{value}\"
                         ]
                         self.assertEqual(tool_format, expected)
                     await stack.aclose()
+
+    async def test_tool_recovery_format_variants(self):
+        config = """
+[agent]
+role = \"assistant\"
+
+[engine]
+uri = \"ai://local/model\"
+
+[tool]
+recovery_formats = [\"fenced\", \"tool_call_block\"]
+"""
+        with TemporaryDirectory() as tmp:
+            path = f"{tmp}/agent.toml"
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(config)
+
+            stack = AsyncExitStack()
+            hub = MagicMock(spec=HuggingfaceHub)
+            logger = MagicMock(spec=Logger)
+
+            with patch.object(
+                OrchestratorLoader,
+                "from_settings",
+                new=AsyncMock(return_value="orch"),
+            ) as from_settings:
+                loader = OrchestratorLoader(
+                    hub=hub,
+                    logger=logger,
+                    participant_id=uuid4(),
+                    stack=stack,
+                )
+                await loader.from_file(path, agent_id=uuid4())
+
+                self.assertEqual(
+                    from_settings.call_args.kwargs["tool_recovery_formats"],
+                    [
+                        ToolCallRecoveryFormat.FENCED,
+                        ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                    ],
+                )
+            await stack.aclose()
+
+    async def test_tool_recovery_formats_reject_non_list(self):
+        config = """
+[agent]
+role = \"assistant\"
+
+[engine]
+uri = \"ai://local/model\"
+
+[tool]
+recovery_formats = \"fenced\"
+"""
+        with TemporaryDirectory() as tmp:
+            path = f"{tmp}/agent.toml"
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(config)
+
+            stack = AsyncExitStack()
+            hub = MagicMock(spec=HuggingfaceHub)
+            logger = MagicMock(spec=Logger)
+
+            loader = OrchestratorLoader(
+                hub=hub,
+                logger=logger,
+                participant_id=uuid4(),
+                stack=stack,
+            )
+            with self.assertRaises(AssertionError):
+                await loader.from_file(path, agent_id=uuid4())
+            await stack.aclose()
+
+    async def test_tool_recovery_formats_reject_unknown_value(self):
+        config = """
+[agent]
+role = \"assistant\"
+
+[engine]
+uri = \"ai://local/model\"
+
+[tool]
+recovery_formats = [\"unknown\"]
+"""
+        with TemporaryDirectory() as tmp:
+            path = f"{tmp}/agent.toml"
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(config)
+
+            stack = AsyncExitStack()
+            hub = MagicMock(spec=HuggingfaceHub)
+            logger = MagicMock(spec=Logger)
+
+            loader = OrchestratorLoader(
+                hub=hub,
+                logger=logger,
+                participant_id=uuid4(),
+                stack=stack,
+            )
+            with self.assertRaises(ValueError):
+                await loader.from_file(path, agent_id=uuid4())
+            await stack.aclose()
 
     async def test_tool_settings_argument(self):
         config = """

--- a/tests/agent/orchestrator_response_more_test.py
+++ b/tests/agent/orchestrator_response_more_test.py
@@ -116,6 +116,30 @@ class OrchestratorResponseMoreCoverageTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(await resp.__anext__(), flushed[1])
         self.assertEqual(resp._tool_process_events.get_nowait(), flushed[0])
 
+    async def test_flush_queues_diagnostic_after_plain_tokens(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        tool = MagicMock(spec=ToolManager)
+        tool.is_empty = False
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _empty_response(),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+        resp._tool_parser = MagicMock()
+        diagnostic = Event(type=EventType.TOOL_DIAGNOSTIC)
+        token = Token(id=1, token="x")
+        resp._tool_parser.flush = AsyncMock(return_value=[diagnostic, token])
+        resp.__aiter__()
+
+        self.assertEqual(await resp.__anext__(), token)
+        self.assertEqual(await resp.__anext__(), diagnostic)
+
     async def test_emit_parsed_event(self):
         engine = _DummyEngine()
         agent = MagicMock(spec=EngineAgent)

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -2,6 +2,7 @@ from asyncio import wait_for
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from io import StringIO
+from json import loads
 from logging import getLogger
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
@@ -25,6 +26,9 @@ from avalan.entities import (
     TokenDetail,
     ToolCall,
     ToolCallContext,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallResult,
     ToolCallToken,
     ToolFormat,
@@ -36,6 +40,7 @@ from avalan.model import TextGenerationResponse
 from avalan.model.call import ModelCallContext
 from avalan.model.response.parsers.reasoning import ReasoningParser
 from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool import ToolSet
 from avalan.tool.manager import ToolManager
 from avalan.tool.parser import ToolCallParser
 
@@ -627,6 +632,100 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         assert isinstance(context.input, list)
         self.assertEqual(context.input[-2].tool_calls[0].id, "call1")
         self.assertEqual(context.input[-1].content, "4")
+
+    async def test_to_str_returns_anchored_diagnostic_to_model(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        async def known(value: str) -> str:
+            """Return the provided value.
+
+            Args:
+                value: Value to return.
+
+            Returns:
+                Provided value.
+            """
+            return value
+
+        tool = ToolManager.create_instance(
+            available_toolsets=[ToolSet(tools=[known])]
+        )
+        call = ToolCall(
+            id="call1",
+            name="missing",
+            arguments={"value": "x"},
+        )
+
+        async def outer_gen():
+            yield ToolCallToken(token="", call=call)
+
+        outer_response = TextGenerationResponse(
+            lambda **_: outer_gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
+        )
+        agent.return_value = _string_response("recovered", async_gen=False)
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            outer_response,
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+            tool=tool,
+        )
+
+        result = await resp.to_str()
+
+        self.assertEqual(result, "recovered")
+        context = agent.await_args.args[0]
+        assert isinstance(context.input, list)
+        assistant_message = context.input[-2]
+        diagnostic_message = context.input[-1]
+        self.assertEqual(assistant_message.tool_calls[0].id, "call1")
+        self.assertEqual(assistant_message.tool_calls[0].name, "missing")
+        self.assertEqual(diagnostic_message.role, MessageRole.TOOL)
+        self.assertIsNone(diagnostic_message.tool_call_result)
+        self.assertIsNone(diagnostic_message.tool_call_error)
+        self.assertIsNotNone(diagnostic_message.tool_call_diagnostic)
+        diagnostic = diagnostic_message.tool_call_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        )
+        self.assertEqual(diagnostic.call_id, "call1")
+        payload = loads(str(diagnostic_message.content))
+        self.assertEqual(payload["code"], "tool.unknown")
+        self.assertEqual(payload["requested_name"], "missing")
+
+    async def test_unanchored_diagnostic_uses_recovery_message(self):
+        diagnostic = ToolCallDiagnostic(
+            id="diag1",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Could not parse tool call.",
+        )
+
+        messages = OrchestratorResponse._tool_observation_messages(
+            diagnostic,
+            json_output=False,
+        )
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].role, MessageRole.ASSISTANT)
+        self.assertIs(messages[0].tool_call_diagnostic, diagnostic)
+        self.assertIsNone(messages[0].tool_calls)
+        payload = loads(str(messages[0].content))
+        self.assertEqual(payload["code"], "tool_call.malformed")
 
     async def test_iteration_carries_tool_messages_to_nested_tool_call(self):
         engine = _DummyEngine()

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -34,7 +34,7 @@ from avalan.entities import (
     ToolFormat,
     TransformerEngineSettings,
 )
-from avalan.event import EventType
+from avalan.event import Event, EventType
 from avalan.event.manager import EventManager
 from avalan.model import TextGenerationResponse
 from avalan.model.call import ModelCallContext
@@ -706,6 +706,236 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         payload = loads(str(diagnostic_message.content))
         self.assertEqual(payload["code"], "tool.unknown")
         self.assertEqual(payload["requested_name"], "missing")
+
+    async def test_to_str_stops_after_consecutive_non_executed_cycles(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        async def known(value: str) -> str:
+            """Return the provided value.
+
+            Args:
+                value: Value to return.
+
+            Returns:
+                Provided value.
+            """
+            return value
+
+        tool = ToolManager.create_instance(
+            available_toolsets=[ToolSet(tools=[known])]
+        )
+        call = ToolCall(
+            id="call1",
+            name="missing",
+            arguments={"value": "x"},
+        )
+
+        async def outer_gen():
+            yield ToolCallToken(token="", call=call)
+
+        async def inner_gen():
+            yield ToolCallToken(token="", call=call)
+
+        outer_response = TextGenerationResponse(
+            lambda **_: outer_gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
+        )
+        inner_response = TextGenerationResponse(
+            lambda **_: inner_gen(),
+            logger=getLogger(),
+            use_async_generator=True,
+            generation_settings=GenerationSettings(),
+            settings=GenerationSettings(),
+        )
+        agent.return_value = inner_response
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            outer_response,
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+            tool=tool,
+        )
+        resp._MAXIMUM_CONSECUTIVE_NON_EXECUTED_CYCLES = 1
+
+        result = await resp.to_str()
+
+        self.assertEqual(result, "")
+        agent.assert_awaited_once()
+        self.assertEqual(resp._call_history, [])
+
+    async def test_to_str_does_not_rerun_model_without_tool_observation(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={})
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.get_calls.side_effect = lambda text: (
+            [call] if text == "call" else None
+        )
+        tool.return_value = None
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+
+        result = await resp.to_str()
+
+        self.assertEqual(result, "call")
+        agent.assert_not_awaited()
+        tool.assert_awaited_once()
+        self.assertEqual(resp._call_history, [])
+
+    async def test_repeated_tool_attempt_returns_guard_diagnostic(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={"value": 1})
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.return_value = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result="ok",
+        )
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+        context = ToolCallContext(input=resp._input, calls=[])
+
+        first = await resp._execute_tool_call(
+            call,
+            context,
+            confirm=False,
+        )
+        second = await resp._execute_tool_call(
+            call,
+            context,
+            confirm=False,
+        )
+
+        self.assertIsInstance(first, ToolCallResult)
+        self.assertIsInstance(second, ToolCallDiagnostic)
+        assert isinstance(second, ToolCallDiagnostic)
+        self.assertEqual(second.code, ToolCallDiagnosticCode.REPEATED_CALL)
+        self.assertEqual(second.stage, ToolCallDiagnosticStage.GUARD)
+        tool.assert_awaited_once()
+
+    async def test_iteration_stops_without_tool_observation(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _dummy_response(),
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+        )
+        resp.__aiter__()
+        resp._tool_result_events.put(
+            Event(type=EventType.TOOL_RESULT, payload={"result": None})
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            await resp.__anext__()
+
+        agent.assert_not_awaited()
+        self.assertTrue(resp._finished)
+        self.assertEqual(
+            event_manager.trigger.await_args.args[0].type,
+            EventType.END,
+        )
+
+    async def test_tool_cycle_guard_rejects_duplicate_and_maximum_cycles(
+        self,
+    ):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={"value": 1})
+        result = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result="ok",
+        )
+        messages = OrchestratorResponse._tool_observation_messages(
+            result,
+            json_output=False,
+        )
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+        )
+
+        self.assertTrue(resp._should_continue_tool_cycle(messages, [result]))
+        self.assertFalse(resp._should_continue_tool_cycle(messages, [result]))
+
+        limited = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+        )
+        limited._MAXIMUM_TOOL_CYCLES = 0
+        self.assertFalse(
+            limited._should_continue_tool_cycle(messages, [result])
+        )
+
+    async def test_null_tool_result_projects_empty_observation(self):
+        call = ToolCall(id="call1", name="calc", arguments={})
+        result = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result=None,
+        )
+
+        messages = OrchestratorResponse._tool_observation_messages(
+            result,
+            json_output=False,
+        )
+
+        self.assertEqual(messages[-1].content, "")
 
     async def test_unanchored_diagnostic_uses_recovery_message(self):
         diagnostic = ToolCallDiagnostic(

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -559,6 +559,12 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(result, "r")
         agent.assert_awaited_once()
         tool.assert_awaited_once()
+        events = [
+            call.args[0] for call in event_manager.trigger.await_args_list
+        ]
+        self.assertFalse(
+            any(event.type is EventType.TOOL_DIAGNOSTIC for event in events)
+        )
 
     async def test_to_str_with_structured_tool_call_token(self):
         engine = _DummyEngine()
@@ -706,6 +712,29 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         payload = loads(str(diagnostic_message.content))
         self.assertEqual(payload["code"], "tool.unknown")
         self.assertEqual(payload["requested_name"], "missing")
+        events = [
+            call.args[0] for call in event_manager.trigger.await_args_list
+        ]
+        diagnostic_events = [
+            event
+            for event in events
+            if event.type is EventType.TOOL_DIAGNOSTIC
+        ]
+        result_events = [
+            event for event in events if event.type is EventType.TOOL_RESULT
+        ]
+        self.assertEqual(len(diagnostic_events), 1)
+        self.assertEqual(len(result_events), 1)
+        diagnostic_event = diagnostic_events[0]
+        diagnostic_payload = diagnostic_event.payload
+        result_payload = result_events[0].payload
+        assert diagnostic_payload is not None
+        assert result_payload is not None
+        self.assertEqual(diagnostic_payload["call"], call)
+        self.assertIs(diagnostic_payload["diagnostic"], diagnostic)
+        self.assertEqual(diagnostic_payload["diagnostics"], [diagnostic])
+        self.assertIs(diagnostic_payload["result"], diagnostic)
+        self.assertIs(result_payload["result"], diagnostic)
 
     async def test_to_str_stops_after_consecutive_non_executed_cycles(self):
         engine = _DummyEngine()

--- a/tests/agent/tool_call_parser_extra_test.py
+++ b/tests/agent/tool_call_parser_extra_test.py
@@ -2,14 +2,53 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 
 from avalan.entities import (
+    ToolCallDiagnostic,
     ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallParseOutcome,
     ToolCallToken,
     ToolFormat,
+    ToolManagerSettings,
 )
 from avalan.event import EventType
 from avalan.model.response.parsers.tool import ToolCallResponseParser
 from avalan.tool.manager import ToolManager
 from avalan.tool.parser import ToolCallParser
+
+
+class DiagnosticFallbackToolManager(ToolManager):
+    def parse_calls(self, text: str) -> ToolCallParseOutcome:
+        return ToolCallParseOutcome()
+
+    def stream_buffer_diagnostics(
+        self, buffer: str
+    ) -> list[ToolCallDiagnostic]:
+        return [
+            ToolCallDiagnostic(
+                id="diagnostic-1",
+                code=ToolCallDiagnosticCode.MALFORMED_CALL,
+                stage=ToolCallDiagnosticStage.PARSE,
+                message="Tool call stream is malformed.",
+            )
+        ]
+
+
+class NoDiagnosticToolManager(ToolManager):
+    def parse_calls(self, text: str) -> ToolCallParseOutcome:
+        return ToolCallParseOutcome()
+
+    def stream_buffer_diagnostics(
+        self, buffer: str
+    ) -> list[ToolCallDiagnostic]:
+        return []
+
+
+class CapturingToolManager(ToolManager):
+    parsed_texts: list[str]
+
+    def parse_calls(self, text: str) -> ToolCallParseOutcome:
+        self.parsed_texts.append(text)
+        return super().parse_calls(text)
 
 
 class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
@@ -37,12 +76,12 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         event_manager.trigger = AsyncMock()
 
         parser = ToolCallResponseParser(manager, event_manager)
-        items = await parser.push("<tool_call>")
+        items = await parser.push("<tool_call></tool_call>")
 
         self.assertIsInstance(items[0], ToolCallToken)
         self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
         event_manager.trigger.assert_awaited_once()
-        manager.get_calls.assert_called_once_with("<tool_call>")
+        manager.get_calls.assert_called_once_with("<tool_call></tool_call>")
         self.assertEqual(parser._buffer.getvalue(), "")
         self.assertFalse(parser._inside_call)
 
@@ -80,6 +119,82 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         manager.get_calls.assert_called_once_with('<tool_call name="calc"/>')
         self.assertFalse(parser._inside_call)
         self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_self_closing_tag_with_gt_attribute_value(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push(
+            '<tool_call name="math.calculator" arguments=\'{"expression": '
+            '"1 > 0"}\'/> tail'
+        )
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(
+            items[0].token,
+            '<tool_call name="math.calculator" arguments=\'{"expression": '
+            '"1 > 0"}\'/>',
+        )
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[1].payload[0].name, "math.calculator")
+        self.assertEqual(
+            items[1].payload[0].arguments,
+            {"expression": "1 > 0"},
+        )
+        self.assertEqual(items[2], " tail")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " tail")
+
+    async def test_self_closing_tag_with_inner_attribute_quote(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push(
+            '<tool_call name="math.calculator" arguments=\'{"phrase": '
+            '"rock \', roll", "expression": "1 > 0"}\'/> tail'
+        )
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(
+            items[0].token,
+            '<tool_call name="math.calculator" arguments=\'{"phrase": '
+            '"rock \', roll", "expression": "1 > 0"}\'/>',
+        )
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[1].payload[0].name, "math.calculator")
+        self.assertEqual(
+            items[1].payload[0].arguments,
+            {"phrase": "rock ', roll", "expression": "1 > 0"},
+        )
+        self.assertEqual(items[2], " tail")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " tail")
+
+    async def test_quoted_self_close_marker_keeps_tag_open(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push(
+            '<tool_call name="math.calculator" arguments=\'{"expression": '
+            '"/>"}\'>'
+        )
+        flushed = await parser.flush()
+
+        self.assertEqual(len(pushed), 1)
+        self.assertIsInstance(pushed[0], ToolCallToken)
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+        self.assertFalse(parser._inside_call)
 
     async def test_harmony_long_call_followed_by_final_channel(self):
         manager = MagicMock()
@@ -173,6 +288,144 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(trigger_event.type, EventType.TOOL_DETECT)
         self.assertFalse(parser._inside_call)
 
+    async def test_harmony_final_channel_closes_missing_call_marker(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(tool_format=ToolFormat.HARMONY),
+        )
+        parser = ToolCallResponseParser(manager, None)
+        text = (
+            "<|start|>assistant<|channel|>commentary "
+            "to=functions.browser.open <|constrain|>json<|message|>"
+            '{"url":"https://example.com"}'
+        )
+
+        first = await parser.push(text)
+        second = await parser.push("<|channel|>final<|message|>")
+        third = await parser.push("done")
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertEqual(len(second), 2)
+        self.assertEqual(second[0].type, EventType.TOOL_PROCESS)
+        call = second[0].payload[0]
+        self.assertEqual(call.name, "browser.open")
+        self.assertEqual(call.arguments, {"url": "https://example.com"})
+        self.assertEqual(second[1], "<|channel|>final<|message|>")
+        self.assertEqual(third, ["done"])
+        self.assertEqual(
+            parser._buffer.getvalue(),
+            "<|channel|>final<|message|>done",
+        )
+        self.assertFalse(parser._inside_call)
+
+    async def test_harmony_final_channel_splits_from_whole_token(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(tool_format=ToolFormat.HARMONY),
+        )
+        parser = ToolCallResponseParser(manager, None)
+        text = (
+            "<|start|>assistant<|channel|>commentary "
+            "to=functions.browser.open <|constrain|>json<|message|>"
+            '{"url":"https://example.com"}'
+        )
+
+        items = await parser.push(text + "<|channel|>final<|message|>done")
+
+        self.assertEqual(len(items), 3)
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[0].token, text)
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[1].payload[0].name, "browser.open")
+        self.assertEqual(
+            items[1].payload[0].arguments,
+            {"url": "https://example.com"},
+        )
+        self.assertEqual(items[2], "<|channel|>final<|message|>done")
+        self.assertEqual(
+            parser._buffer.getvalue(),
+            "<|channel|>final<|message|>done",
+        )
+
+    async def test_harmony_final_channel_diagnoses_malformed_call(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(tool_format=ToolFormat.HARMONY),
+        )
+        parser = ToolCallResponseParser(manager, None)
+        text = (
+            "<|start|>assistant<|channel|>commentary "
+            "to=functions.browser.open <|constrain|>json<|message|>"
+            '{"url":}'
+        )
+
+        await parser.push(text)
+        items = await parser.push("<|channel|>final<|message|>")
+
+        self.assertEqual(len(items), 2)
+        diagnostic_event = items[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].requested_name, "browser.open")
+        self.assertEqual(diagnostics[0].details["stream_status"], "malformed")
+        self.assertEqual(items[1], "<|channel|>final<|message|>")
+        self.assertFalse(parser._inside_call)
+
+    def test_split_current_call_close_skips_preexisting_harmony_final(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(tool_format=ToolFormat.HARMONY),
+        )
+        parser = ToolCallResponseParser(manager, None)
+        text = (
+            "<|channel|>commentary to=functions.browser.open"
+            '<|message|>{"url":"https://example.com"}'
+            "<|channel|>final<|message|>done"
+        )
+
+        self.assertIsNone(parser._split_current_call_close(text, len(text)))
+
+    async def test_tool_manager_mock_uses_legacy_get_calls(self) -> None:
+        manager = MagicMock(spec=ToolManager)
+        manager.is_potential_tool_call.return_value = True
+        manager.tool_format = ToolFormat.HARMONY
+        base_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
+        manager.get_calls.side_effect = base_parser
+        manager.parse_calls.side_effect = AssertionError(
+            "parse_calls should not be used"
+        )
+
+        parser = ToolCallResponseParser(manager, None)
+        await parser.push(
+            "<|start|>assistant<|channel|>commentary "
+            "to=functions.browser.open <|constrain|>json<|message|>"
+            '{"url":"https://example.com"}'
+        )
+        flushed = await parser.flush()
+
+        self.assertEqual(len(flushed), 1)
+        event = flushed[0]
+        self.assertEqual(event.type, EventType.TOOL_PROCESS)
+        call = event.payload[0]
+        self.assertEqual(call.name, "browser.open")
+        self.assertGreaterEqual(manager.get_calls.call_count, 1)
+        manager.parse_calls.assert_not_called()
+
     async def test_pending_tokens_flushed_on_status_none(self):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = False
@@ -187,6 +440,836 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(parser._pending_tokens, [])
         self.assertEqual(parser._pending_str, "")
 
+    async def test_visible_text_before_split_tool_marker_is_preserved(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push("answer <to")
+        second = await parser.push(
+            'ol_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        self.assertEqual(first, ["answer "])
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[0].token, "<to")
+        self.assertEqual(second[-1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(second[-1].payload[0].name, "math.calculator")
+        self.assertEqual(second[-1].payload[0].arguments, {"x": 1})
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_angle_text_before_closed_tool_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        items = await parser.push("answer <x " + tool_text)
+
+        self.assertEqual(items[0], "answer <x ")
+        self.assertIsInstance(items[1], ToolCallToken)
+        self.assertEqual(items[1].token, tool_text)
+        self.assertEqual(items[-1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[-1].payload[0].name, "math.calculator")
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_quoted_visible_marker_before_tool_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call name="math.calculator" arguments=\'{"x": 1}\'/>'
+        )
+
+        items = await parser.push('answer "<tool_call" ' + tool_text + " done")
+
+        self.assertEqual(items[0], 'answer "<tool_call" ')
+        self.assertIsInstance(items[1], ToolCallToken)
+        self.assertEqual(items[1].token, tool_text)
+        self.assertEqual(items[2].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[2].payload[0].name, "math.calculator")
+        self.assertEqual(items[2].payload[0].arguments, {"x": 1})
+        self.assertEqual(items[3], " done")
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_split_quoted_visible_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call name="math.calculator" arguments=\'{"x": 1}\'/>'
+        )
+
+        first = await parser.push('answer "<to')
+        second = await parser.push('ol_call" ')
+        third = await parser.push(tool_text)
+
+        self.assertEqual(first, ['answer "<to'])
+        self.assertEqual(second, ['ol_call" '])
+        self.assertIsInstance(third[0], ToolCallToken)
+        self.assertEqual(third[0].token, tool_text)
+        self.assertEqual(third[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(third[1].payload[0].arguments, {"x": 1})
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_visible_apostrophe_before_tool_does_not_block_call(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call name="math.calculator" arguments=\'{"x": 1}\'/>'
+        )
+
+        items = await parser.push("don't " + tool_text)
+
+        self.assertEqual(items[0], "don't ")
+        self.assertIsInstance(items[1], ToolCallToken)
+        self.assertEqual(items[1].token, tool_text)
+        self.assertEqual(items[2].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[2].payload[0].arguments, {"x": 1})
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_only_quoted_visible_marker_does_not_trigger_tool_event(
+        self,
+    ) -> None:
+        manager = MagicMock()
+        manager.is_potential_tool_call.return_value = True
+        base_parser = ToolCallParser()
+        manager.tool_call_status.side_effect = base_parser.tool_call_status
+        manager.get_calls.side_effect = AssertionError(
+            "quoted marker should stay visible"
+        )
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push('answer "<tool_call" only')
+        flushed = await parser.flush()
+
+        self.assertEqual(items, ['answer "<tool_call" only'])
+        self.assertEqual(flushed, [])
+        manager.get_calls.assert_not_called()
+
+    async def test_next_line_tool_after_unclosed_quote_executes(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push('Visible "quoted text\n')
+        second = await parser.push(
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"expression": "1 + 1"}}</tool_call>'
+        )
+
+        process_event = next(
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+
+        self.assertEqual(first, ['Visible "quoted text\n'])
+        self.assertEqual(process_event.payload[0].name, "math.calculator")
+        self.assertEqual(
+            process_event.payload[0].arguments,
+            {"expression": "1 + 1"},
+        )
+        self.assertEqual(await parser.flush(), [])
+
+    async def test_same_line_tool_after_unclosed_quote_stays_visible(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+        text = (
+            'Visible "quoted <tool_call>{"name": "math.calculator", '
+            '"arguments": {}}</tool_call>'
+        )
+
+        items = await parser.push(text)
+
+        self.assertEqual(items, [text])
+        self.assertEqual(await parser.flush(), [])
+
+    async def test_text_after_closed_tool_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        items = await parser.push("answer " + tool_text + " done")
+
+        self.assertEqual(items[0], "answer ")
+        self.assertIsInstance(items[1], ToolCallToken)
+        self.assertEqual(items[1].token, tool_text)
+        self.assertEqual(items[2].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[2].payload[0].name, "math.calculator")
+        self.assertEqual(items[2].payload[0].arguments, {"x": 1})
+        self.assertEqual(items[3], " done")
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+        self.assertEqual(parser._buffer.getvalue(), " done")
+
+    async def test_slash_close_text_after_tool_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {}}</tool_call>'
+        )
+
+        items = await parser.push(tool_text + " visible /> tail")
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[0].token, tool_text)
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[2], " visible /> tail")
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_slash_close_inside_json_string_keeps_stream_open(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": {"x": "/>"}}'
+        )
+        self.assertTrue(parser._inside_call)
+        second = await parser.push("</tool_call> done")
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(second[1].payload[0].arguments, {"x": "/>"})
+        self.assertEqual(second[2], " done")
+
+    async def test_self_closing_marker_inside_json_string_keeps_stream_open(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "<tool_call name=\\"inner\\"/>"}}'
+        )
+        self.assertTrue(parser._inside_call)
+        second = await parser.push("</tool_call> done")
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(
+            second[1].payload[0].arguments,
+            {"text": '<tool_call name="inner"/>'},
+        )
+        self.assertEqual(second[2], " done")
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "<tool_call name=\\"inner\\"/>"}}</tool_call>',
+        )
+
+    async def test_nested_marker_string_keeps_stream_open(self) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "<tool_call></tool_call>"}}'
+        )
+        self.assertTrue(parser._inside_call)
+        second = await parser.push("</tool_call> done")
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(
+            second[1].payload[0].arguments,
+            {"text": "<tool_call></tool_call>"},
+        )
+        self.assertEqual(second[2], " done")
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "<tool_call></tool_call>"}}</tool_call>',
+        )
+
+    async def test_close_marker_inside_json_string_keeps_stream_open(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "</tool_call>"}}'
+        )
+        self.assertTrue(parser._inside_call)
+        second = await parser.push("</tool_call> done")
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(
+            second[1].payload[0].arguments,
+            {"text": "</tool_call>"},
+        )
+        self.assertEqual(second[2], " done")
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "</tool_call>"}}</tool_call>',
+        )
+
+    async def test_split_close_marker_inside_json_string_keeps_stream_open(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": {"text": "'
+        )
+        self.assertTrue(parser._inside_call)
+        second = await parser.push('</tool_call>"}}</tool_call> done')
+
+        self.assertEqual(len(first), 1)
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(
+            second[1].payload[0].arguments,
+            {"text": "</tool_call>"},
+        )
+        self.assertEqual(second[2], " done")
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "</tool_call>"}}</tool_call>',
+        )
+
+    async def test_split_quoted_close_marker_without_close_diagnoses_stream(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = []
+        pushed.extend(
+            await parser.push(
+                '<tool_call>{"name": "math.calculator", "arguments": '
+                '{"text": "'
+            )
+        )
+        pushed.extend(await parser.push('</tool_call>"}}'))
+        flushed = await parser.flush()
+
+        self.assertTrue(
+            all(isinstance(item, ToolCallToken) for item in pushed)
+        )
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+
+    async def test_quoted_close_marker_without_close_reports_diagnostic(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push(
+            '<tool_call>{"name": "math.calculator", "arguments": '
+            '{"text": "</tool_call>"}}'
+        )
+        flushed = await parser.flush()
+
+        self.assertTrue(
+            all(isinstance(item, ToolCallToken) for item in pushed)
+        )
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+
+    async def test_closed_tool_marker_without_suffix_has_no_text_tail(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        items = await parser.push(tool_text)
+
+        self.assertEqual(len(items), 2)
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[0].token, tool_text)
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(manager.parsed_texts[-1], tool_text)
+
+    async def test_angle_text_before_split_tool_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+        tool_remainder = (
+            'ol_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        first = await parser.push("answer <x <to")
+        second = await parser.push(tool_remainder)
+
+        self.assertEqual(first, ["answer <x "])
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[0].token, "<to")
+        self.assertIsInstance(second[1], ToolCallToken)
+        self.assertEqual(second[1].token, tool_remainder)
+        self.assertEqual(second[-1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(second[-1].payload[0].arguments, {"x": 1})
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            "<tool_call>"
+            '{"name": "math.calculator", "arguments": {"x": 1}}'
+            "</tool_call>",
+        )
+
+    async def test_stale_pending_prefix_before_tool_marker_stays_visible(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push("<to")
+        second = await parser.push(
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        self.assertEqual(first, [])
+        self.assertEqual(second[0], "<to")
+        self.assertIsInstance(second[1], ToolCallToken)
+        self.assertTrue(second[1].token.startswith("<tool_call>"))
+        self.assertEqual(second[-1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(second[-1].payload[0].name, "math.calculator")
+        self.assertEqual(second[-1].payload[0].arguments, {"x": 1})
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>',
+        )
+
+    async def test_stale_pending_prefix_before_new_partial_marker_flushes_text(
+        self,
+    ) -> None:
+        manager = CapturingToolManager.create_instance(enable_tools=[])
+        assert isinstance(manager, CapturingToolManager)
+        manager.parsed_texts = []
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push("<to")
+        second = await parser.push(" visible <tool")
+        third = await parser.push(
+            '_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        self.assertEqual(first, [])
+        self.assertEqual(second, ["<to visible "])
+        self.assertIsInstance(third[0], ToolCallToken)
+        self.assertEqual(third[0].token, "<tool")
+        self.assertIsInstance(third[1], ToolCallToken)
+        self.assertEqual(third[-1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(third[-1].payload[0].arguments, {"x": 1})
+        self.assertEqual(
+            manager.parsed_texts[-1],
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>',
+        )
+
+    async def test_non_marker_text_with_angle_bracket_is_not_split(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        result = await parser.push("answer <x")
+
+        self.assertEqual(result, ["answer <x"])
+        self.assertEqual(parser._pending_tokens, [])
+        self.assertEqual(parser._pending_str, "")
+
+    async def test_markdown_fenced_tool_call_stays_visible(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+        text = (
+            "```xml\n"
+            '<tool_call>{"name": "math.calculator", "arguments": {}}'
+            "</tool_call>\n"
+            "```"
+        )
+
+        pushed = await parser.push(text)
+        flushed = await parser.flush()
+
+        self.assertEqual(pushed, [text])
+        self.assertEqual(flushed, [])
+        event_manager.trigger.assert_not_awaited()
+        self.assertEqual(parser._pending_tokens, [])
+        self.assertEqual(parser._pending_str, "")
+
+    async def test_split_markdown_fenced_tool_call_stays_visible(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+
+        first = await parser.push("```xml\n<to")
+        second = await parser.push(
+            'ol_call>{"name": "math.calculator", "arguments": {}}'
+            "</tool_call>\n```"
+        )
+        flushed = await parser.flush()
+
+        self.assertEqual(first, ["```xml\n<to"])
+        self.assertEqual(
+            second,
+            [
+                'ol_call>{"name": "math.calculator", "arguments": {}}'
+                "</tool_call>\n```"
+            ],
+        )
+        self.assertEqual(flushed, [])
+        event_manager.trigger.assert_not_awaited()
+
+    async def test_tool_call_after_closed_markdown_fence_executes(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+        tool_text = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        items = await parser.push("```xml\n<tool_call></tool_call>\n```\n")
+        items.extend(await parser.push(tool_text))
+
+        self.assertEqual(items[0], "```xml\n<tool_call></tool_call>\n```\n")
+        self.assertIsInstance(items[1], ToolCallToken)
+        self.assertEqual(items[1].token, tool_text)
+        self.assertEqual(items[2].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[2].payload[0].name, "math.calculator")
+        self.assertEqual(items[2].payload[0].arguments, {"x": 1})
+
+    async def test_fence_opened_after_tool_suffix_blocks_next_call(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+        first_tool = (
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+        fenced_tool = (
+            '<tool_call>{"name": "should.not_run", '
+            '"arguments": {}}</tool_call>\n```'
+        )
+
+        first = await parser.push(first_tool + "\n```xml\n")
+        second = await parser.push(fenced_tool)
+
+        self.assertIsInstance(first[0], ToolCallToken)
+        self.assertEqual(first[0].token, first_tool)
+        self.assertEqual(first[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(first[1].payload[0].name, "math.calculator")
+        self.assertEqual(first[2], "\n```xml\n")
+        self.assertEqual(second, [fenced_tool])
+        self.assertEqual(
+            [
+                call.args[0].type
+                for call in event_manager.trigger.await_args_list
+            ],
+            [EventType.TOOL_DETECT],
+        )
+
+    def test_split_visible_prefix_rejects_unconfirmed_marker(self) -> None:
+        manager = MagicMock()
+        manager.tool_call_status.return_value = (
+            ToolCallParser.ToolCallBufferStatus.NONE
+        )
+        parser = ToolCallResponseParser(manager, None)
+
+        result = parser._split_visible_prefix(
+            "answer <tool_call>",
+            ToolCallParser.ToolCallBufferStatus.NONE,
+        )
+
+        self.assertEqual(result, (None, "answer <tool_call>"))
+
+    def test_split_closed_visible_suffix_keeps_adjacent_tool_marker(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+        text = '<tool_call name="first"/> <tool_call'
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(text),
+            (text, ""),
+        )
+
+    def test_split_closed_visible_suffix_handles_dsml_suffix(self) -> None:
+        manager = MagicMock()
+        manager.tool_format = ToolFormat.DSML
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(
+                "<tool_calls></tool_calls> done"
+            ),
+            ("<tool_calls></tool_calls>", " done"),
+        )
+
+    def test_split_closed_visible_suffix_ignores_slash_close_in_text(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+        text = '<tool_call name="first"></tool_call> visible /> tail'
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(text),
+            ('<tool_call name="first"></tool_call>', " visible /> tail"),
+        )
+
+    def test_split_closed_visible_suffix_handles_self_closing_tag(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(
+                '<tool_call name="first"/> done'
+            ),
+            ('<tool_call name="first"/>', " done"),
+        )
+
+    def test_split_closed_visible_suffix_skips_quoted_close_marker(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(
+                '<tool_call>{"name": "calculator", "arguments": '
+                '{"text": "</tool_call>"}}</tool_call> done'
+            ),
+            (
+                (
+                    '<tool_call>{"name": "calculator", "arguments": '
+                    '{"text": "</tool_call>"}}</tool_call>'
+                ),
+                " done",
+            ),
+        )
+
+    def test_split_closed_visible_suffix_skips_escaped_marker(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix(
+                '<tool_call>{"name": "calculator", "arguments": '
+                '{"text": "\\</tool_call>"}}</tool_call> done'
+            ),
+            (
+                (
+                    '<tool_call>{"name": "calculator", "arguments": '
+                    '{"text": "\\</tool_call>"}}</tool_call>'
+                ),
+                " done",
+            ),
+        )
+
+    def test_split_current_call_close_skips_fenced_markers(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertIsNone(
+            parser._split_current_call_close(
+                '<tool_call>{"name": "calculator", "arguments": {}}\n'
+                "```xml\n"
+                "</tool_call>\n"
+                "```",
+                0,
+            )
+        )
+
+    def test_split_current_call_close_handles_self_closing_tag(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_current_call_close(
+                '<tool_call name="first"/> tail',
+                len("<tool_call"),
+            ),
+            ('<tool_call name="first"/>', " tail"),
+        )
+
+    def test_split_current_call_close_skips_preexisting_self_close(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+        first = '<tool_call name="first"/>'
+        text = first + '<tool_call name="second"/> tail'
+
+        self.assertEqual(
+            parser._split_current_call_close(text, len(first) + 1),
+            (
+                '<tool_call name="first"/><tool_call name="second"/>',
+                " tail",
+            ),
+        )
+
+    def test_self_closing_tool_end_indexes_handles_open_tag(self) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            list(parser._self_closing_tool_end_indexes("<tool_call")),
+            [],
+        )
+
+    def test_self_closing_tool_end_indexes_include_close_positions(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        indexes = list(
+            parser._self_closing_tool_end_indexes(
+                '<tool_call name="first"/><tool name="second"/>'
+            )
+        )
+
+        self.assertEqual(indexes, [25, 46])
+
+    def test_marker_indexes_returns_all_matches(self) -> None:
+        self.assertEqual(
+            list(
+                ToolCallResponseParser._marker_indexes(
+                    "</tool> text </tool>", "</tool>"
+                )
+            ),
+            [0, 13],
+        )
+
+    def test_visible_quote_detection_handles_escapes_and_single_quotes(
+        self,
+    ) -> None:
+        parser = ToolCallResponseParser(MagicMock(), None)
+        escaped_quote = r'"quoted \" marker <tool_call'
+        single_quote = "'<tool_call'"
+
+        self.assertTrue(
+            parser._index_is_inside_visible_quote(
+                escaped_quote, escaped_quote.index("<tool_call")
+            )
+        )
+        self.assertTrue(
+            parser._index_is_inside_visible_quote(
+                single_quote, single_quote.index("<tool_call")
+            )
+        )
+        self.assertFalse(
+            parser._index_is_inside_visible_quote(
+                "don't <tool_call", len("don't ")
+            )
+        )
+
+    def test_split_closed_visible_suffix_without_close_marker(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        self.assertEqual(
+            parser._split_closed_visible_suffix("<tool_call>"),
+            ("<tool_call>", ""),
+        )
+
     async def test_flush_returns_pending_tokens(self):
         manager = MagicMock()
         manager.is_potential_tool_call.return_value = False
@@ -199,6 +1282,68 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(await parser.flush(), ["<tool"])
         self.assertEqual(parser._pending_tokens, [])
         self.assertEqual(parser._pending_str, "")
+
+    async def test_flush_pending_tool_prefix_emits_diagnostic_event(self):
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push("<tool")
+        flushed = await parser.flush()
+
+        self.assertEqual(pushed, [])
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+        self.assertEqual(parser._pending_tokens, [])
+        self.assertEqual(parser._pending_str, "")
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_flush_split_pending_tool_prefix_emits_diagnostic_event(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push("answer <tool")
+        flushed = await parser.flush()
+
+        self.assertEqual(pushed, ["answer "])
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+        self.assertEqual(parser._pending_tokens, [])
+        self.assertEqual(parser._pending_str, "")
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_flush_unsplit_angle_text_returns_plain_text(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push("answer <x")
+        flushed = await parser.flush()
+
+        self.assertEqual(pushed, ["answer <x"])
+        self.assertEqual(flushed, [])
 
     async def test_open_status_returns_empty_without_tokens(self):
         manager = MagicMock()
@@ -217,6 +1362,54 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(await parser.push("<tool_call>"), [])
         self.assertTrue(parser._inside_call)
+
+    async def test_inside_call_rechecks_full_buffer_before_parsing(self):
+        manager = MagicMock()
+        manager.is_potential_tool_call.return_value = True
+        call = MagicMock()
+        manager.get_calls.return_value = [call]
+
+        def _status(buffer: str):
+            if buffer == "prefixEND":
+                return ToolCallParser.ToolCallBufferStatus.CLOSED
+            return ToolCallParser.ToolCallBufferStatus.OPEN
+
+        manager.tool_call_status.side_effect = _status
+        parser = ToolCallResponseParser(manager, None)
+        parser._inside_call = True
+        parser._buffer.write("prefix")
+        parser._tool_buffer.write("prefix")
+        parser._tag_buffer = "tail"
+
+        items = await parser.push("END")
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[1].payload, [call])
+        self.assertFalse(parser._inside_call)
+        manager.get_calls.assert_called_once_with("prefixEND")
+
+    async def test_inside_call_full_buffer_recheck_can_close_stream(self):
+        manager = MagicMock()
+        manager.is_potential_tool_call.return_value = True
+        call = MagicMock()
+        manager.get_calls.return_value = [call]
+        manager.tool_call_status.side_effect = [
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        ]
+        parser = ToolCallResponseParser(manager, None)
+        parser._inside_call = True
+        parser._buffer.write("prefix")
+        parser._tool_buffer.write("prefix")
+
+        items = await parser.push("END")
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(items[1].payload, [call])
+        self.assertFalse(parser._inside_call)
+        manager.get_calls.assert_called_once_with("prefixEND")
 
     async def test_closed_malformed_stream_emits_diagnostic_event(self):
         manager = ToolManager.create_instance(enable_tools=[])
@@ -252,6 +1445,330 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
                 for call in event_manager.trigger.await_args_list
             )
         )
+
+    async def test_malformed_tool_tag_stream_emits_diagnostic_event(self):
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push("<tool>not json</tool>")
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        diagnostic_event = items[-1]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].details["stream_status"], "malformed")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_stream_with_call_and_diagnostic_emits_both_events(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+
+        items = await parser.push(
+            '<tool_call>{"name": "bad..name", "arguments": {}}</tool_call>'
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        diagnostic_event = next(
+            item
+            for item in items
+            if getattr(item, "type", None) is EventType.TOOL_DIAGNOSTIC
+        )
+        process_event = next(
+            item
+            for item in items
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+        diagnostics = diagnostic_event.payload["diagnostics"]
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].requested_name, "bad..name")
+        self.assertEqual(process_event.payload[0].name, "math.calculator")
+        self.assertEqual(process_event.payload[0].arguments, {"x": 1})
+        self.assertEqual(
+            [
+                call.args[0].type
+                for call in event_manager.trigger.await_args_list
+            ],
+            [EventType.TOOL_DETECT, EventType.TOOL_DIAGNOSTIC],
+        )
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_stream_defers_complete_call_before_open_sibling(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "first", "arguments": {}}</tool_call>'
+            ' between <tool_call>{"name": "second", "arguments": {}'
+        )
+        second = await parser.push("}</tool_call> after")
+
+        self.assertTrue(all(isinstance(item, ToolCallToken) for item in first))
+        self.assertFalse(
+            any(
+                getattr(item, "type", None) is EventType.TOOL_PROCESS
+                for item in first
+            )
+        )
+        self.assertIsInstance(second[0], ToolCallToken)
+        process_event = next(
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+        self.assertEqual(
+            [call.name for call in process_event.payload],
+            ["first", "second"],
+        )
+        self.assertEqual(second[-1], " after")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " after")
+
+    async def test_stream_defers_complete_call_before_mixed_open_sibling(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "first", "arguments": {}}</tool_call>'
+            ' between <tool name="second">{"value": '
+        )
+        second = await parser.push("2}</tool> after")
+
+        self.assertTrue(all(isinstance(item, ToolCallToken) for item in first))
+        self.assertFalse(
+            any(
+                getattr(item, "type", None) is EventType.TOOL_PROCESS
+                for item in first
+            )
+        )
+        self.assertIsInstance(second[0], ToolCallToken)
+        process_event = next(
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+
+        self.assertEqual(
+            [call.name for call in process_event.payload],
+            ["first", "second"],
+        )
+        self.assertEqual(process_event.payload[1].arguments, {"value": 2})
+        self.assertEqual(second[-1], " after")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " after")
+
+    async def test_stream_processes_call_after_closed_call_suffix(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "first", "arguments": {}}'
+        )
+        second = await parser.push(
+            '</tool_call> between <tool_call>{"name": "second", '
+            '"arguments": {"value": '
+        )
+        third = await parser.push("2}}</tool_call> tail")
+
+        self.assertTrue(all(isinstance(item, ToolCallToken) for item in first))
+        process_events = [
+            item
+            for item in second + third
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        ]
+
+        self.assertEqual(
+            [event.payload[0].name for event in process_events],
+            ["first", "second"],
+        )
+        self.assertEqual(process_events[1].payload[0].arguments, {"value": 2})
+        self.assertIn(" between ", second)
+        self.assertEqual(third[-1], " tail")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " tail")
+
+    async def test_stream_preserves_suffix_after_split_close_marker(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "first", "arguments": {}}</tool'
+        )
+        second = await parser.push("_call> tail")
+
+        self.assertTrue(all(isinstance(item, ToolCallToken) for item in first))
+        self.assertIsInstance(second[0], ToolCallToken)
+        self.assertEqual(second[0].token, "_call>")
+        self.assertEqual(second[1].type, EventType.TOOL_PROCESS)
+        self.assertEqual(second[1].payload[0].name, "first")
+        self.assertEqual(second[2], " tail")
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), " tail")
+
+    async def test_stream_keeps_fenced_call_after_closed_call_visible(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+        fenced_suffix = (
+            "\n```xml\n"
+            '<tool_call>{"name": "second", "arguments": {}}</tool_call>\n'
+            "```"
+        )
+
+        await parser.push('<tool_call>{"name": "first", "arguments": {}}')
+        second = await parser.push("</tool_call>" + fenced_suffix)
+
+        process_events = [
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        ]
+
+        self.assertEqual(len(process_events), 1)
+        self.assertEqual(process_events[0].payload[0].name, "first")
+        self.assertEqual(second[-1], fenced_suffix)
+        self.assertEqual(parser._buffer.getvalue(), fenced_suffix)
+        self.assertEqual(
+            [
+                call.args[0].type
+                for call in event_manager.trigger.await_args_list
+            ],
+            [EventType.TOOL_DETECT, EventType.TOOL_DETECT],
+        )
+
+    async def test_stream_reports_malformed_open_sibling_after_valid_call(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        first = await parser.push(
+            '<tool_call>{"name": "first", "arguments": {}}</tool_call>'
+            ' between <tool_call>{"name": "bad..name", "arguments": {}'
+        )
+        second = await parser.push("}</tool_call> tail")
+
+        self.assertFalse(
+            any(
+                getattr(item, "type", None) is EventType.TOOL_PROCESS
+                for item in first
+            )
+        )
+        diagnostic_event = next(
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_DIAGNOSTIC
+        )
+        process_event = next(
+            item
+            for item in second
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+        diagnostics = diagnostic_event.payload["diagnostics"]
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].requested_name, "bad..name")
+        self.assertEqual(
+            [call.name for call in process_event.payload], ["first"]
+        )
+        self.assertEqual(second[-1], " tail")
+        self.assertFalse(parser._inside_call)
+
+    async def test_valid_stream_with_call_emits_no_diagnostic_event(
+        self,
+    ) -> None:
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+
+        items = await parser.push(
+            '<tool_call>{"name": "math.calculator", '
+            '"arguments": {"x": 1}}</tool_call>'
+        )
+
+        self.assertTrue(
+            any(
+                getattr(item, "type", None) is EventType.TOOL_PROCESS
+                for item in items
+            )
+        )
+        self.assertFalse(
+            any(
+                getattr(item, "type", None) is EventType.TOOL_DIAGNOSTIC
+                for item in items
+            )
+        )
+        self.assertEqual(
+            [
+                call.args[0].type
+                for call in event_manager.trigger.await_args_list
+            ],
+            [EventType.TOOL_DETECT],
+        )
+
+    async def test_subclassed_manager_closed_stream_uses_diagnostics(
+        self,
+    ) -> None:
+        manager = DiagnosticFallbackToolManager.create_instance(
+            enable_tools=[]
+        )
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push("<tool_call></tool_call>")
+
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[-1].type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = items[-1].payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(parser._buffer.getvalue(), "")
+
+    async def test_closed_stream_without_diagnostics_returns_tokens(
+        self,
+    ) -> None:
+        manager = NoDiagnosticToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        items = await parser.push("<tool_call></tool_call>")
+
+        self.assertEqual(len(items), 1)
+        self.assertIsInstance(items[0], ToolCallToken)
+        self.assertEqual(items[0].token, "<tool_call></tool_call>")
+        self.assertFalse(parser._inside_call)
 
     async def test_flush_unterminated_stream_emits_diagnostic_event(self):
         manager = ToolManager.create_instance(enable_tools=[])

--- a/tests/agent/tool_call_parser_extra_test.py
+++ b/tests/agent/tool_call_parser_extra_test.py
@@ -1,9 +1,14 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 
-from avalan.entities import ToolCallToken, ToolFormat
+from avalan.entities import (
+    ToolCallDiagnosticCode,
+    ToolCallToken,
+    ToolFormat,
+)
 from avalan.event import EventType
 from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.manager import ToolManager
 from avalan.tool.parser import ToolCallParser
 
 
@@ -212,3 +217,64 @@ class ToolCallParserExtraTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(await parser.push("<tool_call>"), [])
         self.assertTrue(parser._inside_call)
+
+    async def test_closed_malformed_stream_emits_diagnostic_event(self):
+        manager = ToolManager.create_instance(enable_tools=[])
+        event_manager = MagicMock()
+        event_manager.trigger = AsyncMock()
+        parser = ToolCallResponseParser(manager, event_manager)
+
+        items: list = []
+        for part in (
+            "<tool_call>",
+            '{"name": "calculator", "arguments": }',
+            "</tool_call>",
+        ):
+            items.extend(await parser.push(part))
+
+        diagnostic_event = items[-1]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertFalse(parser._inside_call)
+        self.assertEqual(parser._buffer.getvalue(), "")
+        self.assertEqual(
+            event_manager.trigger.await_args_list[0].args[0].type,
+            EventType.TOOL_DETECT,
+        )
+        self.assertTrue(
+            any(
+                call.args[0].type == EventType.TOOL_DIAGNOSTIC
+                for call in event_manager.trigger.await_args_list
+            )
+        )
+
+    async def test_flush_unterminated_stream_emits_diagnostic_event(self):
+        manager = ToolManager.create_instance(enable_tools=[])
+        parser = ToolCallResponseParser(manager, None)
+
+        pushed = await parser.push(
+            '<tool_call>{"name": "calculator", "arguments": {}}'
+        )
+        flushed = await parser.flush()
+
+        self.assertTrue(
+            all(isinstance(token, ToolCallToken) for token in pushed)
+        )
+        self.assertEqual(len(flushed), 1)
+        diagnostic_event = flushed[0]
+        self.assertEqual(diagnostic_event.type, EventType.TOOL_DIAGNOSTIC)
+        diagnostics = diagnostic_event.payload["diagnostics"]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+        self.assertFalse(parser._inside_call)

--- a/tests/agent/tool_call_parser_fixture_test.py
+++ b/tests/agent/tool_call_parser_fixture_test.py
@@ -1,0 +1,104 @@
+from json import loads
+from pathlib import Path
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+
+from avalan.entities import (
+    ToolCallDiagnosticCode,
+    ToolCallToken,
+    ToolFormat,
+    ToolManagerSettings,
+)
+from avalan.event import EventType
+from avalan.model.response.parsers.tool import ToolCallResponseParser
+from avalan.tool.manager import ToolManager
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "tool_parsing"
+
+
+def read_json_fixture(name: str) -> Any:
+    return loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class ToolCallParserFixtureTestCase(IsolatedAsyncioTestCase):
+    async def test_marker_stream_boundaries(self) -> None:
+        cases = read_json_fixture("stream_marker_boundaries.json")
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                manager = ToolManager.create_instance(enable_tools=[])
+                parser = ToolCallResponseParser(manager, None)
+                items: list[Any] = []
+
+                for token in case["tokens"]:
+                    items.extend(await parser.push(token))
+                if case.get("flush"):
+                    items.extend(await parser.flush())
+
+                event_name = case["event"]
+                if event_name is None:
+                    self.assertEqual(items, case["strings"])
+                    continue
+
+                event_type = (
+                    EventType.TOOL_PROCESS
+                    if event_name == "tool_process"
+                    else EventType.TOOL_DIAGNOSTIC
+                )
+                event = next(
+                    item
+                    for item in items
+                    if getattr(item, "type", None) is event_type
+                )
+                self.assertEqual(event.type, event_type)
+
+                strings = [item for item in items if isinstance(item, str)]
+                self.assertEqual(strings, case.get("strings", []))
+
+                if event_type is EventType.TOOL_PROCESS:
+                    call = event.payload[0]
+                    self.assertEqual(call.name, case["call"]["name"])
+                    self.assertEqual(
+                        call.arguments,
+                        case["call"]["arguments"],
+                    )
+                    continue
+
+                diagnostics = event.payload["diagnostics"]
+                self.assertEqual(len(diagnostics), 1)
+                self.assertEqual(
+                    diagnostics[0].code,
+                    ToolCallDiagnosticCode[case["diagnostic_code"]],
+                )
+                if "stream_status" in case:
+                    self.assertEqual(
+                        diagnostics[0].details["stream_status"],
+                        case["stream_status"],
+                    )
+
+    async def test_harmony_stream_suppresses_call_bytes(self) -> None:
+        fixture = read_json_fixture("stream_harmony_split_call.json")
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(tool_format=ToolFormat.HARMONY),
+        )
+        parser = ToolCallResponseParser(manager, None)
+        items: list[Any] = []
+
+        for token in fixture["tokens"]:
+            items.extend(await parser.push(token))
+
+        event = next(
+            item
+            for item in items
+            if getattr(item, "type", None) is EventType.TOOL_PROCESS
+        )
+        call = event.payload[0]
+
+        self.assertEqual(call.name, fixture["call"]["name"])
+        self.assertEqual(call.arguments, fixture["call"]["arguments"])
+        self.assertEqual(
+            [item for item in items if isinstance(item, str)],
+            fixture["strings"],
+        )
+        self.assertTrue(any(isinstance(item, ToolCallToken) for item in items))

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -29,6 +29,7 @@ from avalan.entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallRecoveryFormat,
     ToolCallToken,
     ToolFormat,
 )
@@ -859,6 +860,58 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn('format = "json"', output)
         self.assertIn('"math.calculator"', output)
 
+    async def test_agent_init_tool_recovery_formats_output(self):
+        args = Namespace(
+            name="N",
+            role="R",
+            task="T",
+            instructions=None,
+            goal_instructions=None,
+            memory_recent=False,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=500,
+            memory_engine_overlap=125,
+            memory_engine_window=250,
+            engine_uri="uri",
+            run_max_new_tokens=None,
+            run_skip_special_tokens=False,
+            run_temperature=None,
+            run_top_k=None,
+            run_top_p=None,
+            run_use_cache=None,
+            run_cache_strategy=None,
+            run_reasoning_effort=None,
+            run_chat_add_generation_prompt=None,
+            run_chat_enable_thinking=None,
+            tool=None,
+            tool_format=None,
+            tool_recovery_format=["fenced", "tool_call_block"],
+            tool_browser_engine=None,
+            tool_browser_search=None,
+            tool_browser_search_context=None,
+            backend="transformers",
+            no_repl=False,
+            quiet=False,
+        )
+        console = MagicMock()
+        theme = MagicMock()
+        theme._ = lambda s: s
+
+        with (
+            patch.object(agent_cmds.Confirm, "ask", return_value=True),
+            patch.object(agent_cmds, "get_input", side_effect=["R", "T"]),
+            patch.object(agent_cmds.Prompt, "ask", side_effect=["N", "uri"]),
+        ):
+            await agent_cmds.agent_init(args, console, theme)
+
+        output = console.print.call_args.args[0].code
+        self.assertIn("[tool]", output)
+        self.assertIn("recovery_formats = [", output)
+        self.assertIn('"fenced"', output)
+        self.assertIn('"tool_call_block"', output)
+
 
 class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -1327,6 +1380,10 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.args.engine_uri = "engine"
         self.args.role = "assistant"
         self.args.run_skip_special_tokens = True
+        self.args.tool_recovery_format = [
+            ToolCallRecoveryFormat.FENCED.value,
+            ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
+        ]
 
         with (
             patch.object(agent_cmds, "get_input", return_value=None),
@@ -1358,6 +1415,13 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(tool_settings.browser)
         self.assertIsNone(tool_settings.database)
         self.assertIsNone(tool_settings.graph)
+        self.assertEqual(
+            fs_patch.call_args.kwargs["tool_recovery_formats"],
+            [
+                ToolCallRecoveryFormat.FENCED,
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+            ],
+        )
         ff_patch.assert_not_called()
 
     async def test_run_sets_hidden_states(self):
@@ -2047,6 +2111,7 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
             *,
             tool_settings=None,
             tool_format=None,
+            tool_recovery_formats=None,
         ):
             self.orch.tool = ToolManager.create_instance(
                 available_toolsets=[],

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from types import SimpleNamespace
+from typing import Any
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
@@ -34,6 +35,9 @@ from avalan.entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallToken,
     TransformerEngineSettings,
 )
@@ -788,7 +792,7 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
         console = MagicMock()
         console.width = 80
         logger = MagicMock()
-        captured: list[dict[str, object]] = []
+        captured: list[dict[str, Any]] = []
 
         async def fake_tokens(*p, **kw):
             captured.append(
@@ -1601,6 +1605,102 @@ class CliTokenGenerationTestCase(IsolatedAsyncioTestCase):
             fifth["input_token_count"],
             response.input_token_count + inner_response.input_token_count,
         )
+
+    async def test_token_generation_tool_diagnostic_is_result_event(self):
+        diagnostic = ToolCallDiagnostic(
+            id="diag-model",
+            call_id="call-model",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        events = [
+            model_cmds.Event(
+                type=model_cmds.EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostic": diagnostic},
+            ),
+            model_cmds.Token(id=1, token="a"),
+        ]
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                async def gen():
+                    for item in events:
+                        yield item
+
+                return gen()
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+            display_answer_height_expand=False,
+            display_answer_height=12,
+        )
+        console = MagicMock()
+        console.width = 80
+        captured: list[dict[str, object]] = []
+
+        async def fake_tokens(*p, **kw):
+            captured.append(
+                {
+                    "tool_event_calls": list(p[14]),
+                    "tool_event_results": list(p[15]),
+                    "spinner": p[16],
+                }
+            )
+            yield (None, "frame")
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_tokens)
+        theme.get_spinner.return_value = "dots"
+        theme._n = lambda s, p, n: s if n == 1 else p
+        live = MagicMock()
+        live.__enter__.return_value = live
+        live.__exit__.return_value = False
+        lm = SimpleNamespace(
+            model_id="m",
+            tokenizer_config=None,
+            input_token_count=MagicMock(return_value=1),
+        )
+
+        with patch.object(model_cmds, "Live", return_value=live):
+            await model_cmds.token_generation(
+                args=args,
+                console=console,
+                theme=theme,
+                logger=MagicMock(),
+                orchestrator=None,
+                event_stats=None,
+                lm=lm,
+                input_string="text",
+                response=Resp(),
+                display_tokens=0,
+                dtokens_pick=0,
+                with_stats=True,
+                tool_events_limit=2,
+                refresh_per_second=2,
+            )
+
+        self.assertEqual(captured[0]["tool_event_calls"], [])
+        self.assertEqual(
+            captured[0]["tool_event_results"][0].type,
+            model_cmds.EventType.TOOL_DIAGNOSTIC,
+        )
+        self.assertIsNone(captured[0]["spinner"])
 
     async def test_token_generation_display_options_combinations(self):
         combos = [

--- a/tests/cli/model_test.py
+++ b/tests/cli/model_test.py
@@ -33,6 +33,7 @@ from avalan.entities import (
     ReasoningSettings,
     Token,
     TokenDetail,
+    ToolCall,
     ToolCallToken,
     TransformerEngineSettings,
 )
@@ -6491,6 +6492,88 @@ class CliToolCallTokenTestCase(IsolatedAsyncioTestCase):
 
         self.assertTrue(stop_signal.is_set())
         self.assertEqual(captured, [["TOOL"], ["TOOL"]])
+
+    async def test_tool_result_event_with_none_result_is_tracked(self):
+        call_obj = ToolCall(id="call-none", name="tool", arguments={})
+
+        class Resp:
+            input_token_count = 1
+            can_think = False
+            is_thinking = False
+
+            def set_thinking(self, value: bool) -> None:
+                self.is_thinking = value
+
+            def __aiter__(self):
+                async def gen():
+                    yield model_cmds.Event(
+                        type=model_cmds.EventType.TOOL_PROCESS,
+                        payload=[call_obj],
+                    )
+                    yield model_cmds.Event(
+                        type=model_cmds.EventType.TOOL_RESULT,
+                        payload={"call": call_obj, "result": None},
+                    )
+                    yield model_cmds.Token(id=1, token="A")
+
+                return gen()
+
+        args = Namespace(
+            skip_display_reasoning_time=False,
+            display_time_to_n_token=None,
+            display_pause=0,
+            start_thinking=False,
+            display_probabilities=False,
+            display_probabilities_maximum=0.0,
+            display_probabilities_sample_minimum=0.0,
+            record=False,
+        )
+
+        console = MagicMock()
+        console.width = 80
+        logger = MagicMock()
+        stop_signal = asyncio.Event()
+        captures: list[tuple[int, int, object | None]] = []
+
+        async def fake_tokens(*p, **kw):
+            captures.append((len(p[14]), len(p[15]), p[16]))
+            yield (None, "frame")
+
+        theme = MagicMock()
+        theme.tokens = MagicMock(side_effect=fake_tokens)
+        theme.get_spinner.return_value = "dots"
+        theme._n.side_effect = lambda singular, plural, count: singular
+
+        live = MagicMock()
+        group = SimpleNamespace(renderables=[None])
+
+        await model_cmds._token_stream(
+            live=live,
+            group=group,
+            tokens_group_index=0,
+            args=args,
+            console=console,
+            theme=theme,
+            logger=logger,
+            orchestrator=None,
+            event_stats=None,
+            lm=SimpleNamespace(
+                model_id="m",
+                tokenizer_config=None,
+                input_token_count=lambda s: 1,
+            ),
+            input_string="text",
+            response=Resp(),
+            display_tokens=0,
+            dtokens_pick=0,
+            refresh_per_second=2,
+            stop_signal=stop_signal,
+            tool_events_limit=None,
+            with_stats=True,
+        )
+
+        self.assertEqual(captures[-1][:2], (1, 1))
+        self.assertIsNone(captures[-1][2])
 
 
 class CliModelMixedTokensTestCase(IsolatedAsyncioTestCase):

--- a/tests/cli/theme_fancy_test.py
+++ b/tests/cli/theme_fancy_test.py
@@ -28,6 +28,11 @@ from avalan.entities import (
     Token,
     TokenDetail,
     TokenizerConfig,
+    ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallError,
     User,
 )
 from avalan.event import Event, EventStats, EventType
@@ -482,6 +487,14 @@ class FancyThemeTestCase(IsolatedAsyncioTestCase):
             id=UUID(int=2), name="calc", arguments={"x": 1}
         )
         tool_result = SimpleNamespace(call=tool_call, result={"ok": True})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-1",
+            call_id="call-1",
+            requested_name="weather",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
         events = [
             Event(
                 type=EventType.TOOL_EXECUTE,
@@ -504,6 +517,10 @@ class FancyThemeTestCase(IsolatedAsyncioTestCase):
                 payload={"result": tool_result},
                 elapsed=0.01,
             ),
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostic": diagnostic},
+            ),
         ]
 
         log = self.theme._events_log(
@@ -516,7 +533,75 @@ class FancyThemeTestCase(IsolatedAsyncioTestCase):
         )
 
         assert log is not None
-        self.assertEqual(len(log), 5)
+        self.assertEqual(len(log), 6)
+        self.assertIn("tool.unknown", log[-1])
+        self.assertIn("Unknown tool.", log[-1])
+
+    def test_events_log_tool_result_diagnostic_and_error(self):
+        call = ToolCall(id="call-2", name="calc", arguments={"x": 1})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-2",
+            call_id=call.id,
+            requested_name="calc",
+            code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            message="Invalid arguments.",
+        )
+        error = ToolCallError(
+            id="error-1",
+            call=call,
+            name="calc",
+            arguments={"x": 1},
+            error=RuntimeError("secret"),
+            message="Tool failed.",
+        )
+        events = [
+            Event(
+                type=EventType.TOOL_RESULT,
+                payload={"call": call, "result": diagnostic},
+            ),
+            Event(
+                type=EventType.TOOL_RESULT,
+                payload={"result": error},
+                elapsed=0.01,
+            ),
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostics": ["bad"]},
+            ),
+        ]
+
+        log = self.theme._events_log(
+            events,
+            events_limit=None,
+            include_tokens=False,
+            include_tool_detect=False,
+            include_tools=True,
+            include_non_tools=False,
+        )
+
+        assert log is not None
+        self.assertIn("tool_call.arguments_invalid", log[0])
+        self.assertIn("Tool failed.", log[1])
+        self.assertNotIn("secret", log[1])
+        self.assertIn("bad", log[2])
+
+    def test_tool_diagnostic_from_payload_variants(self):
+        diagnostic = ToolCallDiagnostic(
+            id="diag-payload",
+            call_id="call-payload",
+            requested_name="calc",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+
+        self.assertIsNone(self.theme._tool_diagnostic_from_payload("bad"))
+        self.assertIs(
+            self.theme._tool_diagnostic_from_payload({"result": diagnostic}),
+            diagnostic,
+        )
+        self.assertIsNone(self.theme._tool_diagnostic_from_payload({}))
 
     def test_search_message_matches(self):
         msg = EngineMessageScored(

--- a/tests/docs/task_examples_test.py
+++ b/tests/docs/task_examples_test.py
@@ -11,6 +11,7 @@ from avalan.flow import (
     FlowDefinitionLoader,
     FlowInputType,
     FlowNodeDefinition,
+    FlowNodeMetadata,
     FlowNodeRegistry,
     FlowOutputType,
     Node,
@@ -357,7 +358,10 @@ def _poc_flow_loader() -> FlowDefinitionLoader:
             {
                 "agent": _poc_node_factory,
                 "file_convert": _poc_node_factory,
-            }
+            },
+            {
+                "agent": FlowNodeMetadata(supports_ref=True),
+            },
         )
     )
 

--- a/tests/event/event_manager_test.py
+++ b/tests/event/event_manager_test.py
@@ -13,6 +13,25 @@ class EventManagerTestCase(IsolatedAsyncioTestCase):
         self.assertIn(EventType.TOOL_DIAGNOSTIC, TOOL_TYPES)
         self.assertEqual(EventType.TOOL_DIAGNOSTIC.value, "tool_diagnostic")
 
+    def test_tool_progress_event_is_tool_event(self):
+        event = Event(
+            type=EventType.TOOL_PROGRESS,
+            payload={
+                "call_id": "call1",
+                "progress": {"current": 1, "total": 2},
+            },
+        )
+
+        self.assertIs(event.type, EventType.TOOL_PROGRESS)
+        self.assertIn(EventType.TOOL_PROGRESS, TOOL_TYPES)
+        self.assertEqual(EventType.TOOL_PROGRESS.value, "tool_progress")
+        assert event.payload is not None
+        self.assertEqual(event.payload["call_id"], "call1")
+        self.assertEqual(
+            event.payload["progress"],
+            {"current": 1, "total": 2},
+        )
+
     async def test_trigger_and_history(self):
         manager = EventManager(history_length=2)
         called: list[tuple[str, EventType]] = []

--- a/tests/event/event_manager_test.py
+++ b/tests/event/event_manager_test.py
@@ -1,11 +1,18 @@
 import asyncio
 from unittest import IsolatedAsyncioTestCase, main
 
-from avalan.event import Event, EventType
+from avalan.event import TOOL_TYPES, Event, EventType
 from avalan.event.manager import EventManager
 
 
 class EventManagerTestCase(IsolatedAsyncioTestCase):
+    def test_tool_diagnostic_event_is_tool_event(self):
+        event = Event(type=EventType.TOOL_DIAGNOSTIC)
+
+        self.assertIs(event.type, EventType.TOOL_DIAGNOSTIC)
+        self.assertIn(EventType.TOOL_DIAGNOSTIC, TOOL_TYPES)
+        self.assertEqual(EventType.TOOL_DIAGNOSTIC.value, "tool_diagnostic")
+
     async def test_trigger_and_history(self):
         manager = EventManager(history_length=2)
         called: list[tuple[str, EventType]] = []

--- a/tests/fixtures/tool_parsing/harmony_malformed_then_valid.txt
+++ b/tests/fixtures/tool_parsing/harmony_malformed_then_valid.txt
@@ -1,0 +1,2 @@
+<|channel|>commentary to=functions.broken <|constrain|>json<|message|>{"expression": }<|call|>commentary
+<|channel|>commentary to=functions.calculator <|constrain|>json<|message|>{"expression":"4 + 4"}<|call|>

--- a/tests/fixtures/tool_parsing/markdown_fenced_malformed_example.txt
+++ b/tests/fixtures/tool_parsing/markdown_fenced_malformed_example.txt
@@ -1,0 +1,5 @@
+Do not run this example:
+
+```xml
+<tool_call>{"name": "calculator", "arguments": }</tool_call>
+```

--- a/tests/fixtures/tool_parsing/markdown_fenced_tool_call_example.txt
+++ b/tests/fixtures/tool_parsing/markdown_fenced_tool_call_example.txt
@@ -1,0 +1,7 @@
+Here is an example:
+
+```json
+<tool_call>{"name": "calculator", "arguments": {"expression": "3 + 3"}}</tool_call>
+```
+
+That is only illustrative.

--- a/tests/fixtures/tool_parsing/provider_openai_argument_deltas.json
+++ b/tests/fixtures/tool_parsing/provider_openai_argument_deltas.json
@@ -1,0 +1,10 @@
+{
+  "call_id": "call_delta",
+  "provider_name": "pkg__func",
+  "argument_deltas": [
+    "{\"city\":",
+    "\"Paris\",",
+    "\"unit\":\"c\"}"
+  ],
+  "assistant_after": "done"
+}

--- a/tests/fixtures/tool_parsing/recovery_fenced_code_example.txt
+++ b/tests/fixtures/tool_parsing/recovery_fenced_code_example.txt
@@ -1,0 +1,6 @@
+The following snippet documents a payload string:
+
+```python
+payload = "[TOOL_CALL]{\"name\":\"calculator\",\"arguments\":{\"expression\":\"2 + 2\"}}[/TOOL_CALL]"
+print(payload)
+```

--- a/tests/fixtures/tool_parsing/recovery_large_payloads.json
+++ b/tests/fixtures/tool_parsing/recovery_large_payloads.json
@@ -1,0 +1,8 @@
+{
+  "tool_call_block": "[TOOL_CALL]{\"name\":\"calculator\",\"arguments\":{\"payload\":\"0123456789abcdef\"}}[/TOOL_CALL]",
+  "minimax_xml": "<invoke name=\"calculator\"><parameter name=\"payload\">0123456789abcdef</parameter></invoke>",
+  "tool_code": "<tool_code>calculator({\"payload\":\"0123456789abcdef\"})</tool_code>",
+  "broad_xml": "<function name=\"calculator\"><arguments>{\"payload\":\"0123456789abcdef\"}</arguments></function>",
+  "dsml_leakage": "<DSML:tool_calls><DSML:invoke name=\"calculator\"><DSML:parameter name=\"payload\">0123456789abcdef</DSML:parameter></DSML:invoke></DSML:tool_calls>",
+  "fenced": "```json\n{\"name\":\"calculator\",\"arguments\":{\"payload\":\"0123456789abcdef\"}}\n```"
+}

--- a/tests/fixtures/tool_parsing/recovery_malformed_segments_then_valid.txt
+++ b/tests/fixtures/tool_parsing/recovery_malformed_segments_then_valid.txt
@@ -1,0 +1,18 @@
+The assistant mixed several compatibility shapes:
+
+[TOOL_CALL]{bad[/TOOL_CALL]
+[TOOL_CALL]{"name":"calculator","arguments":{"expression":"1 + 1"}}[/TOOL_CALL]
+
+<tool_code>{bad</tool_code>
+<tool_code>database.run({"sql":"SELECT 1"})</tool_code>
+
+<invoke name="broken"><parameter>missing name</parameter></invoke>
+<invoke name="search"><parameter name="query">avalan docs</parameter></invoke>
+
+```json
+{bad
+```
+
+```json
+{"name":"browser.open","arguments":{"url":"https://example.invalid"}}
+```

--- a/tests/fixtures/tool_parsing/recovery_nested_payloads.json
+++ b/tests/fixtures/tool_parsing/recovery_nested_payloads.json
@@ -1,0 +1,8 @@
+{
+  "tool_call_block": "[TOOL_CALL]{\"name\":\"calculator\",\"arguments\":{\"payload\":{\"nested\":{\"value\":1}}}}[/TOOL_CALL]",
+  "minimax_xml": "<invoke name=\"calculator\"><parameter name=\"payload\" string=\"false\">{\"nested\":{\"value\":1}}</parameter></invoke>",
+  "tool_code": "<tool_code>calculator({\"payload\":{\"nested\":{\"value\":1}}})</tool_code>",
+  "broad_xml": "<function name=\"calculator\"><arguments>{\"payload\":{\"nested\":{\"value\":1}}}</arguments></function>",
+  "dsml_leakage": "<DSML:tool_calls><DSML:invoke name=\"calculator\"><DSML:parameter name=\"payload\" string=\"false\">{\"nested\":{\"value\":1}}</DSML:parameter></DSML:invoke></DSML:tool_calls>",
+  "fenced": "```json\n{\"name\":\"calculator\",\"arguments\":{\"payload\":{\"nested\":{\"value\":1}}}}\n```"
+}

--- a/tests/fixtures/tool_parsing/stream_harmony_split_call.json
+++ b/tests/fixtures/tool_parsing/stream_harmony_split_call.json
@@ -1,0 +1,21 @@
+{
+  "tokens": [
+    "<|start|>",
+    "assistant<|channel|>commentary to=functions.calculator ",
+    "<|constrain|>json<|message|>",
+    "{\"expression\":\"2 + 2\"}",
+    "<|call|>",
+    "<|channel|>final<|message|>",
+    "done"
+  ],
+  "call": {
+    "name": "calculator",
+    "arguments": {
+      "expression": "2 + 2"
+    }
+  },
+  "strings": [
+    "<|channel|>final<|message|>",
+    "done"
+  ]
+}

--- a/tests/fixtures/tool_parsing/stream_marker_boundaries.json
+++ b/tests/fixtures/tool_parsing/stream_marker_boundaries.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "prefix_then_text",
+    "tokens": [
+      "<to",
+      "x"
+    ],
+    "event": null,
+    "strings": [
+      "<to",
+      "x"
+    ]
+  },
+  {
+    "name": "split_closed_tag",
+    "tokens": [
+      "pre ",
+      "<tool",
+      "_call>",
+      "{\"name\":\"calculator\",\"arguments\":{\"expression\":\"1 + 1\"}}",
+      "</tool_call>",
+      " post"
+    ],
+    "event": "tool_process",
+    "strings": [
+      "pre ",
+      " post"
+    ],
+    "call": {
+      "name": "calculator",
+      "arguments": {
+        "expression": "1 + 1"
+      }
+    }
+  },
+  {
+    "name": "split_malformed_tag",
+    "tokens": [
+      "<tool",
+      "_call>",
+      "{\"name\":\"calculator\",\"arguments\":}",
+      "</tool_call>"
+    ],
+    "event": "tool_diagnostic",
+    "diagnostic_code": "MALFORMED_CALL"
+  },
+  {
+    "name": "unterminated_tag",
+    "tokens": [
+      "<tool",
+      "_call>",
+      "{\"name\":\"calculator\",\"arguments\":{}}"
+    ],
+    "event": "tool_diagnostic",
+    "flush": true,
+    "diagnostic_code": "MALFORMED_CALL",
+    "stream_status": "unterminated"
+  }
+]

--- a/tests/fixtures/tool_parsing/tag_adjacent_calls.txt
+++ b/tests/fixtures/tool_parsing/tag_adjacent_calls.txt
@@ -1,0 +1,1 @@
+<tool_call>{"name": "calculator", "arguments": {"expression": "1 + 1"}}</tool_call><tool_call>{"name": "database.run", "arguments": {"sql": "SELECT 1"}}</tool_call>

--- a/tests/fixtures/tool_parsing/tag_malformed_envelope.txt
+++ b/tests/fixtures/tool_parsing/tag_malformed_envelope.txt
@@ -1,0 +1,1 @@
+<tool_call>{"name": "calculator", "arguments": }</tool_call>

--- a/tests/fixtures/tool_parsing/tag_malformed_then_valid.txt
+++ b/tests/fixtures/tool_parsing/tag_malformed_then_valid.txt
@@ -1,0 +1,2 @@
+<tool_call>{"name": "broken", "arguments": }</tool_call>
+<tool_call>{"name": "calculator", "arguments": {"expression": "2 + 2"}}</tool_call>

--- a/tests/flow/connection_test.py
+++ b/tests/flow/connection_test.py
@@ -6,7 +6,19 @@ from avalan.flow.node import Node
 
 
 class ConnectionTestCase(TestCase):
-    def test_check_conditions(self):
+    def test_sync_helpers_are_not_exposed(self) -> None:
+        conn = Connection(Node("A"), Node("B"))
+        self.assertFalse(hasattr(conn, "check_conditions"))
+        self.assertFalse(hasattr(conn, "apply_filters"))
+
+    def test_repr(self) -> None:
+        conn = Connection(Node("A"), Node("B"))
+
+        self.assertEqual(repr(conn), "<Conn A->B>")
+
+
+class ConnectionAsyncTestCase(IsolatedAsyncioTestCase):
+    async def test_check_conditions_async_with_sync_callbacks(self) -> None:
         calls = []
 
         def c1(x):
@@ -18,19 +30,11 @@ class ConnectionTestCase(TestCase):
             return False
 
         conn = Connection(Node("A"), Node("B"), conditions=[c1, c2])
-        self.assertFalse(conn.check_conditions(1))
+
+        self.assertFalse(await conn.check_conditions_async(1))
         self.assertEqual(calls, ["c1", "c2"])
 
-    def test_check_conditions_rejects_async_condition(self) -> None:
-        async def condition(_: object) -> bool:
-            return False
-
-        conn = Connection(Node("A"), Node("B"), conditions=[condition])
-
-        with self.assertRaisesRegex(TypeError, "check_conditions_async"):
-            conn.check_conditions(1)
-
-    def test_apply_filters(self):
+    async def test_apply_filters_async_with_sync_callbacks(self) -> None:
         def f1(x):
             return x + 1
 
@@ -38,24 +42,8 @@ class ConnectionTestCase(TestCase):
             return x * 2
 
         conn = Connection(Node("A"), Node("B"), filters=[f1, f2])
-        self.assertEqual(conn.apply_filters(1), 4)
+        self.assertEqual(await conn.apply_filters_async(1), 4)
 
-    def test_apply_filters_rejects_async_filter(self) -> None:
-        async def filter_function(_: object) -> int:
-            return 2
-
-        conn = Connection(Node("A"), Node("B"), filters=[filter_function])
-
-        with self.assertRaisesRegex(TypeError, "apply_filters_async"):
-            conn.apply_filters(1)
-
-    def test_repr(self) -> None:
-        conn = Connection(Node("A"), Node("B"))
-
-        self.assertEqual(repr(conn), "<Conn A->B>")
-
-
-class ConnectionAsyncTestCase(IsolatedAsyncioTestCase):
     async def test_check_conditions_async(self) -> None:
         calls: list[str] = []
 

--- a/tests/flow/definition_entities_test.py
+++ b/tests/flow/definition_entities_test.py
@@ -7,7 +7,9 @@ from avalan.flow import (
     FlowEdgeDefinition,
     FlowInputDefinition,
     FlowInputType,
+    FlowNodeContract,
     FlowNodeDefinition,
+    FlowNodeMetadata,
     FlowOutputDefinition,
     FlowOutputType,
 )
@@ -77,6 +79,12 @@ class FlowDefinitionTestCase(TestCase):
         with self.assertRaises(AssertionError):
             FlowInputDefinition(name="", type=FlowInputType.STRING)
         with self.assertRaises(AssertionError):
+            FlowInputDefinition(
+                name="input",
+                type=FlowInputType.STRING,
+                mime_types=("",),
+            )
+        with self.assertRaises(AssertionError):
             FlowOutputDefinition(
                 name="output",
                 type=FlowOutputType.JSON,
@@ -90,6 +98,61 @@ class FlowDefinitionTestCase(TestCase):
                 entrypoint="start",
                 output_node="start",
                 nodes=(object(),),  # type: ignore[arg-type]
+            )
+
+    def test_node_metadata_is_frozen_and_copy_nested_mappings(self) -> None:
+        schema = {"type": "object", "properties": {"name": {"type": "str"}}}
+        metadata = {"source": {"name": "tool"}, "tags": ["runtime"]}
+        node_metadata = FlowNodeMetadata(
+            supports_ref=True,
+            async_only=True,
+            input_contract=FlowNodeContract(
+                name="payload",
+                type=FlowInputType.OBJECT,
+                schema=schema,
+                metadata=metadata,
+            ),
+            output_contract=FlowNodeContract(
+                name="result",
+                type=FlowOutputType.JSON,
+                schema_ref="schemas/result.json",
+            ),
+            metadata={"canonical_schema": schema},
+        )
+
+        schema["properties"]["name"]["type"] = "number"
+        metadata["source"]["name"] = "changed"
+        metadata["tags"].append("changed")
+
+        input_contract = node_metadata.input_contract
+        assert input_contract is not None
+        assert input_contract.schema is not None
+        self.assertEqual(
+            cast(dict[str, object], input_contract.schema["properties"])[
+                "name"
+            ],
+            {"type": "str"},
+        )
+        self.assertEqual(
+            cast(dict[str, object], input_contract.metadata["source"])["name"],
+            "tool",
+        )
+        self.assertEqual(input_contract.metadata["tags"], ("runtime",))
+        self.assertTrue(node_metadata.supports_ref)
+        self.assertTrue(node_metadata.async_only)
+        with self.assertRaises(FrozenInstanceError):
+            node_metadata.supports_ref = False  # type: ignore[misc]
+
+    def test_invalid_node_metadata_raise_assertion_errors(self) -> None:
+        with self.assertRaises(AssertionError):
+            FlowNodeContract(name="")
+        with self.assertRaises(AssertionError):
+            FlowNodeContract(type="")
+        with self.assertRaises(AssertionError):
+            FlowNodeContract(schema_ref="")
+        with self.assertRaises(AssertionError):
+            FlowNodeMetadata(
+                input_contract=object(),  # type: ignore[arg-type]
             )
 
 

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -10,6 +10,7 @@ from avalan.flow import (
     FlowLoadError,
     FlowLoadIssueCategory,
     FlowNodeDefinition,
+    FlowNodeMetadata,
     FlowNodeRegistry,
     build_flow,
     flow_input_binding,
@@ -20,6 +21,7 @@ from avalan.flow import (
 )
 from avalan.flow import loader as flow_loader
 from avalan.flow.node import Node
+from avalan.flow.registry import FlowNodeConfigurationError
 
 VALID_FLOW = """
 [flow]
@@ -114,6 +116,61 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
                 ),
             ),
             "ready!",
+        )
+
+    async def test_load_accepts_ref_when_registry_metadata_allows_it(
+        self,
+    ) -> None:
+        def factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name, func=lambda _: definition.ref)
+
+        registry = FlowNodeRegistry(
+            {"external": factory},
+            {"external": FlowNodeMetadata(supports_ref=True)},
+        )
+        result = FlowDefinitionLoader(registry).loads_result("""
+            [flow]
+            name = "custom_ref"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "external"
+            ref = "safe.toml"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        self.assertEqual(
+            await result.flow.execute_async(initial_node="start"),
+            "safe.toml",
+        )
+
+    def test_load_rejects_ref_when_registry_metadata_does_not_allow_it(
+        self,
+    ) -> None:
+        def factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name)
+
+        result = FlowDefinitionLoader(
+            FlowNodeRegistry({"external": factory})
+        ).loads_result(
+            """
+            [flow]
+            name = "custom_ref"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "external"
+            ref = "safe.toml"
+            """
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(
+            [issue.code for issue in result.issues],
+            ["flow.untrusted_callable"],
         )
 
     async def test_load_accepts_nested_node_config(self) -> None:
@@ -808,6 +865,65 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(result.issues[0].code, "flow.invalid_node")
         self.assertNotIn("private factory failure", str(result.issues[0]))
 
+    def test_node_configuration_error_returns_declared_issue(self) -> None:
+        def factory(_: FlowNodeDefinition) -> Node:
+            raise FlowNodeConfigurationError(
+                code="flow.invalid_node",
+                path="nodes.start.config",
+                message="Flow node configuration is invalid.",
+                hint="Fix the node configuration.",
+            )
+
+        loader = FlowDefinitionLoader(FlowNodeRegistry({"broken": factory}))
+
+        result = loader.loads_result("""
+            [flow]
+            name = "broken"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "broken"
+            """)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.issues[0].code, "flow.invalid_node")
+        self.assertEqual(result.issues[0].path, "nodes.start.config")
+        self.assertEqual(
+            result.issues[0].hint,
+            "Fix the node configuration.",
+        )
+
+    def test_rejects_invalid_agent_file_selectors(self) -> None:
+        cases: tuple[tuple[str, object, tuple[str, ...]], ...] = (
+            ("non_string", 3, ("start",)),
+            ("invalid", "start", ("start",)),
+            ("reserved", "file.content", ("start",)),
+            ("unknown", "missing.content", ("start",)),
+            ("disconnected", "start.content", ("middle",)),
+        )
+
+        for name, selector, edge_sources in cases:
+            with self.subTest(name=name):
+                result = self._load_agent_selector_case(
+                    selector,
+                    edge_sources=edge_sources,
+                )
+
+                self.assertFalse(result.ok)
+                self.assertIn(
+                    result.issues[0].code,
+                    {
+                        "flow.bad_reference",
+                        "flow.invalid_node",
+                        "flow.invalid_type",
+                    },
+                )
+                self.assertEqual(
+                    result.issues[0].path,
+                    "nodes.agent.config.files_input",
+                )
+
     def test_private_helpers_cover_toml_impossible_shapes(self) -> None:
         issues: list[flow_loader.FlowLoadIssue] = []
         raw = {
@@ -831,6 +947,12 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
             "mime_types",
             issues,
         )
+        list_value = flow_loader._string_tuple(  # type: ignore[attr-defined]
+            {"mime_types": ["text/plain"]},
+            "flow.input.mime_types",
+            "mime_types",
+            issues,
+        )
         metadata = flow_loader._metadata(  # type: ignore[attr-defined]
             {1: "bad"},  # type: ignore[dict-item]
             "metadata",
@@ -839,8 +961,67 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
 
         self.assertFalse(result.ok)
         self.assertEqual(tuple_value, ())
+        self.assertEqual(list_value, ("text/plain",))
         self.assertIsNone(metadata)
         self.assertIn("flow.invalid_type", [issue.code for issue in issues])
+
+    def _load_agent_selector_case(
+        self,
+        selector: object,
+        *,
+        edge_sources: tuple[str, ...],
+    ) -> flow_loader.FlowLoadResult:
+        def agent_factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name)
+
+        def echo_factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name)
+
+        selector_toml = (
+            f'"{selector}"' if isinstance(selector, str) else str(selector)
+        )
+        edge_toml = "\n".join(f"""
+            [[edges]]
+            source = "{source}"
+            target = "agent"
+            """ for source in edge_sources)
+        middle_node_toml = ""
+        if "middle" in edge_sources:
+            middle_node_toml = """
+            [nodes.middle]
+            type = "echo"
+
+            [[edges]]
+            source = "start"
+            target = "middle"
+            """
+        return FlowDefinitionLoader(
+            FlowNodeRegistry(
+                {
+                    "agent": agent_factory,
+                    "echo": echo_factory,
+                }
+            )
+        ).loads_result(
+            f"""
+            [flow]
+            name = "agent_selector"
+            entrypoint = "start"
+            output_node = "agent"
+
+            [nodes.start]
+            type = "echo"
+
+            {middle_node_toml}
+
+            [nodes.agent]
+            type = "agent"
+
+            [nodes.agent.config]
+            files_input = {selector_toml}
+            {edge_toml}
+            """
+        )
 
 
 class FlowBuildTestCase(TestCase):

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest import IsolatedAsyncioTestCase, main
 
 from avalan.entities import ToolManagerSettings
 from avalan.flow import (
@@ -1220,8 +1220,8 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
         )
 
 
-class FlowBuildTestCase(TestCase):
-    def test_build_flow_from_definition(self) -> None:
+class FlowBuildTestCase(IsolatedAsyncioTestCase):
+    async def test_build_flow_from_definition(self) -> None:
         definition = FlowDefinition(
             name="manual",
             entrypoint="start",
@@ -1237,7 +1237,7 @@ class FlowBuildTestCase(TestCase):
 
         flow = build_flow(definition)
 
-        self.assertEqual(flow.execute(), "ok")
+        self.assertEqual(await flow.execute_async(), "ok")
 
 
 if __name__ == "__main__":

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -187,10 +187,10 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
             type = "{FLOW_TOOL_NODE_TYPE}"
             ref = "mcp.call"
 
-            [nodes.start.config]
-            uri = "http://localhost:4000"
-            name = "remote.calculator"
-            arguments = {{expression = "1 + 1"}}
+            [nodes.start.config.arguments]
+            uri = "uri"
+            name = "remote_name"
+            arguments = "remote_arguments"
             """)
 
         self.assertTrue(result.ok)
@@ -198,9 +198,59 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
         assert result.flow is not None
         self.assertEqual(result.definition.nodes[0].ref, "mcp.call")
         self.assertEqual(
-            result.definition.nodes[0].config["name"],
-            "remote.calculator",
+            result.definition.nodes[0].config["arguments"],
+            {
+                "uri": "uri",
+                "name": "remote_name",
+                "arguments": "remote_arguments",
+            },
         )
+
+    def test_tool_node_rejects_invalid_argument_bindings_on_load(
+        self,
+    ) -> None:
+        loader = _tool_loader()
+        cases = (
+            (
+                "unknown",
+                """
+                [nodes.start.config.arguments]
+                expression = "left"
+                a = "left"
+                b = "right"
+                """,
+                "flow.unknown_argument_binding",
+                "nodes.start.config.arguments.expression",
+            ),
+            (
+                "missing",
+                """
+                [nodes.start.config.arguments]
+                a = "left"
+                """,
+                "flow.missing_argument_binding",
+                "nodes.start.config.arguments.b",
+            ),
+        )
+
+        for name, config, code, path in cases:
+            with self.subTest(name=name):
+                result = loader.loads_result(f"""
+                    [flow]
+                    name = "tool_node"
+                    entrypoint = "start"
+                    output_node = "start"
+
+                    [nodes.start]
+                    type = "{FLOW_TOOL_NODE_TYPE}"
+                    ref = "loader_adder"
+
+                    {config}
+                    """)
+
+                self.assertFalse(result.ok)
+                self.assertEqual(result.issues[0].code, code)
+                self.assertEqual(result.issues[0].path, path)
 
     def test_tool_node_rejects_invalid_refs(self) -> None:
         loader = _tool_loader(

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -206,6 +206,34 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_tool_node_executes_from_loaded_flow(self) -> None:
+        loader = _tool_loader()
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_adder"
+
+            [nodes.start.config.arguments]
+            a = "left"
+            b = "right"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        self.assertEqual(
+            await result.flow.execute_async(
+                initial_node="start",
+                initial_inputs={"left": 2, "right": 5},
+            ),
+            7,
+        )
+
     def test_tool_node_rejects_invalid_argument_bindings_on_load(
         self,
     ) -> None:

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -2,8 +2,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 
+from avalan.entities import ToolManagerSettings
 from avalan.flow import (
     FLOW_INPUT_KEY,
+    FLOW_TOOL_NODE_TYPE,
     FlowDefinition,
     FlowDefinitionLoader,
     FlowInputType,
@@ -18,10 +20,14 @@ from avalan.flow import (
     load_flow_definition_result,
     loads_flow_definition,
     loads_flow_definition_result,
+    tool_flow_node_registry,
 )
 from avalan.flow import loader as flow_loader
 from avalan.flow.node import Node
 from avalan.flow.registry import FlowNodeConfigurationError
+from avalan.tool import ToolSet
+from avalan.tool.manager import ToolManager
+from avalan.tool.mcp import McpToolSet
 
 VALID_FLOW = """
 [flow]
@@ -50,6 +56,40 @@ input = "start"
 source = "start"
 target = "finish"
 """
+
+
+async def loader_adder(a: int, b: int) -> int:
+    return a + b
+
+
+loader_adder.aliases = ["loader_sum"]  # type: ignore[attr-defined]
+
+
+async def loader_adder_alt(a: int, b: int) -> int:
+    return a + b
+
+
+loader_adder_alt.aliases = ["loader_sum"]  # type: ignore[attr-defined]
+
+
+async def loader_disabled(a: int) -> int:
+    return a
+
+
+def _tool_loader(
+    *,
+    enable_tools: list[str] | None = None,
+) -> FlowDefinitionLoader:
+    manager = ToolManager.create_instance(
+        enable_tools=enable_tools or ["loader_adder", "mcp.call"],
+        available_toolsets=[
+            ToolSet(tools=[loader_adder, loader_adder_alt]),
+            ToolSet(namespace="disabled", tools=[loader_disabled]),
+            McpToolSet(),
+        ],
+        settings=ToolManagerSettings(),
+    )
+    return FlowDefinitionLoader(tool_flow_node_registry(manager))
 
 
 class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
@@ -117,6 +157,84 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
             ),
             "ready!",
         )
+
+    def test_tool_nodes_require_tool_aware_registry(self) -> None:
+        result = loads_flow_definition_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_adder"
+            """)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.issues[0].code, "flow.unknown_node_type")
+        self.assertEqual(result.issues[0].path, "nodes.start.type")
+
+    def test_tool_node_accepts_enabled_ref_and_mcp_remote_name(self) -> None:
+        loader = _tool_loader()
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "mcp_tool"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "mcp.call"
+
+            [nodes.start.config]
+            uri = "http://localhost:4000"
+            name = "remote.calculator"
+            arguments = {{expression = "1 + 1"}}
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.definition is not None
+        assert result.flow is not None
+        self.assertEqual(result.definition.nodes[0].ref, "mcp.call")
+        self.assertEqual(
+            result.definition.nodes[0].config["name"],
+            "remote.calculator",
+        )
+
+    def test_tool_node_rejects_invalid_refs(self) -> None:
+        loader = _tool_loader(
+            enable_tools=["loader_adder", "loader_adder_alt"]
+        )
+        cases = (
+            ("missing", "", "flow.missing_ref"),
+            ("unknown", 'ref = "missing"', "flow.tool_unknown"),
+            (
+                "disabled",
+                'ref = "disabled.loader_disabled"',
+                "flow.tool_disabled",
+            ),
+            ("ambiguous", 'ref = "loader_sum"', "flow.tool_ambiguous"),
+            ("path", 'ref = "tools/adder.py"', "flow.invalid_ref"),
+            ("uri", 'ref = "urn:mcp:tool"', "flow.invalid_ref"),
+        )
+
+        for name, ref_toml, code in cases:
+            with self.subTest(name=name):
+                result = loader.loads_result(f"""
+                    [flow]
+                    name = "tool_node"
+                    entrypoint = "start"
+                    output_node = "start"
+
+                    [nodes.start]
+                    type = "{FLOW_TOOL_NODE_TYPE}"
+                    {ref_toml}
+                    """)
+
+                self.assertFalse(result.ok)
+                self.assertEqual(result.issues[0].code, code)
+                self.assertEqual(result.issues[0].path, "nodes.start.ref")
 
     async def test_load_accepts_ref_when_registry_metadata_allows_it(
         self,

--- a/tests/flow/definition_loader_test.py
+++ b/tests/flow/definition_loader_test.py
@@ -1,8 +1,17 @@
+from asyncio import CancelledError
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import IsolatedAsyncioTestCase, main
 
-from avalan.entities import ToolManagerSettings
+from avalan.entities import (
+    ToolCall,
+    ToolCallContext,
+    ToolCallDiagnosticCode,
+    ToolFilter,
+    ToolFilterResult,
+    ToolManagerSettings,
+)
 from avalan.flow import (
     FLOW_INPUT_KEY,
     FLOW_TOOL_NODE_TYPE,
@@ -72,22 +81,45 @@ async def loader_adder_alt(a: int, b: int) -> int:
 loader_adder_alt.aliases = ["loader_sum"]  # type: ignore[attr-defined]
 
 
+async def loader_multiplier(a: int, b: int) -> int:
+    return a * b
+
+
+async def loader_status() -> str:
+    return "ready"
+
+
 async def loader_disabled(a: int) -> int:
     return a
+
+
+ToolFilterCallable = Callable[
+    [ToolCall, ToolCallContext],
+    tuple[ToolCall, ToolCallContext] | ToolFilterResult | None,
+]
+ToolFilterConfig = list[ToolFilterCallable | ToolFilter]
 
 
 def _tool_loader(
     *,
     enable_tools: list[str] | None = None,
+    filters: ToolFilterConfig | None = None,
 ) -> FlowDefinitionLoader:
     manager = ToolManager.create_instance(
         enable_tools=enable_tools or ["loader_adder", "mcp.call"],
         available_toolsets=[
-            ToolSet(tools=[loader_adder, loader_adder_alt]),
+            ToolSet(
+                tools=[
+                    loader_adder,
+                    loader_adder_alt,
+                    loader_multiplier,
+                    loader_status,
+                ]
+            ),
             ToolSet(namespace="disabled", tools=[loader_disabled]),
             McpToolSet(),
         ],
-        settings=ToolManagerSettings(),
+        settings=ToolManagerSettings(filters=filters),
     )
     return FlowDefinitionLoader(tool_flow_node_registry(manager))
 
@@ -232,6 +264,293 @@ class FlowDefinitionLoaderTestCase(IsolatedAsyncioTestCase):
                 initial_inputs={"left": 2, "right": 5},
             ),
             7,
+        )
+
+    async def test_loaded_tool_node_validates_arguments_before_filters(
+        self,
+    ) -> None:
+        events: list[str] = []
+
+        async def checked_value(value: int) -> int:
+            events.append("tool")
+            return value + 1
+
+        def repair_argument(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            events.append("filter")
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"value": 3},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["checked_value"],
+            available_toolsets=[ToolSet(tools=[checked_value])],
+            settings=ToolManagerSettings(filters=[repair_argument]),
+        )
+        loader = FlowDefinitionLoader(tool_flow_node_registry(manager))
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "checked_value"
+
+            [nodes.start.config]
+            output_mode = "envelope"
+
+            [nodes.start.config.arguments]
+            value = "value"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        output = await result.flow.execute_async(
+            initial_node="start",
+            initial_inputs={"payload": {"value": "bad"}},
+        )
+
+        assert isinstance(output, dict)
+        diagnostic = output["diagnostic"]
+        assert isinstance(diagnostic, dict)
+        self.assertEqual(output["status"], "diagnostic")
+        self.assertEqual(
+            diagnostic["code"],
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED.value,
+        )
+        self.assertEqual(events, [])
+
+    async def test_tool_node_executes_no_argument_tool_from_loaded_flow(
+        self,
+    ) -> None:
+        loader = _tool_loader(enable_tools=["loader_status"])
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_status"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        self.assertEqual(
+            await result.flow.execute_async(initial_node="start"),
+            "ready",
+        )
+
+    async def test_tool_node_blocks_provider_name_rewrite_from_loaded_flow(
+        self,
+    ) -> None:
+        def set_provider_name(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments=call.arguments,
+                    provider_name="loader_multiplier",
+                ),
+                ToolCallContext(),
+            )
+
+        loader = _tool_loader(
+            enable_tools=["loader_adder", "loader_multiplier"],
+            filters=[set_provider_name],
+        )
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_adder"
+
+            [nodes.start.config]
+            output_mode = "envelope"
+
+            [nodes.start.config.arguments]
+            a = "left"
+            b = "right"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        output = await result.flow.execute_async(
+            initial_node="start",
+            initial_inputs={"left": 2, "right": 5},
+        )
+
+        assert isinstance(output, dict)
+        diagnostic = output["diagnostic"]
+        assert isinstance(diagnostic, dict)
+        self.assertEqual(output["status"], "diagnostic")
+        self.assertEqual(output["result"], None)
+        self.assertEqual(output["canonical_name"], "loader_adder")
+        self.assertEqual(
+            diagnostic["code"],
+            ToolCallDiagnosticCode.FILTER_SUPPRESSED.value,
+        )
+        self.assertEqual(
+            diagnostic["details"], {"filtered_name": "loader_multiplier"}
+        )
+
+    async def test_loaded_tool_node_matches_filter_after_alias_rewrite(
+        self,
+    ) -> None:
+        called: list[str] = []
+
+        def set_alias(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("alias")
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="loader_sum",
+                    arguments=call.arguments,
+                ),
+                ToolCallContext(),
+            )
+
+        def adjust_argument(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            assert call.arguments is not None
+            called.append("adder")
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={
+                        "a": call.arguments["a"],
+                        "b": 8,
+                    },
+                ),
+                context,
+            )
+
+        def unrelated(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("multiplier")
+            return call, context
+
+        loader = _tool_loader(
+            enable_tools=["loader_adder"],
+            filters=[
+                set_alias,
+                ToolFilter(func=unrelated, namespace="loader_multiplier"),
+                ToolFilter(func=adjust_argument, namespace="loader_adder"),
+            ],
+        )
+
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_adder"
+
+            [nodes.start.config.arguments]
+            a = "left"
+            b = "right"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        output = await result.flow.execute_async(
+            initial_node="start",
+            initial_inputs={"left": 2, "right": 5},
+        )
+
+        self.assertEqual(output, 10)
+        self.assertEqual(called, ["alias", "adder"])
+
+    async def test_loaded_tool_node_propagates_cancellation_after_filter(
+        self,
+    ) -> None:
+        called: list[str] = []
+
+        def replace_context(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("filter")
+            return call, ToolCallContext()
+
+        async def cancel() -> None:
+            called.append("cancel")
+            if called.count("cancel") == 6:
+                raise CancelledError()
+
+        loader = _tool_loader(
+            enable_tools=["loader_adder"],
+            filters=[replace_context],
+        )
+        result = loader.loads_result(f"""
+            [flow]
+            name = "tool_node"
+            entrypoint = "start"
+            output_node = "start"
+
+            [nodes.start]
+            type = "{FLOW_TOOL_NODE_TYPE}"
+            ref = "loader_adder"
+
+            [nodes.start.config]
+            output_mode = "envelope"
+
+            [nodes.start.config.arguments]
+            a = "left"
+            b = "right"
+            """)
+
+        self.assertTrue(result.ok)
+        assert result.flow is not None
+        with self.assertRaises(CancelledError):
+            await result.flow.execute_async(
+                initial_node="start",
+                initial_inputs={"left": 2, "right": 5},
+                cancellation_checker=cancel,
+            )
+
+        self.assertEqual(
+            called,
+            [
+                "cancel",
+                "cancel",
+                "cancel",
+                "cancel",
+                "cancel",
+                "filter",
+                "cancel",
+            ],
         )
 
     def test_tool_node_rejects_invalid_argument_bindings_on_load(

--- a/tests/flow/flow_extra_test.py
+++ b/tests/flow/flow_extra_test.py
@@ -63,6 +63,26 @@ class FlowExtraExecutionTestCase(IsolatedAsyncioTestCase):
 
         self.assertIn("cycle", str(context.exception))
 
+    async def test_execute_async_reports_unprocessed_reachable_nodes(
+        self,
+    ) -> None:
+        class CycleBlindFlow(Flow):
+            def _detect_cycle_nodes(self, start_nodes: list[Node]) -> set[str]:
+                return set()
+
+        flow = CycleBlindFlow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=lambda _: 2))
+        flow.add_node(Node("C", func=lambda _: 3))
+        flow.add_connection("A", "B")
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        with self.assertRaises(ValueError) as context:
+            await flow.execute_async()
+
+        self.assertIn("cycle", str(context.exception))
+
     async def test_resolve_start_nodes_with_unknown_node_inputs(self) -> None:
         flow = Flow()
         flow.add_node(Node("A"))
@@ -101,11 +121,50 @@ class FlowExtraExecutionTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(cycle_nodes, set())
 
+    def test_detect_cycle_nodes_excludes_acyclic_ancestors(self) -> None:
+        flow = Flow()
+        flow.add_node(Node("A"))
+        flow.add_node(Node("B"))
+        flow.add_node(Node("C"))
+        flow.add_connection("A", "B")
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        cycle_nodes = flow._detect_cycle_nodes([flow.nodes["A"]])
+
+        self.assertEqual(cycle_nodes, {"B", "C"})
+
+    async def test_execute_async_cycle_error_excludes_acyclic_ancestors(
+        self,
+    ) -> None:
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=lambda _: 2))
+        flow.add_node(Node("C", func=lambda _: 3))
+        flow.add_connection("A", "B")
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        with self.assertRaises(ValueError) as context:
+            await flow.execute_async()
+
+        self.assertEqual(
+            str(context.exception), "Flow contains a cycle involving: B, C"
+        )
+
     def test_queue_guard_rejects_revisited_node(self) -> None:
         with self.assertRaisesRegex(ValueError, "revisited node"):
             Flow._assert_unprocessed_queue_node(
                 Node("A"),
                 {"A"},
+                {"A"},
+            )
+
+    def test_queue_guard_rejects_unreachable_node(self) -> None:
+        with self.assertRaisesRegex(ValueError, "revisited node"):
+            Flow._assert_unprocessed_queue_node(
+                Node("B"),
+                set(),
                 {"A"},
             )
 

--- a/tests/flow/flow_extra_test.py
+++ b/tests/flow/flow_extra_test.py
@@ -1,11 +1,11 @@
-import unittest
+from unittest import IsolatedAsyncioTestCase, TestCase, main
 
 from avalan.flow.connection import Connection
 from avalan.flow.flow import Flow
 from avalan.flow.node import Node
 
 
-class FlowExtraTestCase(unittest.TestCase):
+class FlowExtraTestCase(TestCase):
     def test_parse_mermaid_ignores_invalid_lines(self) -> None:
         mermaid = """graph LR
 A --> B
@@ -32,22 +32,24 @@ invalid
             flow._parse_node("A some label"), ("A", "some label", None)
         )
 
-    def test_execute_missing_input_and_multi_terminal(self) -> None:
+
+class FlowExtraExecutionTestCase(IsolatedAsyncioTestCase):
+    async def test_execute_async_missing_input_and_multi_terminal(
+        self,
+    ) -> None:
         flow = Flow()
         flow.add_node(Node("A", func=lambda _: 2))
         flow.add_node(Node("B"))
         flow.add_connection("A", "B")
-        # Start execution from node B without initial data
-        result_none = flow.execute(initial_node="B")
+        result_none = await flow.execute_async(initial_node="B")
         self.assertIsNone(result_none)
 
-        # Add a second terminal node and run the full graph
         flow.add_node(Node("C"))
         flow.add_connection("A", "C")
-        result = flow.execute()
+        result = await flow.execute_async()
         self.assertEqual(result, {"B": 2, "C": 2})
 
-    def test_execute_detects_reachable_cycle(self) -> None:
+    async def test_execute_async_detects_reachable_cycle(self) -> None:
         flow = Flow()
         flow.add_node(Node("A", func=lambda _: 1))
         flow.add_node(Node("B", func=lambda _: 2))
@@ -57,25 +59,28 @@ invalid
         flow.add_connection("C", "B")
 
         with self.assertRaises(ValueError) as context:
-            flow.execute()
+            await flow.execute_async()
 
         self.assertIn("cycle", str(context.exception))
 
-    def test_resolve_start_nodes_with_unknown_node_inputs(self) -> None:
+    async def test_resolve_start_nodes_with_unknown_node_inputs(self) -> None:
         flow = Flow()
         flow.add_node(Node("A"))
 
         with self.assertRaises(KeyError):
-            flow.execute(initial_node=Node("B"))
+            await flow.execute_async(initial_node=Node("B"))
 
         with self.assertRaises(KeyError):
-            flow.execute(initial_node="B")
+            await flow.execute_async(initial_node="B")
 
-    def test_execute_with_existing_node_instance(self) -> None:
+    async def test_execute_async_with_existing_node_instance(self) -> None:
         flow = Flow()
         flow.add_node(Node("A", func=lambda inputs: inputs.get("__init__", 0)))
 
-        result = flow.execute(initial_node=Node("A"), initial_data=7)
+        result = await flow.execute_async(
+            initial_node=Node("A"),
+            initial_data=7,
+        )
 
         self.assertEqual(result, 7)
 
@@ -105,11 +110,11 @@ invalid
             )
 
 
-class ConnectionReprTestCase(unittest.TestCase):
+class ConnectionReprTestCase(TestCase):
     def test_repr(self) -> None:
         conn = Connection(Node("A"), Node("B"))
         self.assertEqual(repr(conn), "<Conn A->B>")
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/tests/flow/flow_test.py
+++ b/tests/flow/flow_test.py
@@ -68,8 +68,11 @@ class FlowParseMermaidTestCase(TestCase):
         self.assertIn("B", flow.nodes)
 
 
-class FlowExecutionTestCase(TestCase):
-    def test_manual_execution(self):
+class FlowExecutionTestCase(IsolatedAsyncioTestCase):
+    def test_sync_execute_is_not_exposed(self) -> None:
+        self.assertFalse(hasattr(Flow(), "execute"))
+
+    async def test_manual_execution(self):
         executed = []
 
         def start(_):
@@ -93,12 +96,12 @@ class FlowExecutionTestCase(TestCase):
         flow.add_connection("A", "B")
         flow.add_connection("B", "C")
 
-        result = flow.execute()
+        result = await flow.execute_async()
 
         self.assertEqual(result, 4)
         self.assertEqual(executed, ["A", "B", "C"])
 
-    def test_skip_node_without_inputs(self):
+    async def test_skip_node_without_inputs(self):
         executed = []
 
         def start(_):
@@ -114,12 +117,12 @@ class FlowExecutionTestCase(TestCase):
         flow.add_node(Node("B", func=should_not_run))
         flow.add_connection("A", "B", conditions=[lambda _: False])
 
-        result = flow.execute()
+        result = await flow.execute_async()
 
         self.assertIsNone(result)
         self.assertEqual(executed, ["A"])
 
-    def test_none_output_forwards_to_downstream_node(self) -> None:
+    async def test_none_output_forwards_to_downstream_node(self) -> None:
         executed: list[str] = []
 
         def start(_: dict[str, object]) -> None:
@@ -136,44 +139,12 @@ class FlowExecutionTestCase(TestCase):
         flow.add_node(Node("B", func=finish))
         flow.add_connection("A", "B")
 
-        result = flow.execute()
+        result = await flow.execute_async()
 
         self.assertEqual(result, "forwarded")
         self.assertEqual(executed, ["A", "B"])
 
-    def test_execute_rejects_async_only_nodes_before_work(self) -> None:
-        executed: list[str] = []
-
-        def start(_: dict[str, object]) -> int:
-            executed.append("A")
-            return 1
-
-        flow = Flow()
-        flow.add_node(Node("A", func=start))
-        flow.add_node(Node("B", func=lambda _: 2, async_only=True))
-        flow.add_connection("A", "B")
-
-        with self.assertRaisesRegex(TypeError, "execute_async: B"):
-            flow.execute()
-
-        self.assertEqual(executed, [])
-
-    def test_execute_rejects_async_only_subgraph_before_work(self) -> None:
-        executed: list[str] = []
-        subgraph = Flow()
-        subgraph.add_node(Node("inner", func=lambda _: 1, async_only=True))
-
-        flow = Flow()
-        flow.add_node(Node("A", func=lambda _: executed.append("A") or 1))
-        flow.add_node(Node("B", subgraph=subgraph))
-        flow.add_connection("A", "B")
-
-        with self.assertRaisesRegex(TypeError, "execute_async: B"):
-            flow.execute()
-
-        self.assertEqual(executed, [])
-
-    def test_execute_with_initial_node(self):
+    async def test_execute_with_initial_node(self):
         executed = []
 
         def start(_):
@@ -197,42 +168,30 @@ class FlowExecutionTestCase(TestCase):
         flow.add_connection("A", "B")
         flow.add_connection("B", "C")
 
-        result = flow.execute(initial_node="B", initial_data=5)
+        result = await flow.execute_async(initial_node="B", initial_data=5)
 
         self.assertEqual(result, 12)
         self.assertEqual(executed, ["B", "C"])
 
-    def test_execute_raises_when_no_start_nodes(self):
+    async def test_execute_raises_when_no_start_nodes(self):
         flow = Flow()
         flow.add_node(Node("A"))
         flow.add_node(Node("B"))
         flow.add_connection("A", "B")
         flow.add_connection("B", "A")
         with self.assertRaises(ValueError) as context:
-            flow.execute()
+            await flow.execute_async()
         self.assertIn("cycle", str(context.exception))
 
-    def test_execute_detects_cycle_with_initial_node(self):
+    async def test_execute_detects_cycle_with_initial_node(self):
         flow = Flow()
         flow.add_node(Node("A"))
         flow.add_node(Node("B"))
         flow.add_connection("A", "B")
         flow.add_connection("B", "A")
         with self.assertRaises(ValueError) as context:
-            flow.execute(initial_node="A", initial_data=1)
+            await flow.execute_async(initial_node="A", initial_data=1)
         self.assertIn("cycle", str(context.exception))
-
-    def test_execute_rejects_async_connection_hooks(self) -> None:
-        async def should_not_forward(_: object) -> bool:
-            return False
-
-        flow = Flow()
-        flow.add_node(Node("A", func=lambda _: 1))
-        flow.add_node(Node("B", func=lambda _: 2))
-        flow.add_connection("A", "B", conditions=[should_not_forward])
-
-        with self.assertRaisesRegex(TypeError, "check_conditions_async"):
-            flow.execute()
 
 
 class FlowAsyncExecutionTestCase(IsolatedAsyncioTestCase):

--- a/tests/flow/flow_test.py
+++ b/tests/flow/flow_test.py
@@ -119,6 +119,60 @@ class FlowExecutionTestCase(TestCase):
         self.assertIsNone(result)
         self.assertEqual(executed, ["A"])
 
+    def test_none_output_forwards_to_downstream_node(self) -> None:
+        executed: list[str] = []
+
+        def start(_: dict[str, object]) -> None:
+            executed.append("A")
+            return None
+
+        def finish(inputs: dict[str, object]) -> str:
+            executed.append("B")
+            self.assertEqual(inputs, {"A": None})
+            return "forwarded"
+
+        flow = Flow()
+        flow.add_node(Node("A", func=start))
+        flow.add_node(Node("B", func=finish))
+        flow.add_connection("A", "B")
+
+        result = flow.execute()
+
+        self.assertEqual(result, "forwarded")
+        self.assertEqual(executed, ["A", "B"])
+
+    def test_execute_rejects_async_only_nodes_before_work(self) -> None:
+        executed: list[str] = []
+
+        def start(_: dict[str, object]) -> int:
+            executed.append("A")
+            return 1
+
+        flow = Flow()
+        flow.add_node(Node("A", func=start))
+        flow.add_node(Node("B", func=lambda _: 2, async_only=True))
+        flow.add_connection("A", "B")
+
+        with self.assertRaisesRegex(TypeError, "execute_async: B"):
+            flow.execute()
+
+        self.assertEqual(executed, [])
+
+    def test_execute_rejects_async_only_subgraph_before_work(self) -> None:
+        executed: list[str] = []
+        subgraph = Flow()
+        subgraph.add_node(Node("inner", func=lambda _: 1, async_only=True))
+
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: executed.append("A") or 1))
+        flow.add_node(Node("B", subgraph=subgraph))
+        flow.add_connection("A", "B")
+
+        with self.assertRaisesRegex(TypeError, "execute_async: B"):
+            flow.execute()
+
+        self.assertEqual(executed, [])
+
     def test_execute_with_initial_node(self):
         executed = []
 
@@ -281,6 +335,30 @@ class FlowAsyncExecutionTestCase(IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
         self.assertEqual(executed, ["A"])
+
+    async def test_execute_async_forwards_none_output(self) -> None:
+        executed: list[str] = []
+
+        async def start(_: dict[str, object]) -> None:
+            await sleep(0)
+            executed.append("A")
+            return None
+
+        async def finish(inputs: dict[str, object]) -> str:
+            await sleep(0)
+            executed.append("B")
+            self.assertEqual(inputs, {"A": None})
+            return "forwarded"
+
+        flow = Flow()
+        flow.add_node(Node("A", func=start))
+        flow.add_node(Node("B", func=finish))
+        flow.add_connection("A", "B")
+
+        result = await flow.execute_async()
+
+        self.assertEqual(result, "forwarded")
+        self.assertEqual(executed, ["A", "B"])
 
     async def test_execute_async_missing_input_and_multi_terminal(
         self,

--- a/tests/flow/flow_test.py
+++ b/tests/flow/flow_test.py
@@ -173,6 +173,88 @@ class FlowExecutionTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(result, 12)
         self.assertEqual(executed, ["B", "C"])
 
+    async def test_execute_with_initial_inputs(self) -> None:
+        def selected(inputs: dict[str, object]) -> int:
+            return int(inputs["value"]) + 3
+
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=selected))
+        flow.add_connection("A", "B")
+
+        result = await flow.execute_async(
+            initial_node="B",
+            initial_inputs={"value": 4},
+        )
+
+        self.assertEqual(result, 7)
+
+    async def test_execute_with_initial_node_ignores_unreachable_terminal(
+        self,
+    ) -> None:
+        executed: list[str] = []
+
+        def selected(inputs: dict[str, object]) -> int:
+            executed.append("B")
+            return int(inputs["__init__"]) + 1
+
+        def should_not_run(_: dict[str, object]) -> str:
+            executed.append("D")
+            return "unreachable"
+
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=selected))
+        flow.add_node(Node("C", func=lambda _: 2))
+        flow.add_node(Node("D", func=should_not_run))
+        flow.add_connection("A", "B")
+        flow.add_connection("C", "D")
+
+        result = await flow.execute_async(initial_node="B", initial_data=5)
+
+        self.assertEqual(result, 6)
+        self.assertEqual(executed, ["B"])
+
+    async def test_execute_with_initial_node_omits_unreachable_terminal_output(
+        self,
+    ) -> None:
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 1))
+        flow.add_node(Node("B", func=lambda inputs: inputs["A"] + 1))
+        flow.add_node(Node("C", func=lambda inputs: inputs["A"] + 2))
+        flow.add_node(Node("D", func=lambda _: "unreachable"))
+        flow.add_connection("A", "B")
+        flow.add_connection("A", "C")
+
+        result = await flow.execute_async(initial_node="A")
+
+        self.assertEqual(result, {"B": 2, "C": 3})
+
+    async def test_execute_with_initial_node_ignores_unreachable_parent(
+        self,
+    ) -> None:
+        executed: list[str] = []
+
+        def selected(_: dict[str, object]) -> int:
+            executed.append("B")
+            return 4
+
+        def finish(inputs: dict[str, object]) -> int:
+            executed.append("D")
+            return int(inputs["B"]) + 1
+
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: 100))
+        flow.add_node(Node("B", func=selected))
+        flow.add_node(Node("D", func=finish))
+        flow.add_connection("A", "D")
+        flow.add_connection("B", "D")
+
+        result = await flow.execute_async(initial_node="B")
+
+        self.assertEqual(result, 5)
+        self.assertEqual(executed, ["B", "D"])
+
     async def test_execute_raises_when_no_start_nodes(self):
         flow = Flow()
         flow.add_node(Node("A"))
@@ -358,6 +440,41 @@ class FlowAsyncExecutionTestCase(IsolatedAsyncioTestCase):
             await flow.execute_async()
 
         self.assertIn("cycle", str(context.exception))
+
+    async def test_execute_async_detects_cycle_before_running_nodes(
+        self,
+    ) -> None:
+        executed: list[str] = []
+
+        def start(_: dict[str, object]) -> int:
+            executed.append("A")
+            return 1
+
+        flow = Flow()
+        flow.add_node(Node("A", func=start))
+        flow.add_node(Node("B", func=lambda _: 2))
+        flow.add_node(Node("C", func=lambda _: 3))
+        flow.add_connection("A", "B")
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        with self.assertRaises(ValueError) as context:
+            await flow.execute_async()
+
+        self.assertIn("cycle", str(context.exception))
+        self.assertEqual(executed, [])
+
+    async def test_execute_async_ignores_unreachable_cycle(self) -> None:
+        flow = Flow()
+        flow.add_node(Node("A", func=lambda _: "ok"))
+        flow.add_node(Node("B", func=lambda _: "unreachable"))
+        flow.add_node(Node("C", func=lambda _: "unreachable"))
+        flow.add_connection("B", "C")
+        flow.add_connection("C", "B")
+
+        result = await flow.execute_async(initial_node="A")
+
+        self.assertEqual(result, "ok")
 
     async def test_execute_async_detects_cycle_with_initial_node(self) -> None:
         flow = Flow()

--- a/tests/flow/node_test.py
+++ b/tests/flow/node_test.py
@@ -28,6 +28,11 @@ class NodeExecuteTestCase(TestCase):
         self.assertEqual(node.execute({"a": 1, "b": 2}), {"a": 1, "b": 2})
         self.assertIsNone(node.execute({}))
 
+    def test_execute_none_output_bypasses_output_schema(self):
+        node = Node("n", func=lambda _: None, output_schema=str)
+
+        self.assertIsNone(node.execute({"x": 1}))
+
     def test_schema_validation(self):
         node = Node(
             "n",
@@ -122,6 +127,16 @@ class NodeAsyncTestCase(IsolatedAsyncioTestCase):
 
         with self.assertRaises(CancelledError):
             await node.execute_async({}, cancellation_checker=cancelled)
+
+    async def test_execute_async_none_output_bypasses_output_schema(
+        self,
+    ) -> None:
+        async def no_output(_: dict[str, int]) -> None:
+            await sleep(0)
+
+        node = Node("n", func=no_output, output_schema=str)
+
+        self.assertIsNone(await node.execute_async({"x": 1}))
 
 
 class NodeImportTestCase(TestCase):

--- a/tests/flow/node_test.py
+++ b/tests/flow/node_test.py
@@ -6,88 +6,71 @@ from avalan.flow.node import Node
 
 
 class NodeExecuteTestCase(TestCase):
-    def test_execute_with_function(self):
+    def test_sync_execute_is_not_exposed(self) -> None:
+        self.assertFalse(hasattr(Node("n"), "execute"))
+
+    def test_repr(self):
+        node = Node("repr")
+        self.assertEqual(repr(node), "<Node repr>")
+
+
+class NodeAsyncTestCase(IsolatedAsyncioTestCase):
+    async def test_execute_async_with_function(self) -> None:
         def inc(inputs):
             return inputs["x"] + 1
 
         node = Node("n", func=inc)
-        result = node.execute({"x": 1})
-        self.assertEqual(result, 2)
 
-    def test_execute_function_varargs(self):
+        self.assertEqual(await node.execute_async({"x": 1}), 2)
+
+    async def test_execute_async_function_varargs(self) -> None:
         def add(a, b):
             return a + b
 
         node = Node("n", func=add)
-        result = node.execute({"a": 1, "b": 2})
-        self.assertEqual(result, 3)
 
-    def test_execute_no_function(self):
+        self.assertEqual(await node.execute_async({"a": 1, "b": 2}), 3)
+
+    async def test_execute_async_no_function(self) -> None:
         node = Node("n")
-        self.assertEqual(node.execute({"a": 1}), 1)
-        self.assertEqual(node.execute({"a": 1, "b": 2}), {"a": 1, "b": 2})
-        self.assertIsNone(node.execute({}))
+        self.assertEqual(await node.execute_async({"a": 1}), 1)
+        self.assertEqual(
+            await node.execute_async({"a": 1, "b": 2}),
+            {"a": 1, "b": 2},
+        )
+        self.assertIsNone(await node.execute_async({}))
 
-    def test_execute_none_output_bypasses_output_schema(self):
+    async def test_execute_async_sync_none_output_bypasses_output_schema(
+        self,
+    ) -> None:
         node = Node("n", func=lambda _: None, output_schema=str)
 
-        self.assertIsNone(node.execute({"x": 1}))
+        self.assertIsNone(await node.execute_async({"x": 1}))
 
-    def test_schema_validation(self):
+    async def test_schema_validation(self) -> None:
         node = Node(
             "n",
             func=lambda inputs: str(inputs["x"]),
             input_schema=int,
             output_schema=str,
         )
-        self.assertEqual(node.execute({"x": 2}), "2")
+        self.assertEqual(await node.execute_async({"x": 2}), "2")
         with self.assertRaises(TypeError):
-            node.execute({"x": "a"})
+            await node.execute_async({"x": "a"})
         bad_node = Node("b", func=lambda inputs: 1, output_schema=str)
         with self.assertRaises(TypeError):
-            bad_node.execute({"x": 1})
+            await bad_node.execute_async({"x": 1})
 
-    def test_execute_subgraph(self):
+    async def test_execute_async_subgraph(self) -> None:
         sub = Flow()
         sub.add_node(Node("A", func=lambda inp: inp["__init__"] * 2))
         sub.add_node(Node("B", func=lambda inp: inp["A"] + 3))
         sub.add_connection("A", "B")
         node = Node("sub", subgraph=sub, output_schema=int)
-        result = node.execute({"val": 5})
-        self.assertEqual(result, 13)
 
+        self.assertEqual(await node.execute_async({"val": 5}), 13)
 
-class NodeExtraTestCase(TestCase):
-    def test_execute_output_schema_mismatch_subgraph(self):
-        sub = Flow()
-        sub.add_node(Node("A", func=lambda inp: 42))
-        node = Node("sub", subgraph=sub, output_schema=str)
-        with self.assertRaises(TypeError):
-            node.execute({"val": 1})
-
-    def test_execute_input_schema_mismatch_multiple_inputs(self):
-        node = Node(
-            "n", input_schema=int, func=lambda inputs: sum(inputs.values())
-        )
-        with self.assertRaises(TypeError):
-            node.execute({"a": 1, "b": 2})
-
-    def test_repr(self):
-        node = Node("repr")
-        self.assertEqual(repr(node), "<Node repr>")
-
-    def test_execute_rejects_async_function(self) -> None:
-        async def inc(inputs: dict[str, int]) -> int:
-            return inputs["x"] + 1
-
-        node = Node("n", func=inc)
-
-        with self.assertRaisesRegex(TypeError, "execute_async"):
-            node.execute({"x": 1})
-
-
-class NodeAsyncTestCase(IsolatedAsyncioTestCase):
-    async def test_execute_async_with_function(self) -> None:
+    async def test_execute_async_awaits_function(self) -> None:
         async def inc(inputs: dict[str, int]) -> int:
             await sleep(0)
             return inputs["x"] + 1
@@ -96,7 +79,7 @@ class NodeAsyncTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(await node.execute_async({"x": 1}), 2)
 
-    async def test_execute_async_function_varargs(self) -> None:
+    async def test_execute_async_awaits_varargs_function(self) -> None:
         async def add(a: int, b: int) -> int:
             await sleep(0)
             return a + b
@@ -105,19 +88,21 @@ class NodeAsyncTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(await node.execute_async({"a": 1, "b": 2}), 3)
 
-    async def test_execute_async_subgraph(self) -> None:
+    async def test_execute_async_output_schema_mismatch_subgraph(self) -> None:
         sub = Flow()
+        sub.add_node(Node("A", func=lambda inp: 42))
+        node = Node("sub", subgraph=sub, output_schema=str)
+        with self.assertRaises(TypeError):
+            await node.execute_async({"val": 1})
 
-        async def double(inp: dict[str, int]) -> int:
-            await sleep(0)
-            return inp["__init__"] * 2
-
-        sub.add_node(Node("A", func=double))
-        sub.add_node(Node("B", func=lambda inp: inp["A"] + 3))
-        sub.add_connection("A", "B")
-        node = Node("sub", subgraph=sub, output_schema=int)
-
-        self.assertEqual(await node.execute_async({"val": 5}), 13)
+    async def test_execute_async_input_schema_mismatch_multiple_inputs(
+        self,
+    ) -> None:
+        node = Node(
+            "n", input_schema=int, func=lambda inputs: sum(inputs.values())
+        )
+        with self.assertRaises(TypeError):
+            await node.execute_async({"a": 1, "b": 2})
 
     async def test_execute_async_checks_cancellation(self) -> None:
         async def cancelled() -> None:

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -1,7 +1,10 @@
-from unittest import TestCase, main
+from collections.abc import Mapping
+from unittest import IsolatedAsyncioTestCase, TestCase, main
 
+from avalan.entities import ToolManagerSettings
 from avalan.flow import (
     FLOW_INPUT_KEY,
+    FLOW_TOOL_NODE_TYPE,
     FlowInputDefinition,
     FlowInputType,
     FlowNodeContract,
@@ -11,9 +14,50 @@ from avalan.flow import (
     FlowOutputType,
     default_flow_node_registry,
     flow_input_binding,
+    tool_flow_node_registry,
 )
 from avalan.flow.node import Node
 from avalan.flow.registry import FlowNodeConfigurationError
+from avalan.tool import ToolSet
+from avalan.tool.manager import ToolManager
+from avalan.tool.mcp import McpToolSet
+
+
+async def flow_adder(a: int, b: int) -> int:
+    return a + b
+
+
+flow_adder.aliases = ["sum"]  # type: ignore[attr-defined]
+
+
+async def flow_adder_alt(a: int, b: int) -> int:
+    return a + b
+
+
+flow_adder_alt.aliases = ["sum"]  # type: ignore[attr-defined]
+
+
+async def flow_disabled(a: int) -> int:
+    return a
+
+
+def _tool_manager(
+    *,
+    enable_tools: list[str] | None = None,
+) -> ToolManager:
+    return ToolManager.create_instance(
+        enable_tools=enable_tools
+        or [
+            "flow_adder",
+            "mcp.call",
+        ],
+        available_toolsets=[
+            ToolSet(tools=[flow_adder, flow_adder_alt]),
+            ToolSet(namespace="disabled", tools=[flow_disabled]),
+            McpToolSet(),
+        ],
+        settings=ToolManagerSettings(),
+    )
 
 
 class FlowNodeRegistryTestCase(TestCase):
@@ -216,6 +260,91 @@ class FlowNodeRegistryTestCase(TestCase):
                 message="Flow node configuration is invalid.",
                 hint="Fix the node configuration.",
             )
+
+
+class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
+    async def test_tool_registry_builds_async_tool_node_with_metadata(
+        self,
+    ) -> None:
+        registry = tool_flow_node_registry(_tool_manager())
+
+        self.assertTrue(registry.supports(FLOW_TOOL_NODE_TYPE))
+        self.assertTrue(registry.supports_ref(FLOW_TOOL_NODE_TYPE))
+        self.assertTrue(registry.is_async_only(FLOW_TOOL_NODE_TYPE))
+        metadata = registry.metadata(FLOW_TOOL_NODE_TYPE)
+        input_contract = registry.input_contract(FLOW_TOOL_NODE_TYPE)
+        output_contract = registry.output_contract(FLOW_TOOL_NODE_TYPE)
+        assert metadata is not None
+        assert input_contract is not None
+        assert output_contract is not None
+        tools = metadata.metadata["tools"]
+        assert isinstance(tools, Mapping)
+        self.assertIn("flow_adder", tools)
+        self.assertEqual(input_contract.name, "arguments")
+        self.assertEqual(input_contract.type, FlowInputType.OBJECT)
+        self.assertEqual(output_contract.name, "result")
+        self.assertEqual(output_contract.type, FlowOutputType.JSON)
+
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+
+        self.assertEqual(node.label, "flow_adder")
+        with self.assertRaises(NotImplementedError):
+            await node.execute_async({})
+
+    def test_tool_registry_can_extend_custom_base_registry(self) -> None:
+        def factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name, func=lambda _: "custom")
+
+        base_registry = FlowNodeRegistry({"custom": factory})
+
+        registry = tool_flow_node_registry(
+            _tool_manager(),
+            base_registry=base_registry,
+        )
+
+        self.assertIs(registry, base_registry)
+        self.assertTrue(registry.supports("custom"))
+        self.assertTrue(registry.supports(FLOW_TOOL_NODE_TYPE))
+
+    def test_tool_registry_rejects_invalid_arguments(self) -> None:
+        with self.assertRaises(AssertionError):
+            tool_flow_node_registry(object())  # type: ignore[arg-type]
+        with self.assertRaises(AssertionError):
+            tool_flow_node_registry(
+                _tool_manager(),
+                base_registry=object(),  # type: ignore[arg-type]
+            )
+
+    def test_tool_node_factory_rejects_bad_refs(self) -> None:
+        manager = _tool_manager(enable_tools=["flow_adder", "flow_adder_alt"])
+        registry = tool_flow_node_registry(manager)
+        cases = (
+            (None, "flow.missing_ref"),
+            ("tools/adder.py", "flow.invalid_ref"),
+            ("mcp://server/tool", "flow.invalid_ref"),
+            ("missing", "flow.tool_unknown"),
+            ("disabled.flow_disabled", "flow.tool_disabled"),
+            ("sum", "flow.tool_ambiguous"),
+        )
+
+        for ref, code in cases:
+            with self.subTest(ref=ref):
+                definition = FlowNodeDefinition(
+                    name="calculate",
+                    type=FLOW_TOOL_NODE_TYPE,
+                    ref=ref,
+                )
+                with self.assertRaises(FlowNodeConfigurationError) as context:
+                    registry.build(definition)
+
+                self.assertEqual(context.exception.code, code)
+                self.assertEqual(context.exception.path, "nodes.calculate.ref")
 
 
 if __name__ == "__main__":

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from unittest import IsolatedAsyncioTestCase, TestCase, main
+from unittest import IsolatedAsyncioTestCase, main
 
 from avalan.entities import (
     ToolCall,
@@ -158,8 +158,10 @@ class StaticToolResolver:
         )
 
 
-class FlowNodeRegistryTestCase(TestCase):
-    def test_default_nodes_execute_without_mutating_inputs(self) -> None:
+class FlowNodeRegistryTestCase(IsolatedAsyncioTestCase):
+    async def test_default_nodes_execute_without_mutating_inputs(
+        self,
+    ) -> None:
         registry = default_flow_node_registry()
         payload = {"items": ["first"]}
         binding = flow_input_binding(
@@ -190,14 +192,18 @@ class FlowNodeRegistryTestCase(TestCase):
             )
         )
 
-        input_value = input_node.execute(binding)
+        input_value = await input_node.execute_async(binding)
         self.assertEqual(input_value, {"items": ["first"]})
         self.assertEqual(
-            echo_node.execute({"input": input_value}), input_value
+            await echo_node.execute_async({"input": input_value}),
+            input_value,
         )
-        self.assertEqual(select_node.execute({"input": input_value}), "first")
         self.assertEqual(
-            constant_node.execute({}),
+            await select_node.execute_async({"input": input_value}),
+            "first",
+        )
+        self.assertEqual(
+            await constant_node.execute_async({}),
             {"answer": "ok"},
         )
         self.assertEqual(payload, {"items": ["first", "changed"]})
@@ -222,19 +228,21 @@ class FlowNodeRegistryTestCase(TestCase):
         self.assertEqual(mapping["payload"], {"name": "Ada"})
         self.assertNotIn("value", mapping)
 
-    def test_echo_node_falls_back_to_available_inputs(self) -> None:
+    async def test_echo_node_falls_back_to_available_inputs(self) -> None:
         node = default_flow_node_registry().build(
             FlowNodeDefinition(name="echo", type="echo")
         )
 
-        self.assertEqual(node.execute({FLOW_INPUT_KEY: "flow"}), "flow")
-        self.assertEqual(node.execute({"only": "value"}), "value")
         self.assertEqual(
-            node.execute({"left": "L", "right": "R"}),
+            await node.execute_async({FLOW_INPUT_KEY: "flow"}), "flow"
+        )
+        self.assertEqual(await node.execute_async({"only": "value"}), "value")
+        self.assertEqual(
+            await node.execute_async({"left": "L", "right": "R"}),
             {"left": "L", "right": "R"},
         )
 
-    def test_custom_registry_and_select_errors(self) -> None:
+    async def test_custom_registry_and_select_errors(self) -> None:
         registry = FlowNodeRegistry()
 
         def factory(definition: FlowNodeDefinition) -> Node:
@@ -247,9 +255,9 @@ class FlowNodeRegistryTestCase(TestCase):
 
         self.assertTrue(registry.supports("upper"))
         self.assertEqual(
-            registry.build(
+            await registry.build(
                 FlowNodeDefinition(name="upper", type="upper")
-            ).execute({"value": "ok"}),
+            ).execute_async({"value": "ok"}),
             "OK",
         )
 
@@ -262,7 +270,7 @@ class FlowNodeRegistryTestCase(TestCase):
             )
         )
         with self.assertRaises(KeyError):
-            select_node.execute({"input": {"answer": "ok"}})
+            await select_node.execute_async({"input": {"answer": "ok"}})
 
     def test_registry_exposes_node_metadata(self) -> None:
         registry = default_flow_node_registry()
@@ -282,7 +290,7 @@ class FlowNodeRegistryTestCase(TestCase):
         self.assertEqual(echo_output.name, "value")
         self.assertTrue(echo_output.metadata["dynamic"])
 
-    def test_custom_registry_metadata_supports_refs_and_contracts(
+    async def test_custom_registry_metadata_supports_refs_and_contracts(
         self,
     ) -> None:
         def factory(definition: FlowNodeDefinition) -> Node:
@@ -315,13 +323,13 @@ class FlowNodeRegistryTestCase(TestCase):
             metadata.output_contract,
         )
         self.assertEqual(
-            registry.build(
+            await registry.build(
                 FlowNodeDefinition(
                     name="remote",
                     type="remote",
                     ref="safe.toml",
                 )
-            ).execute({}),
+            ).execute_async({}),
             "safe.toml",
         )
 

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -1,3 +1,4 @@
+from asyncio import CancelledError
 from collections.abc import Mapping
 from unittest import IsolatedAsyncioTestCase, main
 
@@ -5,6 +6,8 @@ from avalan.entities import (
     ToolCall,
     ToolCallContext,
     ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallOutcome,
     ToolCallResult,
     ToolDescriptor,
@@ -49,6 +52,10 @@ async def flow_adder_alt(a: int, b: int) -> int:
 flow_adder_alt.aliases = ["sum"]  # type: ignore[attr-defined]
 
 
+async def flow_multiplier(a: int, b: int) -> int:
+    return a * b
+
+
 async def flow_disabled(a: int) -> int:
     return a
 
@@ -59,6 +66,10 @@ async def flow_identity(value: int) -> int:
 
 async def flow_none(value: int) -> None:
     return None
+
+
+async def flow_status() -> str:
+    return "ready"
 
 
 async def flow_fails(value: int) -> None:
@@ -82,8 +93,10 @@ def _tool_manager(
                 tools=[
                     flow_adder,
                     flow_adder_alt,
+                    flow_multiplier,
                     flow_identity,
                     flow_none,
+                    flow_status,
                     flow_fails,
                 ]
             ),
@@ -156,6 +169,33 @@ class StaticToolResolver:
             arguments=call.arguments,
             result=call.arguments or {},
         )
+
+
+class ValidatingToolResolver(StaticToolResolver):
+    def __init__(self, descriptors: list[ToolDescriptor]) -> None:
+        super().__init__(descriptors)
+        self.executed = False
+        self.validated: list[ToolCall] = []
+
+    def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
+        self.validated.append(call)
+        return ToolCallDiagnostic(
+            id="diagnostic-1",
+            call_id=call.id,
+            requested_name=call.name,
+            canonical_name=call.name,
+            code=ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            message="Tool node arguments are invalid.",
+        )
+
+    async def execute_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> ToolCallOutcome:
+        self.executed = True
+        return await super().execute_call(call, context)
 
 
 class FlowNodeRegistryTestCase(IsolatedAsyncioTestCase):
@@ -472,6 +512,25 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(resolver.calls[0].arguments, {"value": 7})
 
+    async def test_tool_node_executes_no_argument_tool_without_bindings(
+        self,
+    ) -> None:
+        resolver = RecordingToolResolver(
+            _tool_manager(enable_tools=["flow_status"])
+        )
+        registry = tool_flow_node_registry(resolver)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="status",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_status",
+            )
+        )
+
+        self.assertEqual(await node.execute_async({}), "ready")
+
+        self.assertEqual(resolver.calls[0].arguments, {})
+
     async def test_tool_node_passes_flow_cancellation_checker(self) -> None:
         resolver = RecordingToolResolver(_tool_manager())
         registry = tool_flow_node_registry(resolver)
@@ -553,6 +612,66 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
                 with self.assertRaises(FlowNodeConfigurationError) as context:
                     await node.execute_async(inputs)
                 self.assertEqual(context.exception.code, code)
+
+    async def test_tool_node_validates_bound_arguments_before_execution(
+        self,
+    ) -> None:
+        descriptor = ToolDescriptor(
+            name="validated",
+            parameter_schema={
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"],
+            },
+        )
+        raw_resolver = ValidatingToolResolver([descriptor])
+        raw_node = tool_flow_node_registry(raw_resolver).build(
+            FlowNodeDefinition(
+                name="validated",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="validated",
+                config={"arguments": {"value": "value"}},
+            )
+        )
+
+        with self.assertRaises(FlowNodeConfigurationError) as raw_context:
+            await raw_node.execute_async({"payload": {"value": "bad"}})
+
+        self.assertEqual(raw_context.exception.code, "flow.invalid_arguments")
+        self.assertFalse(raw_resolver.executed)
+        self.assertEqual(len(raw_resolver.validated), 1)
+        self.assertEqual(
+            raw_resolver.validated[0].arguments,
+            {"value": "bad"},
+        )
+
+        envelope_resolver = ValidatingToolResolver([descriptor])
+        envelope_node = tool_flow_node_registry(envelope_resolver).build(
+            FlowNodeDefinition(
+                name="validated",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="validated",
+                config={
+                    "arguments": {"value": "value"},
+                    "output_mode": "envelope",
+                },
+            )
+        )
+
+        envelope = await envelope_node.execute_async(
+            {"payload": {"value": "bad"}}
+        )
+
+        assert isinstance(envelope, dict)
+        diagnostic = envelope["diagnostic"]
+        assert isinstance(diagnostic, dict)
+        self.assertEqual(envelope["status"], "diagnostic")
+        self.assertEqual(
+            diagnostic["code"],
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED.value,
+        )
+        self.assertFalse(envelope_resolver.executed)
+        self.assertEqual(len(envelope_resolver.validated), 1)
 
     async def test_tool_node_output_modes_cover_outcomes(self) -> None:
         success = tool_flow_node_registry(_tool_manager()).build(
@@ -672,6 +791,148 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(context.exception.code, "flow.tool_diagnostic")
 
+    async def test_tool_node_envelope_keeps_filter_guard_after_context_replace(
+        self,
+    ) -> None:
+        def replace_context(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return call, ToolCallContext()
+
+        def rename(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="flow_multiplier",
+                    arguments=call.arguments,
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["flow_adder", "flow_multiplier"],
+            available_toolsets=[ToolSet(tools=[flow_adder, flow_multiplier])],
+            settings=ToolManagerSettings(filters=[replace_context, rename]),
+        )
+        registry = tool_flow_node_registry(manager)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                config={"output_mode": "envelope"},
+            )
+        )
+
+        envelope = await node.execute_async({"payload": {"a": 2, "b": 3}})
+
+        assert isinstance(envelope, dict)
+        diagnostic = envelope["diagnostic"]
+        assert isinstance(diagnostic, dict)
+        self.assertEqual(envelope["status"], "diagnostic")
+        self.assertEqual(envelope["canonical_name"], "flow_adder")
+        self.assertIsNone(envelope["result"])
+        self.assertEqual(
+            diagnostic["code"],
+            ToolCallDiagnosticCode.FILTER_SUPPRESSED.value,
+        )
+        self.assertEqual(
+            diagnostic["details"], {"filtered_name": "flow_multiplier"}
+        )
+
+    async def test_tool_node_accepts_filter_alias_for_same_tool(
+        self,
+    ) -> None:
+        def set_alias(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="sum",
+                    arguments=call.arguments,
+                ),
+                ToolCallContext(),
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["flow_adder"],
+            available_toolsets=[ToolSet(tools=[flow_adder])],
+            settings=ToolManagerSettings(filters=[set_alias]),
+        )
+        registry = tool_flow_node_registry(manager)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+
+        self.assertEqual(
+            await node.execute_async({"payload": {"a": 2, "b": 3}}),
+            5,
+        )
+
+    async def test_tool_node_propagates_cancellation_after_context_replace(
+        self,
+    ) -> None:
+        cases = (
+            {},
+            {"output_mode": "envelope"},
+        )
+
+        for config in cases:
+            with self.subTest(config=config):
+                called: list[str] = []
+
+                async def cancellable_adder(a: int, b: int) -> int:
+                    called.append("tool")
+                    return a + b
+
+                def replace_context(
+                    call: ToolCall,
+                    _context: ToolCallContext,
+                ) -> tuple[ToolCall, ToolCallContext]:
+                    called.append("filter")
+                    return call, ToolCallContext()
+
+                async def cancel() -> None:
+                    called.append("cancel")
+                    if called.count("cancel") == 4:
+                        raise CancelledError()
+
+                manager = ToolManager.create_instance(
+                    enable_tools=["cancellable_adder"],
+                    available_toolsets=[ToolSet(tools=[cancellable_adder])],
+                    settings=ToolManagerSettings(filters=[replace_context]),
+                )
+                registry = tool_flow_node_registry(manager)
+                node = registry.build(
+                    FlowNodeDefinition(
+                        name="calculate",
+                        type=FLOW_TOOL_NODE_TYPE,
+                        ref="cancellable_adder",
+                        config=config,
+                    )
+                )
+
+                with self.assertRaises(CancelledError):
+                    await node.execute_async(
+                        {"payload": {"a": 2, "b": 3}},
+                        cancellation_checker=cancel,
+                    )
+
+                self.assertEqual(
+                    called,
+                    ["cancel", "cancel", "cancel", "filter", "cancel"],
+                )
+
     async def test_tool_node_rejects_invalid_runtime_bindings(
         self,
     ) -> None:
@@ -763,6 +1024,28 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
 
                 self.assertEqual(context.exception.code, code)
                 self.assertEqual(context.exception.path, path)
+
+        no_arg_registry = tool_flow_node_registry(
+            _tool_manager(enable_tools=["flow_status"])
+        )
+        with self.assertRaises(FlowNodeConfigurationError) as context:
+            no_arg_registry.build(
+                FlowNodeDefinition(
+                    name="status",
+                    type=FLOW_TOOL_NODE_TYPE,
+                    ref="flow_status",
+                    config={"arguments": {"value": "payload"}},
+                )
+            )
+
+        self.assertEqual(
+            context.exception.code,
+            "flow.unknown_argument_binding",
+        )
+        self.assertEqual(
+            context.exception.path,
+            "nodes.status.config.arguments.value",
+        )
 
     def test_tool_registry_can_extend_custom_base_registry(self) -> None:
         def factory(definition: FlowNodeDefinition) -> Node:

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -4,12 +4,16 @@ from avalan.flow import (
     FLOW_INPUT_KEY,
     FlowInputDefinition,
     FlowInputType,
+    FlowNodeContract,
     FlowNodeDefinition,
+    FlowNodeMetadata,
     FlowNodeRegistry,
+    FlowOutputType,
     default_flow_node_registry,
     flow_input_binding,
 )
 from avalan.flow.node import Node
+from avalan.flow.registry import FlowNodeConfigurationError
 
 
 class FlowNodeRegistryTestCase(TestCase):
@@ -117,6 +121,101 @@ class FlowNodeRegistryTestCase(TestCase):
         )
         with self.assertRaises(KeyError):
             select_node.execute({"input": {"answer": "ok"}})
+
+    def test_registry_exposes_node_metadata(self) -> None:
+        registry = default_flow_node_registry()
+
+        self.assertFalse(registry.supports_ref("echo"))
+        self.assertFalse(registry.is_async_only("echo"))
+        self.assertIsNone(registry.metadata("missing"))
+        self.assertIsNone(registry.input_contract("missing"))
+        self.assertIsNone(registry.output_contract("missing"))
+        echo_input = registry.input_contract("echo")
+        echo_output = registry.output_contract("echo")
+
+        assert echo_input is not None
+        assert echo_output is not None
+        self.assertEqual(echo_input.name, "value")
+        self.assertTrue(echo_input.metadata["dynamic"])
+        self.assertEqual(echo_output.name, "value")
+        self.assertTrue(echo_output.metadata["dynamic"])
+
+    def test_custom_registry_metadata_supports_refs_and_contracts(
+        self,
+    ) -> None:
+        def factory(definition: FlowNodeDefinition) -> Node:
+            return Node(definition.name, func=lambda _: definition.ref)
+
+        metadata = FlowNodeMetadata(
+            supports_ref=True,
+            async_only=True,
+            input_contract=FlowNodeContract(
+                name="payload",
+                type=FlowInputType.OBJECT,
+                schema={"type": "object"},
+            ),
+            output_contract=FlowNodeContract(
+                name="result",
+                type=FlowOutputType.JSON,
+                schema={"type": "string"},
+            ),
+        )
+        registry = FlowNodeRegistry({"remote": factory}, {"remote": metadata})
+
+        self.assertTrue(registry.supports("remote"))
+        self.assertTrue(registry.supports_ref("remote"))
+        self.assertTrue(registry.is_async_only("remote"))
+        self.assertEqual(
+            registry.input_contract("remote"), metadata.input_contract
+        )
+        self.assertEqual(
+            registry.output_contract("remote"),
+            metadata.output_contract,
+        )
+        self.assertEqual(
+            registry.build(
+                FlowNodeDefinition(
+                    name="remote",
+                    type="remote",
+                    ref="safe.toml",
+                )
+            ).execute({}),
+            "safe.toml",
+        )
+
+    def test_registry_rejects_invalid_metadata(self) -> None:
+        registry = FlowNodeRegistry()
+
+        with self.assertRaises(AssertionError):
+            registry.register(
+                "bad",
+                lambda definition: Node(definition.name),
+                metadata=object(),  # type: ignore[arg-type]
+            )
+
+    def test_configuration_error_carries_public_fields(self) -> None:
+        error = FlowNodeConfigurationError(
+            code="flow.invalid_node",
+            path="nodes.start",
+            message="Flow node configuration is invalid.",
+            hint="Fix the node configuration.",
+        )
+
+        self.assertEqual(str(error), "flow.invalid_node")
+        self.assertEqual(error.code, "flow.invalid_node")
+        self.assertEqual(error.path, "nodes.start")
+        self.assertEqual(
+            error.message,
+            "Flow node configuration is invalid.",
+        )
+        self.assertEqual(error.hint, "Fix the node configuration.")
+        with self.assertRaises(AssertionError):
+            FlowNodeConfigurationError(
+                code="",
+                path="nodes.start",
+                message="Flow node configuration is invalid.",
+                hint="Fix the node configuration.",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -3,8 +3,13 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main
 
 from avalan.entities import (
     ToolCall,
+    ToolCallContext,
     ToolCallDiagnostic,
+    ToolCallOutcome,
+    ToolCallResult,
     ToolDescriptor,
+    ToolFilterResult,
+    ToolFilterResultStatus,
     ToolManagerSettings,
     ToolNameResolution,
     ToolNameResolutionStatus,
@@ -52,6 +57,14 @@ async def flow_identity(value: int) -> int:
     return value
 
 
+async def flow_none(value: int) -> None:
+    return None
+
+
+async def flow_fails(value: int) -> None:
+    raise ValueError(f"bad {value}")
+
+
 def _tool_manager(
     *,
     enable_tools: list[str] | None = None,
@@ -61,10 +74,19 @@ def _tool_manager(
         or [
             "flow_adder",
             "flow_identity",
+            "flow_none",
             "mcp.call",
         ],
         available_toolsets=[
-            ToolSet(tools=[flow_adder, flow_adder_alt, flow_identity]),
+            ToolSet(
+                tools=[
+                    flow_adder,
+                    flow_adder_alt,
+                    flow_identity,
+                    flow_none,
+                    flow_fails,
+                ]
+            ),
             ToolSet(namespace="disabled", tools=[flow_disabled]),
             McpToolSet(),
         ],
@@ -76,6 +98,7 @@ class RecordingToolResolver:
     def __init__(self, manager: ToolManager) -> None:
         self.manager = manager
         self.calls: list[ToolCall] = []
+        self.contexts: list[ToolCallContext] = []
 
     def list_tools(self) -> list[ToolDescriptor]:
         return self.manager.list_tools()
@@ -89,8 +112,16 @@ class RecordingToolResolver:
         )
 
     def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
-        self.calls.append(call)
         return self.manager.validate_tool_call(call)
+
+    async def execute_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> ToolCallOutcome:
+        self.calls.append(call)
+        self.contexts.append(context)
+        return await self.manager.execute_call(call, context)
 
 
 class StaticToolResolver:
@@ -112,6 +143,19 @@ class StaticToolResolver:
 
     def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
         return None
+
+    async def execute_call(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> ToolCallOutcome:
+        return ToolCallResult(
+            id="result-1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result=call.arguments or {},
+        )
 
 
 class FlowNodeRegistryTestCase(TestCase):
@@ -348,8 +392,11 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(node.label, "flow_adder")
-        with self.assertRaises(NotImplementedError):
-            await node.execute_async({"payload": {"a": 1, "b": 2}})
+        self.assertTrue(node.async_only)
+        self.assertEqual(
+            await node.execute_async({"payload": {"a": 1, "b": 2}}),
+            3,
+        )
 
     async def test_tool_node_binds_explicit_argument_selectors(
         self,
@@ -366,14 +413,17 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
             )
         )
 
-        with self.assertRaises(NotImplementedError):
+        self.assertEqual(
             await node.execute_async(
                 {"payload": {"left": 2, "right": 3, "ignored": 4}}
-            )
+            ),
+            5,
+        )
 
         self.assertEqual(len(resolver.calls), 1)
         self.assertEqual(resolver.calls[0].name, "flow_adder")
         self.assertEqual(resolver.calls[0].arguments, {"b": 3, "a": 2})
+        self.assertTrue(resolver.contexts[0].flow_tool_node)
 
     async def test_tool_node_binds_implicit_object_by_parameter_name(
         self,
@@ -388,8 +438,10 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
             )
         )
 
-        with self.assertRaises(NotImplementedError):
-            await node.execute_async({"payload": {"b": 5, "a": 4}})
+        self.assertEqual(
+            await node.execute_async({"payload": {"b": 5, "a": 4}}),
+            9,
+        )
 
         self.assertEqual(resolver.calls[0].arguments, {"a": 4, "b": 5})
 
@@ -408,10 +460,32 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
             )
         )
 
-        with self.assertRaises(NotImplementedError):
-            await node.execute_async({"payload": 7})
+        self.assertEqual(await node.execute_async({"payload": 7}), 7)
 
         self.assertEqual(resolver.calls[0].arguments, {"value": 7})
+
+    async def test_tool_node_passes_flow_cancellation_checker(self) -> None:
+        resolver = RecordingToolResolver(_tool_manager())
+        registry = tool_flow_node_registry(resolver)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+
+        async def cancel() -> None:
+            return None
+
+        self.assertEqual(
+            await node.execute_async(
+                {"payload": {"a": 2, "b": 4}},
+                cancellation_checker=cancel,
+            ),
+            6,
+        )
+        self.assertIs(resolver.contexts[0].cancellation_checker, cancel)
 
     async def test_tool_node_handles_descriptor_schema_edge_cases(
         self,
@@ -465,13 +539,130 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
                 )
 
                 if code is None:
-                    with self.assertRaises(NotImplementedError):
-                        await node.execute_async(inputs)
+                    self.assertEqual(await node.execute_async(inputs), {})
                     continue
 
                 with self.assertRaises(FlowNodeConfigurationError) as context:
                     await node.execute_async(inputs)
                 self.assertEqual(context.exception.code, code)
+
+    async def test_tool_node_output_modes_cover_outcomes(self) -> None:
+        success = tool_flow_node_registry(_tool_manager()).build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                config={"output_mode": "envelope"},
+            )
+        )
+        diagnostic = tool_flow_node_registry(_tool_manager()).build(
+            FlowNodeDefinition(
+                name="typed",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                config={
+                    "arguments": {"a": "left", "b": "right"},
+                    "output_mode": "envelope",
+                },
+            )
+        )
+        error = tool_flow_node_registry(
+            _tool_manager(enable_tools=["flow_fails"])
+        ).build(
+            FlowNodeDefinition(
+                name="fail",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_fails",
+                config={"output_mode": "envelope"},
+            )
+        )
+
+        success_envelope = await success.execute_async(
+            {"payload": {"a": 2, "b": 3}}
+        )
+        diagnostic_envelope = await diagnostic.execute_async(
+            {
+                "left": "one",
+                "right": 2,
+            }
+        )
+        error_envelope = await error.execute_async({"payload": 5})
+
+        assert isinstance(success_envelope, dict)
+        self.assertEqual(success_envelope["status"], "result")
+        self.assertEqual(success_envelope["canonical_name"], "flow_adder")
+        self.assertEqual(success_envelope["result"], 5)
+        self.assertIsNone(success_envelope["error"])
+        self.assertIsNone(success_envelope["diagnostic"])
+        assert isinstance(diagnostic_envelope, dict)
+        self.assertEqual(diagnostic_envelope["status"], "diagnostic")
+        self.assertEqual(
+            diagnostic_envelope["canonical_name"],
+            "flow_adder",
+        )
+        self.assertIsNotNone(diagnostic_envelope["diagnostic"])
+        assert isinstance(error_envelope, dict)
+        self.assertEqual(error_envelope["status"], "error")
+        self.assertEqual(error_envelope["canonical_name"], "flow_fails")
+        self.assertEqual(
+            error_envelope["error"],
+            {"type": "ValueError", "message": "bad 5"},
+        )
+
+    async def test_tool_node_raw_mode_preserves_null_result(self) -> None:
+        registry = tool_flow_node_registry(
+            _tool_manager(enable_tools=["flow_none"])
+        )
+        node = registry.build(
+            FlowNodeDefinition(
+                name="null",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_none",
+            )
+        )
+
+        self.assertIsNone(await node.execute_async({"payload": 1}))
+
+    async def test_tool_node_raw_mode_raises_on_execution_error(self) -> None:
+        registry = tool_flow_node_registry(
+            _tool_manager(enable_tools=["flow_fails"])
+        )
+        node = registry.build(
+            FlowNodeDefinition(
+                name="fail",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_fails",
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "ValueError: bad 3"):
+            await node.execute_async({"payload": 3})
+
+    async def test_tool_node_raw_mode_raises_on_diagnostic(self) -> None:
+        def suppress(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(status=ToolFilterResultStatus.SUPPRESS)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["flow_adder"],
+            available_toolsets=[ToolSet(tools=[flow_adder])],
+            settings=ToolManagerSettings(filters=[suppress]),
+        )
+        registry = tool_flow_node_registry(manager)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+
+        with self.assertRaises(FlowNodeConfigurationError) as context:
+            await node.execute_async({"payload": {"a": 1, "b": 2}})
+
+        self.assertEqual(context.exception.code, "flow.tool_diagnostic")
 
     async def test_tool_node_rejects_invalid_runtime_bindings(
         self,
@@ -543,6 +734,11 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
                 {"arguments": {"a": "left"}},
                 "flow.missing_argument_binding",
                 "nodes.calculate.config.arguments.b",
+            ),
+            (
+                {"output_mode": "wrapped"},
+                "flow.invalid_output_mode",
+                "nodes.calculate.config.output_mode",
             ),
         )
 

--- a/tests/flow/registry_test.py
+++ b/tests/flow/registry_test.py
@@ -1,7 +1,14 @@
 from collections.abc import Mapping
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 
-from avalan.entities import ToolManagerSettings
+from avalan.entities import (
+    ToolCall,
+    ToolCallDiagnostic,
+    ToolDescriptor,
+    ToolManagerSettings,
+    ToolNameResolution,
+    ToolNameResolutionStatus,
+)
 from avalan.flow import (
     FLOW_INPUT_KEY,
     FLOW_TOOL_NODE_TYPE,
@@ -41,6 +48,10 @@ async def flow_disabled(a: int) -> int:
     return a
 
 
+async def flow_identity(value: int) -> int:
+    return value
+
+
 def _tool_manager(
     *,
     enable_tools: list[str] | None = None,
@@ -49,15 +60,58 @@ def _tool_manager(
         enable_tools=enable_tools
         or [
             "flow_adder",
+            "flow_identity",
             "mcp.call",
         ],
         available_toolsets=[
-            ToolSet(tools=[flow_adder, flow_adder_alt]),
+            ToolSet(tools=[flow_adder, flow_adder_alt, flow_identity]),
             ToolSet(namespace="disabled", tools=[flow_disabled]),
             McpToolSet(),
         ],
         settings=ToolManagerSettings(),
     )
+
+
+class RecordingToolResolver:
+    def __init__(self, manager: ToolManager) -> None:
+        self.manager = manager
+        self.calls: list[ToolCall] = []
+
+    def list_tools(self) -> list[ToolDescriptor]:
+        return self.manager.list_tools()
+
+    def resolve_tool_name(
+        self, name: str, *, provider_originated: bool = False
+    ) -> ToolNameResolution:
+        return self.manager.resolve_tool_name(
+            name,
+            provider_originated=provider_originated,
+        )
+
+    def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
+        self.calls.append(call)
+        return self.manager.validate_tool_call(call)
+
+
+class StaticToolResolver:
+    def __init__(self, descriptors: list[ToolDescriptor]) -> None:
+        self.descriptors = descriptors
+
+    def list_tools(self) -> list[ToolDescriptor]:
+        return self.descriptors
+
+    def resolve_tool_name(
+        self, name: str, *, provider_originated: bool = False
+    ) -> ToolNameResolution:
+        return ToolNameResolution(
+            requested_name=name,
+            status=ToolNameResolutionStatus.EXACT,
+            canonical_name=name,
+            candidates=[name],
+        )
+
+    def validate_tool_call(self, call: ToolCall) -> ToolCallDiagnostic | None:
+        return None
 
 
 class FlowNodeRegistryTestCase(TestCase):
@@ -295,7 +349,216 @@ class FlowToolNodeRegistryTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(node.label, "flow_adder")
         with self.assertRaises(NotImplementedError):
-            await node.execute_async({})
+            await node.execute_async({"payload": {"a": 1, "b": 2}})
+
+    async def test_tool_node_binds_explicit_argument_selectors(
+        self,
+    ) -> None:
+        resolver = RecordingToolResolver(_tool_manager())
+        registry = tool_flow_node_registry(resolver)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                input="payload",
+                config={"arguments": {"b": "right", "a": "left"}},
+            )
+        )
+
+        with self.assertRaises(NotImplementedError):
+            await node.execute_async(
+                {"payload": {"left": 2, "right": 3, "ignored": 4}}
+            )
+
+        self.assertEqual(len(resolver.calls), 1)
+        self.assertEqual(resolver.calls[0].name, "flow_adder")
+        self.assertEqual(resolver.calls[0].arguments, {"b": 3, "a": 2})
+
+    async def test_tool_node_binds_implicit_object_by_parameter_name(
+        self,
+    ) -> None:
+        resolver = RecordingToolResolver(_tool_manager())
+        registry = tool_flow_node_registry(resolver)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+
+        with self.assertRaises(NotImplementedError):
+            await node.execute_async({"payload": {"b": 5, "a": 4}})
+
+        self.assertEqual(resolver.calls[0].arguments, {"a": 4, "b": 5})
+
+    async def test_tool_node_binds_single_parameter_from_whole_input(
+        self,
+    ) -> None:
+        resolver = RecordingToolResolver(
+            _tool_manager(enable_tools=["flow_identity"])
+        )
+        registry = tool_flow_node_registry(resolver)
+        node = registry.build(
+            FlowNodeDefinition(
+                name="identity",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_identity",
+            )
+        )
+
+        with self.assertRaises(NotImplementedError):
+            await node.execute_async({"payload": 7})
+
+        self.assertEqual(resolver.calls[0].arguments, {"value": 7})
+
+    async def test_tool_node_handles_descriptor_schema_edge_cases(
+        self,
+    ) -> None:
+        cases = (
+            (
+                ToolDescriptor(name="raw", parameter_schema=None),
+                {"arguments": {}},
+                {},
+                None,
+            ),
+            (
+                ToolDescriptor(
+                    name="bad_required",
+                    parameter_schema={
+                        "type": "object",
+                        "properties": {},
+                        "required": "bad",
+                    },
+                ),
+                {"arguments": {}},
+                {},
+                None,
+            ),
+            (
+                ToolDescriptor(
+                    name="bad_properties",
+                    parameter_schema={
+                        "type": "object",
+                        "properties": [],
+                    },
+                ),
+                {},
+                {"payload": {"value": 1}},
+                "flow.ambiguous_argument_binding",
+            ),
+        )
+
+        for descriptor, config, inputs, code in cases:
+            with self.subTest(name=descriptor.name):
+                registry = tool_flow_node_registry(
+                    StaticToolResolver([descriptor])
+                )
+                node = registry.build(
+                    FlowNodeDefinition(
+                        name=descriptor.name,
+                        type=FLOW_TOOL_NODE_TYPE,
+                        ref=descriptor.name,
+                        config=config,
+                    )
+                )
+
+                if code is None:
+                    with self.assertRaises(NotImplementedError):
+                        await node.execute_async(inputs)
+                    continue
+
+                with self.assertRaises(FlowNodeConfigurationError) as context:
+                    await node.execute_async(inputs)
+                self.assertEqual(context.exception.code, code)
+
+    async def test_tool_node_rejects_invalid_runtime_bindings(
+        self,
+    ) -> None:
+        registry = tool_flow_node_registry(_tool_manager())
+        unresolved = registry.build(
+            FlowNodeDefinition(
+                name="calculate",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                config={"arguments": {"a": "left", "b": "missing"}},
+            )
+        )
+        ambiguous = registry.build(
+            FlowNodeDefinition(
+                name="sum",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+            )
+        )
+        invalid = registry.build(
+            FlowNodeDefinition(
+                name="typed",
+                type=FLOW_TOOL_NODE_TYPE,
+                ref="flow_adder",
+                config={"arguments": {"a": "left", "b": "right"}},
+            )
+        )
+
+        cases = (
+            (
+                unresolved,
+                {"left": 1},
+                "flow.unresolved_argument_selector",
+            ),
+            (ambiguous, {"value": 1}, "flow.ambiguous_argument_binding"),
+            (
+                invalid,
+                {"left": "one", "right": 2},
+                "flow.invalid_arguments",
+            ),
+        )
+        for node, inputs, code in cases:
+            with self.subTest(code=code):
+                with self.assertRaises(FlowNodeConfigurationError) as context:
+                    await node.execute_async(inputs)
+
+                self.assertEqual(context.exception.code, code)
+
+    def test_tool_node_factory_rejects_invalid_argument_bindings(self) -> None:
+        registry = tool_flow_node_registry(_tool_manager())
+        cases = (
+            (
+                {"arguments": "a"},
+                "flow.invalid_arguments",
+                "nodes.calculate.config.arguments",
+            ),
+            (
+                {"arguments": {"c": "left", "a": "left", "b": "right"}},
+                "flow.unknown_argument_binding",
+                "nodes.calculate.config.arguments.c",
+            ),
+            (
+                {"arguments": {"a": "left", "b": ""}},
+                "flow.invalid_argument_selector",
+                "nodes.calculate.config.arguments.b",
+            ),
+            (
+                {"arguments": {"a": "left"}},
+                "flow.missing_argument_binding",
+                "nodes.calculate.config.arguments.b",
+            ),
+        )
+
+        for config, code, path in cases:
+            with self.subTest(code=code):
+                definition = FlowNodeDefinition(
+                    name="calculate",
+                    type=FLOW_TOOL_NODE_TYPE,
+                    ref="flow_adder",
+                    config=config,
+                )
+                with self.assertRaises(FlowNodeConfigurationError) as context:
+                    registry.build(definition)
+
+                self.assertEqual(context.exception.code, code)
+                self.assertEqual(context.exception.path, path)
 
     def test_tool_registry_can_extend_custom_base_registry(self) -> None:
         def factory(definition: FlowNodeDefinition) -> Node:

--- a/tests/model/nlp/vendor_anthropic_test.py
+++ b/tests/model/nlp/vendor_anthropic_test.py
@@ -486,7 +486,7 @@ def test_template_messages_and_exclude_roles(anthropic_mod):
         Message(role=MessageRole.TOOL, tool_call_result=result),
     ]
     templated = client._template_messages(messages, ["system"])
-    assert templated[1]["content"][1]["name"] == "pkg__tool"
+    assert templated[1]["content"][1]["name"] == "avl_cGtnLnRvb2w"
     assert templated[2]["content"][0]["tool_use_id"] == "id1"
 
     no_assistant = client._template_messages(
@@ -825,7 +825,7 @@ def test_tool_schemas_variants(anthropic_mod):
     out = mod.AnthropicClient._tool_schemas(DummyTool(schemas))
     assert out == [
         {
-            "name": "pkg__tool",
+            "name": "avl_cGtnLnRvb2w",
             "description": "d",
             "input_schema": {
                 "type": "object",

--- a/tests/model/nlp/vendor_anthropic_test.py
+++ b/tests/model/nlp/vendor_anthropic_test.py
@@ -5,6 +5,7 @@ import types
 from base64 import b64encode
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
+from json import loads
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,6 +23,9 @@ from avalan.entities import (
     ReasoningToken,
     Token,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -623,6 +627,63 @@ def test_template_messages_tool_error_details(anthropic_mod):
     tool_result = templated[2]["content"][0]
     assert tool_result["tool_use_id"] == "call1"
     assert tool_result["is_error"] is True
+
+
+def test_template_messages_tool_diagnostic_details(anthropic_mod):
+    mod, _ = anthropic_mod
+    exit_stack = AsyncExitStack()
+    client = mod.AnthropicClient("k", exit_stack=exit_stack)
+
+    diagnostic = ToolCallDiagnostic(
+        id="diag1",
+        call_id="call1",
+        requested_name="missing",
+        code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        stage=ToolCallDiagnosticStage.RESOLVE,
+        message="Tool is unknown.",
+    )
+    messages = [
+        Message(role=MessageRole.USER, content="hi"),
+        Message(
+            role=MessageRole.TOOL,
+            name="missing",
+            arguments={"a": 1},
+            tool_call_diagnostic=diagnostic,
+        ),
+    ]
+
+    templated = client._template_messages(messages)
+
+    tool_use = templated[1]["content"][0]
+    tool_result = templated[2]["content"][0]
+    assert tool_use["type"] == "tool_use"
+    assert tool_use["id"] == "call1"
+    assert tool_use["name"] == "missing"
+    assert tool_use["input"] == {"a": 1}
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["tool_use_id"] == "call1"
+    assert tool_result["is_error"] is True
+    assert loads(tool_result["content"])["code"] == "tool.unknown"
+
+
+def test_template_messages_unanchored_tool_diagnostic(anthropic_mod):
+    mod, _ = anthropic_mod
+    exit_stack = AsyncExitStack()
+    client = mod.AnthropicClient("k", exit_stack=exit_stack)
+    diagnostic = ToolCallDiagnostic(
+        id="diag1",
+        code=ToolCallDiagnosticCode.MALFORMED_CALL,
+        stage=ToolCallDiagnosticStage.PARSE,
+        message="Tool call could not be parsed.",
+    )
+
+    templated = client._template_messages(
+        [Message(role=MessageRole.TOOL, tool_call_diagnostic=diagnostic)]
+    )
+
+    assert templated[0]["role"] == str(MessageRole.ASSISTANT)
+    text = templated[0]["content"][0]["text"]
+    assert loads(text)["code"] == "tool_call.malformed"
 
 
 def test_file_content_translation_and_beta_header(anthropic_mod):

--- a/tests/model/nlp/vendor_bedrock_test.py
+++ b/tests/model/nlp/vendor_bedrock_test.py
@@ -728,7 +728,7 @@ class BedrockTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(len(templated), 1)
         self.assertEqual(templated[0]["role"], "assistant")
         tool_block = templated[0]["content"][-1]["toolUse"]
-        self.assertEqual(tool_block["name"], "pkg__tool")
+        self.assertEqual(tool_block["name"], "avl_cGtnLnRvb2w")
         self.assertEqual(tool_block["toolUseId"], "c1")
 
     def test_format_content_image_base64(self):
@@ -934,7 +934,7 @@ class BedrockTestCase(IsolatedAsyncioTestCase):
         config = client._tool_config(tool_manager)
         self.assertEqual(
             config["tools"][0]["toolSpec"]["name"],
-            "pkg__tool",
+            "avl_cGtnLnRvb2w",
         )
 
     def test_model_loads_client(self):

--- a/tests/model/nlp/vendor_bedrock_test.py
+++ b/tests/model/nlp/vendor_bedrock_test.py
@@ -3,6 +3,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from importlib import import_module, reload
 from importlib.machinery import ModuleSpec
+from json import loads
 from sys import modules
 from types import ModuleType, SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
@@ -18,6 +19,9 @@ from avalan.entities import (
     ReasoningToken,
     Token,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -936,6 +940,52 @@ class BedrockTestCase(IsolatedAsyncioTestCase):
             config["tools"][0]["toolSpec"]["name"],
             "avl_cGtnLnRvb2w",
         )
+
+    def test_template_messages_tool_diagnostic(self):
+        client = self.mod.BedrockClient(exit_stack=AsyncExitStack())
+        diagnostic = ToolCallDiagnostic(
+            id="diag1",
+            call_id="call1",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Tool is unknown.",
+        )
+
+        templated = client._template_messages(
+            [
+                Message(
+                    role=MessageRole.TOOL,
+                    name="missing",
+                    arguments={"a": 1},
+                    tool_call_diagnostic=diagnostic,
+                )
+            ]
+        )
+
+        tool_result = templated[0]["content"][0]["toolResult"]
+        self.assertEqual(tool_result["toolUseId"], "call1")
+        self.assertEqual(tool_result["status"], "error")
+        payload = loads(tool_result["content"][0]["text"])
+        self.assertEqual(payload["code"], "tool.unknown")
+        self.assertEqual(payload["requested_name"], "missing")
+
+    def test_template_messages_unanchored_tool_diagnostic(self):
+        client = self.mod.BedrockClient(exit_stack=AsyncExitStack())
+        diagnostic = ToolCallDiagnostic(
+            id="diag1",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Tool call could not be parsed.",
+        )
+
+        templated = client._template_messages(
+            [Message(role=MessageRole.TOOL, tool_call_diagnostic=diagnostic)]
+        )
+
+        self.assertEqual(templated[0]["role"], "assistant")
+        payload = loads(templated[0]["content"][0]["text"])
+        self.assertEqual(payload["code"], "tool_call.malformed")
 
     def test_model_loads_client(self):
         settings = TransformerEngineSettings(

--- a/tests/model/nlp/vendor_extra_test.py
+++ b/tests/model/nlp/vendor_extra_test.py
@@ -214,7 +214,7 @@ class AnthropicTestCase(IsolatedAsyncioTestCase):
             Message(role=MessageRole.TOOL, tool_call_result=result),
         ]
         templated = client._template_messages(messages)
-        self.assertEqual(templated[1]["content"][1]["name"], "pkg__tool")
+        self.assertEqual(templated[1]["content"][1]["name"], "avl_cGtnLnRvb2w")
         self.assertEqual(templated[2]["content"][0]["tool_use_id"], "id1")
 
         dup = client._template_messages(
@@ -247,7 +247,7 @@ class AnthropicTestCase(IsolatedAsyncioTestCase):
             schema_out,
             [
                 {
-                    "name": "pkg__tool",
+                    "name": "avl_cGtnLnRvb2w",
                     "description": "d",
                     "input_schema": {
                         "type": "object",

--- a/tests/model/nlp/vendor_file_envelope_golden_test.py
+++ b/tests/model/nlp/vendor_file_envelope_golden_test.py
@@ -180,17 +180,17 @@ def test_base_vendor_boundary_branches() -> None:
     ) == [{"role": "user", "content": "keep"}]
 
     invalid_arguments = TextGenerationVendor.build_tool_call_token(
-        object(), object(), "{"
+        object(), "tool", "{"
     )
     assert invalid_arguments.call.id.startswith("<object object at ")
-    assert invalid_arguments.call.name.startswith("<object object at ")
+    assert invalid_arguments.call.name == "tool"
     assert invalid_arguments.call.arguments == {}
 
     dict_arguments = TextGenerationVendor.build_tool_call_token(
         None, "pkg__tool", {"ok": True}
     )
     assert dict_arguments.call.id is None
-    assert dict_arguments.call.name == "pkg.tool"
+    assert dict_arguments.call.name == "pkg__tool"
     assert dict_arguments.call.arguments == {"ok": True}
     assert '"id"' not in dict_arguments.token
 

--- a/tests/model/nlp/vendor_file_envelope_golden_test.py
+++ b/tests/model/nlp/vendor_file_envelope_golden_test.py
@@ -185,6 +185,7 @@ def test_base_vendor_boundary_branches() -> None:
     assert invalid_arguments.call.id.startswith("<object object at ")
     assert invalid_arguments.call.name == "tool"
     assert invalid_arguments.call.arguments == {}
+    assert invalid_arguments.call.provider_arguments_malformed is True
 
     dict_arguments = TextGenerationVendor.build_tool_call_token(
         None, "pkg__tool", {"ok": True}

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -23,6 +23,9 @@ from avalan.entities import (
     ReasoningToken,
     Token,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -1659,6 +1662,51 @@ class TemplateAndToolSchemaTestCase(TestCase):
                 },
             ],
         )
+
+    def test_template_messages_tool_diagnostic(self):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        diagnostic = ToolCallDiagnostic(
+            id="d1",
+            call_id="c1",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Tool is unknown.",
+        )
+        msg = Message(
+            role=MessageRole.TOOL,
+            name="missing",
+            arguments={"a": 1},
+            tool_call_diagnostic=diagnostic,
+        )
+
+        templated = client._template_messages([msg])
+
+        self.assertEqual(templated[0]["call_id"], "c1")
+        self.assertEqual(templated[0]["name"], "missing")
+        self.assertEqual(templated[0]["arguments"], '{"a": 1}')
+        output = loads(templated[1]["output"])
+        self.assertEqual(output["code"], "tool.unknown")
+        self.assertEqual(output["requested_name"], "missing")
+
+    def test_template_messages_unanchored_tool_diagnostic(self):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        diagnostic = ToolCallDiagnostic(
+            id="d1",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Tool call could not be parsed.",
+        )
+        msg = Message(
+            role=MessageRole.TOOL,
+            tool_call_diagnostic=diagnostic,
+        )
+
+        templated = client._template_messages([msg])
+
+        self.assertEqual(templated[0]["role"], "assistant")
+        output = loads(templated[0]["content"])
+        self.assertEqual(output["code"], "tool_call.malformed")
 
 
 class OpenAIAdditionalCoverageTestCase(TestCase):

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -3,6 +3,8 @@ import sys
 import types
 from dataclasses import dataclass
 from importlib.machinery import ModuleSpec
+from json import loads
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -30,6 +32,9 @@ from avalan.task.usage import (
     usage_observation_from_response,
     usage_totals_from_response,
 )
+from avalan.tool.parser import ToolCallParser
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "tool_parsing"
 
 
 class AsyncIter:
@@ -670,6 +675,77 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertEqual(t4.call.arguments, {"p": 1})
         with self.assertRaises(StopAsyncIteration):
             await stream.__anext__()
+
+    async def test_provider_argument_deltas_match_serialized_call(self):
+        fixture = loads(
+            (FIXTURES / "provider_openai_argument_deltas.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        call_id = fixture["call_id"]
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(
+                    id=call_id,
+                    custom_tool_call=SimpleNamespace(
+                        id=call_id,
+                        name=fixture["provider_name"],
+                    ),
+                ),
+            ),
+            *[
+                SimpleNamespace(
+                    type="response.function_call_arguments.delta",
+                    id=call_id,
+                    delta=delta,
+                )
+                for delta in fixture["argument_deltas"]
+            ],
+            SimpleNamespace(
+                type="response.output_item.done",
+                item=SimpleNamespace(id=call_id),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                delta=fixture["assistant_after"],
+            ),
+        ]
+
+        stream = self.mod.OpenAIStream(AsyncIter(events))
+        outputs = []
+        async for output in stream:
+            outputs.append(output)
+
+        delta_outputs = outputs[: len(fixture["argument_deltas"])]
+        self.assertTrue(
+            all(isinstance(output, ToolCallToken) for output in delta_outputs)
+        )
+        self.assertEqual(
+            [output.token for output in delta_outputs],
+            fixture["argument_deltas"],
+        )
+
+        final_token = outputs[len(fixture["argument_deltas"])]
+        self.assertIsInstance(final_token, ToolCallToken)
+        self.assertIsNotNone(final_token.call)
+        self.assertEqual(final_token.call.id, call_id)
+        self.assertEqual(final_token.call.name, fixture["provider_name"])
+        self.assertEqual(
+            final_token.call.arguments,
+            {"city": "Paris", "unit": "c"},
+        )
+
+        parsed = ToolCallParser().parse(final_token.token)
+        self.assertEqual(len(parsed.calls), 1)
+        self.assertEqual(parsed.diagnostics, [])
+        self.assertEqual(parsed.calls[0].id, final_token.call.id)
+        self.assertEqual(parsed.calls[0].name, final_token.call.name)
+        self.assertEqual(
+            parsed.calls[0].arguments,
+            final_token.call.arguments,
+        )
+        self.assertEqual(outputs[-1].token, fixture["assistant_after"])
 
     async def test_generation_settings_and_tools(self):
         stream_instance = AsyncIter([])

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -291,7 +291,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             text={"format": {"type": "json_object"}, "stop": ["END"]},
             reasoning={"effort": "high"},
             prompt_cache_retention="24h",
-            tools=[{"type": "function", "name": "pkg__lookup"}],
+            tools=[{"type": "function", "name": "avl_cGtnLmxvb2t1cA"}],
         )
         self.assertNotIn(
             "top-level policy", str(create_mock.await_args.kwargs["input"])
@@ -620,11 +620,11 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         t5 = await stream.__anext__()
         self.assertIsInstance(t5, ToolCallToken)
         self.assertEqual(t5.call.id, "c1")
-        self.assertEqual(t5.call.name, "pkg.func")
+        self.assertEqual(t5.call.name, "pkg__func")
         self.assertEqual(t5.call.arguments, {})
         self.assertEqual(
             t5.token,
-            '<tool_call>{"name": "pkg.func", "arguments": {}, "id":'
+            '<tool_call>{"name": "pkg__func", "arguments": {}, "id":'
             ' "c1"}</tool_call>',
         )
         t6 = await stream.__anext__()
@@ -666,7 +666,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertEqual(t3.call.arguments, {})
         t4 = await stream.__anext__()
         self.assertEqual(t4.call.id, "c3")
-        self.assertEqual(t4.call.name, "pkg.f")
+        self.assertEqual(t4.call.name, "pkg__f")
         self.assertEqual(t4.call.arguments, {"p": 1})
         with self.assertRaises(StopAsyncIteration):
             await stream.__anext__()
@@ -724,7 +724,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
                 },
                 "stop": ["stop"],
             },
-            tools=[{"type": "function", "name": "pkg__func"}],
+            tools=[{"type": "function", "name": "avl_cGtnLmZ1bmM"}],
         )
 
     async def test_azure_responses_payload_uses_text_format(self):
@@ -1493,7 +1493,7 @@ class TemplateAndToolSchemaTestCase(TestCase):
             [
                 {
                     "type": "function_call",
-                    "name": "pkg__func",
+                    "name": "avl_cGtnLmZ1bmM",
                     "call_id": "c1",
                     "arguments": '{"a": 1}',
                 },
@@ -1504,7 +1504,7 @@ class TemplateAndToolSchemaTestCase(TestCase):
                 },
                 {
                     "type": "function_call",
-                    "name": "pkg__func2",
+                    "name": "avl_cGtnLmZ1bmMy",
                     "call_id": "c2",
                     "arguments": "null",
                 },
@@ -1539,7 +1539,7 @@ class TemplateAndToolSchemaTestCase(TestCase):
             [
                 {
                     "type": "function_call",
-                    "name": "pkg__func",
+                    "name": "avl_cGtnLmZ1bmM",
                     "call_id": str(call_id),
                     "arguments": (
                         '{"entity_id": "11111111-1111-1111-1111-111111111111"}'
@@ -1572,7 +1572,7 @@ class TemplateAndToolSchemaTestCase(TestCase):
             [
                 {
                     "type": "function_call",
-                    "name": "pkg__func",
+                    "name": "avl_cGtnLmZ1bmM",
                     "call_id": "c1",
                     "arguments": '{"a": 1}',
                 },

--- a/tests/model/vendor_encode_decode_test.py
+++ b/tests/model/vendor_encode_decode_test.py
@@ -41,3 +41,7 @@ class VendorEncodeDecodeTestCase(TestCase):
     def test_decode_rejects_malformed_encoded_name(self) -> None:
         with self.assertRaises(AssertionError):
             TextGenerationVendor.decode_tool_name("avl_notbase64")
+
+    def test_decode_rejects_invalid_encoded_payload(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextGenerationVendor.decode_tool_name("avl_A")

--- a/tests/model/vendor_encode_decode_test.py
+++ b/tests/model/vendor_encode_decode_test.py
@@ -7,7 +7,7 @@ class VendorEncodeDecodeTestCase(TestCase):
     def test_encode_decode_roundtrip(self) -> None:
         original = "pkg.sub.tool"
         encoded = TextGenerationVendor.encode_tool_name(original)
-        self.assertEqual(encoded, "pkg__sub__tool")
+        self.assertEqual(encoded, "avl_cGtnLnN1Yi50b29s")
         self.assertEqual(
             TextGenerationVendor.decode_tool_name(encoded), original
         )
@@ -16,3 +16,28 @@ class VendorEncodeDecodeTestCase(TestCase):
         name = "plain"
         self.assertEqual(TextGenerationVendor.encode_tool_name(name), name)
         self.assertEqual(TextGenerationVendor.decode_tool_name(name), name)
+
+    def test_decode_preserves_plain_double_underscore_name(self) -> None:
+        self.assertEqual(
+            TextGenerationVendor.decode_tool_name("pkg__tool"), "pkg__tool"
+        )
+
+    def test_encode_prefix_name_to_preserve_provenance(self) -> None:
+        encoded = TextGenerationVendor.encode_tool_name("avl_plain")
+
+        self.assertEqual(encoded, "avl_YXZsX3BsYWlu")
+        self.assertEqual(
+            TextGenerationVendor.decode_tool_name(encoded), "avl_plain"
+        )
+
+    def test_encode_rejects_empty_name(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextGenerationVendor.encode_tool_name(" ")
+
+    def test_decode_rejects_invalid_provider_name(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextGenerationVendor.decode_tool_name("pkg.tool")
+
+    def test_decode_rejects_malformed_encoded_name(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextGenerationVendor.decode_tool_name("avl_notbase64")

--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -1,12 +1,92 @@
+from asyncio import run
 from json import loads
 from unittest import TestCase
 from uuid import uuid4
 
-from avalan.entities import ToolCall, ToolCallToken
-from avalan.model.vendor import TextGenerationVendor
+from avalan.entities import (
+    Message,
+    MessageContentFile,
+    MessageContentImage,
+    MessageContentText,
+    MessageRole,
+    ToolCall,
+    ToolCallToken,
+)
+from avalan.model.vendor import (
+    TextGenerationVendor,
+    TextGenerationVendorStream,
+)
 
 
 class VendorBuildToolCallTokenTestCase(TestCase):
+    def test_call_is_abstract_boundary(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            run(TextGenerationVendor()("model", []))
+
+    def test_system_prompt_returns_string_content(self) -> None:
+        prompt = TextGenerationVendor()._system_prompt(
+            [
+                Message(role=MessageRole.USER, content="skip"),
+                Message(role=MessageRole.SYSTEM, content="system"),
+            ]
+        )
+
+        self.assertEqual(prompt, "system")
+
+    def test_template_messages_wraps_content_blocks(self) -> None:
+        messages = [
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentText(type="text", text="hello"),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentImage(
+                    type="image_url", image_url={"url": "image"}
+                ),
+            ),
+            Message(
+                role=MessageRole.USER,
+                content=MessageContentFile(
+                    type="file", file={"file_id": "file"}
+                ),
+            ),
+            Message(role=MessageRole.USER, content=None),
+        ]
+
+        templated = TextGenerationVendor()._template_messages(messages)
+
+        self.assertEqual(
+            templated,
+            [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "image"}}
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "file", "file": {"file_id": "file"}}],
+                },
+                {"role": "user", "content": "None"},
+            ],
+        )
+
+    def test_stream_exposes_provider_metadata(self) -> None:
+        async def generator():
+            yield "token"
+
+        stream = TextGenerationVendorStream(
+            generator(),
+            provider_family="openai",
+            usage={"tokens": 1},
+        )
+
+        self.assertEqual(stream.provider_family, "openai")
+        self.assertEqual(stream.usage, {"tokens": 1})
+
     def test_build_tool_call_token_from_string_json(self) -> None:
         token = TextGenerationVendor.build_tool_call_token(
             call_id="1",
@@ -18,7 +98,13 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 '<tool_call>{"name": "pkg.tool", "arguments": {"a":'
                 ' 1}, "id": "1"}</tool_call>'
             ),
-            call=ToolCall(id="1", name="pkg.tool", arguments={"a": 1}),
+            call=ToolCall(
+                id="1",
+                name="pkg.tool",
+                arguments={"a": 1},
+                provider_name="avl_cGtnLnRvb2w",
+                provider_name_encoded=True,
+            ),
             provider_name="avl_cGtnLnRvb2w",
         )
         self.assertEqual(token, expected)
@@ -34,7 +120,12 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 '<tool_call>{"name": "pkg__tool", "arguments": {"a":'
                 ' 1}, "id": "1"}</tool_call>'
             ),
-            call=ToolCall(id="1", name="pkg__tool", arguments={"a": 1}),
+            call=ToolCall(
+                id="1",
+                name="pkg__tool",
+                arguments={"a": 1},
+                provider_name="pkg__tool",
+            ),
             provider_name="pkg__tool",
         )
         self.assertEqual(token, expected)
@@ -50,7 +141,13 @@ class VendorBuildToolCallTokenTestCase(TestCase):
 
         self.assertEqual(
             token.call,
-            ToolCall(id="call_1", name="pkg.tool", arguments={"value": 3}),
+            ToolCall(
+                id="call_1",
+                name="pkg.tool",
+                arguments={"value": 3},
+                provider_name="avl_cGtnLnRvb2w",
+                provider_name_encoded=True,
+            ),
         )
         self.assertEqual(token.provider_name, "avl_cGtnLnRvb2w")
         payload = loads(
@@ -71,7 +168,12 @@ class VendorBuildToolCallTokenTestCase(TestCase):
         )
         expected = ToolCallToken(
             token='<tool_call>{"name": "tool", "arguments": {}}</tool_call>',
-            call=ToolCall(id=None, name="tool", arguments={}),
+            call=ToolCall(
+                id=None,
+                name="tool",
+                arguments={},
+                provider_name="tool",
+            ),
             provider_name="tool",
         )
         self.assertEqual(token, expected)
@@ -103,7 +205,12 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 '<tool_call>{"name": "tool", "arguments": {"b": 2}, '
                 f'"id": "{call_id}"}}</tool_call>'
             ),
-            call=ToolCall(id=str(call_id), name="tool", arguments={"b": 2}),
+            call=ToolCall(
+                id=str(call_id),
+                name="tool",
+                arguments={"b": 2},
+                provider_name="tool",
+            ),
             provider_name="tool",
         )
         self.assertEqual(token, expected)

--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -1,3 +1,4 @@
+from json import loads
 from unittest import TestCase
 from uuid import uuid4
 
@@ -37,6 +38,30 @@ class VendorBuildToolCallTokenTestCase(TestCase):
             provider_name="pkg__tool",
         )
         self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_keeps_call_as_executable_boundary(
+        self,
+    ) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="call_1",
+            tool_name=TextGenerationVendor.encode_tool_name("pkg.tool"),
+            arguments={"value": 3},
+        )
+
+        self.assertEqual(
+            token.call,
+            ToolCall(id="call_1", name="pkg.tool", arguments={"value": 3}),
+        )
+        self.assertEqual(token.provider_name, "avl_cGtnLnRvb2w")
+        payload = loads(
+            token.token.removeprefix("<tool_call>").removesuffix(
+                "</tool_call>"
+            )
+        )
+        self.assertEqual(
+            payload,
+            {"name": "pkg.tool", "arguments": {"value": 3}, "id": "call_1"},
+        )
 
     def test_build_tool_call_token_handles_invalid_json_str(self) -> None:
         token = TextGenerationVendor.build_tool_call_token(

--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -173,10 +173,40 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 name="tool",
                 arguments={},
                 provider_name="tool",
+                provider_arguments_malformed=True,
             ),
             provider_name="tool",
         )
         self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_marks_non_object_json_str(self) -> None:
+        for arguments in ("null", '["a"]', '"text"'):
+            with self.subTest(arguments=arguments):
+                token = TextGenerationVendor.build_tool_call_token(
+                    call_id="call-1",
+                    tool_name="tool",
+                    arguments=arguments,
+                )
+
+                self.assertEqual(token.call.arguments, {})
+                self.assertTrue(token.call.provider_arguments_malformed)
+                self.assertEqual(
+                    token.token,
+                    '<tool_call>{"name": "tool", "arguments": {},'
+                    ' "id": "call-1"}</tool_call>',
+                )
+
+    def test_build_tool_call_token_keeps_empty_object_arguments_valid(
+        self,
+    ) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="call-1",
+            tool_name="tool",
+            arguments="{}",
+        )
+
+        self.assertEqual(token.call.arguments, {})
+        self.assertFalse(token.call.provider_arguments_malformed)
 
     def test_build_tool_call_token_from_dict(self) -> None:
         token = TextGenerationVendor.build_tool_call_token(

--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -9,7 +9,7 @@ class VendorBuildToolCallTokenTestCase(TestCase):
     def test_build_tool_call_token_from_string_json(self) -> None:
         token = TextGenerationVendor.build_tool_call_token(
             call_id="1",
-            tool_name="pkg__tool",
+            tool_name=TextGenerationVendor.encode_tool_name("pkg.tool"),
             arguments='{"a": 1}',
         )
         expected = ToolCallToken(
@@ -18,6 +18,23 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 ' 1}, "id": "1"}</tool_call>'
             ),
             call=ToolCall(id="1", name="pkg.tool", arguments={"a": 1}),
+            provider_name="avl_cGtnLnRvb2w",
+        )
+        self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_preserves_plain_provider_name(self) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="1",
+            tool_name="pkg__tool",
+            arguments='{"a": 1}',
+        )
+        expected = ToolCallToken(
+            token=(
+                '<tool_call>{"name": "pkg__tool", "arguments": {"a":'
+                ' 1}, "id": "1"}</tool_call>'
+            ),
+            call=ToolCall(id="1", name="pkg__tool", arguments={"a": 1}),
+            provider_name="pkg__tool",
         )
         self.assertEqual(token, expected)
 
@@ -30,6 +47,7 @@ class VendorBuildToolCallTokenTestCase(TestCase):
         expected = ToolCallToken(
             token='<tool_call>{"name": "tool", "arguments": {}}</tool_call>',
             call=ToolCall(id=None, name="tool", arguments={}),
+            provider_name="tool",
         )
         self.assertEqual(token, expected)
 
@@ -61,5 +79,14 @@ class VendorBuildToolCallTokenTestCase(TestCase):
                 f'"id": "{call_id}"}}</tool_call>'
             ),
             call=ToolCall(id=str(call_id), name="tool", arguments={"b": 2}),
+            provider_name="tool",
         )
         self.assertEqual(token, expected)
+
+    def test_build_tool_call_token_rejects_invalid_provider_name(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextGenerationVendor.build_tool_call_token(
+                call_id="1",
+                tool_name="pkg.tool",
+                arguments={},
+            )

--- a/tests/model/vendor_tool_call_token_test.py
+++ b/tests/model/vendor_tool_call_token_test.py
@@ -1,5 +1,6 @@
 from asyncio import run
 from json import loads
+from typing import Any, cast
 from unittest import TestCase
 from uuid import uuid4
 
@@ -32,6 +33,38 @@ class VendorBuildToolCallTokenTestCase(TestCase):
         )
 
         self.assertEqual(prompt, "system")
+
+    def test_system_prompt_returns_text_content_or_none(self) -> None:
+        vendor = TextGenerationVendor()
+
+        self.assertEqual(
+            vendor._system_prompt(
+                [
+                    Message(
+                        role=MessageRole.SYSTEM,
+                        content=MessageContentText(type="text", text="system"),
+                    )
+                ]
+            ),
+            "system",
+        )
+        self.assertIsNone(
+            vendor._system_prompt(
+                [
+                    Message(
+                        role=MessageRole.SYSTEM,
+                        content=MessageContentImage(
+                            type="image_url", image_url={"url": "image"}
+                        ),
+                    )
+                ]
+            )
+        )
+        self.assertIsNone(
+            vendor._system_prompt(
+                [Message(role=MessageRole.USER, content="skip")]
+            )
+        )
 
     def test_template_messages_wraps_content_blocks(self) -> None:
         messages = [
@@ -74,6 +107,45 @@ class VendorBuildToolCallTokenTestCase(TestCase):
             ],
         )
 
+    def test_template_messages_wraps_strings_lists_and_excluded_roles(
+        self,
+    ) -> None:
+        messages = [
+            Message(role=MessageRole.SYSTEM, content="skip"),
+            Message(role=MessageRole.USER, content="hello"),
+            Message(
+                role=MessageRole.USER,
+                content=[
+                    MessageContentText(type="text", text="listed"),
+                    MessageContentImage(
+                        type="image_url", image_url={"url": "image"}
+                    ),
+                ],
+            ),
+        ]
+
+        templated = TextGenerationVendor()._template_messages(
+            messages,
+            exclude_roles=["system"],
+        )
+
+        self.assertEqual(
+            templated,
+            [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "listed"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "image"},
+                        },
+                    ],
+                },
+            ],
+        )
+
     def test_stream_exposes_provider_metadata(self) -> None:
         async def generator():
             yield "token"
@@ -86,6 +158,29 @@ class VendorBuildToolCallTokenTestCase(TestCase):
 
         self.assertEqual(stream.provider_family, "openai")
         self.assertEqual(stream.usage, {"tokens": 1})
+
+    def test_stream_iterates_generator_and_rejects_missing_generator(
+        self,
+    ) -> None:
+        async def generator():
+            yield "token"
+
+        async def next_token() -> object:
+            stream = TextGenerationVendorStream(generator())
+            iterator = stream()
+            self.assertIs(iterator, stream)
+            return await anext(iterator)
+
+        self.assertEqual(run(next_token()), "token")
+
+        with self.assertRaises(AssertionError):
+            TextGenerationVendorStream(cast(Any, None)).__aiter__()
+
+    def test_encode_tool_name_preserves_provider_safe_names(self) -> None:
+        self.assertEqual(
+            TextGenerationVendor.encode_tool_name("tool_name"),
+            "tool_name",
+        )
 
     def test_build_tool_call_token_from_string_json(self) -> None:
         token = TextGenerationVendor.build_tool_call_token(
@@ -158,6 +253,40 @@ class VendorBuildToolCallTokenTestCase(TestCase):
         self.assertEqual(
             payload,
             {"name": "pkg.tool", "arguments": {"value": 3}, "id": "call_1"},
+        )
+
+    def test_build_tool_call_token_preserves_malformed_encoded_name(
+        self,
+    ) -> None:
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="call-1",
+            tool_name="avl_notbase64",
+            arguments={"value": 3},
+        )
+
+        self.assertEqual(
+            token.call,
+            ToolCall(
+                id="call-1",
+                name="avl_notbase64",
+                arguments={"value": 3},
+                provider_name="avl_notbase64",
+                provider_name_encoded=True,
+            ),
+        )
+        self.assertEqual(token.provider_name, "avl_notbase64")
+        payload = loads(
+            token.token.removeprefix("<tool_call>").removesuffix(
+                "</tool_call>"
+            )
+        )
+        self.assertEqual(
+            payload,
+            {
+                "name": "avl_notbase64",
+                "arguments": {"value": 3},
+                "id": "call-1",
+            },
         )
 
     def test_build_tool_call_token_handles_invalid_json_str(self) -> None:

--- a/tests/server/a2a_router_unit_extra_test.py
+++ b/tests/server/a2a_router_unit_extra_test.py
@@ -18,6 +18,9 @@ from avalan.entities import (
     ReasoningToken,
     Token,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -416,6 +419,43 @@ async def _run_tool_handlers_cover_branches() -> None:
     error_events = await translator_error._handle_tool_result(error_event)
     assert any(
         event["event"] == "artifact.completed" for event in error_events
+    )
+    error_artifact = await translator_error._store.get_artifact(
+        "tool-error", "call-4"
+    )
+    assert error_artifact["content"][0]["data"]["error"] == {
+        "type": "RuntimeError",
+        "message": "fail",
+    }
+
+    translator_diagnostic = await prepare("tool-diagnostic")
+    diagnostic_call = ToolCall(id="call-d", name="missing", arguments=None)
+    diagnostic = ToolCallDiagnostic(
+        id="diag-d",
+        call_id=diagnostic_call.id,
+        requested_name="missing",
+        code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        stage=ToolCallDiagnosticStage.RESOLVE,
+        message="Unknown tool.",
+    )
+    diagnostic_event = Event(
+        type=EventType.TOOL_DIAGNOSTIC,
+        payload={"call": diagnostic_call, "diagnostic": diagnostic},
+    )
+    diagnostic_events = await translator_diagnostic._handle_tool_result(
+        diagnostic_event
+    )
+    assert any(
+        event["event"] == "artifact.completed" for event in diagnostic_events
+    )
+    diagnostic_artifact = await translator_diagnostic._store.get_artifact(
+        "tool-diagnostic", "call-d"
+    )
+    assert diagnostic_artifact["metadata"]["status"] == "diagnostic"
+    assert diagnostic_artifact["metadata"]["diagnostic_code"] == "tool.unknown"
+    assert (
+        diagnostic_artifact["content"][0]["data"]["diagnostic"]["message"]
+        == "Unknown tool."
     )
 
     translator_payload = await prepare("tool-payload")
@@ -940,6 +980,10 @@ async def _run_additional_router_helpers() -> None:
         _state_for_item(Event(type=EventType.TOOL_RESULT, payload={}))
         is StreamState.TOOL
     )
+    assert (
+        _state_for_item(Event(type=EventType.TOOL_DIAGNOSTIC, payload={}))
+        is StreamState.TOOL
+    )
     assert _state_for_item(Event(type=EventType.START, payload={})) is None
     assert _state_for_item("text") is StreamState.ANSWER
     assert _state_for_item(Token(token="text")) is StreamState.ANSWER
@@ -967,6 +1011,41 @@ async def _run_additional_router_helpers() -> None:
             Event(type=EventType.TOOL_RESULT, payload={"call": call})
         )
         == "call"
+    )
+    diagnostic = ToolCallDiagnostic(
+        id="diag",
+        call_id="call-d",
+        requested_name="tool",
+        code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        stage=ToolCallDiagnosticStage.RESOLVE,
+        message="Unknown tool.",
+    )
+    assert (
+        _call_identifier(
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostic": diagnostic},
+            )
+        )
+        == "call-d"
+    )
+    assert (
+        _call_identifier(
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostics": ["bad", diagnostic]},
+            )
+        )
+        == "call-d"
+    )
+    assert (
+        _call_identifier(
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostic": "bad"},
+            )
+        )
+        is None
     )
     assert (
         _call_identifier(Event(type=EventType.TOOL_RESULT, payload={})) is None

--- a/tests/server/chat_router_unit_test.py
+++ b/tests/server/chat_router_unit_test.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from json import loads
 from logging import Logger, getLogger
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase
@@ -15,6 +16,11 @@ from avalan.entities import (
     MessageRole,
     ReasoningEffort,
     ReasoningToken,
+    ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallError,
     ToolCallToken,
 )
 from avalan.model import TextGenerationResponse
@@ -318,6 +324,132 @@ class ChatRouterUnitTest(IsolatedAsyncioTestCase):
         self.assertIn('"content":"a"', chunks[0])
         self.assertIn('"content":"b"', chunks[1])
         self.assertEqual(len(chunks), 3)
+
+    async def test_streaming_projects_tool_diagnostic_event(self) -> None:
+        from avalan.event import Event, EventType
+
+        diagnostic = ToolCallDiagnostic(
+            id="diag-chat",
+            call_id="call-chat",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+
+        async def output_gen():
+            yield Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostic": diagnostic},
+            )
+            yield Event(type=EventType.START, payload={})
+            yield "b"
+
+        logger = AsyncMock(spec=Logger)
+        orch = AsyncMock(spec=DummyOrchestrator)
+        orch.return_value = output_gen()
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+        with patch("avalan.server.routers.time", return_value=1):
+            resp = await self.chat.create_chat_completion(req, logger, orch)
+        chunks = [chunk async for chunk in resp.body_iterator]
+        diagnostic_chunk = loads(chunks[0][6:])
+        diagnostic_payload = loads(
+            diagnostic_chunk["choices"][0]["delta"]["content"]
+        )
+        self.assertEqual(diagnostic_payload["type"], "tool_diagnostic")
+        self.assertEqual(
+            diagnostic_payload["diagnostic"]["code"], "tool.unknown"
+        )
+        self.assertIn('"content":"b"', chunks[1])
+        self.assertEqual(len(chunks), 3)
+
+    async def test_event_text_handles_diagnostic_payload_variants(
+        self,
+    ) -> None:
+        from avalan.event import Event, EventType
+
+        diagnostic = ToolCallDiagnostic(
+            id="diag-chat-list",
+            call_id="call-chat",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+
+        diagnostic_text = self.chat._event_text(
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostics": ["bad", diagnostic]},
+            )
+        )
+        diagnostic_payload = loads(diagnostic_text)
+        self.assertEqual(diagnostic_payload["type"], "tool_diagnostic")
+        self.assertEqual(
+            diagnostic_payload["diagnostic"]["code"], "tool.unknown"
+        )
+
+        result_text = self.chat._event_text(
+            Event(
+                type=EventType.TOOL_RESULT,
+                payload={"result": diagnostic},
+            )
+        )
+        result_payload = loads(result_text)
+        self.assertEqual(result_payload["type"], "tool_diagnostic")
+
+        self.assertEqual(
+            self.chat._event_text(
+                Event(
+                    type=EventType.TOOL_DIAGNOSTIC,
+                    payload={"diagnostic": "bad"},
+                )
+            ),
+            "",
+        )
+
+    async def test_streaming_projects_tool_error_safely(self) -> None:
+        from avalan.event import Event, EventType
+
+        call = ToolCall(id="call-error", name="tool", arguments={})
+        error = ToolCallError(
+            id="error-chat",
+            call=call,
+            name="tool",
+            arguments={},
+            error=RuntimeError("secret"),
+            message="Tool failed.",
+        )
+
+        async def output_gen():
+            yield Event(
+                type=EventType.TOOL_RESULT,
+                payload={"result": error},
+            )
+
+        logger = AsyncMock(spec=Logger)
+        orch = AsyncMock(spec=DummyOrchestrator)
+        orch.return_value = output_gen()
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+        with patch("avalan.server.routers.time", return_value=1):
+            resp = await self.chat.create_chat_completion(req, logger, orch)
+        chunks = [chunk async for chunk in resp.body_iterator]
+        error_chunk = loads(chunks[0][6:])
+        error_payload = loads(error_chunk["choices"][0]["delta"]["content"])
+        self.assertEqual(error_payload["type"], "tool_error")
+        self.assertEqual(
+            error_payload["error"],
+            {"type": "RuntimeError", "message": "Tool failed."},
+        )
+        self.assertNotIn("secret", chunks[0])
         orch.assert_awaited_once()
 
     async def test_streaming_includes_reasoning_tokens(self) -> None:

--- a/tests/server/create_response_sse_test.py
+++ b/tests/server/create_response_sse_test.py
@@ -15,6 +15,9 @@ from avalan.entities import (
     MessageRole,
     ReasoningToken,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -395,14 +398,94 @@ class CreateResponseSSEEventsTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(second_delta["arguments"], {"x": 1})
 
         third_data = loads(data_lines[function_indices[2]][6:])
-        self.assertEqual(loads(third_data["error"]), "fail")
+        self.assertEqual(
+            third_data["error"], {"type": "RuntimeError", "message": "fail"}
+        )
         third_delta = loads(third_data["delta"])
-        self.assertEqual(loads(third_delta["error"]), "fail")
+        self.assertEqual(
+            third_delta["error"], {"type": "RuntimeError", "message": "fail"}
+        )
 
         output_index = events.index("response.output_text.delta")
         output_data = loads(data_lines[output_index][6:])
         self.assertEqual(output_data["delta"], "final")
 
+        orchestrator.sync_messages.assert_awaited_once()
+
+    async def test_streaming_includes_tool_diagnostic_event(self) -> None:
+        logger = getLogger()
+        orchestrator = Orchestrator.__new__(Orchestrator)
+        orchestrator.sync_messages = AsyncMock()
+
+        request = ResponsesRequest(
+            model="m",
+            input=[ChatMessage(role=MessageRole.USER, content="hi")],
+            stream=True,
+        )
+
+        call = ToolCall(id="call-d", name="missing", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-d",
+            call_id=call.id,
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        tokens = [
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"diagnostics": ["bad"]},
+            ),
+            Event(
+                type=EventType.TOOL_DIAGNOSTIC,
+                payload={"call": call, "diagnostic": diagnostic},
+            ),
+            "final",
+        ]
+
+        class DummyResponse:
+            def __init__(self, items) -> None:  # type: ignore[no-untyped-def]
+                self._items = items
+                self.input_token_count = 0
+                self.output_token_count = 0
+
+            def __aiter__(self):  # type: ignore[override]
+                async def gen():
+                    for item in self._items:
+                        yield item
+
+                return gen()
+
+        response = DummyResponse(tokens)
+
+        async def orchestrate_stub(request, logger, orch):
+            return response, uuid4(), 0
+
+        self.responses.orchestrate = orchestrate_stub  # type: ignore[attr-defined]
+
+        streaming_resp = await self.responses.create_response(
+            request, logger, orchestrator
+        )
+        chunks: list[str] = []
+        async for chunk in streaming_resp.body_iterator:
+            chunks.append(
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+            )
+
+        text = "".join(chunks)
+        blocks = [b for b in text.strip().split("\n\n") if b]
+        events = [block.split("\n")[0].split(": ")[1] for block in blocks]
+        data_lines = [block.split("\n")[1] for block in blocks]
+
+        self.assertIn("response.tool_call_diagnostic.delta", events)
+        diagnostic_index = events.index("response.tool_call_diagnostic.delta")
+        diagnostic_data = loads(data_lines[diagnostic_index][6:])
+        self.assertEqual(diagnostic_data["id"], "call-d")
+        self.assertEqual(diagnostic_data["diagnostic"]["code"], "tool.unknown")
+        output_index = events.index("response.output_text.delta")
+        output_data = loads(data_lines[output_index][6:])
+        self.assertEqual(output_data["delta"], "final")
         orchestrator.sync_messages.assert_awaited_once()
 
     async def test_streaming_serializes_tool_result_temporal_types(

--- a/tests/server/mcp_router_test.py
+++ b/tests/server/mcp_router_test.py
@@ -19,6 +19,9 @@ from avalan.entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -306,7 +309,10 @@ class MCPUtilityTestCase(TestCase):
             },
         )
         error_item = mcp_router._tool_call_event_item(error_event)
-        self.assertEqual(error_item["error"], "boom")
+        self.assertEqual(
+            error_item["error"],
+            {"type": "Exception", "message": "boom"},
+        )
 
         result_event = Event(
             type=EventType.TOOL_RESULT,
@@ -344,6 +350,50 @@ class MCPUtilityTestCase(TestCase):
             type=EventType.TOOL_PROCESS, payload={"call": None}
         )
         self.assertIsNone(mcp_router._tool_call_event_item(null_call_event))
+
+        diagnostic = ToolCallDiagnostic(
+            id="diag-1",
+            call_id="c1",
+            requested_name="run",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        diagnostic_event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"call": call, "diagnostic": diagnostic},
+        )
+        diagnostic_item = mcp_router._tool_call_event_item(diagnostic_event)
+        self.assertEqual(diagnostic_item["id"], "c1")
+        self.assertEqual(diagnostic_item["diagnostic"]["code"], "tool.unknown")
+
+        result_diagnostic_event = Event(
+            type=EventType.TOOL_RESULT,
+            payload={"call": call, "result": diagnostic},
+        )
+        result_diagnostic_item = mcp_router._tool_call_event_item(
+            result_diagnostic_event
+        )
+        self.assertEqual(result_diagnostic_item["id"], "c1")
+        self.assertEqual(
+            result_diagnostic_item["diagnostic"]["code"], "tool.unknown"
+        )
+
+        malformed_diagnostic_event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"diagnostics": ["bad"]},
+        )
+        self.assertIsNone(
+            mcp_router._tool_call_event_item(malformed_diagnostic_event)
+        )
+
+        invalid_diagnostic_event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"diagnostic": "bad"},
+        )
+        self.assertIsNone(
+            mcp_router._tool_call_event_item(invalid_diagnostic_event)
+        )
 
     def test_get_resource_store_reuses_instance(self) -> None:
         request = self._request()
@@ -1136,6 +1186,47 @@ class MCPRouterAsyncTestCase(IsolatedAsyncioTestCase):
         message = notifications[-1]["params"]["message"]
         self.assertEqual(message["resultDelta"], '{"payload":"value"}')
 
+    async def test_tool_event_notifications_serializes_diagnostic(
+        self,
+    ) -> None:
+        call = ToolCall(id="c-d", name="missing", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-d",
+            call_id=call.id,
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"call": call, "diagnostic": diagnostic},
+            started=4.0,
+            finished=5.0,
+            elapsed=1.0,
+        )
+        store = mcp_router.MCPResourceStore()
+        tool_summaries: dict[str, dict[str, Any]] = {}
+        resources: dict[str, mcp_router.MCPResource] = {}
+        notifications = []
+        async for item in mcp_router._tool_event_notifications(
+            event=event,
+            tool_summaries=tool_summaries,
+            resources=resources,
+            resource_store=store,
+            base_path="/base",
+        ):
+            notifications.append(item)
+
+        self.assertFalse(resources)
+        self.assertIn(str(call.id), tool_summaries)
+        summary = tool_summaries[str(call.id)]
+        self.assertEqual(summary["diagnostic"]["code"], "tool.unknown")
+        message = notifications[-1]["params"]["message"]
+        self.assertEqual(message["type"], "tool.diagnostic")
+        self.assertEqual(message["toolCallId"], "c-d")
+        self.assertEqual(message["diagnostic"]["message"], "Unknown tool.")
+
 
 class MCPRouterEdgeCaseAsyncTestCase(IsolatedAsyncioTestCase):
     def _chat_request(self, stream: bool = False) -> ChatCompletionRequest:
@@ -1733,6 +1824,64 @@ class MCPRouterEdgeCaseAsyncTestCase(IsolatedAsyncioTestCase):
             and item.get("method") == "notifications/message"
         ]
         self.assertTrue(any("error" in e["params"]["message"] for e in errors))
+
+    async def test_stream_mcp_response_handles_tool_diagnostic(self) -> None:
+        call = ToolCall(id="c-d", name="missing", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-d",
+            call_id=call.id,
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        response = DummyResponse(
+            [
+                Event(
+                    type=EventType.TOOL_DIAGNOSTIC,
+                    payload={"call": call, "diagnostic": diagnostic},
+                    started=1.0,
+                    finished=2.0,
+                    elapsed=1.0,
+                ),
+                Token(token="done"),
+            ]
+        )
+        response.input_token_count = 0
+        response.output_token_count = 0
+        orchestrator = MagicMock()
+        orchestrator.sync_messages = AsyncMock()
+        cancel_event = AsyncEvent()
+        store = mcp_router.MCPResourceStore()
+        request_model = self._chat_request(stream=True)
+        payloads = []
+        async for chunk in mcp_router._stream_mcp_response(
+            request_id="id",
+            request_model=request_model,
+            response=response,
+            response_id=uuid4(),
+            timestamp=1,
+            progress_token="tok",
+            orchestrator=orchestrator,
+            logger=MagicMock(),
+            resource_store=store,
+            base_path="/m",
+            cancel_event=cancel_event,
+        ):
+            payloads.append(loads(chunk.decode("utf-8")))
+        orchestrator.sync_messages.assert_awaited()
+        diagnostics = [
+            item
+            for item in payloads
+            if isinstance(item, dict)
+            and item.get("method") == "notifications/message"
+            and item["params"]["message"].get("type") == "tool.diagnostic"
+        ]
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0]["params"]["message"]["diagnostic"]["code"],
+            "tool.unknown",
+        )
 
     async def test_stream_mcp_response_cancellation_closes_resources(
         self,

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -93,6 +93,22 @@ class ResponsesUtilsTestCase(TestCase):
         data = loads(events[0].split("data: ")[1])
         self.assertIsNone(data["result"])
 
+    def test_token_to_sse_handles_current_none_tool_result(self) -> None:
+        call = ToolCall(id="c-none", name="tool", arguments={"x": 1})
+        event = Event(
+            type=EventType.TOOL_RESULT,
+            payload={0: call, "result": None},
+        )
+
+        events = _token_to_sse(event, 5)
+
+        self.assertEqual(len(events), 1)
+        data = loads(events[0].split("data: ")[1])
+        self.assertEqual(data["id"], "c-none")
+        self.assertEqual(data["name"], "tool")
+        self.assertEqual(data["arguments"], {"x": 1})
+        self.assertIsNone(data["result"])
+
     def test_token_to_sse_handles_tool_call_token_with_call(self) -> None:
         call = ToolCall(id="c4", name="adder", arguments={"x": 1})
         token = ToolCallToken(token="ignored", call=call)

--- a/tests/server/responses_utils_test.py
+++ b/tests/server/responses_utils_test.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from json import loads
 from unittest import TestCase
 
@@ -7,6 +8,9 @@ from avalan.entities import (
     Token,
     TokenDetail,
     ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolCallToken,
@@ -75,7 +79,98 @@ class ResponsesUtilsTestCase(TestCase):
         self.assertEqual(len(events), 1)
         data = loads(events[0].split("data: ")[1])
         self.assertEqual(data["id"], "c2")
-        self.assertEqual(data["error"], '"boom"')
+        self.assertEqual(
+            data["error"], {"type": "RuntimeError", "message": "boom"}
+        )
+        delta = loads(data["delta"])
+        self.assertEqual(
+            delta["error"], {"type": "RuntimeError", "message": "boom"}
+        )
+
+    def test_token_to_sse_handles_tool_diagnostic(self) -> None:
+        call = ToolCall(id="c-diagnostic", name="missing", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-1",
+            call_id=call.id,
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"call": call, "diagnostic": diagnostic},
+        )
+
+        events = _token_to_sse(event, 3)
+
+        self.assertEqual(len(events), 1)
+        self.assertIn("response.tool_call_diagnostic.delta", events[0])
+        data = loads(events[0].split("data: ")[1])
+        self.assertEqual(data["id"], "c-diagnostic")
+        self.assertEqual(data["diagnostic"]["code"], "tool.unknown")
+        delta = loads(data["delta"])
+        self.assertEqual(delta["diagnostic"]["call_id"], "c-diagnostic")
+
+    def test_tool_call_event_item_handles_tool_result_diagnostic(
+        self,
+    ) -> None:
+        call = ToolCall(id="c-result-diagnostic", name="missing", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-result",
+            call_id=call.id,
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+        event = Event(
+            type=EventType.TOOL_RESULT,
+            payload={"call": call, "result": diagnostic},
+        )
+
+        item = _tool_call_event_item(event)
+
+        self.assertEqual(item["id"], "c-result-diagnostic")
+        self.assertEqual(item["diagnostic"]["code"], "tool.unknown")
+
+    def test_tool_call_event_item_handles_diagnostic_timing_fields(
+        self,
+    ) -> None:
+        diagnostic = ToolCallDiagnostic(
+            id="diag-timing",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+            started_at=datetime(2026, 1, 1, 12, 0, 0),
+            finished_at=datetime(2026, 1, 1, 12, 0, 1),
+            duration_ms=1000.0,
+        )
+        event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"diagnostics": [diagnostic]},
+        )
+
+        item = _tool_call_event_item(event)
+
+        self.assertEqual(item["id"], "diag-timing")
+        self.assertEqual(item["name"], "missing")
+        self.assertEqual(
+            item["diagnostic"]["started_at"], "2026-01-01T12:00:00"
+        )
+        self.assertEqual(
+            item["diagnostic"]["finished_at"], "2026-01-01T12:00:01"
+        )
+        self.assertEqual(item["diagnostic"]["duration_ms"], 1000.0)
+
+    def test_token_to_sse_ignores_malformed_tool_diagnostic(self) -> None:
+        event = Event(
+            type=EventType.TOOL_DIAGNOSTIC,
+            payload={"diagnostics": ["bad"]},
+        )
+
+        self.assertEqual(_token_to_sse(event, 4), [])
 
     def test_token_to_sse_handles_tool_result_without_payload(self) -> None:
         call = ToolCall(id="c3", name="tool", arguments={})
@@ -108,6 +203,21 @@ class ResponsesUtilsTestCase(TestCase):
         self.assertEqual(data["name"], "tool")
         self.assertEqual(data["arguments"], {"x": 1})
         self.assertIsNone(data["result"])
+
+    def test_tool_call_event_item_ignores_missing_tool_call(self) -> None:
+        event = Event(
+            type=EventType.TOOL_PROCESS,
+            payload={"call": None},
+        )
+
+        self.assertIsNone(_tool_call_event_item(event))
+
+    def test_tool_call_event_item_ignores_unexpected_payload(
+        self,
+    ) -> None:
+        event = Event(type=EventType.TOOL_PROCESS, payload="bad")
+
+        self.assertIsNone(_tool_call_event_item(event))
 
     def test_token_to_sse_handles_tool_call_token_with_call(self) -> None:
         call = ToolCall(id="c4", name="adder", arguments={"x": 1})

--- a/tests/tool/browser_tool_test.py
+++ b/tests/tool/browser_tool_test.py
@@ -85,6 +85,21 @@ class BrowserToolSetTestCase(IsolatedAsyncioTestCase):
         dummy_stack.enter_async_context.assert_awaited_once_with("client1")
         dummy_tool.with_client.assert_called_once_with("client2")
 
+    async def test_init_uses_default_exit_stack(self):
+        dummy_tool = MagicMock()
+
+        with (
+            patch(
+                "avalan.tool.browser.async_playwright", return_value="client1"
+            ),
+            patch("avalan.tool.browser.BrowserTool", return_value=dummy_tool),
+        ):
+            toolset = BrowserToolSet(settings=BrowserToolSettings())
+
+        self.assertIsInstance(toolset._exit_stack, AsyncExitStack)
+        self.assertEqual(toolset._client, "client1")
+        self.assertEqual(toolset.tools, [dummy_tool])
+
 
 class BrowserToolWithClientTestCase(TestCase):
     def test_with_client(self):

--- a/tests/tool/calculator_test.py
+++ b/tests/tool/calculator_test.py
@@ -4,7 +4,7 @@ from pytest import raises
 from sympy.core.sympify import SympifyError
 
 from avalan.entities import ToolCallContext
-from avalan.tool.math import CalculatorTool
+from avalan.tool.math import CalculatorTool, MathToolSet
 
 
 class CalculatorToolTestCase(IsolatedAsyncioTestCase):
@@ -30,6 +30,15 @@ class CalculatorToolTestCase(IsolatedAsyncioTestCase):
             + "because of exception being raised"
             in str(exc.value)
         )
+
+
+class MathToolSetTestCase(IsolatedAsyncioTestCase):
+    async def test_defaults_to_calculator_tool(self):
+        toolset = MathToolSet(namespace="math")
+
+        self.assertEqual(toolset.namespace, "math")
+        self.assertEqual(len(toolset.tools), 1)
+        self.assertIsInstance(toolset.tools[0], CalculatorTool)
 
 
 if __name__ == "__main__":

--- a/tests/tool/dsml_test.py
+++ b/tests/tool/dsml_test.py
@@ -252,6 +252,34 @@ class DsmlToolsTestCase(TestCase):
             ),
         )
 
+    def test_parser_dsml_returns_tool_call_list(self):
+        text = (
+            "<think>Use calculator.</think>I will calculate.\n\n"
+            "<｜DSML｜tool_calls>\n"
+            '<｜DSML｜invoke name="math.calculator">\n'
+            '<｜DSML｜parameter name="expression" string="true">'
+            "2 + 2"
+            "</｜DSML｜parameter>\n"
+            "</｜DSML｜invoke>\n"
+            "</｜DSML｜tool_calls>"
+        )
+        call_id = _uuid4()
+        parser = ToolCallParser(tool_format=ToolFormat.DSML)
+
+        with patch("avalan.tool.dsml.uuid4", return_value=call_id):
+            parsed = parser(text)
+
+        self.assertEqual(
+            parsed,
+            [
+                ToolCall(
+                    id=f"ds4_tool_{call_id.hex}",
+                    name="math.calculator",
+                    arguments={"expression": "2 + 2"},
+                )
+            ],
+        )
+
     def test_parse_accepts_short_marker_and_plain_xml_fallback(self):
         short = (
             "<DSML｜tool_calls>"

--- a/tests/tool/json_schema_additional_test.py
+++ b/tests/tool/json_schema_additional_test.py
@@ -1,11 +1,20 @@
-from typing import Literal
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, TypedDict
 from unittest import TestCase
 from unittest.mock import patch
 
 from avalan.tool.json_schema import (
+    _annotation_schema,
+    _enum_schema,
     _json_type,
     _literal_schema,
+    _mapping_schema,
     _parse_docstring_sections,
+    _tuple_schema,
+    _union_schema,
+    _unique_schemas,
     get_json_schema,
 )
 
@@ -22,7 +31,7 @@ class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
             )
 
         mixed_literal = _literal_schema(Literal["x", 1])
-        self.assertEqual(mixed_literal, {"type": "object"})
+        self.assertEqual(mixed_literal, {"enum": ["x", 1]})
 
     def test_get_json_schema_maps_unhandled_types_to_object(self) -> None:
         def transform(
@@ -42,15 +51,175 @@ class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
         schema = get_json_schema(transform)
         properties = schema["function"]["parameters"]["properties"]
         self.assertEqual(properties["payload"]["type"], "object")
+        self.assertEqual(
+            properties["payload"]["additionalProperties"],
+            {"type": "integer"},
+        )
         self.assertEqual(properties["items"]["type"], "array")
+        self.assertEqual(properties["items"]["items"], {"type": "string"})
         self.assertEqual(properties["note"]["type"], "object")
         self.assertEqual(schema["function"]["return"]["type"], "array")
+        self.assertEqual(
+            schema["function"]["return"]["items"]["anyOf"],
+            [{"type": "string"}, {"type": "integer"}],
+        )
 
     def test_json_type_covers_builtin_and_unknown_annotations(self) -> None:
         class CustomType:
             pass
 
+        self.assertEqual(_annotation_schema(float), {"type": "number"})
         self.assertEqual(_json_type(dict), "object")
         self.assertEqual(_json_type(list), "array")
         self.assertEqual(_json_type(CustomType), "object")
         self.assertEqual(_json_type(str | int), "object")
+        self.assertEqual(_json_type(str | None), "string")
+
+    def test_annotation_schema_handles_nested_arrays_and_mappings(
+        self,
+    ) -> None:
+        schema = _annotation_schema(dict[str, list[int | None]])
+        sequence_schema = _annotation_schema(Sequence[str])
+
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(
+            schema["additionalProperties"],
+            {
+                "type": "array",
+                "items": {"type": ["integer", "null"]},
+            },
+        )
+        self.assertEqual(
+            sequence_schema,
+            {"type": "array", "items": {"type": "string"}},
+        )
+
+    def test_annotation_schema_handles_fixed_tuples(self) -> None:
+        schema = _annotation_schema(tuple[str, int])
+
+        self.assertEqual(
+            schema,
+            {
+                "type": "array",
+                "prefixItems": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                ],
+                "minItems": 2,
+                "maxItems": 2,
+            },
+        )
+
+    def test_annotation_schema_handles_dataclasses(self) -> None:
+        @dataclass(frozen=True)
+        class Payload:
+            name: str
+            tags: list[str]
+            retries: int = 0
+
+        schema = _annotation_schema(Payload)
+
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(schema["required"], ["name", "tags"])
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(schema["properties"]["name"], {"type": "string"})
+        self.assertEqual(
+            schema["properties"]["tags"],
+            {"type": "array", "items": {"type": "string"}},
+        )
+
+    def test_annotation_schema_handles_typed_dicts(self) -> None:
+        class Payload(TypedDict):
+            name: str
+            metadata: dict[str, int]
+
+        schema = _annotation_schema(Payload)
+
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(schema["required"], ["metadata", "name"])
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(schema["properties"]["name"], {"type": "string"})
+        self.assertEqual(
+            schema["properties"]["metadata"],
+            {
+                "type": "object",
+                "additionalProperties": {"type": "integer"},
+            },
+        )
+
+    def test_enum_schema_handles_string_and_mixed_value_enums(self) -> None:
+        class Empty(Enum):
+            pass
+
+        class Color(Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class Mixed(Enum):
+            NAME = "name"
+            COUNT = 3
+
+        self.assertEqual(
+            _enum_schema(Color),
+            {"type": "string", "enum": ["red", "blue"]},
+        )
+        self.assertEqual(_annotation_schema(Color), _enum_schema(Color))
+        self.assertEqual(_enum_schema(Empty), {"type": "object"})
+        self.assertEqual(_enum_schema(Mixed), {"enum": ["name", 3]})
+        self.assertIsNone(_enum_schema(str))
+
+    def test_schema_helpers_handle_empty_and_duplicate_inputs(self) -> None:
+        self.assertEqual(_union_schema(()), {"type": "object"})
+        self.assertEqual(
+            _union_schema((Literal["x", 1], type(None))),
+            {"anyOf": [{"enum": ["x", 1]}, {"type": "null"}]},
+        )
+        self.assertEqual(_tuple_schema(()), {"type": "array"})
+        self.assertEqual(_mapping_schema(()), {"type": "object"})
+        self.assertEqual(
+            _unique_schemas(
+                [
+                    {"type": "string"},
+                    {"type": "string"},
+                    {"type": "integer"},
+                ]
+            ),
+            [{"type": "string"}, {"type": "integer"}],
+        )
+
+    def test_get_json_schema_closes_parameters_and_excludes_context(
+        self,
+    ) -> None:
+        class NonJsonDefault:
+            pass
+
+        class Mode(Enum):
+            FAST = "fast"
+
+        def configure(
+            name: str,
+            context: object,
+            mode: Mode = Mode.FAST,
+            enabled: bool = True,
+            payload: object = NonJsonDefault(),
+        ) -> None:
+            """Configure a tool.
+
+            Args:
+                name: Configuration name.
+                enabled: Whether configuration is active.
+            """
+
+        schema = get_json_schema(configure)
+        parameters = schema["function"]["parameters"]
+        properties = parameters["properties"]
+
+        self.assertFalse(parameters["additionalProperties"])
+        self.assertEqual(
+            set(properties), {"name", "mode", "enabled", "payload"}
+        )
+        self.assertEqual(parameters["required"], ["name"])
+        self.assertEqual(properties["mode"]["default"], "fast")
+        self.assertEqual(properties["enabled"]["default"], True)
+        self.assertNotIn("default", properties["payload"])
+        self.assertEqual(schema["function"]["return"]["type"], "null")

--- a/tests/tool/json_schema_additional_test.py
+++ b/tests/tool/json_schema_additional_test.py
@@ -31,7 +31,12 @@ class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
             )
 
         mixed_literal = _literal_schema(Literal["x", 1])
+        string_literal = _literal_schema(Literal["x", "y"])
         self.assertEqual(mixed_literal, {"enum": ["x", 1]})
+        self.assertEqual(
+            string_literal,
+            {"type": "string", "enum": ["x", "y"]},
+        )
 
     def test_get_json_schema_maps_unhandled_types_to_object(self) -> None:
         def transform(
@@ -62,6 +67,121 @@ class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
         self.assertEqual(
             schema["function"]["return"]["items"]["anyOf"],
             [{"type": "string"}, {"type": "integer"}],
+        )
+
+    def test_get_json_schema_return_schemas_cover_supported_shapes(
+        self,
+    ) -> None:
+        class Payload(TypedDict):
+            name: str
+            scores: list[int]
+
+        def scalar_result() -> int:
+            """Count records.
+
+            Returns:
+                Record count.
+            """
+            return 1
+
+        def object_result() -> Payload:
+            """Build a payload.
+
+            Returns:
+                Structured payload.
+            """
+            return {"name": "ok", "scores": [1]}
+
+        def array_result() -> list[str]:
+            """List names.
+
+            Returns:
+                Names.
+            """
+            return ["ok"]
+
+        def nullable_result() -> str | None:
+            """Maybe return a name.
+
+            Returns:
+                Optional name.
+            """
+            return None
+
+        def union_result() -> str | int:
+            """Return an identifier.
+
+            Returns:
+                Identifier.
+            """
+            return "ok"
+
+        cases = (
+            (
+                scalar_result,
+                {"type": "integer", "description": "Record count."},
+            ),
+            (
+                object_result,
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "scores": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        },
+                    },
+                    "required": ["name", "scores"],
+                    "additionalProperties": False,
+                    "description": "Structured payload.",
+                },
+            ),
+            (
+                array_result,
+                {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Names.",
+                },
+            ),
+            (
+                nullable_result,
+                {
+                    "type": ["string", "null"],
+                    "description": "Optional name.",
+                },
+            ),
+            (
+                union_result,
+                {
+                    "anyOf": [{"type": "string"}, {"type": "integer"}],
+                    "description": "Identifier.",
+                },
+            ),
+        )
+
+        for function, expected_schema in cases:
+            with self.subTest(function=function.__name__):
+                schema = get_json_schema(function)
+
+                self.assertEqual(
+                    schema["function"]["return"],
+                    expected_schema,
+                )
+
+    def test_get_json_schema_unannotated_return_defaults_to_object(
+        self,
+    ) -> None:
+        def build_value():
+            """Build a value."""
+            return "ok"
+
+        schema = get_json_schema(build_value)
+
+        self.assertEqual(
+            schema["function"]["return"],
+            {"type": "object", "description": ""},
         )
 
     def test_json_type_covers_builtin_and_unknown_annotations(self) -> None:

--- a/tests/tool/json_schema_additional_test.py
+++ b/tests/tool/json_schema_additional_test.py
@@ -184,6 +184,37 @@ class JsonSchemaUtilitiesAdditionalTestCase(TestCase):
             {"type": "object", "description": ""},
         )
 
+    def test_get_json_schema_supports_variadic_keyword_values(self) -> None:
+        def collect(**values: int) -> dict[str, int]:
+            """Collect values."""
+            return values
+
+        def collect_untyped(**values) -> dict[str, object]:
+            """Collect untyped values."""
+            return values
+
+        typed_schema = get_json_schema(collect)
+        untyped_schema = get_json_schema(collect_untyped)
+
+        self.assertEqual(
+            typed_schema["function"]["parameters"],
+            {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": {"type": "integer"},
+            },
+        )
+        self.assertEqual(
+            untyped_schema["function"]["parameters"],
+            {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": True,
+            },
+        )
+
     def test_json_type_covers_builtin_and_unknown_annotations(self) -> None:
         class CustomType:
             pass

--- a/tests/tool/mcp_tool_test.py
+++ b/tests/tool/mcp_tool_test.py
@@ -3,7 +3,13 @@ from types import ModuleType
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from avalan.entities import ToolCallContext
+from avalan.entities import (
+    ToolCall,
+    ToolCallContext,
+    ToolFilter,
+    ToolManagerSettings,
+)
+from avalan.tool.manager import ToolManager
 from avalan.tool.mcp import McpCallTool, McpToolSet
 
 
@@ -43,6 +49,49 @@ class McpCallToolTestCase(IsolatedAsyncioTestCase):
         await tool("http://host", "calc", None, context=context)
         self.Client.assert_called_once_with("http://host", token="x")
         self.client.call_tool.assert_awaited_once_with("calc", {}, timeout=1)
+
+    async def test_manager_filters_match_mcp_tool_not_remote_name(self):
+        filtered_names: list[str] = []
+
+        def filter_call(call: ToolCall, context: ToolCallContext):
+            filtered_names.append(call.name)
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={
+                        "uri": "http://host",
+                        "name": "blocked",
+                        "arguments": {},
+                    },
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["mcp.call"],
+            available_toolsets=[McpToolSet()],
+            settings=ToolManagerSettings(
+                filters=[ToolFilter(func=filter_call, namespace="math")]
+            ),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="mcp.call",
+            arguments={
+                "uri": "http://host",
+                "name": "math.calculator",
+                "arguments": {"a": 1},
+            },
+        )
+
+        result = await manager(call, context=ToolCallContext())
+
+        self.assertEqual(result.result, ["result"])
+        self.assertEqual(filtered_names, [])
+        self.client.call_tool.assert_awaited_once_with(
+            "math.calculator", {"a": 1}
+        )
 
 
 class McpToolSetTestCase(TestCase):

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -66,6 +66,7 @@ class ToolCallDiagnosticTestCase(TestCase):
                 "tool_call.filter_suppressed",
                 "tool_call.user_rejected",
                 "tool_call.repeated",
+                "tool_call.maximum_size",
                 "tool_call.maximum_depth",
                 "tool_call.cancelled",
                 "tool_call.timeout",

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -264,26 +264,61 @@ class ToolDescriptorTestCase(TestCase):
     def test_fields_are_stable(self):
         self.assertEqual(
             [field.name for field in fields(ToolDescriptor)],
-            ["name", "aliases", "schema"],
+            [
+                "name",
+                "callable",
+                "aliases",
+                "schema",
+                "parameter_schema",
+                "return_schema",
+                "provider_safe_schema",
+                "namespace",
+                "policy",
+                "metadata",
+            ],
         )
 
     def test_create_descriptor(self):
+        def calculator() -> int:
+            return 1
+
         descriptor = ToolDescriptor(
             name="math.calculator",
+            callable=calculator,
             aliases=["calc"],
             schema={"type": "function"},
+            parameter_schema={"type": "object"},
+            return_schema={"type": "integer"},
+            provider_safe_schema={"type": "function"},
+            namespace="math",
+            policy={"confirmation": False},
+            metadata={"source": "test"},
         )
 
         self.assertEqual(descriptor.name, "math.calculator")
+        self.assertIs(descriptor.callable, calculator)
         self.assertEqual(descriptor.aliases, ["calc"])
         self.assertEqual(descriptor.schema, {"type": "function"})
+        self.assertEqual(descriptor.parameter_schema, {"type": "object"})
+        self.assertEqual(descriptor.return_schema, {"type": "integer"})
+        self.assertEqual(descriptor.provider_safe_schema, {"type": "function"})
+        self.assertEqual(descriptor.namespace, "math")
+        self.assertEqual(descriptor.policy, {"confirmation": False})
+        self.assertEqual(descriptor.metadata, {"source": "test"})
 
     def test_rejects_invalid_values(self):
         invalid_cases = (
             {"name": " "},
+            {"callable": "calculator"},
             {"aliases": ("calc",)},
             {"aliases": [" "]},
             {"schema": []},
+            {"parameter_schema": []},
+            {"return_schema": []},
+            {"provider_safe_schema": []},
+            {"namespace": " "},
+            {"policy": []},
+            {"metadata": []},
         )
         for kwargs in invalid_cases:
             with self.subTest(kwargs=kwargs):

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -460,6 +460,25 @@ class EntityHelperTestCase(TestCase):
 
         self.assertTrue(message.is_from_agent)
 
+    def test_message_can_carry_tool_call_diagnostic(self):
+        diagnostic = ToolCallDiagnostic(
+            id=uuid4(),
+            call_id="call1",
+            requested_name="missing",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Tool is unknown.",
+        )
+        message = Message(
+            role=MessageRole.TOOL,
+            content='{"code": "tool.unknown"}',
+            tool_call_diagnostic=diagnostic,
+        )
+
+        self.assertIs(message.tool_call_diagnostic, diagnostic)
+        self.assertIsNone(message.tool_call_result)
+        self.assertIsNone(message.tool_call_error)
+
     def test_reasoning_token_initializes_base_token(self):
         token = ReasoningToken(token="thinking", id=1, probability=0.5)
 

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -1,0 +1,269 @@
+from dataclasses import FrozenInstanceError, fields
+from datetime import UTC, datetime
+from typing import get_args
+from unittest import TestCase, main
+from uuid import uuid4
+
+from avalan.entities import (
+    ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallDiagnosticStatus,
+    ToolCallError,
+    ToolCallOutcome,
+    ToolCallParseOutcome,
+    ToolCallResult,
+)
+
+
+class ToolCallDiagnosticTestCase(TestCase):
+    def test_fields_are_stable(self):
+        self.assertEqual(
+            [field.name for field in fields(ToolCallDiagnostic)],
+            [
+                "id",
+                "call_id",
+                "requested_name",
+                "canonical_name",
+                "status",
+                "code",
+                "stage",
+                "message",
+                "retryable",
+                "details",
+                "started_at",
+                "finished_at",
+                "duration_ms",
+            ],
+        )
+
+    def test_codes_cover_non_executed_categories(self):
+        self.assertEqual(
+            {code.value for code in ToolCallDiagnosticCode},
+            {
+                "tool.unknown",
+                "tool.disabled",
+                "tool.ambiguous_name",
+                "tool_call.malformed",
+                "tool_call.arguments_malformed",
+                "tool_call.arguments_invalid",
+                "tool_call.policy_suppressed",
+                "tool_call.filter_suppressed",
+                "tool_call.user_rejected",
+                "tool_call.repeated",
+                "tool_call.maximum_depth",
+                "tool_call.cancelled",
+                "tool_call.timeout",
+                "tool_call.loop_guard",
+                "tool_call.runaway_guard",
+            },
+        )
+
+    def test_stages_cover_parse_and_execution_preconditions(self):
+        self.assertEqual(
+            {stage.value for stage in ToolCallDiagnosticStage},
+            {
+                "parse",
+                "resolve",
+                "validate",
+                "policy",
+                "filter",
+                "confirm",
+                "dispatch",
+                "guard",
+            },
+        )
+
+    def test_create_non_executed_diagnostic(self):
+        diagnostic_id = uuid4()
+        call_id = uuid4()
+        started_at = datetime(2026, 6, 5, 1, 2, 3, tzinfo=UTC)
+        finished_at = datetime(2026, 6, 5, 1, 2, 4, tzinfo=UTC)
+
+        diagnostic = ToolCallDiagnostic(
+            id=diagnostic_id,
+            call_id=call_id,
+            requested_name=" calculator ",
+            canonical_name="math.calculator",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Tool is not enabled.",
+            retryable=True,
+            details={"available": ["math.calculator"]},
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=1.5,
+        )
+
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertEqual(diagnostic.call_id, call_id)
+        self.assertEqual(diagnostic.requested_name, " calculator ")
+        self.assertEqual(diagnostic.canonical_name, "math.calculator")
+        self.assertIs(diagnostic.status, ToolCallDiagnosticStatus.NON_EXECUTED)
+        self.assertTrue(diagnostic.retryable)
+        self.assertEqual(diagnostic.details["available"], ["math.calculator"])
+        self.assertEqual(diagnostic.started_at, started_at)
+        self.assertEqual(diagnostic.finished_at, finished_at)
+        self.assertEqual(diagnostic.duration_ms, 1.5)
+        self.assertNotIsInstance(diagnostic, ToolCallError)
+
+    def test_default_details_are_independent(self):
+        first = ToolCallDiagnostic(
+            id="diag-1",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Malformed call.",
+        )
+        second = ToolCallDiagnostic(
+            id="diag-2",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Malformed call.",
+        )
+
+        first.details["source"] = "tag"
+
+        self.assertEqual(second.details, {})
+
+    def test_rejects_invalid_identifiers(self):
+        for field_name in ("id", "call_id"):
+            with self.subTest(field_name=field_name):
+                kwargs = {
+                    "id": "diag",
+                    "code": ToolCallDiagnosticCode.MALFORMED_CALL,
+                    "stage": ToolCallDiagnosticStage.PARSE,
+                    "message": "Malformed call.",
+                    field_name: "",
+                }
+                with self.assertRaises(AssertionError):
+                    ToolCallDiagnostic(**kwargs)
+
+    def test_rejects_invalid_names(self):
+        for field_name in ("requested_name", "canonical_name"):
+            with self.subTest(field_name=field_name):
+                kwargs = {
+                    "id": "diag",
+                    "code": ToolCallDiagnosticCode.UNKNOWN_TOOL,
+                    "stage": ToolCallDiagnosticStage.RESOLVE,
+                    "message": "Tool is unknown.",
+                    field_name: " ",
+                }
+                with self.assertRaises(AssertionError):
+                    ToolCallDiagnostic(**kwargs)
+
+    def test_rejects_invalid_enums(self):
+        with self.assertRaises(AssertionError):
+            ToolCallDiagnostic(
+                id="diag",
+                code="tool.unknown",
+                stage=ToolCallDiagnosticStage.RESOLVE,
+                message="Tool is unknown.",
+            )
+        with self.assertRaises(AssertionError):
+            ToolCallDiagnostic(
+                id="diag",
+                code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+                stage="resolve",
+                message="Tool is unknown.",
+            )
+        with self.assertRaises(AssertionError):
+            ToolCallDiagnostic(
+                id="diag",
+                code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+                stage=ToolCallDiagnosticStage.RESOLVE,
+                status="non_executed",
+                message="Tool is unknown.",
+            )
+
+    def test_rejects_invalid_message_retry_details_and_timing(self):
+        invalid_kwargs = (
+            {"message": ""},
+            {"retryable": 1},
+            {"details": []},
+            {"started_at": "2026-06-05T00:00:00Z"},
+            {"finished_at": "2026-06-05T00:00:01Z"},
+            {"duration_ms": True},
+            {"duration_ms": -1},
+        )
+        for kwargs in invalid_kwargs:
+            with self.subTest(kwargs=kwargs):
+                diagnostic_kwargs = {
+                    "id": "diag",
+                    "code": ToolCallDiagnosticCode.MALFORMED_CALL,
+                    "stage": ToolCallDiagnosticStage.PARSE,
+                    "message": "Malformed call.",
+                }
+                diagnostic_kwargs.update(kwargs)
+                with self.assertRaises(AssertionError):
+                    ToolCallDiagnostic(**diagnostic_kwargs)
+
+
+class ToolCallParseOutcomeTestCase(TestCase):
+    def test_fields_are_stable(self):
+        self.assertEqual(
+            [field.name for field in fields(ToolCallParseOutcome)],
+            ["calls", "diagnostics"],
+        )
+
+    def test_defaults_to_empty_calls_and_diagnostics(self):
+        outcome = ToolCallParseOutcome()
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(outcome.diagnostics, [])
+
+    def test_create_parse_outcome(self):
+        call = ToolCall(id="call-1", name="calculator", arguments={})
+        diagnostic = ToolCallDiagnostic(
+            id="diag-1",
+            call_id="call-2",
+            requested_name="calculator",
+            code=ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Arguments must be an object.",
+        )
+
+        outcome = ToolCallParseOutcome(
+            calls=[call],
+            diagnostics=[diagnostic],
+        )
+
+        self.assertEqual(outcome.calls, [call])
+        self.assertEqual(outcome.diagnostics, [diagnostic])
+
+    def test_rejects_invalid_calls_and_diagnostics(self):
+        diagnostic = ToolCallDiagnostic(
+            id="diag-1",
+            code=ToolCallDiagnosticCode.MALFORMED_CALL,
+            stage=ToolCallDiagnosticStage.PARSE,
+            message="Malformed call.",
+        )
+        invalid_cases = (
+            {"calls": (ToolCall(id="call-1", name="calculator"),)},
+            {"calls": ["call"]},
+            {"diagnostics": (diagnostic,)},
+            {"diagnostics": ["diagnostic"]},
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolCallParseOutcome(**kwargs)
+
+    def test_is_frozen(self):
+        outcome = ToolCallParseOutcome()
+
+        with self.assertRaises(FrozenInstanceError):
+            outcome.calls = []
+
+
+class ToolCallOutcomeTestCase(TestCase):
+    def test_public_outcome_union(self):
+        self.assertEqual(
+            set(get_args(ToolCallOutcome)),
+            {ToolCallResult, ToolCallError, ToolCallDiagnostic},
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -14,6 +14,9 @@ from avalan.entities import (
     ToolCallOutcome,
     ToolCallParseOutcome,
     ToolCallResult,
+    ToolDescriptor,
+    ToolNameResolution,
+    ToolNameResolutionStatus,
 )
 
 
@@ -255,6 +258,83 @@ class ToolCallParseOutcomeTestCase(TestCase):
 
         with self.assertRaises(FrozenInstanceError):
             outcome.calls = []
+
+
+class ToolDescriptorTestCase(TestCase):
+    def test_fields_are_stable(self):
+        self.assertEqual(
+            [field.name for field in fields(ToolDescriptor)],
+            ["name", "aliases", "schema"],
+        )
+
+    def test_create_descriptor(self):
+        descriptor = ToolDescriptor(
+            name="math.calculator",
+            aliases=["calc"],
+            schema={"type": "function"},
+        )
+
+        self.assertEqual(descriptor.name, "math.calculator")
+        self.assertEqual(descriptor.aliases, ["calc"])
+        self.assertEqual(descriptor.schema, {"type": "function"})
+
+    def test_rejects_invalid_values(self):
+        invalid_cases = (
+            {"name": " "},
+            {"aliases": ("calc",)},
+            {"aliases": [" "]},
+            {"schema": []},
+        )
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                valid = {"name": "calculator"}
+                valid.update(kwargs)
+                with self.assertRaises(AssertionError):
+                    ToolDescriptor(**valid)
+
+
+class ToolNameResolutionTestCase(TestCase):
+    def test_statuses_are_stable(self):
+        self.assertEqual(
+            {status.value for status in ToolNameResolutionStatus},
+            {"exact", "alias", "ambiguous", "unknown", "disabled"},
+        )
+
+    def test_create_resolution(self):
+        resolution = ToolNameResolution(
+            requested_name="calc",
+            status=ToolNameResolutionStatus.ALIAS,
+            canonical_name="calculator",
+            candidates=["calculator"],
+            diagnostic_code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+        )
+
+        self.assertEqual(resolution.requested_name, "calc")
+        self.assertIs(resolution.status, ToolNameResolutionStatus.ALIAS)
+        self.assertEqual(resolution.canonical_name, "calculator")
+        self.assertEqual(resolution.candidates, ["calculator"])
+        self.assertIs(
+            resolution.diagnostic_code, ToolCallDiagnosticCode.UNKNOWN_TOOL
+        )
+
+    def test_rejects_invalid_values(self):
+        invalid_cases = (
+            {"requested_name": " "},
+            {"status": "exact"},
+            {"canonical_name": " "},
+            {"candidates": ("calculator",)},
+            {"candidates": [" "]},
+            {"diagnostic_code": "tool.unknown"},
+        )
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                valid = {
+                    "requested_name": "calculator",
+                    "status": ToolNameResolutionStatus.EXACT,
+                }
+                valid.update(kwargs)
+                with self.assertRaises(AssertionError):
+                    ToolNameResolution(**valid)
 
 
 class ToolCallOutcomeTestCase(TestCase):

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -214,6 +214,52 @@ class ToolCallDiagnosticTestCase(TestCase):
                     ToolCallDiagnostic(**diagnostic_kwargs)
 
 
+class ToolCallTestCase(TestCase):
+    def test_create_with_provider_provenance(self):
+        call = ToolCall(
+            id="call-1",
+            name="pkg.tool",
+            arguments={"a": 1},
+            provider_name="avl_cGtnLnRvb2w",
+            provider_name_encoded=True,
+        )
+
+        self.assertEqual(call.id, "call-1")
+        self.assertEqual(call.name, "pkg.tool")
+        self.assertEqual(call.arguments, {"a": 1})
+        self.assertEqual(call.provider_name, "avl_cGtnLnRvb2w")
+        self.assertTrue(call.provider_name_encoded)
+
+    def test_allows_missing_id_and_name_for_legacy_provider_calls(self):
+        call = ToolCall(id=None, name="", arguments={})
+
+        self.assertIsNone(call.id)
+        self.assertEqual(call.name, "")
+
+    def test_rejects_invalid_provider_provenance(self):
+        invalid_cases = (
+            {"id": "", "name": "tool"},
+            {"id": "call-1", "name": 1},
+            {"id": "call-1", "name": "tool", "provider_name": ""},
+            {
+                "id": "call-1",
+                "name": "tool",
+                "provider_name_encoded": True,
+            },
+            {
+                "id": "call-1",
+                "name": "tool",
+                "provider_name": "tool",
+                "provider_name_encoded": 1,
+            },
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolCall(**kwargs)
+
+
 class ToolCallParseOutcomeTestCase(TestCase):
     def test_fields_are_stable(self):
         self.assertEqual(

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -5,7 +5,9 @@ from unittest import TestCase, main
 from uuid import uuid4
 
 from avalan.entities import (
+    PreparedToolCall,
     ToolCall,
+    ToolCallContext,
     ToolCallDiagnostic,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
@@ -326,6 +328,80 @@ class ToolDescriptorTestCase(TestCase):
                 valid.update(kwargs)
                 with self.assertRaises(AssertionError):
                     ToolDescriptor(**valid)
+
+
+class PreparedToolCallTestCase(TestCase):
+    def test_fields_are_stable(self):
+        self.assertEqual(
+            [field.name for field in fields(PreparedToolCall)],
+            ["call", "callable", "descriptor", "arguments", "context"],
+        )
+
+    def test_create_prepared_tool_call(self):
+        def calculator(expression: str) -> str:
+            return expression
+
+        call = ToolCall(
+            id="call-1",
+            name="calculator",
+            arguments={"expression": "1"},
+        )
+        descriptor = ToolDescriptor(name="calculator", callable=calculator)
+        context = ToolCallContext()
+
+        prepared = PreparedToolCall(
+            call=call,
+            callable=calculator,
+            descriptor=descriptor,
+            arguments={"expression": "1"},
+            context=context,
+        )
+
+        self.assertEqual(prepared.call, call)
+        self.assertIs(prepared.callable, calculator)
+        self.assertEqual(prepared.descriptor, descriptor)
+        self.assertEqual(prepared.arguments, {"expression": "1"})
+        self.assertEqual(prepared.context, context)
+
+    def test_rejects_invalid_values(self):
+        def calculator(expression: str) -> str:
+            return expression
+
+        call = ToolCall(
+            id="call-1",
+            name="calculator",
+            arguments={"expression": "1"},
+        )
+        descriptor = ToolDescriptor(name="calculator", callable=calculator)
+        valid = {
+            "call": call,
+            "callable": calculator,
+            "descriptor": descriptor,
+            "arguments": {"expression": "1"},
+            "context": ToolCallContext(),
+        }
+        invalid_cases = (
+            {"call": "call"},
+            {"callable": "calculator"},
+            {"descriptor": "descriptor"},
+            {"arguments": [("expression", "1")]},
+            {"context": "context"},
+            {
+                "call": ToolCall(
+                    id="call-1",
+                    name="other",
+                    arguments={"expression": "1"},
+                )
+            },
+            {"arguments": {"expression": "2"}},
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                candidate = dict(valid)
+                candidate.update(kwargs)
+                with self.assertRaises(AssertionError):
+                    PreparedToolCall(**candidate)
 
 
 class ToolNameResolutionTestCase(TestCase):

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -222,6 +222,7 @@ class ToolCallTestCase(TestCase):
             arguments={"a": 1},
             provider_name="avl_cGtnLnRvb2w",
             provider_name_encoded=True,
+            provider_arguments_malformed=True,
         )
 
         self.assertEqual(call.id, "call-1")
@@ -229,6 +230,7 @@ class ToolCallTestCase(TestCase):
         self.assertEqual(call.arguments, {"a": 1})
         self.assertEqual(call.provider_name, "avl_cGtnLnRvb2w")
         self.assertTrue(call.provider_name_encoded)
+        self.assertTrue(call.provider_arguments_malformed)
 
     def test_allows_missing_id_and_name_for_legacy_provider_calls(self):
         call = ToolCall(id=None, name="", arguments={})
@@ -251,6 +253,17 @@ class ToolCallTestCase(TestCase):
                 "name": "tool",
                 "provider_name": "tool",
                 "provider_name_encoded": 1,
+            },
+            {
+                "id": "call-1",
+                "name": "tool",
+                "provider_name": "tool",
+                "provider_arguments_malformed": 1,
+            },
+            {
+                "id": "call-1",
+                "name": "tool",
+                "provider_arguments_malformed": True,
             },
         )
 

--- a/tests/tool/tool_call_outcome_test.py
+++ b/tests/tool/tool_call_outcome_test.py
@@ -5,7 +5,13 @@ from unittest import TestCase, main
 from uuid import uuid4
 
 from avalan.entities import (
+    EngineMessage,
+    EngineUri,
+    GenericProxyConfig,
+    Message,
+    MessageRole,
     PreparedToolCall,
+    ReasoningToken,
     ToolCall,
     ToolCallContext,
     ToolCallDiagnostic,
@@ -17,8 +23,11 @@ from avalan.entities import (
     ToolCallParseOutcome,
     ToolCallResult,
     ToolDescriptor,
+    ToolFilterResult,
+    ToolFilterResultStatus,
     ToolNameResolution,
     ToolNameResolutionStatus,
+    WebshareProxyConfig,
 )
 
 
@@ -260,6 +269,163 @@ class ToolCallParseOutcomeTestCase(TestCase):
 
         with self.assertRaises(FrozenInstanceError):
             outcome.calls = []
+
+
+class ToolFilterResultTestCase(TestCase):
+    def test_create_pass_result(self):
+        result = ToolFilterResult(status=ToolFilterResultStatus.PASS)
+
+        self.assertIs(result.status, ToolFilterResultStatus.PASS)
+        self.assertIsNone(result.call)
+        self.assertIsNone(result.context)
+        self.assertIs(result.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED)
+        self.assertIsNone(result.message)
+        self.assertEqual(result.details, {})
+
+    def test_create_modify_result(self):
+        call = ToolCall(id="call-1", name="calculator", arguments={})
+        context = ToolCallContext(flow_tool_node=True)
+
+        result = ToolFilterResult(
+            status=ToolFilterResultStatus.MODIFY,
+            call=call,
+            context=context,
+        )
+
+        self.assertEqual(result.call, call)
+        self.assertEqual(result.context, context)
+
+    def test_create_suppress_result(self):
+        result = ToolFilterResult(
+            status=ToolFilterResultStatus.SUPPRESS,
+            code=ToolCallDiagnosticCode.POLICY_SUPPRESSED,
+            message="Suppressed by policy.",
+            details={"reason": "policy"},
+        )
+
+        self.assertIs(result.status, ToolFilterResultStatus.SUPPRESS)
+        self.assertIs(result.code, ToolCallDiagnosticCode.POLICY_SUPPRESSED)
+        self.assertEqual(result.message, "Suppressed by policy.")
+        self.assertEqual(result.details, {"reason": "policy"})
+
+    def test_default_details_are_independent(self):
+        first = ToolFilterResult(status=ToolFilterResultStatus.PASS)
+        second = ToolFilterResult(status=ToolFilterResultStatus.PASS)
+
+        first.details["reason"] = "policy"
+
+        self.assertEqual(second.details, {})
+
+    def test_rejects_invalid_status(self):
+        with self.assertRaises(AssertionError):
+            ToolFilterResult(status="pass")
+
+    def test_rejects_invalid_call_context_code_message_and_details(self):
+        invalid_cases = (
+            {"status": ToolFilterResultStatus.PASS, "call": "call"},
+            {"status": ToolFilterResultStatus.PASS, "context": "context"},
+            {"status": ToolFilterResultStatus.PASS, "code": "code"},
+            {"status": ToolFilterResultStatus.PASS, "message": ""},
+            {"status": ToolFilterResultStatus.PASS, "details": []},
+            {"status": ToolFilterResultStatus.MODIFY},
+            {
+                "status": ToolFilterResultStatus.MODIFY,
+                "call": ToolCall(id="call-1", name="calculator"),
+            },
+            {
+                "status": ToolFilterResultStatus.MODIFY,
+                "context": ToolCallContext(),
+            },
+        )
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolFilterResult(**kwargs)
+
+    def test_is_frozen(self):
+        result = ToolFilterResult(status=ToolFilterResultStatus.PASS)
+
+        with self.assertRaises(FrozenInstanceError):
+            result.message = "Changed."
+
+
+class EntityHelperTestCase(TestCase):
+    def test_engine_uri_is_local(self):
+        self.assertTrue(
+            EngineUri(
+                host=None,
+                port=None,
+                user=None,
+                password=None,
+                vendor=None,
+                model_id=None,
+                params={},
+            ).is_local
+        )
+        self.assertFalse(
+            EngineUri(
+                host=None,
+                port=None,
+                user=None,
+                password=None,
+                vendor="openai",
+                model_id="gpt",
+                params={},
+            ).is_local
+        )
+
+    def test_generic_proxy_config_to_dict(self):
+        proxy = GenericProxyConfig(
+            scheme="http",
+            host="proxy.example",
+            port=8080,
+            username="user",
+            password="pass",
+        )
+
+        self.assertEqual(
+            proxy.to_dict(),
+            {
+                "http": "http://user:pass@proxy.example:8080",
+                "https": "http://user:pass@proxy.example:8080",
+            },
+        )
+
+    def test_engine_message_is_from_agent(self):
+        message = EngineMessage(
+            agent_id=uuid4(),
+            model_id="model",
+            message=Message(role=MessageRole.ASSISTANT, content="content"),
+        )
+
+        self.assertTrue(message.is_from_agent)
+
+    def test_reasoning_token_initializes_base_token(self):
+        token = ReasoningToken(token="thinking", id=1, probability=0.5)
+
+        self.assertEqual(token.id, 1)
+        self.assertEqual(token.token, "thinking")
+        self.assertEqual(token.probability, 0.5)
+
+    def test_webshare_proxy_config_to_generic(self):
+        proxy = WebshareProxyConfig(
+            scheme="https",
+            host="proxy.example",
+            port=8080,
+            username="user",
+            password="pass",
+        )
+
+        self.assertEqual(
+            proxy.to_generic(),
+            GenericProxyConfig(
+                scheme="https",
+                host="proxy.example",
+                port=8080,
+                username="user",
+                password="pass",
+            ),
+        )
 
 
 class ToolDescriptorTestCase(TestCase):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -52,6 +52,11 @@ class ToolManagerCreationTestCase(TestCase):
             settings.provider_arguments_mode,
             ToolProviderArgumentsMode.EMPTY_ON_MALFORMED,
         )
+        self.assertIsNone(settings.maximum_argument_depth)
+        self.assertIsNone(settings.maximum_argument_size)
+        self.assertIsNone(settings.maximum_parser_input_size)
+        self.assertIsNone(settings.maximum_parser_payload_depth)
+        self.assertIsNone(settings.maximum_parser_payload_size)
 
     def test_settings_accept_outcome_compatibility_modes(self):
         settings = ToolManagerSettings(
@@ -61,6 +66,11 @@ class ToolManagerCreationTestCase(TestCase):
             provider_arguments_mode=(
                 ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
             ),
+            maximum_argument_depth=3,
+            maximum_argument_size=64,
+            maximum_parser_input_size=128,
+            maximum_parser_payload_depth=4,
+            maximum_parser_payload_size=96,
         )
 
         self.assertIs(
@@ -78,6 +88,11 @@ class ToolManagerCreationTestCase(TestCase):
             settings.provider_arguments_mode,
             ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED,
         )
+        self.assertEqual(settings.maximum_argument_depth, 3)
+        self.assertEqual(settings.maximum_argument_size, 64)
+        self.assertEqual(settings.maximum_parser_input_size, 128)
+        self.assertEqual(settings.maximum_parser_payload_depth, 4)
+        self.assertEqual(settings.maximum_parser_payload_size, 96)
 
     def test_settings_reject_invalid_compatibility_modes(self):
         invalid_cases = (
@@ -85,6 +100,12 @@ class ToolManagerCreationTestCase(TestCase):
             {"missing_call_mode": "legacy_none"},
             {"parser_return_mode": "legacy"},
             {"provider_arguments_mode": "empty_on_malformed"},
+            {"maximum_depth": 0},
+            {"maximum_argument_depth": 0},
+            {"maximum_argument_size": -1},
+            {"maximum_parser_input_size": True},
+            {"maximum_parser_payload_depth": "1"},
+            {"maximum_parser_payload_size": 0},
         )
 
         for kwargs in invalid_cases:
@@ -732,6 +753,48 @@ class ToolManagerCreationTestCase(TestCase):
         )
         self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
 
+    def test_validate_tool_call_rejects_excessive_argument_depth(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["nested_value"],
+            available_toolsets=[ToolSet(tools=[nested_value])],
+            settings=ToolManagerSettings(maximum_argument_depth=2),
+        )
+
+        diagnostic = manager.validate_tool_call(
+            ToolCall(
+                id="call-1",
+                name="nested_value",
+                arguments={"payload": {"nested": {"value": 1}}},
+            )
+        )
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.canonical_name, "nested_value")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(diagnostic.details["limit"], 2)
+
+    def test_validate_tool_call_rejects_oversized_arguments(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["nested_value"],
+            available_toolsets=[ToolSet(tools=[nested_value])],
+            settings=ToolManagerSettings(maximum_argument_size=8),
+        )
+
+        diagnostic = manager.validate_tool_call(
+            ToolCall(
+                id="call-1",
+                name="nested_value",
+                arguments={"payload": "large value"},
+            )
+        )
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.canonical_name, "nested_value")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_SIZE)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(diagnostic.details["limit"], 8)
+
     def test_validate_tool_call_rejects_wrong_json_types(self):
         async def typed_tool(
             payload: RuntimePayload,
@@ -1002,6 +1065,10 @@ class RuntimeMode(str, Enum):
     SLOW = "slow"
 
 
+async def nested_value(payload: Any) -> Any:
+    return payload
+
+
 class NativeAdderTool(Tool):
     def __init__(self) -> None:
         super().__init__()
@@ -1180,6 +1247,42 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
             diagnostic.code,
             ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
         )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    async def test_prepare_call_applies_argument_limits_after_filters(self):
+        def deepen_argument(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"payload": {"nested": {"value": 1}}},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["nested_value"],
+            available_toolsets=[ToolSet(tools=[nested_value])],
+            settings=ToolManagerSettings(
+                filters=[deepen_argument],
+                maximum_argument_depth=2,
+            ),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="nested_value",
+            arguments={"payload": 1},
+        )
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.canonical_name, "nested_value")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH)
         self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
 
     async def test_execute_prepared_call_does_not_rerun_filters(self):
@@ -1580,6 +1683,34 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(diagnostic.message, "$.count must be integer.")
         self.assertEqual(calls, [valid_arguments])
+
+    async def test_execute_call_rejects_argument_limits_before_dispatch(self):
+        calls: list[Any] = []
+
+        async def limited_tool(payload: Any) -> Any:
+            calls.append(payload)
+            return payload
+
+        manager = ToolManager.create_instance(
+            enable_tools=["limited_tool"],
+            available_toolsets=[ToolSet(tools=[limited_tool])],
+            settings=ToolManagerSettings(maximum_argument_size=8),
+        )
+
+        outcome = await manager.execute_call(
+            ToolCall(
+                id="call-1",
+                name="limited_tool",
+                arguments={"payload": "large value"},
+            ),
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.MAXIMUM_SIZE)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(calls, [])
 
     async def test_execute_call_returns_execution_error(self):
         async def failing_tool(a: int) -> None:
@@ -2057,6 +2188,46 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
                     enable_tools=["calculator"],
                     available_toolsets=[ToolSet(tools=[CalculatorTool()])],
                     settings=ToolManagerSettings(tool_format=tool_format),
+                )
+
+                self.assertIsNone(manager.get_calls(text))
+
+    async def test_get_calls_returns_none_for_parser_resource_diagnostics(
+        self,
+    ):
+        cases = (
+            (
+                ToolManagerSettings(
+                    tool_format=ToolFormat.JSON,
+                    maximum_parser_input_size=4,
+                ),
+                '{"tool": "calculator", "arguments": {}}',
+            ),
+            (
+                ToolManagerSettings(
+                    tool_format=ToolFormat.JSON,
+                    maximum_parser_payload_depth=1,
+                ),
+                (
+                    '{"tool": "calculator", "arguments": '
+                    '{"payload": {"value": 1}}}'
+                ),
+            ),
+            (
+                ToolManagerSettings(
+                    tool_format=ToolFormat.JSON,
+                    maximum_parser_payload_size=8,
+                ),
+                '{"tool": "calculator", "arguments": {"payload": "large"}}',
+            ),
+        )
+
+        for settings, text in cases:
+            with self.subTest(settings=settings):
+                manager = ToolManager.create_instance(
+                    enable_tools=["calculator"],
+                    available_toolsets=[ToolSet(tools=[CalculatorTool()])],
+                    settings=settings,
                 )
 
                 self.assertIsNone(manager.get_calls(text))

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1888,6 +1888,7 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
         self.assertIsInstance(diagnostic, ToolCallDiagnostic)
         assert isinstance(diagnostic, ToolCallDiagnostic)
         self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertEqual(diagnostic.canonical_name, "adder")
         self.assertIs(
             diagnostic.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED
         )
@@ -1946,7 +1947,441 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
             diagnostic.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED
         )
         self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.FILTER)
+        self.assertEqual(diagnostic.canonical_name, "adder")
         self.assertEqual(diagnostic.details, {"filtered_name": "multiplier"})
+
+    async def test_prepare_call_keeps_unknown_filter_suppression_uncanonical(
+        self,
+    ) -> None:
+        for rewritten_name in ("missing", ""):
+            with self.subTest(rewritten_name=rewritten_name):
+
+                def rename(
+                    call: ToolCall,
+                    context: ToolCallContext,
+                ) -> tuple[ToolCall, ToolCallContext]:
+                    return (
+                        ToolCall(
+                            id=call.id,
+                            name=rewritten_name,
+                            arguments=call.arguments,
+                        ),
+                        context,
+                    )
+
+                def suppress(
+                    _call: ToolCall,
+                    _context: ToolCallContext,
+                ) -> ToolFilterResult:
+                    return ToolFilterResult(
+                        status=ToolFilterResultStatus.SUPPRESS
+                    )
+
+                manager = ToolManager.create_instance(
+                    enable_tools=["adder"],
+                    available_toolsets=[ToolSet(tools=[DummyAdder()])],
+                    settings=ToolManagerSettings(filters=[rename, suppress]),
+                )
+                call = ToolCall(
+                    id="call-1",
+                    name="adder",
+                    arguments={"a": 2, "b": 3},
+                )
+
+                diagnostic = await manager.prepare_call(
+                    call,
+                    context=ToolCallContext(),
+                )
+
+                self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+                assert isinstance(diagnostic, ToolCallDiagnostic)
+                self.assertIsNone(diagnostic.canonical_name)
+                self.assertIs(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.FILTER_SUPPRESSED,
+                )
+
+    async def test_prepare_call_keeps_flow_filter_guard_after_context_replace(
+        self,
+    ) -> None:
+        seen_flow_markers: list[bool] = []
+
+        def replace_context(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            seen_flow_markers.append(context.flow_tool_node)
+            return call, ToolCallContext()
+
+        def rename(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            seen_flow_markers.append(context.flow_tool_node)
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="multiplier",
+                    arguments=call.arguments,
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+            ],
+            settings=ToolManagerSettings(filters=[replace_context, rename]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.FILTER)
+        self.assertEqual(diagnostic.canonical_name, "adder")
+        self.assertEqual(diagnostic.details, {"filtered_name": "multiplier"})
+        self.assertEqual(seen_flow_markers, [True, True])
+
+    async def test_prepare_call_rejects_flow_provider_name_rewrite(
+        self,
+    ) -> None:
+        cases = ("multiplier", "pkg.tool")
+
+        for provider_name in cases:
+            with self.subTest(provider_name=provider_name):
+
+                def set_provider_name(
+                    call: ToolCall,
+                    _context: ToolCallContext,
+                ) -> tuple[ToolCall, ToolCallContext]:
+                    return (
+                        ToolCall(
+                            id=call.id,
+                            name=call.name,
+                            arguments=call.arguments,
+                            provider_name=provider_name,
+                        ),
+                        ToolCallContext(),
+                    )
+
+                manager = ToolManager.create_instance(
+                    enable_tools=["adder", "multiplier"],
+                    available_toolsets=[
+                        ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+                    ],
+                    settings=ToolManagerSettings(filters=[set_provider_name]),
+                )
+                call = ToolCall(
+                    id="call-1",
+                    name="adder",
+                    arguments={"a": 2, "b": 3},
+                )
+
+                diagnostic = await manager.prepare_call(
+                    call,
+                    context=ToolCallContext(flow_tool_node=True),
+                )
+
+                self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+                assert isinstance(diagnostic, ToolCallDiagnostic)
+                self.assertIs(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.FILTER_SUPPRESSED,
+                )
+                self.assertIs(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.FILTER,
+                )
+                self.assertEqual(
+                    diagnostic.details, {"filtered_name": provider_name}
+                )
+
+    async def test_prepare_call_accepts_flow_same_provider_name(
+        self,
+    ) -> None:
+        def set_provider_name(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments=call.arguments,
+                    provider_name="adder",
+                ),
+                ToolCallContext(),
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[set_provider_name]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        prepared = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call.name, "adder")
+
+    async def test_prepare_call_accepts_flow_alias_for_same_tool(
+        self,
+    ) -> None:
+        def set_alias(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="sum",
+                    arguments=call.arguments,
+                ),
+                ToolCallContext(),
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[set_alias]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        prepared = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call.name, "adder")
+
+    async def test_prepare_call_matches_filter_after_flow_alias_rewrite(
+        self,
+    ) -> None:
+        called: list[str] = []
+
+        def set_alias(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            assert call.arguments is not None
+            called.append("alias")
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="sum",
+                    arguments={"a": call.arguments["a"]},
+                ),
+                ToolCallContext(),
+            )
+
+        def add_argument(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            assert call.arguments is not None
+            called.append("adder")
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"a": call.arguments["a"], "b": 5},
+                ),
+                context,
+            )
+
+        def unrelated(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("multiplier")
+            return call, context
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                filters=[
+                    set_alias,
+                    ToolFilter(func=unrelated, namespace="multiplier"),
+                    ToolFilter(func=add_argument, namespace="adder"),
+                ],
+            ),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        prepared = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call.name, "adder")
+        self.assertEqual(prepared.arguments, {"a": 2, "b": 5})
+        self.assertEqual(called, ["alias", "adder"])
+
+    async def test_prepare_call_rejects_flow_alias_for_other_tool(
+        self,
+    ) -> None:
+        multiplier = DummyMultiplier()
+        multiplier.aliases = ["product"]
+
+        def set_alias(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="product",
+                    arguments=call.arguments,
+                ),
+                ToolCallContext(),
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[ToolSet(tools=[DummyAdder(), multiplier])],
+            settings=ToolManagerSettings(filters=[set_alias]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.FILTER_SUPPRESSED,
+        )
+        self.assertEqual(diagnostic.details, {"filtered_name": "multiplier"})
+
+    async def test_prepare_call_rejects_flow_blank_filter_name(
+        self,
+    ) -> None:
+        def clear_name(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="",
+                    arguments=call.arguments,
+                ),
+                ToolCallContext(),
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[clear_name]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.FILTER_SUPPRESSED,
+        )
+        self.assertEqual(diagnostic.details, {"filtered_name": ""})
+
+    async def test_prepare_call_keeps_flow_cancellation_after_context_replace(
+        self,
+    ) -> None:
+        called: list[str] = []
+
+        async def cancel() -> None:
+            called.append("cancel")
+            if len(called) == 3:
+                raise CancelledError()
+
+        def replace_context(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("filter")
+            return call, ToolCallContext()
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[replace_context]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        with self.assertRaises(CancelledError):
+            await manager.prepare_call(
+                call,
+                context=ToolCallContext(
+                    cancellation_checker=cancel,
+                    flow_tool_node=True,
+                ),
+            )
+
+        self.assertEqual(called, ["cancel", "filter", "cancel"])
+
+    async def test_prepare_call_keeps_explicit_flow_cancellation_replacement(
+        self,
+    ) -> None:
+        called: list[str] = []
+
+        async def first_check() -> None:
+            called.append("first")
+
+        async def second_check() -> None:
+            called.append("second")
+            raise CancelledError()
+
+        def replace_context(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            called.append("filter")
+            return call, ToolCallContext(cancellation_checker=second_check)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[replace_context]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        with self.assertRaises(CancelledError):
+            await manager.prepare_call(
+                call,
+                context=ToolCallContext(
+                    cancellation_checker=first_check,
+                    flow_tool_node=True,
+                ),
+            )
+
+        self.assertEqual(called, ["first", "filter", "second"])
 
 
 class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -14,6 +14,8 @@ from avalan.entities import (
     ToolCallError,
     ToolCallResult,
     ToolFilter,
+    ToolFilterResult,
+    ToolFilterResultStatus,
     ToolFormat,
     ToolManagerExecutionMode,
     ToolManagerMissingCallMode,
@@ -559,6 +561,16 @@ class DummyAdderAlt(DummyAdder):
         self.aliases = ["sum"]
 
 
+class DummyMultiplier(DummyAdder):
+    def __init__(self) -> None:
+        self.__name__ = "multiplier"
+        self.aliases = []
+
+    async def __call__(self, a: int, b: int) -> int:
+        """Return the product of ``a`` and ``b``."""
+        return a * b
+
+
 class DummySum(DummyAdder):
     def __init__(self) -> None:
         self.__name__ = "sum"
@@ -813,10 +825,67 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
         assert isinstance(prepared, PreparedToolCall)
         self.assertEqual(prepared.arguments, {"a": 1, "b": 2})
 
-    async def test_legacy_call_preserves_filter_name_rewrite(self):
+    async def test_prepare_call_resolves_filter_name_rewrite(self):
         def rename(call: ToolCall, context: ToolCallContext):
             return (
-                ToolCall(id=call.id, name="renamed", arguments=call.arguments),
+                ToolCall(
+                    id=call.id,
+                    name="multiplier",
+                    arguments=call.arguments,
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+            ],
+            settings=ToolManagerSettings(filters=[rename]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call.name, "multiplier")
+        result = await manager.execute_prepared_call(prepared)
+        self.assertIsInstance(result, ToolCallResult)
+        assert isinstance(result, ToolCallResult)
+        self.assertEqual(result.result, 6)
+
+    async def test_prepare_call_returns_diagnostic_for_filter_unknown_rewrite(
+        self,
+    ):
+        def rename(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(id=call.id, name="missing", arguments=call.arguments),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[rename]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.requested_name, "missing")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.UNKNOWN_TOOL)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    async def test_legacy_call_returns_none_for_filter_unknown_rewrite(self):
+        def rename(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(id=call.id, name="missing", arguments=call.arguments),
                 context,
             )
 
@@ -829,10 +898,166 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
 
         result = await manager(call, context=ToolCallContext())
 
-        self.assertIsInstance(result, ToolCallResult)
-        assert isinstance(result, ToolCallResult)
-        self.assertEqual(result.name, "renamed")
-        self.assertEqual(result.result, 3)
+        self.assertIsNone(result)
+
+    async def test_prepare_call_accepts_explicit_filter_pass(self):
+        def pass_call(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(status=ToolFilterResultStatus.PASS)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[pass_call]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call, call)
+
+    async def test_prepare_call_preserves_legacy_filter_none(self):
+        def pass_call(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> None:
+            return None
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[pass_call]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.call, call)
+
+    async def test_prepare_call_accepts_explicit_filter_modify(self):
+        def modify(
+            call: ToolCall,
+            context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(
+                status=ToolFilterResultStatus.MODIFY,
+                call=ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"a": 3, "b": 4},
+                ),
+                context=context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[modify]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.arguments, {"a": 3, "b": 4})
+
+    async def test_prepare_call_returns_explicit_filter_suppress_diagnostic(
+        self,
+    ):
+        diagnostic_id = _uuid4()
+
+        def suppress(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(
+                status=ToolFilterResultStatus.SUPPRESS,
+                message="Blocked by policy.",
+                details={"reason": "policy"},
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[suppress]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            diagnostic = await manager.prepare_call(
+                call,
+                context=ToolCallContext(),
+            )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.FILTER)
+        self.assertEqual(diagnostic.message, "Blocked by policy.")
+        self.assertEqual(diagnostic.details, {"reason": "policy"})
+
+    async def test_legacy_call_returns_none_for_explicit_filter_suppress(self):
+        def suppress(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(status=ToolFilterResultStatus.SUPPRESS)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[suppress]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        result = await manager(call, context=ToolCallContext())
+
+        self.assertIsNone(result)
+
+    async def test_prepare_call_rejects_flow_tool_node_filter_name_rewrite(
+        self,
+    ):
+        def rename(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="multiplier",
+                    arguments=call.arguments,
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+            ],
+            settings=ToolManagerSettings(filters=[rename]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(flow_tool_node=True),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.FILTER)
+        self.assertEqual(diagnostic.details, {"filtered_name": "multiplier"})
 
 
 class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -684,6 +684,26 @@ class ToolManagerCreationTestCase(TestCase):
         self.assertEqual(resolution.canonical_name, "adder")
         self.assertEqual(resolution.candidates, ["adder"])
 
+    def test_resolve_tool_name_disabled_exact_wins_over_enabled_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder()]),
+                ToolSet(tools=[DummySum()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name("sum")
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.DISABLED)
+        self.assertIsNone(resolution.canonical_name)
+        self.assertEqual(resolution.candidates, ["sum"])
+        self.assertIs(
+            resolution.diagnostic_code,
+            ToolCallDiagnosticCode.DISABLED_TOOL,
+        )
+
     def test_resolve_tool_name_disabled_alias_is_not_recovered(self):
         manager = ToolManager.create_instance(
             enable_tools=[],
@@ -727,6 +747,29 @@ class ToolManagerCreationTestCase(TestCase):
         call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
 
         self.assertIsNone(manager.validate_tool_call(call))
+
+    def test_validate_tool_call_rejects_disabled_exact_alias_collision(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder()]),
+                ToolSet(tools=[DummySum()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+
+        diagnostic = manager.validate_tool_call(call)
+
+        assert diagnostic is not None
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.DISABLED_TOOL,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+        self.assertEqual(diagnostic.requested_name, "sum")
+        self.assertIsNone(diagnostic.canonical_name)
+        self.assertEqual(diagnostic.details["candidates"], ["sum"])
 
     def test_validate_tool_call_resolves_provider_encoded_name(self):
         manager = ToolManager.create_instance(
@@ -1366,6 +1409,34 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
                 result=5,
             ),
         )
+
+    async def test_execute_call_reports_malformed_provider_encoded_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        token = TextGenerationVendor.build_tool_call_token(
+            call_id="call-1",
+            tool_name="avl_notbase64",
+            arguments={"a": 2, "b": 3},
+        )
+        diagnostic_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            outcome = await manager.execute_call(
+                token.call,
+                context=ToolCallContext(),
+            )
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertEqual(outcome.id, diagnostic_id)
+        self.assertEqual(outcome.call_id, "call-1")
+        self.assertEqual(outcome.requested_name, "avl_notbase64")
+        self.assertIsNone(outcome.canonical_name)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.MALFORMED_CALL)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.RESOLVE)
 
     async def test_prepare_call_returns_resolution_diagnostic(self):
         manager = ToolManager.create_instance(
@@ -2049,6 +2120,29 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(valid_empty.result, "ok")
         self.assertEqual(calls, 1)
 
+    async def test_execute_call_rejects_disabled_exact_alias_collision(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder()]),
+                ToolSet(tools=[DummySum()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        outcome = await manager.execute_call(
+            ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2}),
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.DISABLED_TOOL)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.RESOLVE)
+        self.assertEqual(outcome.requested_name, "sum")
+        self.assertIsNone(outcome.canonical_name)
+        self.assertEqual(outcome.details["candidates"], ["sum"])
+
     async def test_execute_call_returns_execution_error(self):
         async def failing_tool(a: int) -> None:
             raise ValueError("boom")
@@ -2281,6 +2375,131 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
         self.assertIs(outcome.stage, ToolCallDiagnosticStage.CONFIRM)
 
 
+class ToolManagerOutcomeModeCallTestCase(IsolatedAsyncioTestCase):
+    async def test_call_uses_outcome_mode_to_execute_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                execution_mode=ToolManagerExecutionMode.OUTCOMES
+            ),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+        result_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=result_id):
+            outcome = await manager(call, context=ToolCallContext())
+
+        self.assertEqual(
+            outcome,
+            ToolCallResult(
+                id=result_id,
+                call=ToolCall(
+                    id="call-1",
+                    name="adder",
+                    arguments={"a": 1, "b": 2},
+                ),
+                name="adder",
+                arguments={"a": 1, "b": 2},
+                result=3,
+            ),
+        )
+
+    async def test_legacy_call_still_returns_none_for_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+
+        outcome = await manager(call, context=ToolCallContext())
+
+        self.assertIsNone(outcome)
+
+    async def test_call_uses_outcome_mode_for_resolution_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                execution_mode=ToolManagerExecutionMode.OUTCOMES
+            ),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+        diagnostic_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            outcome = await manager(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertEqual(outcome.id, diagnostic_id)
+        self.assertEqual(outcome.call_id, "call-1")
+        self.assertEqual(outcome.requested_name, "sum")
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.DISABLED_TOOL)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    async def test_call_uses_outcome_mode_for_validation_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                execution_mode=ToolManagerExecutionMode.OUTCOMES
+            ),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1})
+
+        outcome = await manager(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertEqual(outcome.call_id, "call-1")
+        self.assertIs(
+            outcome.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    async def test_call_uses_outcome_mode_for_provider_argument_diagnostic(
+        self,
+    ):
+        calls = 0
+
+        async def provider_no_args() -> str:
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["provider_no_args"],
+            available_toolsets=[ToolSet(tools=[provider_no_args])],
+            settings=ToolManagerSettings(
+                execution_mode=ToolManagerExecutionMode.OUTCOMES,
+                provider_arguments_mode=(
+                    ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+                ),
+            ),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="provider_no_args",
+            arguments={},
+            provider_name="provider_no_args",
+            provider_arguments_malformed=True,
+        )
+
+        outcome = await manager(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(
+            outcome.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(calls, 0)
+
+
 class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):
     async def test_native_tool_with_arguments(self):
         tool = NativeAdderTool()
@@ -2499,6 +2718,189 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
                         ],
                     )
 
+    async def test_react_calls_after_malformed_input_execute(self):
+        async def echo_input(input: str) -> str:
+            return input
+
+        manager = ToolManager.create_instance(
+            enable_tools=["calculator", "echo_input"],
+            available_toolsets=[ToolSet(tools=[CalculatorTool(), echo_input])],
+            settings=ToolManagerSettings(tool_format=ToolFormat.REACT),
+        )
+        outcome = manager.parse_calls(
+            'Action: broken\nAction Input: {"expression": '
+            "\nAction: calculator\n"
+            'Action Input: {"expression": "1 + 1"}\n'
+            "Action: echo_input\n"
+            'Action Input: {"input": "done"}'
+        )
+
+        self.assertEqual(len(outcome.calls), 2)
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+        first = await manager.execute_call(
+            outcome.calls[0],
+            context=ToolCallContext(),
+        )
+        second = await manager.execute_call(
+            outcome.calls[1],
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(first, ToolCallResult)
+        self.assertIsInstance(second, ToolCallResult)
+        assert isinstance(first, ToolCallResult)
+        assert isinstance(second, ToolCallResult)
+        self.assertEqual(first.result, "2")
+        self.assertEqual(second.result, "done")
+
+    def test_get_calls_preserves_multiple_tag_calls_after_xml_parse_error(
+        self,
+    ):
+        text = (
+            '<tool_call name="calculator">{"expression": "1"}</tool_call>'
+            "&"
+            '<tool_call name="calculator">{"expression": "2"}</tool_call>'
+        )
+        first_id = _uuid4()
+        second_id = _uuid4()
+
+        with patch(
+            "avalan.tool.parser.uuid4", side_effect=[first_id, second_id]
+        ):
+            calls = self.manager.get_calls(text)
+
+        self.assertEqual(
+            calls,
+            [
+                ToolCall(
+                    id=first_id,
+                    name="calculator",
+                    arguments={"expression": "1"},
+                ),
+                ToolCall(
+                    id=second_id,
+                    name="calculator",
+                    arguments={"expression": "2"},
+                ),
+            ],
+        )
+
+    async def test_react_namespaced_tool_executes(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["math.calculator"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[CalculatorTool()])
+            ],
+            settings=ToolManagerSettings(tool_format=ToolFormat.REACT),
+        )
+        call_id = _uuid4()
+        result_id = _uuid4()
+
+        with (
+            patch("avalan.tool.parser.uuid4", return_value=call_id),
+            patch("avalan.tool.manager.uuid4", return_value=result_id),
+        ):
+            calls = manager.get_calls(
+                'Action: math.calculator\nAction Input: {"expression": "2"}'
+            )
+            assert calls is not None
+            result = await manager(calls[0], context=ToolCallContext())
+
+        expected_call = ToolCall(
+            id=call_id,
+            name="math.calculator",
+            arguments={"expression": "2"},
+        )
+        self.assertEqual(calls, [expected_call])
+        self.assertEqual(
+            result,
+            ToolCallResult(
+                id=result_id,
+                call=expected_call,
+                name="math.calculator",
+                arguments={"expression": "2"},
+                result="2",
+            ),
+        )
+
+    async def test_bracket_namespaced_tool_executes(self):
+        async def echo_input(input: str) -> str:
+            return input
+
+        manager = ToolManager.create_instance(
+            enable_tools=["text.echo_input"],
+            available_toolsets=[ToolSet(namespace="text", tools=[echo_input])],
+            settings=ToolManagerSettings(tool_format=ToolFormat.BRACKET),
+        )
+        call_id = _uuid4()
+        result_id = _uuid4()
+
+        with (
+            patch("avalan.tool.parser.uuid4", return_value=call_id),
+            patch("avalan.tool.manager.uuid4", return_value=result_id),
+        ):
+            calls = manager.get_calls("[text.echo_input](hello)")
+            assert calls is not None
+            result = await manager(calls[0], context=ToolCallContext())
+
+        expected_call = ToolCall(
+            id=call_id,
+            name="text.echo_input",
+            arguments={"input": "hello"},
+        )
+        self.assertEqual(calls, [expected_call])
+        self.assertEqual(
+            result,
+            ToolCallResult(
+                id=result_id,
+                call=expected_call,
+                name="text.echo_input",
+                arguments={"input": "hello"},
+                result="hello",
+            ),
+        )
+
+    def test_parse_calls_reports_malformed_bracket_with_valid_call(self):
+        manager = ToolManager.create_instance(
+            settings=ToolManagerSettings(tool_format=ToolFormat.BRACKET),
+        )
+        call_id = _uuid4()
+        diagnostic_id = _uuid4()
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[call_id, diagnostic_id],
+        ):
+            outcome = manager.parse_calls(
+                "[math..calculator](bad)\n[math.calculator](2)"
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=call_id,
+                    name="math.calculator",
+                    arguments={"input": "2"},
+                )
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(outcome.diagnostics[0].id, diagnostic_id)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            outcome.diagnostics[0].stage,
+            ToolCallDiagnosticStage.PARSE,
+        )
+
     async def test_get_calls_returns_none_for_parse_diagnostics_only(self):
         cases = (
             (
@@ -2516,6 +2918,14 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
             (
                 ToolFormat.JSON,
                 '{"tool": "calculator", "arguments": ',
+            ),
+            (
+                ToolFormat.JSON,
+                '{"tool": "math..calculator", "arguments": {}}',
+            ),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "math/calculator", "arguments": {}}',
             ),
         )
 

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -153,6 +153,21 @@ class ToolManagerCreationTestCase(TestCase):
         )
         self.assertTrue(manager.is_empty)
 
+    def test_enable_tools_namespace_uses_segment_boundaries(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["math"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[CalculatorTool()]),
+                ToolSet(namespace="mathx", tools=[CalculatorTool()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        self.assertEqual(
+            [descriptor.name for descriptor in manager.list_tools()],
+            ["math.calculator"],
+        )
+
     def test_nested_toolset_names_are_enabled_with_parent_namespace(self):
         inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
         outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
@@ -1312,6 +1327,46 @@ class ToolManagerFiltersTransformersTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(res_other.call.arguments, {"expression": "1"})
         self.assertEqual(res_other.result, "1")
 
+    async def test_filter_namespace_uses_segment_boundaries(self):
+        def modify(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"expression": "2 + 2"},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["math.calculator", "mathx.calculator"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[CalculatorTool()]),
+                ToolSet(namespace="mathx", tools=[CalculatorTool()]),
+            ],
+            settings=ToolManagerSettings(
+                filters=[ToolFilter(func=modify, namespace="math")]
+            ),
+        )
+        call_math = ToolCall(
+            id=_uuid4(), name="math.calculator", arguments={"expression": "1"}
+        )
+        call_mathx = ToolCall(
+            id=_uuid4(), name="mathx.calculator", arguments={"expression": "1"}
+        )
+
+        with patch(
+            "avalan.tool.manager.uuid4",
+            side_effect=[_uuid4(), _uuid4()],
+        ):
+            res_math = await manager(call_math, context=ToolCallContext())
+            res_mathx = await manager(call_mathx, context=ToolCallContext())
+
+        self.assertEqual(res_math.call.arguments, {"expression": "2 + 2"})
+        self.assertEqual(res_math.result, "4")
+        self.assertEqual(res_mathx.call.arguments, {"expression": "1"})
+        self.assertEqual(res_mathx.result, "1")
+
     async def test_transformer_scoped_to_full_namespace(self):
         def transform(_: ToolCall, __: ToolCallContext, result: str | None):
             return f"{result}!"
@@ -1346,6 +1401,39 @@ class ToolManagerFiltersTransformersTestCase(IsolatedAsyncioTestCase):
 
         self.assertEqual(res_math.result, "1!")
         self.assertEqual(res_plain.result, "1")
+
+    async def test_transformer_namespace_uses_segment_boundaries(self):
+        def transform(_: ToolCall, __: ToolCallContext, result: str | None):
+            return f"{result}!"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["math.calculator", "mathx.calculator"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[CalculatorTool()]),
+                ToolSet(namespace="mathx", tools=[CalculatorTool()]),
+            ],
+            settings=ToolManagerSettings(
+                transformers=[
+                    ToolTransformer(func=transform, namespace="math")
+                ]
+            ),
+        )
+        call_math = ToolCall(
+            id=_uuid4(), name="math.calculator", arguments={"expression": "1"}
+        )
+        call_mathx = ToolCall(
+            id=_uuid4(), name="mathx.calculator", arguments={"expression": "1"}
+        )
+
+        with patch(
+            "avalan.tool.manager.uuid4",
+            side_effect=[_uuid4(), _uuid4()],
+        ):
+            res_math = await manager(call_math, context=ToolCallContext())
+            res_mathx = await manager(call_mathx, context=ToolCallContext())
+
+        self.assertEqual(res_math.result, "1!")
+        self.assertEqual(res_mathx.result, "1")
 
 
 if __name__ == "__main__":

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -24,6 +24,7 @@ from avalan.entities import (
     ToolParserReturnMode,
     ToolProviderArgumentsMode,
     ToolTransformer,
+    ToolTransformerResult,
 )
 from avalan.model.vendor import TextGenerationVendor
 from avalan.tool import Tool, ToolSet
@@ -88,6 +89,38 @@ class ToolManagerCreationTestCase(TestCase):
             with self.subTest(kwargs=kwargs):
                 with self.assertRaises(AssertionError):
                     ToolManagerSettings(**kwargs)
+
+    def test_tool_call_error_type_uses_exception_or_projection(self):
+        call = ToolCall(id="call-1", name="tool", arguments={})
+
+        exception_error = ToolCallError(
+            id="error-1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            error=ValueError("boom"),
+            message="boom",
+        )
+        projected_error = ToolCallError(
+            id="error-2",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            error={"type": "ProjectedError"},
+            message="boom",
+        )
+        unknown_error = ToolCallError(
+            id="error-3",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            error={"message": "boom"},
+            message="boom",
+        )
+
+        self.assertEqual(exception_error.error_type, "ValueError")
+        self.assertEqual(projected_error.error_type, "ProjectedError")
+        self.assertEqual(unknown_error.error_type, "ToolCallError")
 
     def test_default_instance_empty(self):
         manager = ToolManager.create_instance(
@@ -1102,7 +1135,8 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
 
         self.assertIsInstance(outcome, ToolCallError)
         assert isinstance(outcome, ToolCallError)
-        self.assertIsInstance(outcome.error, ValueError)
+        self.assertEqual(outcome.error, {"type": "ValueError"})
+        self.assertEqual(outcome.error_type, "ValueError")
         self.assertEqual(outcome.message, "boom")
 
     async def test_execute_call_returns_resolution_diagnostics(self):
@@ -1358,6 +1392,76 @@ class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):
         result = await manager(call, context=ToolCallContext())
         self.assertEqual(result.result, 3)
 
+    async def test_non_native_tool_dispatches_arguments_by_keyword(self):
+        async def subtract(a: int, b: int) -> int:
+            return a - b
+
+        manager = ToolManager.create_instance(
+            enable_tools=[subtract.__name__],
+            available_toolsets=[ToolSet(tools=[subtract])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id=_uuid4(), name=subtract.__name__, arguments={"b": 2, "a": 5}
+        )
+        result = await manager(call, context=ToolCallContext())
+        self.assertEqual(result.result, 3)
+
+    async def test_non_native_tool_supports_positional_only_arguments(self):
+        async def subtract(a: int, /, b: int) -> int:
+            return a - b
+
+        manager = ToolManager.create_instance(
+            enable_tools=[subtract.__name__],
+            available_toolsets=[ToolSet(tools=[subtract])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id=_uuid4(), name=subtract.__name__, arguments={"b": 2, "a": 5}
+        )
+        result = await manager(call, context=ToolCallContext())
+        self.assertEqual(result.result, 3)
+
+    async def test_execute_call_rejects_varargs_arguments(self):
+        async def collect(*values: int) -> int:
+            return sum(values)
+
+        manager = ToolManager.create_instance(
+            enable_tools=[collect.__name__],
+            available_toolsets=[ToolSet(tools=[collect])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id=_uuid4(),
+            name=collect.__name__,
+            arguments={"values": cast(Any, [1, 2])},
+        )
+
+        outcome = await manager.execute_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(
+            outcome.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    async def test_non_native_tool_supports_variadic_keywords(self):
+        async def collect(**values: int) -> dict[str, int]:
+            return values
+
+        manager = ToolManager.create_instance(
+            enable_tools=[collect.__name__],
+            available_toolsets=[ToolSet(tools=[collect])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id=_uuid4(), name=collect.__name__, arguments={"b": 2, "a": 1}
+        )
+        result = await manager(call, context=ToolCallContext())
+        self.assertEqual(result.result, {"b": 2, "a": 1})
+
     async def test_non_native_tool_without_arguments(self):
         def greet() -> str:
             return "hi"
@@ -1513,7 +1617,9 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
         call = ToolCall(id=_uuid4(), name="failing_tool", arguments={"a": 1})
         result = await manager(call, context=ToolCallContext())
         self.assertIsInstance(result, ToolCallError)
-        self.assertIsInstance(result.error, ValueError)
+        assert isinstance(result, ToolCallError)
+        self.assertEqual(result.error, {"type": "ValueError"})
+        self.assertEqual(result.error_type, "ValueError")
         self.assertEqual(result.message, "boom")
 
     async def test_tool_keyboard_interrupt_propagates(self):
@@ -1948,6 +2054,48 @@ class ToolManagerFiltersTransformersTestCase(IsolatedAsyncioTestCase):
             result = await manager(call, context=ToolCallContext())
 
         self.assertEqual(result.result, "2!")
+
+    async def test_transformer_none_keeps_current_result(self):
+        def transform(
+            _: ToolCall,
+            __: ToolCallContext,
+            ___: str | None,
+        ) -> None:
+            return None
+
+        manager = ToolManager.create_instance(
+            enable_tools=["calculator"],
+            available_toolsets=[ToolSet(tools=[CalculatorTool()])],
+            settings=ToolManagerSettings(transformers=[transform]),
+        )
+
+        call = ToolCall(
+            id=_uuid4(), name="calculator", arguments={"expression": "1 + 1"}
+        )
+        result = await manager(call, context=ToolCallContext())
+
+        self.assertEqual(result.result, "2")
+
+    async def test_transformer_result_can_set_null_result(self):
+        def transform(
+            _: ToolCall,
+            __: ToolCallContext,
+            ___: str | None,
+        ) -> ToolTransformerResult:
+            return ToolTransformerResult(result=None)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["calculator"],
+            available_toolsets=[ToolSet(tools=[CalculatorTool()])],
+            settings=ToolManagerSettings(transformers=[transform]),
+        )
+
+        call = ToolCall(
+            id=_uuid4(), name="calculator", arguments={"expression": "1 + 1"}
+        )
+        result = await manager(call, context=ToolCallContext())
+
+        self.assertIsNone(result.result)
 
     async def test_filters_and_transformers(self):
         def modify(call: ToolCall, context: ToolCallContext):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1,4 +1,5 @@
 from asyncio import CancelledError, sleep
+from typing import Any, cast
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4 as _uuid4
@@ -6,6 +7,8 @@ from uuid import uuid4 as _uuid4
 from avalan.entities import (
     ToolCall,
     ToolCallContext,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolCallError,
     ToolCallResult,
     ToolFilter,
@@ -13,6 +16,7 @@ from avalan.entities import (
     ToolManagerExecutionMode,
     ToolManagerMissingCallMode,
     ToolManagerSettings,
+    ToolNameResolutionStatus,
     ToolParserReturnMode,
     ToolProviderArgumentsMode,
     ToolTransformer,
@@ -147,10 +151,190 @@ class ToolManagerCreationTestCase(TestCase):
         )
         self.assertTrue(manager.is_empty)
 
+    def test_list_and_describe_enabled_tools(self):
+        adder = DummyAdder()
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[adder])],
+            settings=ToolManagerSettings(),
+        )
+
+        descriptors = manager.list_tools()
+
+        self.assertEqual(len(descriptors), 1)
+        self.assertEqual(descriptors[0].name, "adder")
+        self.assertEqual(descriptors[0].aliases, ["sum"])
+        assert descriptors[0].schema is not None
+        self.assertEqual(
+            descriptors[0].schema["function"]["name"],
+            "adder",
+        )
+        self.assertEqual(manager.describe_tool("adder"), descriptors[0])
+        self.assertEqual(manager.describe_tool("sum"), descriptors[0])
+        self.assertIsNone(manager.describe_tool("missing"))
+
+    def test_list_tools_prefixes_function_schema(self):
+        def multiply(a: int, b: int) -> int:
+            """Multiply numbers.
+
+            Args:
+                a: Left number.
+                b: Right number.
+            """
+            return a * b
+
+        manager = ToolManager.create_instance(
+            enable_tools=["math.multiply"],
+            available_toolsets=[ToolSet(namespace="math", tools=[multiply])],
+            settings=ToolManagerSettings(),
+        )
+
+        descriptor = manager.list_tools()[0]
+
+        assert descriptor.schema is not None
+        self.assertEqual(
+            descriptor.schema["function"]["name"],
+            "math.multiply",
+        )
+
+    def test_resolve_tool_name_exact_alias_ambiguous_disabled_unknown(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "adder_alt"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyAdderAlt()]),
+                ToolSet(namespace="disabled", tools=[CalculatorTool()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        exact = manager.resolve_tool_name("adder")
+        self.assertIs(exact.status, ToolNameResolutionStatus.EXACT)
+        self.assertEqual(exact.canonical_name, "adder")
+        self.assertEqual(exact.candidates, ["adder"])
+
+        ambiguous = manager.resolve_tool_name("sum")
+        self.assertIs(ambiguous.status, ToolNameResolutionStatus.AMBIGUOUS)
+        self.assertEqual(ambiguous.candidates, ["adder", "adder_alt"])
+        self.assertIs(
+            ambiguous.diagnostic_code,
+            ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME,
+        )
+
+        disabled = manager.resolve_tool_name("disabled.calculator")
+        self.assertIs(disabled.status, ToolNameResolutionStatus.DISABLED)
+        self.assertIs(
+            disabled.diagnostic_code, ToolCallDiagnosticCode.DISABLED_TOOL
+        )
+
+        unknown = manager.resolve_tool_name("missing")
+        self.assertIs(unknown.status, ToolNameResolutionStatus.UNKNOWN)
+        self.assertIs(
+            unknown.diagnostic_code, ToolCallDiagnosticCode.UNKNOWN_TOOL
+        )
+
+    def test_resolve_tool_name_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name("sum")
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.ALIAS)
+        self.assertEqual(resolution.canonical_name, "adder")
+        self.assertEqual(resolution.candidates, ["adder"])
+
+    def test_resolve_tool_name_rejects_empty_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(),
+        )
+
+        with self.assertRaises(AssertionError):
+            manager.resolve_tool_name(" ")
+
+    def test_invalid_tool_aliases_are_rejected(self):
+        with self.assertRaises(AssertionError):
+            ToolManager.create_instance(
+                enable_tools=["invalid_aliases"],
+                available_toolsets=[ToolSet(tools=[InvalidAliasesTool()])],
+                settings=ToolManagerSettings(),
+            )
+
+    def test_validate_tool_call_accepts_resolved_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+
+        self.assertIsNone(manager.validate_tool_call(call))
+
+    def test_validate_tool_call_returns_resolution_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(),
+        )
+        diagnostic_id = _uuid4()
+        call = ToolCall(id="call-1", name="missing", arguments={})
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            diagnostic = manager.validate_tool_call(call)
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertEqual(diagnostic.call_id, "call-1")
+        self.assertEqual(diagnostic.requested_name, "missing")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.UNKNOWN_TOOL)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    def test_validate_tool_call_returns_malformed_arguments_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        diagnostic_id = _uuid4()
+        call = ToolCall(id="call-1", name="adder", arguments=cast(Any, ["a"]))
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            diagnostic = manager.validate_tool_call(call)
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.MALFORMED_ARGUMENTS
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    def test_validate_tool_call_returns_argument_validation_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        diagnostic_id = _uuid4()
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1})
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            diagnostic = manager.validate_tool_call(call)
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertEqual(diagnostic.canonical_name, "adder")
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
 
 class DummyAdder:
     def __init__(self) -> None:
         self.__name__ = "adder"
+        self.aliases = ["sum"]
 
     async def __call__(self, a: int, b: int) -> int:
         """Return the sum of ``a`` and ``b``."""
@@ -160,6 +344,13 @@ class DummyAdder:
 class DummyAdderAlt(DummyAdder):
     def __init__(self) -> None:
         self.__name__ = "adder_alt"
+        self.aliases = ["sum"]
+
+
+class InvalidAliasesTool(DummyAdder):
+    def __init__(self) -> None:
+        self.__name__ = "invalid_aliases"
+        self.aliases = "sum"
 
 
 class NativeAdderTool(Tool):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -697,6 +697,60 @@ class ToolManagerCreationTestCase(TestCase):
 
         self.assertIsNone(manager.validate_tool_call(call))
 
+    def test_validate_tool_call_rejects_malformed_provider_arguments(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                provider_arguments_mode=(
+                    ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+                )
+            ),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="adder",
+            arguments={},
+            provider_name="adder",
+            provider_arguments_malformed=True,
+        )
+
+        diagnostic = manager.validate_tool_call(call)
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.call_id, "call-1")
+        self.assertEqual(diagnostic.requested_name, "adder")
+        self.assertEqual(diagnostic.canonical_name, "adder")
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(
+            diagnostic.message,
+            "Provider tool call arguments are malformed.",
+        )
+
+    def test_validate_tool_call_accepts_legacy_provider_arguments_mode(self):
+        async def provider_no_args() -> str:
+            return "ok"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["provider_no_args"],
+            available_toolsets=[ToolSet(tools=[provider_no_args])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="provider_no_args",
+            arguments={},
+            provider_name="provider_no_args",
+            provider_arguments_malformed=True,
+        )
+
+        self.assertIsNone(manager.validate_tool_call(call))
+
     def test_validate_tool_call_rejects_ambiguous_provider_alias(self):
         manager = ToolManager.create_instance(
             enable_tools=["adder", "adder_alt"],
@@ -1318,6 +1372,38 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
                     ToolCallDiagnosticStage.VALIDATE,
                 )
 
+    async def test_prepare_call_rejects_malformed_provider_arguments(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                provider_arguments_mode=(
+                    ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+                )
+            ),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="adder",
+            arguments={},
+            provider_name="adder",
+            provider_arguments_malformed=True,
+        )
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertEqual(diagnostic.canonical_name, "adder")
+
     async def test_prepare_call_returns_repeated_call_diagnostic(self):
         manager = ToolManager.create_instance(
             enable_tools=["adder"],
@@ -1863,6 +1949,55 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
         self.assertIs(outcome.code, ToolCallDiagnosticCode.MAXIMUM_SIZE)
         self.assertIs(outcome.stage, ToolCallDiagnosticStage.VALIDATE)
         self.assertEqual(calls, [])
+
+    async def test_execute_call_rejects_malformed_provider_arguments(self):
+        calls = 0
+
+        async def provider_no_args() -> str:
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["provider_no_args"],
+            available_toolsets=[ToolSet(tools=[provider_no_args])],
+            settings=ToolManagerSettings(
+                provider_arguments_mode=(
+                    ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+                )
+            ),
+        )
+        malformed = await manager.execute_call(
+            ToolCall(
+                id="call-1",
+                name="provider_no_args",
+                arguments={},
+                provider_name="provider_no_args",
+                provider_arguments_malformed=True,
+            ),
+            context=ToolCallContext(),
+        )
+        valid_empty = await manager.execute_call(
+            ToolCall(
+                id="call-2",
+                name="provider_no_args",
+                arguments={},
+                provider_name="provider_no_args",
+            ),
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(malformed, ToolCallDiagnostic)
+        assert isinstance(malformed, ToolCallDiagnostic)
+        self.assertIs(
+            malformed.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertIs(malformed.stage, ToolCallDiagnosticStage.VALIDATE)
+        self.assertIsInstance(valid_empty, ToolCallResult)
+        assert isinstance(valid_empty, ToolCallResult)
+        self.assertEqual(valid_empty.result, "ok")
+        self.assertEqual(calls, 1)
 
     async def test_execute_call_returns_execution_error(self):
         async def failing_tool(a: int) -> None:

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1644,6 +1644,49 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
         self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH)
         self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
 
+    async def test_prepare_call_rechecks_repetition_after_filters(self):
+        def rewrite_to_adder(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="adder",
+                    arguments={"a": 2, "b": 3},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+            ],
+            settings=ToolManagerSettings(
+                avoid_repetition=True,
+                filters=[rewrite_to_adder],
+            ),
+        )
+        previous = ToolCall(
+            id="call-0",
+            name="adder",
+            arguments={"a": 2, "b": 3},
+        )
+        call = ToolCall(
+            id="call-1",
+            name="multiplier",
+            arguments={"a": 2, "b": 3},
+        )
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(calls=[previous]),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.REPEATED_CALL)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.GUARD)
+        self.assertEqual(diagnostic.requested_name, "adder")
+
     async def test_execute_prepared_call_does_not_rerun_filters(self):
         filter_calls = 0
 
@@ -2695,6 +2738,36 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
                 assert isinstance(outcome, ToolCallDiagnostic)
                 self.assertIs(outcome.code, code)
                 self.assertIs(outcome.stage, ToolCallDiagnosticStage.GUARD)
+
+    async def test_execute_call_rechecks_depth_after_filter_context(self):
+        previous = ToolCall(
+            id="call-0",
+            name="adder",
+            arguments={"a": 2, "b": 3},
+        )
+
+        def add_history(
+            call: ToolCall,
+            _context: ToolCallContext,
+        ) -> tuple[ToolCall, ToolCallContext]:
+            return call, ToolCallContext(calls=[previous])
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                maximum_depth=1,
+                filters=[add_history],
+            ),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 2, "b": 3})
+
+        outcome = await manager.execute_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.GUARD)
 
     async def test_execute_call_returns_cancellation_before_filters(self):
         called: list[str] = []
@@ -3765,6 +3838,42 @@ class ToolManagerExtraCallTestCase(IsolatedAsyncioTestCase):
         self.assertIsNotNone(result1)
         result2 = await manager(call, context=ToolCallContext(calls=[call]))
         self.assertIsNone(result2)
+
+    async def test_legacy_call_rechecks_repetition_after_filters(self):
+        def rewrite_to_adder(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name="adder",
+                    arguments={"a": 2, "b": 3},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "multiplier"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyMultiplier()])
+            ],
+            settings=ToolManagerSettings(
+                avoid_repetition=True,
+                filters=[rewrite_to_adder],
+            ),
+        )
+        previous = ToolCall(
+            id="call-0",
+            name="adder",
+            arguments={"a": 2, "b": 3},
+        )
+        call = ToolCall(
+            id="call-1",
+            name="multiplier",
+            arguments={"a": 2, "b": 3},
+        )
+
+        result = await manager(call, context=ToolCallContext(calls=[previous]))
+
+        self.assertIsNone(result)
 
     async def test_async_context(self):
         calculator = CalculatorTool()

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1060,6 +1060,264 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(diagnostic.details, {"filtered_name": "multiplier"})
 
 
+class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
+    async def test_execute_call_returns_result_for_prepared_call(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+        result_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=result_id):
+            outcome = await manager.execute_call(
+                call,
+                context=ToolCallContext(),
+            )
+
+        self.assertEqual(
+            outcome,
+            ToolCallResult(
+                id=result_id,
+                call=call,
+                name="adder",
+                arguments={"a": 1, "b": 2},
+                result=3,
+            ),
+        )
+
+    async def test_execute_call_returns_execution_error(self):
+        async def failing_tool(a: int) -> None:
+            raise ValueError("boom")
+
+        manager = ToolManager.create_instance(
+            enable_tools=["failing_tool"],
+            available_toolsets=[ToolSet(tools=[failing_tool])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="failing_tool", arguments={"a": 1})
+
+        outcome = await manager.execute_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallError)
+        assert isinstance(outcome, ToolCallError)
+        self.assertIsInstance(outcome.error, ValueError)
+        self.assertEqual(outcome.message, "boom")
+
+    async def test_execute_call_returns_resolution_diagnostics(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "adder_alt"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyAdderAlt()]),
+                ToolSet(namespace="disabled", tools=[CalculatorTool()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+        cases = (
+            (
+                ToolCall(id="call-1", name="missing", arguments={}),
+                ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            ),
+            (
+                ToolCall(
+                    id="call-2",
+                    name="disabled.calculator",
+                    arguments={},
+                ),
+                ToolCallDiagnosticCode.DISABLED_TOOL,
+            ),
+            (
+                ToolCall(id="call-3", name="sum", arguments={}),
+                ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME,
+            ),
+        )
+
+        for call, code in cases:
+            with self.subTest(code=code):
+                outcome = await manager.execute_call(
+                    call,
+                    context=ToolCallContext(),
+                )
+
+                self.assertIsInstance(outcome, ToolCallDiagnostic)
+                assert isinstance(outcome, ToolCallDiagnostic)
+                self.assertIs(outcome.code, code)
+                self.assertIs(outcome.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    async def test_execute_call_returns_filter_diagnostic(self):
+        def suppress(
+            _call: ToolCall,
+            _context: ToolCallContext,
+        ) -> ToolFilterResult:
+            return ToolFilterResult(status=ToolFilterResultStatus.SUPPRESS)
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[suppress]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        outcome = await manager.execute_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.FILTER_SUPPRESSED)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.FILTER)
+
+    async def test_execute_call_returns_guard_diagnostics(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(
+                avoid_repetition=True,
+                maximum_depth=1,
+            ),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+        cases = (
+            (
+                ToolCallContext(calls=[call]),
+                ToolCallDiagnosticCode.REPEATED_CALL,
+            ),
+            (
+                ToolCallContext(
+                    calls=[
+                        ToolCall(
+                            id="call-2",
+                            name="adder",
+                            arguments={"a": 3, "b": 4},
+                        )
+                    ]
+                ),
+                ToolCallDiagnosticCode.MAXIMUM_DEPTH,
+            ),
+        )
+
+        for context, code in cases:
+            with self.subTest(code=code):
+                outcome = await manager.execute_call(call, context=context)
+
+                self.assertIsInstance(outcome, ToolCallDiagnostic)
+                assert isinstance(outcome, ToolCallDiagnostic)
+                self.assertIs(outcome.code, code)
+                self.assertIs(outcome.stage, ToolCallDiagnosticStage.GUARD)
+
+    async def test_execute_call_returns_cancellation_before_filters(self):
+        called: list[str] = []
+
+        async def adder(a: int) -> int:
+            called.append("tool")
+            return a + 1
+
+        def filter_call(call: ToolCall, context: ToolCallContext):
+            called.append("filter")
+            return call, context
+
+        async def cancel() -> None:
+            called.append("cancel")
+            raise CancelledError()
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[adder])],
+            settings=ToolManagerSettings(filters=[filter_call]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1})
+
+        outcome = await manager.execute_call(
+            call,
+            context=ToolCallContext(cancellation_checker=cancel),
+        )
+
+        self.assertEqual(called, ["cancel"])
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.CANCELLED)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.GUARD)
+        self.assertEqual(outcome.details, {})
+
+    async def test_execute_call_returns_cancellation_after_confirmation(self):
+        called: list[str] = []
+
+        async def adder(a: int) -> int:
+            called.append("tool")
+            return a + 1
+
+        async def first_check() -> None:
+            called.append("first")
+
+        second_checks = 0
+
+        async def second_check() -> None:
+            nonlocal second_checks
+            second_checks += 1
+            called.append(f"second:{second_checks}")
+            if second_checks == 2:
+                raise CancelledError()
+
+        def replace_checker(call: ToolCall, context: ToolCallContext):
+            called.append("filter")
+            return (
+                call,
+                ToolCallContext(
+                    calls=context.calls,
+                    cancellation_checker=second_check,
+                ),
+            )
+
+        def confirm(call: ToolCall) -> str:
+            called.append(f"confirm:{call.name}")
+            return "y"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[adder])],
+            settings=ToolManagerSettings(filters=[replace_checker]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1})
+
+        outcome = await manager.execute_call(
+            call,
+            context=ToolCallContext(cancellation_checker=first_check),
+            confirm=confirm,
+        )
+
+        self.assertEqual(
+            called,
+            ["first", "filter", "second:1", "confirm:adder", "second:2"],
+        )
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.CANCELLED)
+        self.assertEqual(outcome.canonical_name, "adder")
+
+    async def test_execute_call_returns_confirmation_rejection(self):
+        async def reject(_call: ToolCall) -> str:
+            return "n"
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+
+        outcome = await manager.execute_call(
+            call,
+            context=ToolCallContext(),
+            confirm=reject,
+        )
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertEqual(outcome.requested_name, "adder")
+        self.assertEqual(outcome.canonical_name, "adder")
+        self.assertIs(outcome.code, ToolCallDiagnosticCode.USER_REJECTED)
+        self.assertIs(outcome.stage, ToolCallDiagnosticStage.CONFIRM)
+
+
 class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):
     async def test_native_tool_with_arguments(self):
         tool = NativeAdderTool()

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -21,6 +21,7 @@ from avalan.entities import (
     ToolProviderArgumentsMode,
     ToolTransformer,
 )
+from avalan.model.vendor import TextGenerationVendor
 from avalan.tool import Tool, ToolSet
 from avalan.tool.manager import ToolManager
 from avalan.tool.math import CalculatorTool
@@ -323,6 +324,122 @@ class ToolManagerCreationTestCase(TestCase):
         self.assertEqual(resolution.canonical_name, "adder")
         self.assertEqual(resolution.candidates, ["adder"])
 
+    def test_resolve_tool_name_exact_canonical_wins_before_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "sum"],
+            available_toolsets=[ToolSet(tools=[DummyAdder(), DummySum()])],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name("sum")
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.EXACT)
+        self.assertEqual(resolution.canonical_name, "sum")
+        self.assertEqual(resolution.candidates, ["sum"])
+
+    def test_resolve_tool_name_strips_one_functions_prefix(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+
+        exact = manager.resolve_tool_name("functions.adder")
+        alias = manager.resolve_tool_name("functions.sum")
+        unknown = manager.resolve_tool_name("functions.functions.adder")
+
+        self.assertIs(exact.status, ToolNameResolutionStatus.EXACT)
+        self.assertEqual(exact.canonical_name, "adder")
+        self.assertIs(alias.status, ToolNameResolutionStatus.ALIAS)
+        self.assertEqual(alias.canonical_name, "adder")
+        self.assertIs(unknown.status, ToolNameResolutionStatus.UNKNOWN)
+
+    def test_resolve_tool_name_decodes_only_provider_originated_names(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["math.adder"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[DummyAdder()])
+            ],
+            settings=ToolManagerSettings(),
+        )
+        encoded = TextGenerationVendor.encode_tool_name("math.adder")
+
+        without_provenance = manager.resolve_tool_name(encoded)
+        with_provenance = manager.resolve_tool_name(
+            encoded,
+            provider_originated=True,
+        )
+
+        self.assertIs(
+            without_provenance.status, ToolNameResolutionStatus.UNKNOWN
+        )
+        self.assertIs(with_provenance.status, ToolNameResolutionStatus.EXACT)
+        self.assertEqual(with_provenance.canonical_name, "math.adder")
+        self.assertEqual(with_provenance.requested_name, encoded)
+
+    def test_resolve_tool_name_provider_origin_plain_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name(
+            "adder",
+            provider_originated=True,
+        )
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.EXACT)
+        self.assertEqual(resolution.canonical_name, "adder")
+
+    def test_resolve_tool_name_rejects_invalid_provider_origin_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(),
+        )
+
+        invalid_names = ("pkg.tool", "avl_notbase64")
+        for name in invalid_names:
+            with self.subTest(name=name):
+                with self.assertRaises(AssertionError):
+                    manager.resolve_tool_name(
+                        name,
+                        provider_originated=True,
+                    )
+
+    def test_resolve_tool_name_alias_recovery_uses_enabled_tools_only(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder()]),
+                ToolSet(namespace="disabled", tools=[DummyAdderAlt()]),
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name("sum")
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.ALIAS)
+        self.assertEqual(resolution.canonical_name, "adder")
+        self.assertEqual(resolution.candidates, ["adder"])
+
+    def test_resolve_tool_name_disabled_alias_is_not_recovered(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+
+        resolution = manager.resolve_tool_name("sum")
+
+        self.assertIs(resolution.status, ToolNameResolutionStatus.DISABLED)
+        self.assertIsNone(resolution.canonical_name)
+        self.assertEqual(resolution.candidates, ["adder"])
+        self.assertIs(
+            resolution.diagnostic_code,
+            ToolCallDiagnosticCode.DISABLED_TOOL,
+        )
+
     def test_resolve_tool_name_rejects_empty_name(self):
         manager = ToolManager.create_instance(
             enable_tools=[],
@@ -423,6 +540,12 @@ class DummyAdderAlt(DummyAdder):
     def __init__(self) -> None:
         self.__name__ = "adder_alt"
         self.aliases = ["sum"]
+
+
+class DummySum(DummyAdder):
+    def __init__(self) -> None:
+        self.__name__ = "sum"
+        self.aliases = []
 
 
 class InvalidAliasesTool(DummyAdder):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -14,6 +14,7 @@ from avalan.entities import (
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
     ToolCallError,
+    ToolCallRecoveryFormat,
     ToolCallResult,
     ToolFilter,
     ToolFilterResult,
@@ -57,6 +58,7 @@ class ToolManagerCreationTestCase(TestCase):
         self.assertIsNone(settings.maximum_parser_input_size)
         self.assertIsNone(settings.maximum_parser_payload_depth)
         self.assertIsNone(settings.maximum_parser_payload_size)
+        self.assertEqual(settings.recovery_formats, [])
 
     def test_settings_accept_outcome_compatibility_modes(self):
         settings = ToolManagerSettings(
@@ -71,6 +73,7 @@ class ToolManagerCreationTestCase(TestCase):
             maximum_parser_input_size=128,
             maximum_parser_payload_depth=4,
             maximum_parser_payload_size=96,
+            recovery_formats=[ToolCallRecoveryFormat.FENCED],
         )
 
         self.assertIs(
@@ -93,6 +96,9 @@ class ToolManagerCreationTestCase(TestCase):
         self.assertEqual(settings.maximum_parser_input_size, 128)
         self.assertEqual(settings.maximum_parser_payload_depth, 4)
         self.assertEqual(settings.maximum_parser_payload_size, 96)
+        self.assertEqual(
+            settings.recovery_formats, [ToolCallRecoveryFormat.FENCED]
+        )
 
     def test_settings_reject_invalid_compatibility_modes(self):
         invalid_cases = (
@@ -106,6 +112,8 @@ class ToolManagerCreationTestCase(TestCase):
             {"maximum_parser_input_size": True},
             {"maximum_parser_payload_depth": "1"},
             {"maximum_parser_payload_size": 0},
+            {"recovery_formats": "fenced"},
+            {"recovery_formats": ["fenced"]},
         )
 
         for kwargs in invalid_cases:
@@ -176,6 +184,23 @@ class ToolManagerCreationTestCase(TestCase):
         settings = ToolManagerSettings(tool_format=ToolFormat.HARMONY)
         manager = ToolManager.create_instance(settings=settings)
         self.assertEqual(manager.tool_format, ToolFormat.HARMONY)
+
+    def test_recovery_formats_pass_to_parser(self):
+        settings = ToolManagerSettings(
+            recovery_formats=[
+                ToolCallRecoveryFormat.FENCED,
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+            ]
+        )
+        manager = ToolManager.create_instance(settings=settings)
+
+        self.assertEqual(
+            manager._parser.recovery_formats,
+            (
+                ToolCallRecoveryFormat.FENCED,
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+            ),
+        )
 
     def test_toolset_without_tools(self):
         manager = ToolManager.create_instance(

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -10,7 +10,11 @@ from avalan.entities import (
     ToolCallResult,
     ToolFilter,
     ToolFormat,
+    ToolManagerExecutionMode,
+    ToolManagerMissingCallMode,
     ToolManagerSettings,
+    ToolParserReturnMode,
+    ToolProviderArgumentsMode,
     ToolTransformer,
 )
 from avalan.tool import Tool, ToolSet
@@ -19,6 +23,62 @@ from avalan.tool.math import CalculatorTool
 
 
 class ToolManagerCreationTestCase(TestCase):
+    def test_settings_default_to_legacy_compatibility(self):
+        settings = ToolManagerSettings()
+
+        self.assertIs(settings.execution_mode, ToolManagerExecutionMode.LEGACY)
+        self.assertIs(
+            settings.missing_call_mode,
+            ToolManagerMissingCallMode.LEGACY_NONE,
+        )
+        self.assertIs(
+            settings.parser_return_mode,
+            ToolParserReturnMode.LEGACY,
+        )
+        self.assertIs(
+            settings.provider_arguments_mode,
+            ToolProviderArgumentsMode.EMPTY_ON_MALFORMED,
+        )
+
+    def test_settings_accept_outcome_compatibility_modes(self):
+        settings = ToolManagerSettings(
+            execution_mode=ToolManagerExecutionMode.OUTCOMES,
+            missing_call_mode=ToolManagerMissingCallMode.DIAGNOSTIC,
+            parser_return_mode=ToolParserReturnMode.OUTCOME,
+            provider_arguments_mode=(
+                ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED
+            ),
+        )
+
+        self.assertIs(
+            settings.execution_mode, ToolManagerExecutionMode.OUTCOMES
+        )
+        self.assertIs(
+            settings.missing_call_mode,
+            ToolManagerMissingCallMode.DIAGNOSTIC,
+        )
+        self.assertIs(
+            settings.parser_return_mode,
+            ToolParserReturnMode.OUTCOME,
+        )
+        self.assertIs(
+            settings.provider_arguments_mode,
+            ToolProviderArgumentsMode.DIAGNOSTIC_ON_MALFORMED,
+        )
+
+    def test_settings_reject_invalid_compatibility_modes(self):
+        invalid_cases = (
+            {"execution_mode": "legacy"},
+            {"missing_call_mode": "legacy_none"},
+            {"parser_return_mode": "legacy"},
+            {"provider_arguments_mode": "empty_on_malformed"},
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolManagerSettings(**kwargs)
+
     def test_default_instance_empty(self):
         manager = ToolManager.create_instance(
             enable_tools=[], settings=ToolManagerSettings()

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1,5 +1,5 @@
 from asyncio import CancelledError, sleep
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4 as _uuid4
@@ -309,6 +309,142 @@ class ToolManagerCreationTestCase(TestCase):
             descriptor.provider_safe_schema["function"]["parameters"],
             descriptor.schema["function"]["parameters"],
         )
+
+    def test_descriptors_expose_canonical_return_schemas(self):
+        class Payload(TypedDict):
+            name: str
+            tags: list[str]
+
+        def scalar() -> int:
+            """Count records.
+
+            Returns:
+                Record count.
+            """
+            return 1
+
+        def object_value() -> Payload:
+            """Build a payload.
+
+            Returns:
+                Payload object.
+            """
+            return {"name": "ok", "tags": ["ready"]}
+
+        def array_value() -> list[str]:
+            """List values.
+
+            Returns:
+                Values.
+            """
+            return ["ready"]
+
+        def nullable_value() -> str | None:
+            """Maybe return a value.
+
+            Returns:
+                Optional value.
+            """
+            return None
+
+        def union_value() -> str | int:
+            """Return an identifier.
+
+            Returns:
+                Identifier.
+            """
+            return "ready"
+
+        manager = ToolManager.create_instance(
+            enable_tools=None,
+            available_toolsets=[
+                ToolSet(
+                    tools=[
+                        scalar,
+                        object_value,
+                        array_value,
+                        nullable_value,
+                        union_value,
+                    ]
+                )
+            ],
+            settings=ToolManagerSettings(),
+        )
+
+        descriptors = {
+            descriptor.name: descriptor for descriptor in manager.list_tools()
+        }
+
+        self.assertEqual(
+            descriptors["scalar"].return_schema,
+            {"type": "integer", "description": "Record count."},
+        )
+        self.assertEqual(
+            descriptors["object_value"].return_schema,
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["name", "tags"],
+                "additionalProperties": False,
+                "description": "Payload object.",
+            },
+        )
+        self.assertEqual(
+            descriptors["array_value"].return_schema,
+            {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Values.",
+            },
+        )
+        self.assertEqual(
+            descriptors["nullable_value"].return_schema,
+            {
+                "type": ["string", "null"],
+                "description": "Optional value.",
+            },
+        )
+        self.assertEqual(
+            descriptors["union_value"].return_schema,
+            {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+                "description": "Identifier.",
+            },
+        )
+        for descriptor in descriptors.values():
+            assert descriptor.schema is not None
+            self.assertEqual(
+                descriptor.return_schema,
+                descriptor.schema["function"]["return"],
+            )
+
+    def test_tool_descriptor_ignores_malformed_return_schema(self):
+        adder = DummyAdder()
+        schema = {
+            "type": "function",
+            "function": {
+                "name": "adder",
+                "parameters": {"type": "object"},
+                "return": ["integer"],
+            },
+        }
+
+        descriptor = ToolManager._tool_descriptor(
+            canonical_name="adder",
+            tool=adder,
+            aliases=[],
+            namespace=None,
+            schema=schema,
+        )
+
+        self.assertEqual(descriptor.parameter_schema, {"type": "object"})
+        self.assertIsNone(descriptor.return_schema)
 
     def test_tool_descriptor_accepts_missing_schema(self):
         adder = DummyAdder()

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -1,5 +1,7 @@
 from asyncio import CancelledError, sleep
-from typing import Any, TypedDict, cast
+from dataclasses import replace
+from enum import Enum
+from typing import Any, Literal, TypedDict, cast
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4 as _uuid4
@@ -679,18 +681,35 @@ class ToolManagerCreationTestCase(TestCase):
             available_toolsets=[ToolSet(tools=[DummyAdder()])],
             settings=ToolManagerSettings(),
         )
-        diagnostic_id = _uuid4()
-        call = ToolCall(id="call-1", name="adder", arguments=cast(Any, ["a"]))
-
-        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
-            diagnostic = manager.validate_tool_call(call)
-
-        assert diagnostic is not None
-        self.assertEqual(diagnostic.id, diagnostic_id)
-        self.assertIs(
-            diagnostic.code, ToolCallDiagnosticCode.MALFORMED_ARGUMENTS
+        calls = (
+            ToolCall(
+                id="call-1",
+                name="adder",
+                arguments=cast(Any, ["a"]),
+            ),
+            ToolCall(id="call-2", name="adder", arguments=cast(Any, [])),
         )
-        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+        for call in calls:
+            with self.subTest(call_id=call.id):
+                diagnostic_id = _uuid4()
+
+                with patch(
+                    "avalan.tool.manager.uuid4",
+                    return_value=diagnostic_id,
+                ):
+                    diagnostic = manager.validate_tool_call(call)
+
+                assert diagnostic is not None
+                self.assertEqual(diagnostic.id, diagnostic_id)
+                self.assertIs(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                )
+                self.assertIs(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.VALIDATE,
+                )
 
     def test_validate_tool_call_returns_argument_validation_diagnostic(self):
         manager = ToolManager.create_instance(
@@ -712,6 +731,226 @@ class ToolManagerCreationTestCase(TestCase):
             ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
         )
         self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    def test_validate_tool_call_rejects_wrong_json_types(self):
+        async def typed_tool(
+            payload: RuntimePayload,
+            count: int,
+            ratio: float,
+            enabled: bool,
+            mode: Literal["fast", "slow"],
+            status: RuntimeMode,
+        ) -> dict[str, Any]:
+            return {"payload": payload, "count": count}
+
+        manager = ToolManager.create_instance(
+            enable_tools=["typed_tool"],
+            available_toolsets=[ToolSet(tools=[typed_tool])],
+            settings=ToolManagerSettings(),
+        )
+        cases = (
+            (
+                {"payload": {"name": "ok", "scores": [1], "note": None}},
+                "$.count is required.",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [1], "note": None},
+                    "count": 1,
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "fast",
+                    "status": "slow",
+                    "extra": "no",
+                },
+                "$.extra is not allowed.",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [1], "note": None},
+                    "count": "1",
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "fast",
+                    "status": "slow",
+                },
+                "$.count must be integer.",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [True], "note": None},
+                    "count": 1,
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "fast",
+                    "status": "slow",
+                },
+                "$.payload.scores[0] must be integer.",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [1], "note": 1},
+                    "count": 1,
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "fast",
+                    "status": "slow",
+                },
+                "$.payload.note must be string or null.",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [1], "note": None},
+                    "count": 1,
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "medium",
+                    "status": "slow",
+                },
+                "$.mode must be one of ['fast', 'slow'].",
+            ),
+            (
+                {
+                    "payload": {"name": "ok", "scores": [1], "note": None},
+                    "count": 1,
+                    "ratio": 1.5,
+                    "enabled": True,
+                    "mode": "fast",
+                    "status": "medium",
+                },
+                "$.status must be one of ['fast', 'slow'].",
+            ),
+        )
+
+        for arguments, message in cases:
+            with self.subTest(message=message):
+                diagnostic = manager.validate_tool_call(
+                    ToolCall(
+                        id="call-1",
+                        name="typed_tool",
+                        arguments=arguments,
+                    )
+                )
+
+                assert diagnostic is not None
+                self.assertIs(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+                )
+                self.assertIs(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.VALIDATE,
+                )
+                self.assertEqual(diagnostic.message, message)
+
+    def test_schema_validation_helper_covers_composite_shapes(self):
+        self.assertIsNone(
+            ToolManager._schema_validation_error(
+                "ok",
+                {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                "$",
+            )
+        )
+        self.assertEqual(
+            ToolManager._schema_validation_error(
+                False,
+                {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                "$",
+            ),
+            "$ does not match any allowed schema.",
+        )
+        self.assertIsNone(
+            ToolManager._object_schema_validation_error(
+                "not-object",
+                {"type": "object"},
+                "$",
+            )
+        )
+        self.assertIsNone(
+            ToolManager._array_schema_validation_error(
+                "not-array",
+                {"type": "array"},
+                "$",
+            )
+        )
+        self.assertEqual(
+            ToolManager._array_schema_validation_error(
+                [],
+                {"type": "array", "minItems": 1},
+                "$",
+            ),
+            "$ must contain at least 1 item(s).",
+        )
+        self.assertEqual(
+            ToolManager._array_schema_validation_error(
+                [1, 2],
+                {"type": "array", "maxItems": 1},
+                "$",
+            ),
+            "$ must contain at most 1 item(s).",
+        )
+        self.assertEqual(
+            ToolManager._array_schema_validation_error(
+                ["ok", "bad"],
+                {
+                    "type": "array",
+                    "prefixItems": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                    "minItems": 2,
+                    "maxItems": 2,
+                },
+                "$",
+            ),
+            "$[1] must be integer.",
+        )
+        self.assertIsNone(
+            ToolManager._array_schema_validation_error(
+                ["ok"],
+                {"type": "array", "prefixItems": [None]},
+                "$",
+            )
+        )
+        self.assertIsNone(
+            ToolManager._array_schema_validation_error(
+                ["ok", 1],
+                {
+                    "type": "array",
+                    "prefixItems": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                },
+                "$",
+            )
+        )
+        self.assertTrue(
+            ToolManager._matches_schema_type(object(), "unhandled")
+        )
+
+    def test_validate_tool_call_uses_signature_when_schema_is_missing(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        descriptor = manager._descriptors["adder"]
+        manager._descriptors["adder"] = replace(
+            descriptor,
+            parameter_schema=None,
+        )
+
+        diagnostic = manager.validate_tool_call(
+            ToolCall(id="call-1", name="adder", arguments={"a": 1})
+        )
+
+        assert diagnostic is not None
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertIn("missing", diagnostic.message)
 
 
 class DummyAdder:
@@ -750,6 +989,17 @@ class InvalidAliasesTool(DummyAdder):
     def __init__(self) -> None:
         self.__name__ = "invalid_aliases"
         self.aliases = "sum"
+
+
+class RuntimePayload(TypedDict):
+    name: str
+    scores: list[int]
+    note: str | None
+
+
+class RuntimeMode(str, Enum):
+    FAST = "fast"
+    SLOW = "slow"
 
 
 class NativeAdderTool(Tool):
@@ -822,24 +1072,32 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
             available_toolsets=[ToolSet(tools=[DummyAdder()])],
             settings=ToolManagerSettings(),
         )
-        call = ToolCall(
-            id="call-1",
-            name="adder",
-            arguments=cast(Any, ["a"]),
+        calls = (
+            ToolCall(
+                id="call-1",
+                name="adder",
+                arguments=cast(Any, ["a"]),
+            ),
+            ToolCall(id="call-2", name="adder", arguments=cast(Any, [])),
         )
 
-        diagnostic = await manager.prepare_call(
-            call,
-            context=ToolCallContext(),
-        )
+        for call in calls:
+            with self.subTest(call_id=call.id):
+                diagnostic = await manager.prepare_call(
+                    call,
+                    context=ToolCallContext(),
+                )
 
-        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
-        assert isinstance(diagnostic, ToolCallDiagnostic)
-        self.assertIs(
-            diagnostic.code,
-            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
-        )
-        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+                self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+                assert isinstance(diagnostic, ToolCallDiagnostic)
+                self.assertIs(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                )
+                self.assertIs(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.VALIDATE,
+                )
 
     async def test_prepare_call_returns_repeated_call_diagnostic(self):
         manager = ToolManager.create_instance(
@@ -1256,6 +1514,73 @@ class ToolManagerExecuteCallTestCase(IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_execute_call_validates_arguments_before_dispatch(self):
+        calls: list[dict[str, Any]] = []
+
+        async def typed_tool(
+            payload: RuntimePayload,
+            count: int,
+            ratio: float,
+            enabled: bool,
+            mode: Literal["fast", "slow"],
+            status: RuntimeMode,
+        ) -> dict[str, Any]:
+            calls.append(
+                {
+                    "payload": payload,
+                    "count": count,
+                    "ratio": ratio,
+                    "enabled": enabled,
+                    "mode": mode,
+                    "status": status,
+                }
+            )
+            return calls[-1]
+
+        manager = ToolManager.create_instance(
+            enable_tools=["typed_tool"],
+            available_toolsets=[ToolSet(tools=[typed_tool])],
+            settings=ToolManagerSettings(),
+        )
+        valid_arguments = {
+            "payload": {"name": "ok", "scores": [1, 2], "note": None},
+            "count": 2,
+            "ratio": 1.5,
+            "enabled": False,
+            "mode": "fast",
+            "status": "slow",
+        }
+
+        result = await manager.execute_call(
+            ToolCall(
+                id="call-1",
+                name="typed_tool",
+                arguments=valid_arguments,
+            ),
+            context=ToolCallContext(),
+        )
+        diagnostic = await manager.execute_call(
+            ToolCall(
+                id="call-2",
+                name="typed_tool",
+                arguments={**valid_arguments, "count": True},
+            ),
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(result, ToolCallResult)
+        assert isinstance(result, ToolCallResult)
+        self.assertEqual(result.result, valid_arguments)
+        self.assertEqual(calls, [valid_arguments])
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertEqual(diagnostic.message, "$.count must be integer.")
+        self.assertEqual(calls, [valid_arguments])
+
     async def test_execute_call_returns_execution_error(self):
         async def failing_tool(a: int) -> None:
             raise ValueError("boom")
@@ -1597,6 +1922,31 @@ class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):
         )
         result = await manager(call, context=ToolCallContext())
         self.assertEqual(result.result, {"b": 2, "a": 1})
+
+    async def test_execute_call_rejects_invalid_variadic_keyword_value(self):
+        async def collect(**values: int) -> dict[str, int]:
+            return values
+
+        manager = ToolManager.create_instance(
+            enable_tools=[collect.__name__],
+            available_toolsets=[ToolSet(tools=[collect])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id=_uuid4(),
+            name=collect.__name__,
+            arguments={"a": "1"},
+        )
+
+        outcome = await manager.execute_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(outcome, ToolCallDiagnostic)
+        assert isinstance(outcome, ToolCallDiagnostic)
+        self.assertIs(
+            outcome.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertEqual(outcome.message, "$.a must be integer.")
 
     async def test_non_native_tool_without_arguments(self):
         def greet() -> str:

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -449,6 +449,33 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
         calls = self.manager.get_calls("no tools here")
         self.assertIsNone(calls)
 
+    async def test_get_calls_preserves_current_tuple_format_none(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": {"expression": "1"}}',
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: {"expression": "2"}',
+            ),
+            (ToolFormat.BRACKET, "[calculator](3)"),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "calculator", "arguments": {"expression": "4"}}',
+            ),
+        )
+
+        for tool_format, text in cases:
+            with self.subTest(tool_format=tool_format):
+                manager = ToolManager.create_instance(
+                    enable_tools=["calculator"],
+                    available_toolsets=[ToolSet(tools=[CalculatorTool()])],
+                    settings=ToolManagerSettings(tool_format=tool_format),
+                )
+
+                self.assertIsNone(manager.get_calls(text))
+
     async def test_call_with_tool(self):
         text = (
             '<tool_call>{"name": "calculator", '
@@ -716,6 +743,18 @@ class ToolManagerExtraCallTestCase(IsolatedAsyncioTestCase):
     async def test_call_name_not_found(self):
         call = ToolCall(id=_uuid4(), name="missing", arguments={})
         result = await self.manager(call, context=ToolCallContext())
+        self.assertIsNone(result)
+
+    async def test_call_alias_still_returns_none_without_canonical_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id=_uuid4(), name="sum", arguments={"a": 1, "b": 2})
+
+        result = await manager(call, context=ToolCallContext())
+
         self.assertIsNone(result)
 
     async def test_aenter_no_toolsets(self):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -678,6 +678,52 @@ class ToolManagerCreationTestCase(TestCase):
 
         self.assertIsNone(manager.validate_tool_call(call))
 
+    def test_validate_tool_call_resolves_provider_encoded_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["math.adder"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[DummyAdder()])
+            ],
+            settings=ToolManagerSettings(),
+        )
+        encoded_name = TextGenerationVendor.encode_tool_name("math.adder")
+        call = ToolCall(
+            id="call-1",
+            name="math.adder",
+            arguments={"a": 1, "b": 2},
+            provider_name=encoded_name,
+            provider_name_encoded=True,
+        )
+
+        self.assertIsNone(manager.validate_tool_call(call))
+
+    def test_validate_tool_call_rejects_ambiguous_provider_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "adder_alt"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyAdderAlt()])
+            ],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="sum",
+            arguments={"a": 1, "b": 2},
+            provider_name="sum",
+        )
+
+        diagnostic = manager.validate_tool_call(call)
+
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.requested_name, "sum")
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+        self.assertEqual(
+            diagnostic.details["candidates"], ["adder", "adder_alt"]
+        )
+
     def test_validate_tool_call_returns_resolution_diagnostic(self):
         manager = ToolManager.create_instance(
             enable_tools=[],
@@ -1110,6 +1156,112 @@ class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(prepared.descriptor.name, "adder")
         self.assertEqual(prepared.arguments, {"a": 1, "b": 2})
         self.assertEqual(prepared.context, context)
+
+    async def test_prepare_call_resolves_provider_encoded_name(self):
+        adder = DummyAdder()
+        manager = ToolManager.create_instance(
+            enable_tools=["math.adder"],
+            available_toolsets=[ToolSet(namespace="math", tools=[adder])],
+            settings=ToolManagerSettings(),
+        )
+        provider_name = TextGenerationVendor.encode_tool_name("math.adder")
+        call = ToolCall(
+            id="call-1",
+            name="math.adder",
+            arguments={"a": 1, "b": 2},
+            provider_name=provider_name,
+            provider_name_encoded=True,
+        )
+        context = ToolCallContext()
+
+        prepared = await manager.prepare_call(call, context=context)
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(
+            prepared.call,
+            ToolCall(
+                id="call-1",
+                name="math.adder",
+                arguments={"a": 1, "b": 2},
+                provider_name=provider_name,
+                provider_name_encoded=True,
+            ),
+        )
+        self.assertIs(prepared.callable, adder)
+
+    async def test_prepare_call_rejects_ambiguous_provider_encoded_alias(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder", "adder_alt"],
+            available_toolsets=[
+                ToolSet(tools=[DummyAdder(), DummyAdderAlt()])
+            ],
+            settings=ToolManagerSettings(),
+        )
+        provider_name = TextGenerationVendor.encode_tool_name("sum")
+        call = ToolCall(
+            id="call-1",
+            name="sum",
+            arguments={"a": 1, "b": 2},
+            provider_name=provider_name,
+            provider_name_encoded=True,
+        )
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.requested_name, provider_name)
+        self.assertIs(
+            diagnostic.code, ToolCallDiagnosticCode.AMBIGUOUS_TOOL_NAME
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    async def test_execute_call_runs_provider_encoded_name(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["math.adder"],
+            available_toolsets=[
+                ToolSet(namespace="math", tools=[DummyAdder()])
+            ],
+            settings=ToolManagerSettings(),
+        )
+        provider_name = TextGenerationVendor.encode_tool_name("math.adder")
+        call = ToolCall(
+            id="call-1",
+            name="math.adder",
+            arguments={"a": 2, "b": 3},
+            provider_name=provider_name,
+            provider_name_encoded=True,
+        )
+        result_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=result_id):
+            outcome = await manager.execute_call(
+                call,
+                context=ToolCallContext(),
+            )
+
+        self.assertEqual(
+            outcome,
+            ToolCallResult(
+                id=result_id,
+                call=ToolCall(
+                    id="call-1",
+                    name="math.adder",
+                    arguments={"a": 2, "b": 3},
+                    provider_name=provider_name,
+                    provider_name_encoded=True,
+                ),
+                name="math.adder",
+                arguments={"a": 2, "b": 3},
+                provider_name=provider_name,
+                provider_name_encoded=True,
+                result=5,
+            ),
+        )
 
     async def test_prepare_call_returns_resolution_diagnostic(self):
         manager = ToolManager.create_instance(

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -202,6 +202,31 @@ class ToolManagerCreationTestCase(TestCase):
             ),
         )
 
+    def test_get_calls_consumes_recovery_parser_output(self):
+        call_id = _uuid4()
+        manager = ToolManager.create_instance(
+            settings=ToolManagerSettings(
+                recovery_formats=[ToolCallRecoveryFormat.TOOL_CALL_BLOCK]
+            )
+        )
+
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            calls = manager.get_calls(
+                '[TOOL_CALL]{"name": "calculator", "arguments": '
+                '{"expression": "1 + 1"}}[/TOOL_CALL]'
+            )
+
+        self.assertEqual(
+            calls,
+            [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={"expression": "1 + 1"},
+                )
+            ],
+        )
+
     def test_toolset_without_tools(self):
         manager = ToolManager.create_instance(
             enable_tools=None,

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4 as _uuid4
 
 from avalan.entities import (
+    PreparedToolCall,
     ToolCall,
     ToolCallContext,
+    ToolCallDiagnostic,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
     ToolCallError,
@@ -585,6 +587,252 @@ class NativeNoArgTool(Tool):
 
     async def __call__(self, context: ToolCallContext) -> str:
         return "hi"
+
+
+class ToolManagerPrepareCallTestCase(IsolatedAsyncioTestCase):
+    async def test_prepare_call_returns_canonical_plan_for_alias(self):
+        adder = DummyAdder()
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[adder])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="sum", arguments={"a": 1, "b": 2})
+        context = ToolCallContext()
+
+        prepared = await manager.prepare_call(call, context=context)
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(
+            prepared.call,
+            ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2}),
+        )
+        self.assertIs(prepared.callable, adder)
+        self.assertEqual(prepared.descriptor.name, "adder")
+        self.assertEqual(prepared.arguments, {"a": 1, "b": 2})
+        self.assertEqual(prepared.context, context)
+
+    async def test_prepare_call_returns_resolution_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=[],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(id="call-1", name="missing", arguments={})
+        diagnostic_id = _uuid4()
+
+        with patch("avalan.tool.manager.uuid4", return_value=diagnostic_id):
+            diagnostic = await manager.prepare_call(
+                call,
+                context=ToolCallContext(),
+            )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.id, diagnostic_id)
+        self.assertEqual(diagnostic.call_id, "call-1")
+        self.assertEqual(diagnostic.requested_name, "missing")
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.UNKNOWN_TOOL)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.RESOLVE)
+
+    async def test_prepare_call_returns_malformed_arguments_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="adder",
+            arguments=cast(Any, ["a"]),
+        )
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    async def test_prepare_call_returns_repeated_call_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(avoid_repetition=True),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(calls=[call]),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.REPEATED_CALL)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.GUARD)
+
+    async def test_prepare_call_returns_maximum_depth_diagnostic(self):
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(maximum_depth=1),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(calls=[call]),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.GUARD)
+
+    async def test_prepare_call_accepts_native_tool_arguments(self):
+        tool = NativeAdderTool()
+        manager = ToolManager.create_instance(
+            enable_tools=["native_adder"],
+            available_toolsets=[ToolSet(tools=[tool])],
+            settings=ToolManagerSettings(),
+        )
+        call = ToolCall(
+            id="call-1",
+            name="native_adder",
+            arguments={"a": 1, "b": 2},
+        )
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.arguments, {"a": 1, "b": 2})
+
+    async def test_prepare_call_validates_arguments_after_filters(self):
+        def drop_argument(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(id=call.id, name=call.name, arguments={"a": 1}),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[drop_argument]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        diagnostic = await manager.prepare_call(
+            call,
+            context=ToolCallContext(),
+        )
+
+        self.assertIsInstance(diagnostic, ToolCallDiagnostic)
+        assert isinstance(diagnostic, ToolCallDiagnostic)
+        self.assertEqual(diagnostic.canonical_name, "adder")
+        self.assertIs(
+            diagnostic.code,
+            ToolCallDiagnosticCode.ARGUMENT_VALIDATION_FAILED,
+        )
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.VALIDATE)
+
+    async def test_execute_prepared_call_does_not_rerun_filters(self):
+        filter_calls = 0
+
+        def replace_argument(call: ToolCall, context: ToolCallContext):
+            nonlocal filter_calls
+            filter_calls += 1
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"a": 3, "b": 4},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[replace_argument]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+        result_id = _uuid4()
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+        self.assertEqual(filter_calls, 1)
+        assert isinstance(prepared, PreparedToolCall)
+
+        with patch("avalan.tool.manager.uuid4", return_value=result_id):
+            result = await manager.execute_prepared_call(prepared)
+
+        self.assertEqual(filter_calls, 1)
+        self.assertEqual(
+            result,
+            ToolCallResult(
+                id=result_id,
+                call=ToolCall(
+                    id="call-1",
+                    name="adder",
+                    arguments={"a": 3, "b": 4},
+                ),
+                name="adder",
+                arguments={"a": 3, "b": 4},
+                result=7,
+            ),
+        )
+
+    async def test_prepare_call_filter_can_repair_arguments(self):
+        def add_argument(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(
+                    id=call.id,
+                    name=call.name,
+                    arguments={"a": 1, "b": 2},
+                ),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[add_argument]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1})
+
+        prepared = await manager.prepare_call(call, context=ToolCallContext())
+
+        self.assertIsInstance(prepared, PreparedToolCall)
+        assert isinstance(prepared, PreparedToolCall)
+        self.assertEqual(prepared.arguments, {"a": 1, "b": 2})
+
+    async def test_legacy_call_preserves_filter_name_rewrite(self):
+        def rename(call: ToolCall, context: ToolCallContext):
+            return (
+                ToolCall(id=call.id, name="renamed", arguments=call.arguments),
+                context,
+            )
+
+        manager = ToolManager.create_instance(
+            enable_tools=["adder"],
+            available_toolsets=[ToolSet(tools=[DummyAdder()])],
+            settings=ToolManagerSettings(filters=[rename]),
+        )
+        call = ToolCall(id="call-1", name="adder", arguments={"a": 1, "b": 2})
+
+        result = await manager(call, context=ToolCallContext())
+
+        self.assertIsInstance(result, ToolCallResult)
+        assert isinstance(result, ToolCallResult)
+        self.assertEqual(result.name, "renamed")
+        self.assertEqual(result.result, 3)
 
 
 class ToolManagerToolTypesTestCase(IsolatedAsyncioTestCase):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -24,6 +24,7 @@ from avalan.entities import (
 from avalan.tool import Tool, ToolSet
 from avalan.tool.manager import ToolManager
 from avalan.tool.math import CalculatorTool
+from avalan.tool.parser import ToolCallParser
 
 
 class ToolManagerCreationTestCase(TestCase):
@@ -150,6 +151,22 @@ class ToolManagerCreationTestCase(TestCase):
             settings=ToolManagerSettings(),
         )
         self.assertTrue(manager.is_empty)
+
+    def test_nested_toolset_names_are_available_but_not_enabled(self):
+        inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
+        outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
+        manager = ToolManager.create_instance(
+            enable_tools=["outer"],
+            available_toolsets=[outer],
+            settings=ToolManagerSettings(),
+        )
+
+        self.assertEqual(
+            [descriptor.name for descriptor in manager.list_tools()],
+            ["outer.calculator"],
+        )
+        resolution = manager.resolve_tool_name("outer.inner.calculator")
+        self.assertIs(resolution.status, ToolNameResolutionStatus.DISABLED)
 
     def test_list_and_describe_enabled_tools(self):
         adder = DummyAdder()
@@ -449,20 +466,68 @@ class ToolManagerCallTestCase(IsolatedAsyncioTestCase):
         calls = self.manager.get_calls("no tools here")
         self.assertIsNone(calls)
 
-    async def test_get_calls_preserves_current_tuple_format_none(self):
+    async def test_get_calls_normalizes_configured_tuple_formats(self):
         cases = (
             (
                 ToolFormat.JSON,
                 '{"tool": "calculator", "arguments": {"expression": "1"}}',
+                {"expression": "1"},
             ),
             (
                 ToolFormat.REACT,
                 'Action: calculator\nAction Input: {"expression": "2"}',
+                {"expression": "2"},
             ),
-            (ToolFormat.BRACKET, "[calculator](3)"),
+            (
+                ToolFormat.BRACKET,
+                "[calculator](3)",
+                {"input": "3"},
+            ),
             (
                 ToolFormat.OPENAI,
                 '{"name": "calculator", "arguments": {"expression": "4"}}',
+                {"expression": "4"},
+            ),
+        )
+
+        for tool_format, text, arguments in cases:
+            with self.subTest(tool_format=tool_format):
+                manager = ToolManager.create_instance(
+                    enable_tools=["calculator"],
+                    available_toolsets=[ToolSet(tools=[CalculatorTool()])],
+                    settings=ToolManagerSettings(tool_format=tool_format),
+                )
+                call_id = _uuid4()
+
+                with patch("avalan.tool.parser.uuid4", return_value=call_id):
+                    self.assertEqual(
+                        manager.get_calls(text),
+                        [
+                            ToolCall(
+                                id=call_id,
+                                name="calculator",
+                                arguments=arguments,
+                            )
+                        ],
+                    )
+
+    async def test_get_calls_returns_none_for_parse_diagnostics_only(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": ["1"]}',
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: ["2"]',
+            ),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "calculator", "arguments": ["3"]}',
+            ),
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": ',
             ),
         )
 
@@ -652,6 +717,12 @@ class ToolManagerPotentialCallTestCase(TestCase):
             result = self.manager.is_potential_tool_call("", "")
             self.assertFalse(result)
             called.assert_called_once_with("", "")
+
+    def test_tool_call_status_proxies_parser(self):
+        self.assertIs(
+            self.manager.tool_call_status("<tool_call>"),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
 
 
 class ToolManagerSchemasTestCase(TestCase):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -2704,6 +2704,29 @@ class ToolManagerPotentialCallTestCase(TestCase):
             ToolCallParser.ToolCallBufferStatus.OPEN,
         )
 
+    def test_tool_call_status_proxies_final_parser_status(self):
+        self.assertIs(
+            self.manager.tool_call_status("<tool_call>", final=True),
+            ToolCallParser.ToolCallBufferStatus.UNTERMINATED,
+        )
+
+    def test_parse_calls_returns_parser_outcome(self):
+        outcome = self.manager.parse_calls(
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+
+        self.assertEqual(len(outcome.calls), 1)
+        self.assertEqual(outcome.calls[0].name, "calculator")
+
+    def test_stream_buffer_diagnostics_proxies_parser(self):
+        diagnostics = self.manager.stream_buffer_diagnostics("<tool_call>")
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
 
 class ToolManagerSchemasTestCase(TestCase):
     def test_json_schemas(self):

--- a/tests/tool/tool_manager_test.py
+++ b/tests/tool/tool_manager_test.py
@@ -152,7 +152,7 @@ class ToolManagerCreationTestCase(TestCase):
         )
         self.assertTrue(manager.is_empty)
 
-    def test_nested_toolset_names_are_available_but_not_enabled(self):
+    def test_nested_toolset_names_are_enabled_with_parent_namespace(self):
         inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
         outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
         manager = ToolManager.create_instance(
@@ -163,9 +163,26 @@ class ToolManagerCreationTestCase(TestCase):
 
         self.assertEqual(
             [descriptor.name for descriptor in manager.list_tools()],
-            ["outer.calculator"],
+            ["outer.calculator", "outer.inner.calculator"],
         )
         resolution = manager.resolve_tool_name("outer.inner.calculator")
+        self.assertIs(resolution.status, ToolNameResolutionStatus.EXACT)
+
+    def test_nested_toolset_can_enable_exact_nested_tool(self):
+        inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
+        outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
+        manager = ToolManager.create_instance(
+            enable_tools=["outer.inner.calculator"],
+            available_toolsets=[outer],
+            settings=ToolManagerSettings(),
+        )
+
+        self.assertEqual(
+            [descriptor.name for descriptor in manager.list_tools()],
+            ["outer.inner.calculator"],
+        )
+        self.assertIsNone(manager.describe_tool("outer.calculator"))
+        resolution = manager.resolve_tool_name("outer.calculator")
         self.assertIs(resolution.status, ToolNameResolutionStatus.DISABLED)
 
     def test_list_and_describe_enabled_tools(self):
@@ -180,12 +197,28 @@ class ToolManagerCreationTestCase(TestCase):
 
         self.assertEqual(len(descriptors), 1)
         self.assertEqual(descriptors[0].name, "adder")
+        self.assertIs(descriptors[0].callable, adder)
         self.assertEqual(descriptors[0].aliases, ["sum"])
         assert descriptors[0].schema is not None
         self.assertEqual(
             descriptors[0].schema["function"]["name"],
             "adder",
         )
+        self.assertEqual(
+            descriptors[0].parameter_schema,
+            descriptors[0].schema["function"]["parameters"],
+        )
+        self.assertEqual(
+            descriptors[0].return_schema,
+            descriptors[0].schema["function"]["return"],
+        )
+        self.assertEqual(
+            descriptors[0].provider_safe_schema,
+            descriptors[0].schema,
+        )
+        self.assertIsNone(descriptors[0].namespace)
+        self.assertEqual(descriptors[0].policy, {})
+        self.assertEqual(descriptors[0].metadata, {})
         self.assertEqual(manager.describe_tool("adder"), descriptors[0])
         self.assertEqual(manager.describe_tool("sum"), descriptors[0])
         self.assertIsNone(manager.describe_tool("missing"))
@@ -213,6 +246,34 @@ class ToolManagerCreationTestCase(TestCase):
             descriptor.schema["function"]["name"],
             "math.multiply",
         )
+        self.assertEqual(descriptor.namespace, "math")
+        assert descriptor.provider_safe_schema is not None
+        self.assertEqual(
+            descriptor.provider_safe_schema["function"]["name"],
+            "avl_bWF0aC5tdWx0aXBseQ",
+        )
+        self.assertEqual(
+            descriptor.provider_safe_schema["function"]["parameters"],
+            descriptor.schema["function"]["parameters"],
+        )
+
+    def test_tool_descriptor_accepts_missing_schema(self):
+        adder = DummyAdder()
+
+        descriptor = ToolManager._tool_descriptor(
+            canonical_name="adder",
+            tool=adder,
+            aliases=[],
+            namespace=None,
+            schema=None,
+        )
+
+        self.assertEqual(descriptor.name, "adder")
+        self.assertIs(descriptor.callable, adder)
+        self.assertIsNone(descriptor.schema)
+        self.assertIsNone(descriptor.parameter_schema)
+        self.assertIsNone(descriptor.return_schema)
+        self.assertIsNone(descriptor.provider_safe_schema)
 
     def test_resolve_tool_name_exact_alias_ambiguous_disabled_unknown(self):
         manager = ToolManager.create_instance(

--- a/tests/tool/tool_parser_fixture_test.py
+++ b/tests/tool/tool_parser_fixture_test.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+from uuid import uuid4 as _uuid4
+
+from avalan.entities import (
+    ToolCall,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolFormat,
+)
+from avalan.tool.parser import ToolCallParser
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "tool_parsing"
+
+
+def read_fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+class ToolCallParserFixtureTestCase(TestCase):
+    def test_malformed_envelope_reports_parse_diagnostic(self):
+        outcome = ToolCallParser().parse(
+            read_fixture("tag_malformed_envelope.txt")
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+
+    def test_malformed_tag_before_valid_call_keeps_valid_call(self):
+        call_id = _uuid4()
+
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            outcome = ToolCallParser().parse(
+                read_fixture("tag_malformed_then_valid.txt")
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={"expression": "2 + 2"},
+                )
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+    def test_malformed_harmony_before_valid_call_keeps_valid_call(self):
+        call_id = _uuid4()
+
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            outcome = ToolCallParser(tool_format=ToolFormat.HARMONY).parse(
+                read_fixture("harmony_malformed_then_valid.txt")
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={"expression": "4 + 4"},
+                )
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(diagnostic.requested_name, "broken")
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+    def test_adjacent_calls_preserve_order(self):
+        first_id = _uuid4()
+        second_id = _uuid4()
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[first_id, second_id],
+        ):
+            outcome = ToolCallParser().parse(
+                read_fixture("tag_adjacent_calls.txt")
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=first_id,
+                    name="calculator",
+                    arguments={"expression": "1 + 1"},
+                ),
+                ToolCall(
+                    id=second_id,
+                    name="database.run",
+                    arguments={"sql": "SELECT 1"},
+                ),
+            ],
+        )
+        self.assertEqual(outcome.diagnostics, [])
+
+    def test_fenced_tool_call_example_does_not_parse_by_default(self):
+        outcome = ToolCallParser().parse(
+            read_fixture("markdown_fenced_tool_call_example.txt")
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(outcome.diagnostics, [])
+
+    def test_fenced_malformed_example_does_not_report_diagnostic(self):
+        outcome = ToolCallParser().parse(
+            read_fixture("markdown_fenced_malformed_example.txt")
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(outcome.diagnostics, [])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tool/tool_parser_fixture_test.py
+++ b/tests/tool/tool_parser_fixture_test.py
@@ -1,4 +1,6 @@
+from json import loads
 from pathlib import Path
+from typing import cast
 from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
@@ -7,6 +9,7 @@ from avalan.entities import (
     ToolCall,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
+    ToolCallRecoveryFormat,
     ToolFormat,
 )
 from avalan.tool.parser import ToolCallParser
@@ -16,6 +19,15 @@ FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "tool_parsing"
 
 def read_fixture(name: str) -> str:
     return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def read_case_fixture(name: str) -> dict[str, str]:
+    data = loads(read_fixture(name))
+    assert isinstance(data, dict)
+    for key, value in data.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+    return cast(dict[str, str], data)
 
 
 class ToolCallParserFixtureTestCase(TestCase):
@@ -127,6 +139,137 @@ class ToolCallParserFixtureTestCase(TestCase):
 
         self.assertEqual(outcome.calls, [])
         self.assertEqual(outcome.diagnostics, [])
+
+    def test_recovery_depth_limits_apply_to_all_formats(self):
+        cases = read_case_fixture("recovery_nested_payloads.json")
+        self.assertEqual(
+            set(cases),
+            {
+                recovery_format.value
+                for recovery_format in ToolCallRecoveryFormat
+            },
+        )
+
+        for recovery_format in ToolCallRecoveryFormat:
+            with self.subTest(recovery_format=recovery_format):
+                parser = ToolCallParser(
+                    recovery_formats=[recovery_format],
+                    maximum_payload_depth=2,
+                )
+
+                outcome = parser.parse(cases[recovery_format.value])
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                diagnostic = outcome.diagnostics[0]
+                self.assertEqual(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MAXIMUM_DEPTH,
+                )
+                self.assertEqual(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.PARSE,
+                )
+                self.assertEqual(diagnostic.requested_name, "calculator")
+                self.assertEqual(diagnostic.details["limit"], 2)
+
+    def test_recovery_size_limits_apply_to_all_formats(self):
+        cases = read_case_fixture("recovery_large_payloads.json")
+        self.assertEqual(
+            set(cases),
+            {
+                recovery_format.value
+                for recovery_format in ToolCallRecoveryFormat
+            },
+        )
+
+        for recovery_format in ToolCallRecoveryFormat:
+            with self.subTest(recovery_format=recovery_format):
+                parser = ToolCallParser(
+                    recovery_formats=[recovery_format],
+                    maximum_payload_size=12,
+                )
+
+                outcome = parser.parse(cases[recovery_format.value])
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                diagnostic = outcome.diagnostics[0]
+                self.assertEqual(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MAXIMUM_SIZE,
+                )
+                self.assertEqual(
+                    diagnostic.stage,
+                    ToolCallDiagnosticStage.PARSE,
+                )
+                self.assertEqual(diagnostic.requested_name, "calculator")
+                self.assertEqual(diagnostic.details["limit"], 12)
+
+    def test_malformed_recovery_segments_keep_later_valid_calls(self):
+        parser = ToolCallParser(
+            recovery_formats=[
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                ToolCallRecoveryFormat.TOOL_CODE,
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                ToolCallRecoveryFormat.FENCED,
+            ]
+        )
+
+        outcome = parser.parse(
+            read_fixture("recovery_malformed_segments_then_valid.txt")
+        )
+
+        self.assertEqual(
+            [(call.name, call.arguments) for call in outcome.calls],
+            [
+                ("calculator", {"expression": "1 + 1"}),
+                ("database.run", {"sql": "SELECT 1"}),
+                ("search", {"query": "avalan docs"}),
+                ("browser.open", {"url": "https://example.invalid"}),
+            ],
+        )
+        self.assertEqual(
+            [diagnostic.code for diagnostic in outcome.diagnostics],
+            [ToolCallDiagnosticCode.MALFORMED_CALL] * 4,
+        )
+        self.assertEqual(
+            [
+                diagnostic.details["source_format"]
+                for diagnostic in outcome.diagnostics
+            ],
+            [
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
+                ToolCallRecoveryFormat.TOOL_CODE.value,
+                ToolCallRecoveryFormat.MINIMAX_XML.value,
+                ToolCallRecoveryFormat.FENCED.value,
+            ],
+        )
+
+    def test_fenced_code_example_does_not_parse_by_default(self):
+        outcome = ToolCallParser().parse(
+            read_fixture("recovery_fenced_code_example.txt")
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(outcome.diagnostics, [])
+
+    def test_fenced_code_recovery_fails_closed(self):
+        outcome = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.FENCED]
+        ).parse(read_fixture("recovery_fenced_code_example.txt"))
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostic.details["source_format"],
+            ToolCallRecoveryFormat.FENCED.value,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -17,6 +17,15 @@ from avalan.tool.parser import ToolCallParser
 
 
 class ToolCallParserFullCoverageTestCase(TestCase):
+    def test_parser_properties_and_stream_token_detection(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+
+        self.assertEqual(parser.tool_format, ToolFormat.JSON)
+        parser.set_eos_token("<eos>")
+        self.assertFalse(parser.is_potential_tool_call("", ""))
+        self.assertFalse(parser.is_potential_tool_call("buffer", "   "))
+        self.assertTrue(parser.is_potential_tool_call("buffer", "<"))
+
     def test_prepare_message_for_template_leaves_existing_list_without_source(
         self,
     ):
@@ -194,6 +203,42 @@ class ToolCallParserFullCoverageTestCase(TestCase):
         ):
             self.assertEqual(parser.message_tool_calls("ignored"), [])
 
+    def test_message_tool_calls_extracts_tuple_payload(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+
+        self.assertEqual(
+            parser.message_tool_calls(
+                '{"tool": "calculator", "arguments": {"expression": "2"}}'
+            ),
+            [
+                {
+                    "id": None,
+                    "name": "calculator",
+                    "arguments": {"expression": "2"},
+                    "content_type": "json",
+                }
+            ],
+        )
+
+    def test_message_tool_calls_rejects_malformed_names(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+        invalid_call = ToolCall(
+            id="call-1",
+            name="math..calculator",
+            arguments={},
+        )
+
+        self.assertEqual(
+            parser.message_tool_calls(
+                '{"tool": "math..calculator", "arguments": {}}'
+            ),
+            [],
+        )
+        with patch.object(
+            ToolCallParser, "__call__", return_value=[invalid_call]
+        ):
+            self.assertEqual(parser.message_tool_calls("ignored"), [])
+
     def test_extract_harmony_content_collects_analysis_and_final_messages(
         self,
     ):
@@ -219,6 +264,23 @@ class ToolCallParserFullCoverageTestCase(TestCase):
         self.assertEqual(thinking, "only analysis")
         self.assertEqual(content, "")
 
+    def test_extract_harmony_content_skips_empty_segments_and_falls_back(
+        self,
+    ):
+        parser = ToolCallParser()
+        thinking, content = parser.extract_harmony_content(
+            "<|channel|>analysis<|message|>   <|call|>"
+            "<|channel|>final<|message|>done<|end|>"
+        )
+
+        self.assertIsNone(thinking)
+        self.assertEqual(content, "done")
+
+        thinking, content = parser.extract_harmony_content("plain\n\n\ntext")
+
+        self.assertIsNone(thinking)
+        self.assertEqual(content, "plain\n\ntext")
+
     def test_resolve_text_source_prefers_template_content_variants(self):
         parser = ToolCallParser()
 
@@ -238,6 +300,27 @@ class ToolCallParserFullCoverageTestCase(TestCase):
                 None,
             ),
             "listed",
+        )
+
+    def test_resolve_text_source_accepts_serialized_content_variants(self):
+        parser = ToolCallParser()
+
+        self.assertEqual(
+            parser._resolve_text_source(None, "serialized"), "serialized"
+        )
+        self.assertEqual(
+            parser._resolve_text_source(
+                None,
+                {"type": "text", "text": "dict text"},
+            ),
+            "dict text",
+        )
+        self.assertEqual(
+            parser._resolve_text_source(
+                None,
+                [{"type": "text", "text": "list text"}],
+            ),
+            "list text",
         )
 
     def test_resolve_text_source_returns_none_for_invalid_serialized_text(
@@ -265,6 +348,20 @@ class ToolCallParserFullCoverageTestCase(TestCase):
         parser._merge_thinking(message_dict, None)
 
         self.assertEqual(message_dict["thinking"], "existing")
+
+    def test_merge_thinking_normalizes_empty_and_combines_existing(self):
+        parser = ToolCallParser()
+        message_dict: dict[str, object] = {"thinking": ""}
+
+        parser._merge_thinking(message_dict, None)
+
+        self.assertIsNone(message_dict["thinking"])
+
+        message_dict = {"thinking": "existing"}
+
+        parser._merge_thinking(message_dict, "fresh")
+
+        self.assertEqual(message_dict["thinking"], "existing\n\nfresh")
 
     def test_merge_thinking_replaces_blank_existing_value(self):
         parser = ToolCallParser()
@@ -471,6 +568,14 @@ class ToolCallParserFullCoverageTestCase(TestCase):
                 }
             )
         )
+        self.assertIsNone(
+            ToolCallParser._tool_call_from_payload(
+                {
+                    "name": "math..calculator",
+                    "arguments": {},
+                }
+            )
+        )
 
     def test_parse_reports_diagnostic_from_invalid_list_call(self):
         parser = ToolCallParser()
@@ -489,6 +594,27 @@ class ToolCallParserFullCoverageTestCase(TestCase):
         self.assertEqual(
             outcome.diagnostics[0].code,
             ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
+    def test_parse_reports_diagnostic_from_invalid_list_call_name(self):
+        parser = ToolCallParser()
+        call = ToolCall(
+            id="call-1",
+            name="math..calculator",
+            arguments={},
+        )
+
+        with patch.object(ToolCallParser, "__call__", return_value=[call]):
+            outcome = parser.parse("ignored")
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(diagnostic.call_id, "call-1")
+        self.assertEqual(diagnostic.requested_name, "math..calculator")
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
         )
 
     def test_parse_reports_diagnostic_from_invalid_tuple_name(self):
@@ -540,6 +666,12 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ),
             [],
         )
+        self.assertEqual(
+            ToolCallParser._decode_react_arguments(
+                '{"expression": "2"}\nObservation: ok'
+            ),
+            ({"expression": "2"}, False),
+        )
 
         diagnostics = parser._react_failure_diagnostics(
             'Action: calculator\nAction Input: {"expression": }'
@@ -551,6 +683,20 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ToolCallDiagnosticCode.MALFORMED_CALL,
         )
         self.assertEqual(diagnostics[0].requested_name, "calculator")
+
+        for text in (
+            "Action: calculator",
+            'Action Input: {"expression": "2"}',
+            "Action: calculator\nAction Input: ",
+        ):
+            with self.subTest(text=text):
+                diagnostics = parser._react_failure_diagnostics(text)
+
+                self.assertEqual(len(diagnostics), 1)
+                self.assertEqual(
+                    diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
 
     def test_harmony_failure_diagnostics_cover_empty_and_invalid_messages(
         self,
@@ -602,6 +748,48 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
         )
 
+    def test_tag_diagnostics_cover_missing_self_closing_arguments(self):
+        parser = ToolCallParser()
+        text = (
+            '<tool_call name="broken"/>'
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+        call_id = _uuid4()
+        diagnostic_id = _uuid4()
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[call_id, diagnostic_id],
+        ):
+            outcome = parser.parse(text)
+
+        self.assertEqual(
+            outcome.calls,
+            [ToolCall(id=call_id, name="calculator", arguments={})],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(outcome.diagnostics[0].id, diagnostic_id)
+        self.assertEqual(outcome.diagnostics[0].requested_name, "broken")
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
+    def test_tag_diagnostics_cover_malformed_self_closing_arguments(self):
+        parser = ToolCallParser()
+        outcome = parser.parse(
+            "<tool_call name=\"calculator\" arguments='{' />"
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(diagnostic.requested_name, "calculator")
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
     def test_tag_diagnostics_cover_regex_fallback_payloads(self):
         parser = ToolCallParser()
 
@@ -639,6 +827,21 @@ class ToolCallParserFullCoverageTestCase(TestCase):
 
         self.assertIsNotNone(diagnostic)
         assert diagnostic is not None
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+        diagnostic = parser._payload_diagnostic(
+            {
+                "name": "math..calculator",
+                "arguments": {},
+            }
+        )
+
+        self.assertIsNotNone(diagnostic)
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.requested_name, "math..calculator")
         self.assertEqual(
             diagnostic.code,
             ToolCallDiagnosticCode.MALFORMED_CALL,
@@ -782,6 +985,61 @@ class ToolCallParserFullCoverageTestCase(TestCase):
 
         self.assertEqual(len(recovered), 1)
         self.assertEqual(recovered[0].payload["name"], "calculator")
+
+    def test_recovery_payloads_skip_overlapping_duplicate_payloads(self):
+        parser = ToolCallParser(
+            recovery_formats=[
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                ToolCallRecoveryFormat.FENCED,
+            ]
+        )
+        text = (
+            "```xml\n"
+            '<invoke name="calculator"><parameter name="expression">'
+            "1 + 1</parameter></invoke>\n"
+            "```"
+        )
+
+        recovered = parser._recovery_payloads(text)
+
+        self.assertEqual(len(recovered), 1)
+        self.assertEqual(recovered[0].payload["name"], "calculator")
+
+    def test_recovery_keeps_non_overlapping_duplicate_payloads(self):
+        first_id = _uuid4()
+        second_id = _uuid4()
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.MINIMAX_XML]
+        )
+        text = (
+            '<invoke name="calculator"><parameter name="expression">'
+            "1 + 1</parameter></invoke>"
+            '<invoke name="calculator"><parameter name="expression">'
+            "1 + 1</parameter></invoke>"
+        )
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[first_id, second_id],
+        ):
+            outcome = parser.parse(text)
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=first_id,
+                    name="calculator",
+                    arguments={"expression": "1 + 1"},
+                ),
+                ToolCall(
+                    id=second_id,
+                    name="calculator",
+                    arguments={"expression": "1 + 1"},
+                ),
+            ],
+        )
+        self.assertEqual(outcome.diagnostics, [])
 
     def test_fenced_recovery_accepts_direct_json_payload(self):
         call_id = _uuid4()

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -10,6 +10,7 @@ from avalan.entities import (
     ToolCall,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
+    ToolCallRecoveryFormat,
     ToolFormat,
 )
 from avalan.tool.parser import ToolCallParser
@@ -628,6 +629,191 @@ class ToolCallParserFullCoverageTestCase(TestCase):
                         stage=ToolCallDiagnosticStage.VALIDATE,
                         **kwargs,
                     )
+
+    def test_recovery_marker_helpers_cover_all_formats(self):
+        cases = (
+            (
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                "[TOOL_CALL]",
+                "plain",
+            ),
+            (
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                "<invoke",
+                "plain",
+            ),
+            (
+                ToolCallRecoveryFormat.TOOL_CODE,
+                "<tool_code>",
+                "plain",
+            ),
+            (
+                ToolCallRecoveryFormat.BROAD_XML,
+                "<function",
+                "plain",
+            ),
+            (
+                ToolCallRecoveryFormat.DSML_LEAKAGE,
+                "<DSML:invoke",
+                "invoke",
+            ),
+            (
+                ToolCallRecoveryFormat.FENCED,
+                "```json\n{}\n```",
+                "plain",
+            ),
+        )
+
+        for recovery_format, positive, negative in cases:
+            with self.subTest(recovery_format=recovery_format):
+                self.assertTrue(
+                    ToolCallParser._has_recovery_marker(
+                        positive, recovery_format
+                    )
+                )
+                self.assertFalse(
+                    ToolCallParser._has_recovery_marker(
+                        negative, recovery_format
+                    )
+                )
+
+    def test_recovery_marker_without_payload_reports_diagnostic(self):
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.TOOL_CALL_BLOCK]
+        )
+
+        outcome = parser.parse("[TOOL_CALL]{bad")
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].details["source_format"],
+            ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
+        )
+
+    def test_recovery_payloads_skip_duplicate_formats(self):
+        parser = ToolCallParser(
+            recovery_formats=[
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                ToolCallRecoveryFormat.BROAD_XML,
+            ]
+        )
+        text = (
+            '<invoke name="calculator"><parameter name="expression">'
+            "1 + 1</parameter></invoke>"
+        )
+
+        recovered = parser._recovery_payloads(text)
+
+        self.assertEqual(len(recovered), 1)
+        self.assertEqual(recovered[0].payload["name"], "calculator")
+
+    def test_fenced_recovery_accepts_direct_json_payload(self):
+        call_id = _uuid4()
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.FENCED]
+        )
+
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            outcome = parser.parse(
+                '```json\n{"name": "calculator", "arguments": {}}\n```'
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [ToolCall(id=call_id, name="calculator", arguments={})],
+        )
+        self.assertEqual(outcome.diagnostics, [])
+
+    def test_xml_recovery_helper_rejects_malformed_xml(self):
+        parser = ToolCallParser()
+
+        self.assertIsNone(parser._xml_payload("<invoke>"))
+        self.assertIsNone(parser._xml_payload("<unknown></unknown>"))
+
+    def test_xml_recovery_parses_tool_call_payload_shapes(self):
+        parser = ToolCallParser()
+
+        self.assertEqual(
+            parser._xml_payload(
+                '<tool_call>{"name": "calculator", "arguments": {}}'
+                "</tool_call>"
+            ),
+            {"name": "calculator", "arguments": {}},
+        )
+        self.assertEqual(
+            parser._xml_payload(
+                '<tool_call name="calculator">{"expression": "2"}</tool_call>'
+            ),
+            {"name": "calculator", "arguments": {"expression": "2"}},
+        )
+        self.assertEqual(
+            parser._xml_payload(
+                "<tool_call><name>calculator</name><arguments>{}"
+                "</arguments></tool_call>"
+            ),
+            {"name": "calculator", "arguments": {}},
+        )
+        self.assertIsNone(
+            parser._xml_payload(
+                "<tool_call><arguments>{}</arguments></tool_call>"
+            )
+        )
+        self.assertIsNone(
+            parser._xml_payload(
+                "<tool_call><name>calculator</name><arguments>[]"
+                "</arguments></tool_call>"
+            )
+        )
+        self.assertIsNone(
+            parser._xml_payload(
+                "<tool_call name='calculator'><parameter>bad</parameter>"
+                "</tool_call>"
+            )
+        )
+
+    def test_xml_recovery_rejects_invalid_named_payloads(self):
+        parser = ToolCallParser()
+
+        self.assertIsNone(
+            parser._xml_payload(
+                "<invoke><parameter name='value'>1</parameter></invoke>"
+            )
+        )
+        self.assertIsNone(
+            parser._xml_payload(
+                "<invoke name='calculator'><parameter>1</parameter></invoke>"
+            )
+        )
+
+    def test_xml_recovery_handles_parameters_and_non_parameters(self):
+        parser = ToolCallParser()
+
+        payload = parser._xml_payload(
+            "<invoke name='calculator'>"
+            "<description>ignored</description>"
+            "<parameter name='expression'>2 + 2</parameter>"
+            "<parameter name='precision' string='false'>2</parameter>"
+            "<parameter name='fallback' string='false'>not-json</parameter>"
+            "</invoke>"
+        )
+
+        self.assertEqual(
+            payload,
+            {
+                "name": "calculator",
+                "arguments": {
+                    "expression": "2 + 2",
+                    "precision": 2,
+                    "fallback": "not-json",
+                },
+            },
+        )
+
+    def test_function_call_payload_rejects_non_object_arguments(self):
+        parser = ToolCallParser()
+
+        self.assertIsNone(parser._function_call_payload("calculator({1})"))
 
 
 if __name__ == "__main__":

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -9,6 +9,7 @@ from avalan.entities import (
     MessageRole,
     ToolCall,
     ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
     ToolFormat,
 )
 from avalan.tool.parser import ToolCallParser
@@ -494,6 +495,67 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             diagnostic.code,
             ToolCallDiagnosticCode.MALFORMED_CALL,
         )
+
+    def test_payload_diagnostic_applies_resource_limits(self):
+        parser = ToolCallParser(maximum_payload_size=4)
+
+        diagnostic = parser._payload_diagnostic(
+            {
+                "id": "call-1",
+                "name": "calculator",
+                "arguments": {"expression": "large"},
+            }
+        )
+
+        self.assertIsNotNone(diagnostic)
+        assert diagnostic is not None
+        self.assertEqual(diagnostic.call_id, "call-1")
+        self.assertEqual(diagnostic.requested_name, "calculator")
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MAXIMUM_SIZE,
+        )
+
+    def test_resource_limit_helper_accepts_payload_within_limits(self):
+        diagnostic = ToolCallParser.resource_limit_diagnostic(
+            value={"items": [1, None, True, False, "ok"]},
+            maximum_depth=2,
+            maximum_size=32,
+            stage=ToolCallDiagnosticStage.VALIDATE,
+            call_id="call-1",
+            requested_name="calculator",
+            canonical_name="math.calculator",
+        )
+
+        self.assertIsNone(diagnostic)
+
+    def test_resource_limit_helper_counts_empty_containers(self):
+        self.assertEqual(ToolCallParser._value_depth({}), 1)
+        self.assertEqual(ToolCallParser._value_depth([]), 1)
+
+    def test_resource_limit_helper_rejects_invalid_stage(self):
+        with self.assertRaises(AssertionError):
+            ToolCallParser.resource_limit_diagnostic(
+                value={},
+                maximum_depth=None,
+                maximum_size=None,
+                stage=cast(Any, "validate"),
+            )
+
+    def test_resource_limit_helper_rejects_invalid_limits(self):
+        invalid_cases = (
+            {"maximum_depth": 0, "maximum_size": None},
+            {"maximum_depth": None, "maximum_size": True},
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolCallParser.resource_limit_diagnostic(
+                        value={},
+                        stage=ToolCallDiagnosticStage.VALIDATE,
+                        **kwargs,
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
@@ -7,6 +8,7 @@ from avalan.entities import (
     MessageContentText,
     MessageRole,
     ToolCall,
+    ToolCallDiagnosticCode,
     ToolFormat,
 )
 from avalan.tool.parser import ToolCallParser
@@ -319,6 +321,178 @@ class ToolCallParserFullCoverageTestCase(TestCase):
                     "arguments": [],
                 }
             )
+        )
+
+    def test_parse_reports_diagnostic_from_invalid_list_call(self):
+        parser = ToolCallParser()
+        call = ToolCall(
+            id="call-1",
+            name="calculator",
+            arguments=cast(Any, ["bad"]),
+        )
+
+        with patch.object(ToolCallParser, "__call__", return_value=[call]):
+            outcome = parser.parse("ignored")
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(outcome.diagnostics[0].call_id, "call-1")
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
+    def test_parse_reports_diagnostic_from_invalid_tuple_name(self):
+        parser = ToolCallParser()
+
+        with patch.object(
+            ToolCallParser,
+            "__call__",
+            return_value=cast(Any, (" ", {})),
+        ):
+            outcome = parser.parse("ignored")
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+    def test_json_failure_diagnostics_cover_valid_and_top_level_array(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+
+        self.assertEqual(
+            parser._json_failure_diagnostics(
+                '{"tool": "calculator", "arguments": {}}',
+                name_field="tool",
+            ),
+            [],
+        )
+
+        diagnostics = parser._json_failure_diagnostics(
+            '["calculator"]',
+            name_field="tool",
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+    def test_react_failure_diagnostics_cover_absent_valid_and_invalid(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+
+        self.assertEqual(parser._react_failure_diagnostics("plain"), [])
+        self.assertEqual(
+            parser._react_failure_diagnostics(
+                'Action: calculator\nAction Input: {"expression": "2"}'
+            ),
+            [],
+        )
+
+        diagnostics = parser._react_failure_diagnostics(
+            'Action: calculator\nAction Input: {"expression": }'
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].requested_name, "calculator")
+
+    def test_harmony_failure_diagnostics_cover_empty_and_invalid_messages(
+        self,
+    ):
+        parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+
+        self.assertEqual(
+            parser._harmony_failure_diagnostics("<|channel|>commentary"),
+            [],
+        )
+        self.assertEqual(
+            parser._harmony_failure_diagnostics(
+                "<|channel|>commentary to=functions.calculator"
+                "<|message|><|call|>"
+            ),
+            [],
+        )
+
+        diagnostics = parser._harmony_failure_diagnostics(
+            "<|channel|>commentary to=functions.calculator"
+            '<|message|>{"expression": }<|call|>'
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].requested_name, "calculator")
+
+    def test_tag_diagnostics_cover_xml_name_attributes(self):
+        parser = ToolCallParser()
+
+        tool_call_outcome = parser.parse(
+            '<tool_call name="calculator">["bad"]</tool_call>'
+        )
+        self.assertEqual(tool_call_outcome.calls, [])
+        self.assertEqual(len(tool_call_outcome.diagnostics), 1)
+        self.assertEqual(
+            tool_call_outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
+        tool_outcome = parser.parse('<tool name="calculator">["bad"]</tool>')
+        self.assertEqual(tool_outcome.calls, [])
+        self.assertEqual(len(tool_outcome.diagnostics), 1)
+        self.assertEqual(
+            tool_outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+
+    def test_tag_diagnostics_cover_regex_fallback_payloads(self):
+        parser = ToolCallParser()
+
+        cases = (
+            (
+                '<tool_call>{"name": "calculator", "arguments": '
+                '["bad"]}</tool_call></extra>'
+            ),
+            '<tool_call name="calculator">["bad"]</tool_call></extra>',
+            '<tool name="calculator">["bad"]</tool></extra>',
+            '<tool_call name="calculator" arguments=\'["bad"]\'/></extra>',
+        )
+
+        for text in cases:
+            with self.subTest(text=text):
+                outcome = parser.parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                self.assertEqual(
+                    outcome.diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                )
+
+    def test_payload_diagnostic_returns_none_for_valid_payload(self):
+        parser = ToolCallParser()
+
+        self.assertIsNone(
+            parser._payload_diagnostic({"name": "calculator", "arguments": {}})
+        )
+
+    def test_payload_diagnostic_rejects_invalid_name(self):
+        parser = ToolCallParser()
+        diagnostic = parser._payload_diagnostic({"name": " ", "arguments": {}})
+
+        self.assertIsNotNone(diagnostic)
+        assert diagnostic is not None
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
         )
 
 

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -238,6 +238,78 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ToolCallParser.ToolCallBufferStatus.CLOSED,
         )
 
+    def test_tool_call_status_reports_final_terminal_states(self):
+        parser = ToolCallParser()
+
+        self.assertEqual(
+            parser.tool_call_status("<tool_call>", final=True),
+            ToolCallParser.ToolCallBufferStatus.UNTERMINATED,
+        )
+        self.assertEqual(
+            parser.tool_call_status("<tool_call></tool_call>", final=True),
+            ToolCallParser.ToolCallBufferStatus.MALFORMED,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", "arguments": {}}'
+                "</tool_call>",
+                final=True,
+            ),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+
+    def test_stream_buffer_diagnostics_reports_unterminated_buffer(self):
+        parser = ToolCallParser()
+
+        diagnostics = parser.stream_buffer_diagnostics(
+            '<tool_call>{"name": "calculator", "arguments": {}}'
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+
+    def test_stream_buffer_diagnostics_reports_malformed_closed_buffer(self):
+        parser = ToolCallParser()
+
+        diagnostics = parser.stream_buffer_diagnostics(
+            '<tool_call>{"name": "calculator", "arguments": }</tool_call>'
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+
+    def test_stream_buffer_diagnostics_reports_malformed_status_fallback(self):
+        parser = ToolCallParser()
+
+        diagnostics = parser.stream_buffer_diagnostics(
+            "<tool_call></tool_call>"
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostics[0].details["stream_status"], "malformed")
+
+    def test_stream_buffer_diagnostics_returns_empty_for_valid_buffer(self):
+        parser = ToolCallParser()
+
+        diagnostics = parser.stream_buffer_diagnostics(
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+
+        self.assertEqual(diagnostics, [])
+
     def test_tool_call_status_reports_harmony_closure(self):
         parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
 

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -2,6 +2,7 @@ from typing import Any, cast
 from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
+from xml.etree import ElementTree
 
 from avalan.entities import (
     Message,
@@ -10,6 +11,7 @@ from avalan.entities import (
     ToolCall,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
+    ToolCallParseOutcome,
     ToolCallRecoveryFormat,
     ToolFormat,
 )
@@ -390,6 +392,280 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             parser.tool_call_status("<tool_call></tool_call>"),
             ToolCallParser.ToolCallBufferStatus.CLOSED,
         )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "/>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "<tool_call name=\\"inner\\"/>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "<tool_call></tool_call>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "</tool_call>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "escaped \\" </tool_call>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call name="first"/>'
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "<tool_call name=\\"inner\\"/>"}}'
+            ),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status('<tool_call name="calculator"/>'),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call name="calculator" arguments=\'{"expression": '
+                '"1 > 0"}\'/>'
+            ),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "first", "arguments": {}}</tool_call>'
+                '<tool_call name="second"/>'
+            ),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+
+    def test_tool_call_status_uses_latest_mixed_tag_start(self) -> None:
+        parser = ToolCallParser()
+        open_sibling = (
+            '<tool_call>{"name": "first", "arguments": {}}</tool_call>'
+            ' between <tool name="second">{"value": 2}'
+        )
+        closed_sibling = open_sibling + "</tool>"
+
+        self.assertEqual(
+            parser.tool_call_status(open_sibling),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(open_sibling, final=True),
+            ToolCallParser.ToolCallBufferStatus.UNTERMINATED,
+        )
+        self.assertEqual(
+            parser.tool_call_status(closed_sibling),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+        self.assertEqual(
+            parser._latest_tool_start(
+                '<tool_call name="first"/><tool name="second">',
+                ["<tool_call", "<tool ", "<tool>"],
+            ),
+            (25, "<tool "),
+        )
+
+    def test_tool_call_status_ignores_quoted_self_close_marker(self) -> None:
+        parser = ToolCallParser()
+        text = (
+            '<tool_call name="calculator" arguments=\'{"expression": "/>"}\'>'
+        )
+
+        self.assertEqual(
+            parser.tool_call_status(text),
+            ToolCallParser.ToolCallBufferStatus.OPEN,
+        )
+        self.assertEqual(
+            parser.tool_call_status(text, final=True),
+            ToolCallParser.ToolCallBufferStatus.UNTERMINATED,
+        )
+        diagnostics = parser.stream_buffer_diagnostics(text)
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            diagnostics[0].details["stream_status"], "unterminated"
+        )
+
+    def test_tool_call_status_handles_visible_quote_text_before_tag(
+        self,
+    ) -> None:
+        parser = ToolCallParser()
+        apostrophe_text = (
+            'don\'t <tool_call name="calculator" arguments=\'{"value": 2}\'/>'
+        )
+        quoted_prefix_text = (
+            '"<tool_call" '
+            '<tool_call name="calculator" arguments=\'{"value": 2}\'/>'
+        )
+
+        for text in (apostrophe_text, quoted_prefix_text):
+            with self.subTest(text=text):
+                self.assertEqual(
+                    parser.tool_call_status(text),
+                    ToolCallParser.ToolCallBufferStatus.CLOSED,
+                )
+                self.assertEqual(
+                    parser.tool_call_status(text, final=True),
+                    ToolCallParser.ToolCallBufferStatus.CLOSED,
+                )
+                outcome = parser.parse(text)
+                self.assertEqual(len(outcome.calls), 1)
+                self.assertEqual(outcome.calls[0].name, "calculator")
+                self.assertEqual(outcome.calls[0].arguments, {"value": 2})
+                self.assertEqual(outcome.diagnostics, [])
+
+        quoted_only = '"<tool_call name=\\"calculator\\" arguments=\'{}\'/>"'
+        self.assertEqual(
+            parser.tool_call_status(quoted_only),
+            ToolCallParser.ToolCallBufferStatus.NONE,
+        )
+        self.assertEqual(parser.parse(quoted_only), ToolCallParseOutcome())
+
+    def test_tool_call_status_ignores_markdown_fenced_markers(self) -> None:
+        parser = ToolCallParser()
+        text = (
+            "```xml\n"
+            '<tool_call>{"name": "calculator", "arguments": {}}'
+            "</tool_call>\n"
+            "```"
+        )
+
+        self.assertEqual(
+            parser.tool_call_status(""),
+            ToolCallParser.ToolCallBufferStatus.NONE,
+        )
+        self.assertEqual(
+            parser.tool_call_status(text),
+            ToolCallParser.ToolCallBufferStatus.NONE,
+        )
+        self.assertEqual(parser.stream_buffer_diagnostics(text), [])
+
+        unterminated = (
+            '```xml\n<tool_call>{"name": "calculator", "arguments": {}}'
+        )
+        self.assertEqual(
+            parser.tool_call_status(unterminated, final=True),
+            ToolCallParser.ToolCallBufferStatus.NONE,
+        )
+        self.assertEqual(parser.stream_buffer_diagnostics(unterminated), [])
+
+    def test_tool_call_status_detects_marker_after_markdown_fence(
+        self,
+    ) -> None:
+        parser = ToolCallParser()
+        fenced_text = "```xml\n<tool_call></tool_call>\n```\n"
+
+        self.assertEqual(
+            parser.tool_call_status(
+                fenced_text
+                + '<tool_call>{"name": "calculator", "arguments": {}}'
+                + "</tool_call>",
+                final=True,
+            ),
+            ToolCallParser.ToolCallBufferStatus.CLOSED,
+        )
+
+    def test_tool_end_helpers_ignore_quoted_markers(self) -> None:
+        parser = ToolCallParser()
+
+        self.assertFalse(
+            parser._has_unquoted_tool_end(
+                '{"text": "</tool_call>"}', ["</tool_call>"]
+            )
+        )
+        self.assertTrue(
+            parser._has_unquoted_tool_end(
+                '{"text": "</tool_call>"}</tool_call>', ["</tool_call>"]
+            )
+        )
+        text = (
+            '<tool_call>{"text": "</tool_call>"}</tool_call>'
+            '<tool_call name="second"/>'
+        )
+        second_start = text.find('<tool_call name="second"')
+        self.assertEqual(
+            parser._last_tool_end_before(
+                text,
+                second_start,
+                ["</tool_call>"],
+            ),
+            second_start,
+        )
+        text_without_real_close = (
+            '<tool_call>{"text": "</tool_call>"}<tool_call name="second"/>'
+        )
+        self.assertEqual(
+            parser._last_tool_end_before(
+                text_without_real_close,
+                text_without_real_close.find('<tool_call name="second"'),
+                ["</tool_call>"],
+            ),
+            -1,
+        )
+        two_self_closing_tags = (
+            '<tool_call name="first"/>'
+            "<tool_call name=\"second\" arguments='{}'/>"
+        )
+        self.assertFalse(
+            parser._has_unclosed_tool_start_before(
+                two_self_closing_tags,
+                two_self_closing_tags.find('<tool_call name="second"'),
+                ["<tool_call", "<tool ", "<tool>"],
+                ["</tool_call>", "</tool>", "<|call|>"],
+            )
+        )
+        open_then_self_closing = (
+            '<tool_call>{"name": "first"}'
+            "<tool_call name=\"second\" arguments='{}'/>"
+        )
+        self.assertTrue(
+            parser._has_unclosed_tool_start_before(
+                open_then_self_closing,
+                open_then_self_closing.find('<tool_call name="second"'),
+                ["<tool_call", "<tool ", "<tool>"],
+                ["</tool_call>", "</tool>", "<|call|>"],
+            )
+        )
+        self.assertFalse(
+            parser._opening_tool_tag_is_self_closing("<tool>", "/>")
+        )
+        tag_text = '<tool_call arguments=\'{"expression": "1 > 0"}\'/>'
+        self.assertEqual(
+            parser._tag_end_index(tag_text, 0),
+            tag_text.rindex(">"),
+        )
+        escaped_tag_text = "<tool_call arguments='escaped \\' > value'>"
+        self.assertEqual(
+            parser._tag_end_index(escaped_tag_text, 0),
+            escaped_tag_text.rindex(">"),
+        )
+        self.assertEqual(
+            parser._tag_end_index(
+                '<tool_call arguments=\'{"expression": "unterminated"}',
+                0,
+            ),
+            -1,
+        )
 
     def test_tool_call_status_reports_dsml_states(self):
         parser = ToolCallParser(tool_format=ToolFormat.DSML)
@@ -430,6 +706,14 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ),
             ToolCallParser.ToolCallBufferStatus.CLOSED,
         )
+        self.assertEqual(
+            parser.tool_call_status(
+                '<tool_call>{"name": "calculator", '
+                '"arguments": {"text": "<tool_call name=\\"inner\\"/>"}}',
+                final=True,
+            ),
+            ToolCallParser.ToolCallBufferStatus.UNTERMINATED,
+        )
 
     def test_stream_buffer_diagnostics_reports_unterminated_buffer(self):
         parser = ToolCallParser()
@@ -459,13 +743,17 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             diagnostics[0].code,
             ToolCallDiagnosticCode.MALFORMED_CALL,
         )
+        self.assertEqual(diagnostics[0].details["stream_status"], "malformed")
 
     def test_stream_buffer_diagnostics_reports_malformed_status_fallback(self):
         parser = ToolCallParser()
 
-        diagnostics = parser.stream_buffer_diagnostics(
-            "<tool_call></tool_call>"
-        )
+        with patch.object(
+            ToolCallParser, "parse", return_value=ToolCallParseOutcome()
+        ):
+            diagnostics = parser.stream_buffer_diagnostics(
+                "<tool_call></tool_call>"
+            )
 
         self.assertEqual(len(diagnostics), 1)
         self.assertEqual(
@@ -473,6 +761,19 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             ToolCallDiagnosticCode.MALFORMED_CALL,
         )
         self.assertEqual(diagnostics[0].details["stream_status"], "malformed")
+
+    def test_stream_buffer_diagnostics_returns_parse_diagnostics(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+
+        diagnostics = parser.stream_buffer_diagnostics(
+            '{"tool": "calculator", "arguments": []}'
+        )
+
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(
+            diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
 
     def test_stream_buffer_diagnostics_returns_empty_for_valid_buffer(self):
         parser = ToolCallParser()
@@ -556,6 +857,62 @@ class ToolCallParserFullCoverageTestCase(TestCase):
                         arguments={"value": 2},
                     )
                 ],
+            )
+
+    def test_tag_payload_helpers_cover_xml_tool_edges(self):
+        parser = ToolCallParser()
+
+        self.assertEqual(
+            parser._tag_payloads("<tool name=\"calculator\" arguments='{}'/>"),
+            [{"name": "calculator", "arguments": {}}],
+        )
+        self.assertEqual(
+            parser._tag_attribute(
+                '<tool_call tool_name="bad" name="calculator"/>',
+                "name",
+            ),
+            "calculator",
+        )
+        self.assertEqual(
+            parser._tag_attribute(
+                '<tool_call name="cal\\"culator"/>',
+                "name",
+            ),
+            'cal\\"culator',
+        )
+        self.assertEqual(
+            parser._tag_attribute_close_index(
+                '"unterminated',
+                1,
+                '"',
+            ),
+            -1,
+        )
+        self.assertEqual(parser._tag_payloads("<tool />"), [])
+        self.assertEqual(parser._tag_body_payloads("<tool_call"), [])
+        self.assertEqual(parser._self_closing_tag_payloads("<tool_call"), [])
+
+        named = ElementTree.fromstring(
+            '<tool_call name="calculator">{"value": 2}</tool_call>'
+        )
+        self.assertEqual(
+            parser._tag_payload_from_element(named),
+            {"name": "calculator", "arguments": {"value": 2}},
+        )
+
+        unnamed = ElementTree.fromstring(
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+        with patch(
+            "avalan.tool.parser.loads",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertIsNone(parser._tag_payload_from_element(unnamed))
+            self.assertEqual(
+                parser._self_closing_tag_payloads(
+                    "<tool_call name=\"calculator\" arguments='{}'/>"
+                ),
+                [{"name": "calculator", "arguments": None}],
             )
 
     def test_tool_call_from_payload_rejects_invalid_inputs(self):

--- a/tests/tool/tool_parser_full_coverage_test.py
+++ b/tests/tool/tool_parser_full_coverage_test.py
@@ -124,10 +124,65 @@ class ToolCallParserFullCoverageTestCase(TestCase):
 
         self.assertIsNone(parser.extract_structured_message("plain text"))
 
+    def test_has_dsml_tool_call_start_handles_lazy_dependency_errors(self):
+        parser = ToolCallParser()
+
+        with patch(
+            "avalan.tool.parser.DsmlTools.tool_call_start_span",
+            return_value=(0, 4),
+        ):
+            self.assertTrue(parser._has_dsml_tool_call_start("tool_calls"))
+
+        with patch(
+            "avalan.tool.parser.DsmlTools.tool_call_start_span",
+            side_effect=RuntimeError("pyds4 unavailable"),
+        ):
+            self.assertFalse(parser._has_dsml_tool_call_start("tool_calls"))
+
+        dsml_parser = ToolCallParser(tool_format=ToolFormat.DSML)
+        with patch(
+            "avalan.tool.parser.DsmlTools.tool_call_start_span",
+            side_effect=RuntimeError("pyds4 unavailable"),
+        ):
+            with self.assertRaises(RuntimeError):
+                dsml_parser._has_dsml_tool_call_start("tool_calls")
+
     def test_message_tool_calls_returns_empty_without_configured_parser(self):
         parser = ToolCallParser()
 
         self.assertEqual(parser.message_tool_calls("plain text"), [])
+
+    def test_message_tool_calls_extracts_dsml_payload(self):
+        parser = ToolCallParser()
+        call = ToolCall(
+            id="call-1",
+            name="calculator",
+            arguments={"expression": "2 + 2"},
+        )
+
+        with (
+            patch(
+                "avalan.tool.parser.DsmlTools.tool_call_start_span",
+                return_value=(0, 12),
+            ),
+            patch(
+                "avalan.tool.parser.DsmlTools.parse_tool_calls",
+                return_value=[call],
+            ),
+        ):
+            tool_calls = parser.message_tool_calls("tool_calls")
+
+        self.assertEqual(
+            tool_calls,
+            [
+                {
+                    "id": "call-1",
+                    "name": "calculator",
+                    "arguments": {"expression": "2 + 2"},
+                    "content_type": "json",
+                }
+            ],
+        )
 
     def test_message_tool_calls_returns_empty_for_unexpected_shape(self):
         parser = ToolCallParser(tool_format=ToolFormat.JSON)
@@ -238,6 +293,26 @@ class ToolCallParserFullCoverageTestCase(TestCase):
             parser.tool_call_status("<tool_call></tool_call>"),
             ToolCallParser.ToolCallBufferStatus.CLOSED,
         )
+
+    def test_tool_call_status_reports_dsml_states(self):
+        parser = ToolCallParser(tool_format=ToolFormat.DSML)
+        cases = (
+            ("prefix", ToolCallParser.ToolCallBufferStatus.PREFIX),
+            ("open", ToolCallParser.ToolCallBufferStatus.OPEN),
+            ("closed", ToolCallParser.ToolCallBufferStatus.CLOSED),
+            ("none", ToolCallParser.ToolCallBufferStatus.NONE),
+        )
+
+        for native_status, expected in cases:
+            with self.subTest(native_status=native_status):
+                with patch(
+                    "avalan.tool.parser.DsmlTools.tool_call_buffer_status",
+                    return_value=native_status,
+                ):
+                    self.assertEqual(
+                        parser.tool_call_status("tool_calls"),
+                        expected,
+                    )
 
     def test_tool_call_status_reports_final_terminal_states(self):
         parser = ToolCallParser()

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -894,6 +894,8 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                 None,
                 '<tool_call>{"name": "calculator", "arguments": }</tool_call>',
             ),
+            (None, "<tool>{bad}</tool>"),
+            (None, "<tool_call>{bad}"),
         )
 
         for tool_format, text in cases:
@@ -1349,8 +1351,41 @@ class ToolCallParserTagTestCase(TestCase):
             ]
             self.assertEqual(self.parser(text), expected)
 
+    def test_self_closing_preserves_inner_attribute_quotes(self):
+        text = (
+            '<tool_call name="calculator" arguments=\'{"phrase": '
+            '"rock \', roll", "expression": "1 > 0"}\'/>'
+        )
+        call_id = _uuid4()
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            expected = [
+                ToolCall(
+                    id=call_id,
+                    name="calculator",
+                    arguments={
+                        "phrase": "rock ', roll",
+                        "expression": "1 > 0",
+                    },
+                )
+            ]
+            self.assertEqual(self.parser(text), expected)
+
     def test_self_closing_rejects_non_object_arguments(self):
         text = '<tool_call name="calculator" arguments=\'["2"]\'/>'
+        outcome = self.parser.parse(text)
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertEqual(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+        self.assertEqual(diagnostic.requested_name, "calculator")
+
+    def test_self_closing_rejects_malformed_inner_attribute_quote(self):
+        text = '<tool_call name="calculator" arguments=\'{"phrase": "rock \'/>'
         outcome = self.parser.parse(text)
 
         self.assertEqual(outcome.calls, [])

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -117,6 +117,28 @@ class ToolCallParserFormatTestCase(TestCase):
 
         self.assertIsNone(parsed)
 
+    def test_configured_text_limit_keeps_legacy_none_shape(self):
+        parser = ToolCallParser(
+            tool_format=ToolFormat.JSON,
+            maximum_text_size=4,
+        )
+
+        parsed = parser('{"tool": "calculator", "arguments": {}}')
+
+        self.assertIsNone(parsed)
+
+    def test_rejects_invalid_resource_limits(self):
+        invalid_cases = (
+            {"maximum_text_size": 0},
+            {"maximum_payload_depth": -1},
+            {"maximum_payload_size": True},
+        )
+
+        for kwargs in invalid_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    ToolCallParser(**kwargs)
+
 
 class ToolCallParserParseOutcomeTestCase(TestCase):
     def test_parse_normalizes_tuple_formats(self):
@@ -294,6 +316,76 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                 self.assertEqual(
                     diagnostic.stage, ToolCallDiagnosticStage.PARSE
                 )
+
+    def test_parse_reports_text_size_limit(self):
+        parser = ToolCallParser(
+            tool_format=ToolFormat.JSON,
+            maximum_text_size=4,
+        )
+
+        outcome = parser.parse('{"tool": "calculator", "arguments": {}}')
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_SIZE)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+        self.assertEqual(diagnostic.details["limit"], 4)
+
+    def test_parse_reports_argument_depth_limit(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                (
+                    '{"tool": "calculator", "arguments": '
+                    '{"payload": {"value": 1}}}'
+                ),
+            ),
+            (
+                None,
+                (
+                    '<tool_call>{"name": "calculator", "arguments": '
+                    '{"payload": {"value": 1}}}</tool_call>'
+                ),
+            ),
+        )
+
+        for tool_format, text in cases:
+            with self.subTest(tool_format=tool_format):
+                parser = ToolCallParser(
+                    tool_format=tool_format,
+                    maximum_payload_depth=1,
+                )
+
+                outcome = parser.parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                diagnostic = outcome.diagnostics[0]
+                self.assertIs(
+                    diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_DEPTH
+                )
+                self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+                self.assertEqual(diagnostic.requested_name, "calculator")
+                self.assertEqual(diagnostic.details["limit"], 1)
+
+    def test_parse_reports_argument_size_limit(self):
+        parser = ToolCallParser(
+            tool_format=ToolFormat.JSON,
+            maximum_payload_size=8,
+        )
+
+        outcome = parser.parse(
+            '{"tool": "calculator", "arguments": {"payload": "large"}}'
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertIs(diagnostic.code, ToolCallDiagnosticCode.MAXIMUM_SIZE)
+        self.assertIs(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+        self.assertEqual(diagnostic.requested_name, "calculator")
+        self.assertEqual(diagnostic.details["limit"], 8)
 
     def test_parse_returns_empty_outcome_for_plain_text(self):
         for tool_format in (None, ToolFormat.JSON):

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -2,7 +2,12 @@ from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
 
-from avalan.entities import ToolCall, ToolFormat
+from avalan.entities import (
+    ToolCall,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolFormat,
+)
 from avalan.tool.parser import ToolCallParser
 
 
@@ -111,6 +116,194 @@ class ToolCallParserFormatTestCase(TestCase):
         parsed = parser('{"name": "calculator", "arguments": ["1 + 1"]}')
 
         self.assertIsNone(parsed)
+
+
+class ToolCallParserParseOutcomeTestCase(TestCase):
+    def test_parse_normalizes_tuple_formats(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": {"expression": "1"}}',
+                "calculator",
+                {"expression": "1"},
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: {"expression": "2"}',
+                "calculator",
+                {"expression": "2"},
+            ),
+            (
+                ToolFormat.BRACKET,
+                "[calculator](3)",
+                "calculator",
+                {"input": "3"},
+            ),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "calculator", "arguments": {"expression": "4"}}',
+                "calculator",
+                {"expression": "4"},
+            ),
+        )
+
+        for tool_format, text, name, arguments in cases:
+            with self.subTest(tool_format=tool_format):
+                call_id = _uuid4()
+                parser = ToolCallParser(tool_format=tool_format)
+
+                with patch("avalan.tool.parser.uuid4", return_value=call_id):
+                    outcome = parser.parse(text)
+
+                self.assertEqual(
+                    outcome.calls,
+                    [
+                        ToolCall(
+                            id=call_id,
+                            name=name,
+                            arguments=arguments,
+                        )
+                    ],
+                )
+                self.assertEqual(outcome.diagnostics, [])
+
+    def test_parse_preserves_call_ids_from_list_formats(self):
+        tag_parser = ToolCallParser()
+        tag_outcome = tag_parser.parse(
+            '<tool_call>{"id": "call-1", "name": "calculator", '
+            '"arguments": {"expression": "2 + 2"}}</tool_call>'
+        )
+        self.assertEqual(
+            tag_outcome.calls,
+            [
+                ToolCall(
+                    id="call-1",
+                    name="calculator",
+                    arguments={"expression": "2 + 2"},
+                )
+            ],
+        )
+        self.assertEqual(tag_outcome.diagnostics, [])
+
+        harmony_id = _uuid4()
+        harmony_parser = ToolCallParser(tool_format=ToolFormat.HARMONY)
+        harmony_text = (
+            "<|channel|>commentary to=functions.calculator"
+            '<|message|>{"expression": "3 + 3"}<|call|>'
+        )
+        with patch("avalan.tool.parser.uuid4", return_value=harmony_id):
+            harmony_outcome = harmony_parser.parse(harmony_text)
+        self.assertEqual(
+            harmony_outcome.calls,
+            [
+                ToolCall(
+                    id=harmony_id,
+                    name="calculator",
+                    arguments={"expression": "3 + 3"},
+                )
+            ],
+        )
+        self.assertEqual(harmony_outcome.diagnostics, [])
+
+        dsml_call = ToolCall(
+            id="dsml-call",
+            name="calculator",
+            arguments={"expression": "4 + 4"},
+        )
+        with patch(
+            "avalan.tool.parser.DsmlTools.parse_tool_calls",
+            return_value=[dsml_call],
+        ):
+            dsml_outcome = ToolCallParser(tool_format=ToolFormat.DSML).parse(
+                "dsml"
+            )
+        self.assertEqual(dsml_outcome.calls, [dsml_call])
+        self.assertEqual(dsml_outcome.diagnostics, [])
+
+    def test_parse_reports_non_object_argument_payloads(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": ["1 + 1"]}',
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: ["2 + 2"]',
+            ),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "calculator", "arguments": ["3 + 3"]}',
+            ),
+            (
+                ToolFormat.HARMONY,
+                (
+                    "<|channel|>commentary to=functions.calculator"
+                    '<|message|>["4 + 4"]<|call|>'
+                ),
+            ),
+            (
+                None,
+                (
+                    '<tool_call>{"name": "calculator", "arguments": '
+                    '["5 + 5"]}</tool_call>'
+                ),
+            ),
+        )
+
+        for tool_format, text in cases:
+            with self.subTest(tool_format=tool_format):
+                outcome = ToolCallParser(tool_format=tool_format).parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                diagnostic = outcome.diagnostics[0]
+                self.assertEqual(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+                )
+                self.assertEqual(
+                    diagnostic.stage, ToolCallDiagnosticStage.PARSE
+                )
+                self.assertEqual(diagnostic.requested_name, "calculator")
+
+    def test_parse_reports_malformed_call_payloads(self):
+        cases = (
+            (ToolFormat.JSON, '{"tool": "calculator", "arguments": '),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: {"expression": ',
+            ),
+            (ToolFormat.OPENAI, '{"name": 3, "arguments": {}}'),
+            (
+                None,
+                '<tool_call>{"name": "calculator", "arguments": }</tool_call>',
+            ),
+        )
+
+        for tool_format, text in cases:
+            with self.subTest(tool_format=tool_format):
+                outcome = ToolCallParser(tool_format=tool_format).parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                diagnostic = outcome.diagnostics[0]
+                self.assertEqual(
+                    diagnostic.code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
+                self.assertEqual(
+                    diagnostic.stage, ToolCallDiagnosticStage.PARSE
+                )
+
+    def test_parse_returns_empty_outcome_for_plain_text(self):
+        for tool_format in (None, ToolFormat.JSON):
+            with self.subTest(tool_format=tool_format):
+                outcome = ToolCallParser(tool_format=tool_format).parse(
+                    "plain assistant content"
+                )
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(outcome.diagnostics, [])
 
 
 class ToolCallParserHarmonyTestCase(TestCase):

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -24,10 +24,24 @@ class ToolCallParserFormatTestCase(TestCase):
         text = 'Action: calculator\nAction Input: {"expression": "2"}'
         self.assertEqual(parser(text), ("calculator", {"expression": "2"}))
 
+    def test_react_dotted_tool_name(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        text = 'Action: math.calculator\nAction Input: {"expression": "2"}'
+        self.assertEqual(
+            parser(text), ("math.calculator", {"expression": "2"})
+        )
+
     def test_bracket(self):
         parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
         text = "[calculator](2)"
         self.assertEqual(parser(text), ("calculator", {"input": "2"}))
+
+    def test_bracket_dotted_tool_name(self):
+        parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
+        text = "[memory.message.read](recent)"
+        self.assertEqual(
+            parser(text), ("memory.message.read", {"input": "recent"})
+        )
 
     def test_openai_json(self):
         parser = ToolCallParser(tool_format=ToolFormat.OPENAI)
@@ -43,6 +57,66 @@ class ToolCallParserFormatTestCase(TestCase):
         parser = ToolCallParser(tool_format=ToolFormat.REACT)
         text = 'Action: calculator\nAction Input: {"expression": 2'
         self.assertIsNone(parser(text))
+
+    def test_react_legacy_returns_first_valid_call_after_malformed_input(
+        self,
+    ):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        text = (
+            'Action: calculator\nAction Input: {"expression": '
+            "\nAction: math.calculator\n"
+            'Action Input: {"expression": "2"}'
+        )
+
+        self.assertEqual(
+            parser(text),
+            ("math.calculator", {"expression": "2"}),
+        )
+
+    def test_react_rejects_empty_tool_name_segment(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        text = 'Action: math..calculator\nAction Input: {"expression": "2"}'
+
+        outcome = parser.parse(text)
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            outcome.diagnostics[0].stage,
+            ToolCallDiagnosticStage.PARSE,
+        )
+
+    def test_bracket_rejects_empty_tool_name_segment(self):
+        parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
+
+        self.assertIsNone(parser("[math..calculator](2)"))
+
+    def test_bracket_reports_malformed_call_diagnostics(self):
+        parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
+
+        for text in (
+            "[math..calculator](2)",
+            "[](2)",
+            "[calculator]()",
+            "[calculator](2",
+        ):
+            with self.subTest(text=text):
+                outcome = parser.parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                self.assertEqual(
+                    outcome.diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].stage,
+                    ToolCallDiagnosticStage.PARSE,
+                )
 
     def test_openai_json_invalid(self):
         parser = ToolCallParser(tool_format=ToolFormat.OPENAI)
@@ -116,6 +190,13 @@ class ToolCallParserFormatTestCase(TestCase):
         parser = ToolCallParser(tool_format=ToolFormat.OPENAI)
 
         parsed = parser('{"name": "calculator", "arguments": ["1 + 1"]}')
+
+        self.assertIsNone(parsed)
+
+    def test_openai_json_non_object_payload_is_rejected(self):
+        parser = ToolCallParser(tool_format=ToolFormat.OPENAI)
+
+        parsed = parser('["calculator", {"expression": "1 + 1"}]')
 
         self.assertIsNone(parsed)
 
@@ -212,6 +293,14 @@ class ToolCallParserFormatTestCase(TestCase):
                     "</tool_call>\n```"
                 ),
             ),
+            (
+                "unterminated_fenced",
+                (
+                    "```xml\n"
+                    '<tool_call>{"name": "calculator", "arguments": {}}'
+                    "</tool_call>"
+                ),
+            ),
         )
 
         parser = ToolCallParser()
@@ -221,6 +310,45 @@ class ToolCallParserFormatTestCase(TestCase):
 
                 self.assertEqual(outcome.calls, [])
                 self.assertEqual(outcome.diagnostics, [])
+
+    def test_unterminated_fenced_recovery_reports_diagnostic(self):
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.FENCED]
+        )
+        outcome = parser.parse(
+            "```xml\n"
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(
+            outcome.diagnostics[0].details["source_format"],
+            ToolCallRecoveryFormat.FENCED.value,
+        )
+
+    def test_longer_closing_fence_does_not_leak_tool_call(self):
+        parser = ToolCallParser()
+        call_id = _uuid4()
+        text = (
+            "```\n"
+            '<tool_call>{"name": "blocked", "arguments": {}}</tool_call>\n'
+            "````\n"
+            '<tool_call>{"name": "calculator", "arguments": {}}</tool_call>'
+        )
+
+        with patch("avalan.tool.parser.uuid4", return_value=call_id):
+            outcome = parser.parse(text)
+
+        self.assertEqual(
+            outcome.calls,
+            [ToolCall(id=call_id, name="calculator", arguments={})],
+        )
+        self.assertEqual(outcome.diagnostics, [])
 
     def test_recovery_diagnostic_details_identify_source_format(self):
         details = {"reason": "malformed"}
@@ -416,6 +544,89 @@ class ToolCallParserFormatTestCase(TestCase):
             ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
         )
 
+    def test_recovery_reports_malformed_marker_after_valid_call(self):
+        cases = (
+            (
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                (
+                    '[TOOL_CALL]{"name": "calculator", "arguments": '
+                    '{"expression": "1 + 1"}}[/TOOL_CALL]'
+                    "[TOOL_CALL]{bad"
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                (
+                    '<invoke name="calculator"><parameter '
+                    'name="expression">2 + 2</parameter></invoke>'
+                    '<invoke name="broken">'
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.TOOL_CODE,
+                (
+                    '<tool_code>{"name": "calculator", "arguments": '
+                    '{"expression": "3 + 3"}}</tool_code>'
+                    "<tool_code>{bad"
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.BROAD_XML,
+                (
+                    '<function name="calculator"><arguments>'
+                    '{"expression": "4 + 4"}</arguments></function>'
+                    '<function name="broken">'
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.DSML_LEAKAGE,
+                (
+                    "<DSML:tool_calls>"
+                    '<DSML:invoke name="calculator">'
+                    '<DSML:parameter name="expression">5 + 5'
+                    "</DSML:parameter></DSML:invoke></DSML:tool_calls>"
+                    '<DSML:invoke name="broken">'
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.FENCED,
+                (
+                    "```json\n"
+                    '{"name": "calculator", "arguments": '
+                    '{"expression": "6 + 6"}}\n'
+                    "```\n"
+                    "```json\n"
+                    "{bad"
+                ),
+            ),
+        )
+
+        for recovery_format, text in cases:
+            with self.subTest(recovery_format=recovery_format):
+                call_id = _uuid4()
+                diagnostic_id = _uuid4()
+                parser = ToolCallParser(recovery_formats=[recovery_format])
+
+                with patch(
+                    "avalan.tool.parser.uuid4",
+                    side_effect=[call_id, diagnostic_id],
+                ):
+                    outcome = parser.parse(text)
+
+                self.assertEqual(len(outcome.calls), 1)
+                self.assertEqual(outcome.calls[0].id, call_id)
+                self.assertEqual(outcome.calls[0].name, "calculator")
+                self.assertEqual(len(outcome.diagnostics), 1)
+                self.assertEqual(outcome.diagnostics[0].id, diagnostic_id)
+                self.assertEqual(
+                    outcome.diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].details["source_format"],
+                    recovery_format.value,
+                )
+
     def test_fenced_recovery_preserves_multiple_calls_in_order(self):
         first_id = _uuid4()
         second_id = _uuid4()
@@ -503,6 +714,73 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                     ],
                 )
                 self.assertEqual(outcome.diagnostics, [])
+
+    def test_parse_preserves_multiple_react_calls_and_diagnostics(self):
+        parser = ToolCallParser(tool_format=ToolFormat.REACT)
+        text = (
+            'Action: broken\nAction Input: {"expression": '
+            "\nAction: calculator\n"
+            'Action Input: {"expression": "2"}\n'
+            "Action: search\n"
+            'Action Input: ["not an object"]\n'
+            "Action: memory.write\n"
+            'Action Input: {"value": "saved"}'
+        )
+
+        outcome = parser.parse(text)
+
+        self.assertEqual(
+            [(call.name, call.arguments) for call in outcome.calls],
+            [
+                ("calculator", {"expression": "2"}),
+                ("memory.write", {"value": "saved"}),
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 2)
+        self.assertEqual(
+            [diagnostic.code for diagnostic in outcome.diagnostics],
+            [
+                ToolCallDiagnosticCode.MALFORMED_CALL,
+                ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+            ],
+        )
+        self.assertEqual(
+            [diagnostic.requested_name for diagnostic in outcome.diagnostics],
+            ["broken", "search"],
+        )
+
+    def test_parse_rejects_malformed_json_tool_names(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "math..calculator", "arguments": {}}',
+                "math..calculator",
+            ),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "math/calculator", "arguments": {}}',
+                "math/calculator",
+            ),
+        )
+
+        for tool_format, text, requested_name in cases:
+            with self.subTest(tool_format=tool_format):
+                outcome = ToolCallParser(tool_format=tool_format).parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                self.assertEqual(
+                    outcome.diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].stage,
+                    ToolCallDiagnosticStage.PARSE,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].requested_name,
+                    requested_name,
+                )
 
     def test_parse_preserves_call_ids_from_list_formats(self):
         tag_parser = ToolCallParser()
@@ -611,6 +889,7 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                 'Action: calculator\nAction Input: {"expression": ',
             ),
             (ToolFormat.OPENAI, '{"name": 3, "arguments": {}}'),
+            (ToolFormat.OPENAI, '["calculator", {"expression": "3"}]'),
             (
                 None,
                 '<tool_call>{"name": "calculator", "arguments": }</tool_call>',
@@ -631,6 +910,30 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                 self.assertEqual(
                     diagnostic.stage, ToolCallDiagnosticStage.PARSE
                 )
+
+    def test_parse_reports_malformed_recovered_tool_name(self):
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.TOOL_CALL_BLOCK]
+        )
+
+        outcome = parser.parse(
+            '[TOOL_CALL]{"name": "math..calculator", "arguments": {}}'
+            "[/TOOL_CALL]"
+        )
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+        self.assertEqual(diagnostic.requested_name, "math..calculator")
+        self.assertEqual(
+            diagnostic.details["source_format"],
+            ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
+        )
 
     def test_parse_reports_text_size_limit(self):
         parser = ToolCallParser(
@@ -662,6 +965,10 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
                     '<tool_call>{"name": "calculator", "arguments": '
                     '{"payload": {"value": 1}}}</tool_call>'
                 ),
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: {"payload": {"value": 1}}',
             ),
         )
 
@@ -711,6 +1018,36 @@ class ToolCallParserParseOutcomeTestCase(TestCase):
 
                 self.assertEqual(outcome.calls, [])
                 self.assertEqual(outcome.diagnostics, [])
+
+    def test_parse_keeps_valid_bracket_call_after_malformed_call(self):
+        parser = ToolCallParser(tool_format=ToolFormat.BRACKET)
+        call_id = _uuid4()
+        diagnostic_id = _uuid4()
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[call_id, diagnostic_id],
+        ):
+            outcome = parser.parse(
+                "[math..calculator](bad)\n[math.calculator](2)"
+            )
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=call_id,
+                    name="math.calculator",
+                    arguments={"input": "2"},
+                )
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(outcome.diagnostics[0].id, diagnostic_id)
+        self.assertEqual(
+            outcome.diagnostics[0].code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
 
 
 class ToolCallParserHarmonyTestCase(TestCase):
@@ -965,6 +1302,25 @@ class ToolCallParserTagTestCase(TestCase):
             ]
             self.assertEqual(self.parser(text), expected)
 
+    def test_multiple_with_malformed_xml_wrapper(self):
+        text = (
+            '<tool_call name="first">{"value": "1"}</tool_call>'
+            "&"
+            '<tool_call name="second">{"value": "2"}</tool_call>'
+        )
+        first_id = _uuid4()
+        second_id = _uuid4()
+        with patch(
+            "avalan.tool.parser.uuid4", side_effect=[first_id, second_id]
+        ):
+            expected = [
+                ToolCall(id=first_id, name="first", arguments={"value": "1"}),
+                ToolCall(
+                    id=second_id, name="second", arguments={"value": "2"}
+                ),
+            ]
+            self.assertEqual(self.parser(text), expected)
+
     def test_with_name_attr(self):
         text = '<tool_call name="calculator">{"expression": "2"}</tool_call>'
         call_id = _uuid4()
@@ -992,6 +1348,33 @@ class ToolCallParserTagTestCase(TestCase):
                 )
             ]
             self.assertEqual(self.parser(text), expected)
+
+    def test_self_closing_rejects_non_object_arguments(self):
+        text = '<tool_call name="calculator" arguments=\'["2"]\'/>'
+        outcome = self.parser.parse(text)
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_ARGUMENTS,
+        )
+        self.assertEqual(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
+        self.assertEqual(diagnostic.requested_name, "calculator")
+
+    def test_self_closing_rejects_missing_name(self):
+        text = '<tool_call arguments=\'{"expression": "2"}\'/>'
+        outcome = self.parser.parse(text)
+
+        self.assertEqual(outcome.calls, [])
+        self.assertEqual(len(outcome.diagnostics), 1)
+        diagnostic = outcome.diagnostics[0]
+        self.assertEqual(
+            diagnostic.code,
+            ToolCallDiagnosticCode.MALFORMED_CALL,
+        )
+        self.assertEqual(diagnostic.stage, ToolCallDiagnosticStage.PARSE)
 
     def test_tool_tag(self):
         text = '<tool name="calculator">{"expression": "2"}</tool>'

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -72,6 +72,46 @@ class ToolCallParserFormatTestCase(TestCase):
         )
         self.assertEqual(parser(text), ("calculator", {"expression": "3"}))
 
+    def test_current_tuple_formats_do_not_return_tool_call_objects(self):
+        cases = (
+            (
+                ToolFormat.JSON,
+                '{"tool": "calculator", "arguments": {"expression": "1"}}',
+            ),
+            (
+                ToolFormat.REACT,
+                'Action: calculator\nAction Input: {"expression": "2"}',
+            ),
+            (ToolFormat.BRACKET, "[calculator](3)"),
+            (
+                ToolFormat.OPENAI,
+                '{"name": "calculator", "arguments": {"expression": "4"}}',
+            ),
+        )
+
+        for tool_format, text in cases:
+            with self.subTest(tool_format=tool_format):
+                parsed = ToolCallParser(tool_format=tool_format)(text)
+
+                self.assertIsInstance(parsed, tuple)
+                self.assertEqual(len(parsed), 2)
+                self.assertIsInstance(parsed[0], str)
+                self.assertNotIsInstance(parsed, list)
+
+    def test_json_non_object_arguments_keep_current_tuple_shape(self):
+        parser = ToolCallParser(tool_format=ToolFormat.JSON)
+
+        parsed = parser('{"tool": "calculator", "arguments": ["1 + 1"]}')
+
+        self.assertEqual(parsed, ("calculator", ["1 + 1"]))
+
+    def test_openai_json_non_object_arguments_are_rejected(self):
+        parser = ToolCallParser(tool_format=ToolFormat.OPENAI)
+
+        parsed = parser('{"name": "calculator", "arguments": ["1 + 1"]}')
+
+        self.assertIsNone(parsed)
+
 
 class ToolCallParserHarmonyTestCase(TestCase):
     def test_multiple_with_commentary(self):

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest import TestCase, main
 from unittest.mock import patch
 from uuid import uuid4 as _uuid4
@@ -6,6 +7,7 @@ from avalan.entities import (
     ToolCall,
     ToolCallDiagnosticCode,
     ToolCallDiagnosticStage,
+    ToolCallRecoveryFormat,
     ToolFormat,
 )
 from avalan.tool.parser import ToolCallParser
@@ -138,6 +140,99 @@ class ToolCallParserFormatTestCase(TestCase):
             with self.subTest(kwargs=kwargs):
                 with self.assertRaises(AssertionError):
                     ToolCallParser(**kwargs)
+
+    def test_recovery_formats_default_to_empty(self):
+        parser = ToolCallParser()
+
+        self.assertEqual(parser.recovery_formats, ())
+
+    def test_recovery_formats_are_explicit(self):
+        parser = ToolCallParser(
+            recovery_formats=[
+                ToolCallRecoveryFormat.FENCED,
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+            ]
+        )
+
+        self.assertEqual(
+            parser.recovery_formats,
+            (
+                ToolCallRecoveryFormat.FENCED,
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+            ),
+        )
+
+    def test_rejects_invalid_recovery_formats(self):
+        with self.assertRaises(AssertionError):
+            ToolCallParser(recovery_formats=cast(Any, ["fenced"]))
+
+    def test_recovery_shaped_text_does_not_parse_by_default(self):
+        cases = (
+            (
+                "tool_call_block",
+                (
+                    '[TOOL_CALL]{"name": "calculator", "arguments": {}}'
+                    "[/TOOL_CALL]"
+                ),
+            ),
+            (
+                "minimax_xml",
+                (
+                    '<invoke name="calculator"><parameter name="expression">'
+                    "2 + 2</parameter></invoke>"
+                ),
+            ),
+            (
+                "tool_code",
+                (
+                    '<tool_code>{"name": "calculator", "arguments":'
+                    " {}}</tool_code>"
+                ),
+            ),
+            (
+                "broad_xml",
+                (
+                    '<function name="calculator"><arguments>{}</arguments>'
+                    "</function>"
+                ),
+            ),
+            (
+                "dsml_leakage",
+                (
+                    "<DSML:tool_calls>"
+                    '<DSML:invoke name="calculator">'
+                    "</DSML:invoke></DSML:tool_calls>"
+                ),
+            ),
+            (
+                "fenced",
+                (
+                    "```xml\n"
+                    '<tool_call>{"name": "calculator", "arguments": {}}'
+                    "</tool_call>\n```"
+                ),
+            ),
+        )
+
+        parser = ToolCallParser()
+        for name, text in cases:
+            with self.subTest(name=name):
+                outcome = parser.parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(outcome.diagnostics, [])
+
+    def test_recovery_diagnostic_details_identify_source_format(self):
+        details = {"reason": "malformed"}
+
+        diagnostic = ToolCallParser._malformed_call_diagnostic(
+            details=details,
+            recovery_format=ToolCallRecoveryFormat.FENCED,
+        )
+
+        self.assertEqual(diagnostic.details["reason"], "malformed")
+        self.assertEqual(diagnostic.details["source_format"], "fenced")
+        self.assertEqual(details, {"reason": "malformed"})
 
 
 class ToolCallParserParseOutcomeTestCase(TestCase):

--- a/tests/tool/tool_parser_test.py
+++ b/tests/tool/tool_parser_test.py
@@ -234,6 +234,226 @@ class ToolCallParserFormatTestCase(TestCase):
         self.assertEqual(diagnostic.details["source_format"], "fenced")
         self.assertEqual(details, {"reason": "malformed"})
 
+    def test_recovery_formats_parse_explicit_payloads(self):
+        cases = (
+            (
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                (
+                    '[TOOL_CALL]{"name": "calculator", "arguments": '
+                    '{"expression": "1 + 1"}}[/TOOL_CALL]'
+                ),
+                {"expression": "1 + 1"},
+            ),
+            (
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                (
+                    '<invoke name="calculator"><parameter name="expression">'
+                    "2 + 2</parameter></invoke>"
+                ),
+                {"expression": "2 + 2"},
+            ),
+            (
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                (
+                    '<mm:invoke name="calculator"><mm:parameter '
+                    'name="expression">3 + 3</mm:parameter></mm:invoke>'
+                ),
+                {"expression": "3 + 3"},
+            ),
+            (
+                ToolCallRecoveryFormat.TOOL_CODE,
+                (
+                    '<tool_code>{"name": "calculator", "arguments": '
+                    '{"expression": "4 + 4"}}</tool_code>'
+                ),
+                {"expression": "4 + 4"},
+            ),
+            (
+                ToolCallRecoveryFormat.TOOL_CODE,
+                '<tool_code>calculator({"expression": "5 + 5"})</tool_code>',
+                {"expression": "5 + 5"},
+            ),
+            (
+                ToolCallRecoveryFormat.BROAD_XML,
+                (
+                    '<function name="calculator"><arguments>'
+                    '{"expression": "6 + 6"}</arguments></function>'
+                ),
+                {"expression": "6 + 6"},
+            ),
+            (
+                ToolCallRecoveryFormat.DSML_LEAKAGE,
+                (
+                    "<DSML:tool_calls>"
+                    '<DSML:invoke name="calculator">'
+                    '<DSML:parameter name="expression">7 + 7'
+                    "</DSML:parameter>"
+                    "</DSML:invoke></DSML:tool_calls>"
+                ),
+                {"expression": "7 + 7"},
+            ),
+            (
+                ToolCallRecoveryFormat.FENCED,
+                (
+                    "```xml\n"
+                    '<invoke name="calculator"><parameter '
+                    'name="expression">8 + 8</parameter></invoke>\n'
+                    "```"
+                ),
+                {"expression": "8 + 8"},
+            ),
+        )
+
+        for recovery_format, text, arguments in cases:
+            with self.subTest(recovery_format=recovery_format):
+                call_id = _uuid4()
+                parser = ToolCallParser(recovery_formats=[recovery_format])
+
+                with patch("avalan.tool.parser.uuid4", return_value=call_id):
+                    outcome = parser.parse(text)
+
+                self.assertEqual(
+                    outcome.calls,
+                    [
+                        ToolCall(
+                            id=call_id,
+                            name="calculator",
+                            arguments=arguments,
+                        )
+                    ],
+                )
+                self.assertEqual(outcome.diagnostics, [])
+
+    def test_recovery_formats_report_malformed_payloads(self):
+        cases = (
+            (
+                ToolCallRecoveryFormat.TOOL_CALL_BLOCK,
+                "[TOOL_CALL]{bad[/TOOL_CALL]",
+            ),
+            (
+                ToolCallRecoveryFormat.MINIMAX_XML,
+                (
+                    '<invoke name="calculator"><parameter>bad</parameter>'
+                    "</invoke>"
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.TOOL_CODE,
+                "<tool_code>{bad</tool_code>",
+            ),
+            (
+                ToolCallRecoveryFormat.BROAD_XML,
+                (
+                    '<function name="calculator"><arguments>[]</arguments>'
+                    "</function>"
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.DSML_LEAKAGE,
+                (
+                    '<DSML:invoke name="calculator"><DSML:parameter>bad'
+                    "</DSML:parameter></DSML:invoke>"
+                ),
+            ),
+            (
+                ToolCallRecoveryFormat.FENCED,
+                "```json\n{bad\n```",
+            ),
+        )
+
+        for recovery_format, text in cases:
+            with self.subTest(recovery_format=recovery_format):
+                outcome = ToolCallParser(
+                    recovery_formats=[recovery_format]
+                ).parse(text)
+
+                self.assertEqual(outcome.calls, [])
+                self.assertEqual(len(outcome.diagnostics), 1)
+                self.assertEqual(
+                    outcome.diagnostics[0].code,
+                    ToolCallDiagnosticCode.MALFORMED_CALL,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].stage,
+                    ToolCallDiagnosticStage.PARSE,
+                )
+                self.assertEqual(
+                    outcome.diagnostics[0].details["source_format"],
+                    recovery_format.value,
+                )
+
+    def test_recovery_keeps_valid_call_after_malformed_segment(self):
+        first_id = _uuid4()
+        second_id = _uuid4()
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.TOOL_CALL_BLOCK]
+        )
+        text = (
+            "[TOOL_CALL]{bad[/TOOL_CALL]"
+            '[TOOL_CALL]{"name": "calculator", "arguments": '
+            '{"expression": "9 + 9"}}[/TOOL_CALL]'
+        )
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[first_id, second_id],
+        ):
+            outcome = parser.parse(text)
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=first_id,
+                    name="calculator",
+                    arguments={"expression": "9 + 9"},
+                )
+            ],
+        )
+        self.assertEqual(len(outcome.diagnostics), 1)
+        self.assertEqual(
+            outcome.diagnostics[0].details["source_format"],
+            ToolCallRecoveryFormat.TOOL_CALL_BLOCK.value,
+        )
+
+    def test_fenced_recovery_preserves_multiple_calls_in_order(self):
+        first_id = _uuid4()
+        second_id = _uuid4()
+        parser = ToolCallParser(
+            recovery_formats=[ToolCallRecoveryFormat.FENCED]
+        )
+        text = (
+            "```xml\n"
+            '<invoke name="first"><parameter name="value">1</parameter>'
+            "</invoke>"
+            '<invoke name="second"><parameter name="value">2</parameter>'
+            "</invoke>\n"
+            "```"
+        )
+
+        with patch(
+            "avalan.tool.parser.uuid4",
+            side_effect=[first_id, second_id],
+        ):
+            outcome = parser.parse(text)
+
+        self.assertEqual(
+            outcome.calls,
+            [
+                ToolCall(
+                    id=first_id,
+                    name="first",
+                    arguments={"value": "1"},
+                ),
+                ToolCall(
+                    id=second_id,
+                    name="second",
+                    arguments={"value": "2"},
+                ),
+            ],
+        )
+        self.assertEqual(outcome.diagnostics, [])
+
 
 class ToolCallParserParseOutcomeTestCase(TestCase):
     def test_parse_normalizes_tuple_formats(self):

--- a/tests/tool/tool_set_test.py
+++ b/tests/tool/tool_set_test.py
@@ -161,13 +161,25 @@ class ToolSetJsonSchemasTestCase(TestCase):
         schemas_outer = outer.json_schemas()
         self.assertEqual(
             [s["function"]["name"] for s in schemas_outer],
-            ["outer.calculator", "outer..calculator"],
+            ["outer.calculator", "outer.inner.calculator"],
         )
 
         schemas_mix = mix.json_schemas()
         self.assertEqual(
             [s["function"]["name"] for s in schemas_mix],
             ["mix.greet"],
+        )
+
+    def test_nested_enabled_tools_filters_by_canonical_name(self):
+        inner = ToolSet(namespace="inner", tools=[CalculatorTool()])
+        outer = ToolSet(namespace="outer", tools=[CalculatorTool(), inner])
+
+        outer.with_enabled_tools(["outer.inner.calculator"])
+
+        schemas = outer.json_schemas()
+        self.assertEqual(
+            [schema["function"]["name"] for schema in schemas],
+            ["outer.inner.calculator"],
         )
 
 

--- a/tests/tool/tool_set_test.py
+++ b/tests/tool/tool_set_test.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 from avalan.tool import Tool, ToolSet
 from avalan.tool.json_schema import get_json_schema
 from avalan.tool.math import CalculatorTool
+from avalan.tool.names import matches_tool_namespace
 
 
 class ToolSetTestCase(TestCase):
@@ -16,6 +17,17 @@ class ToolSetTestCase(TestCase):
         self.assertEqual(list(toolset.tools), [calculator])
         with self.assertRaises(AttributeError):
             toolset.namespace = "other"
+
+
+class ToolNameMatchTestCase(TestCase):
+    def test_namespace_matches_exact_name_and_child_segments(self):
+        self.assertTrue(matches_tool_namespace("math", "math"))
+        self.assertTrue(matches_tool_namespace("math.calculator", "math"))
+        self.assertTrue(matches_tool_namespace("calculator", None))
+
+    def test_namespace_does_not_match_unsafe_prefix(self):
+        self.assertFalse(matches_tool_namespace("mathx", "math"))
+        self.assertFalse(matches_tool_namespace("mathx.calculator", "math"))
 
 
 class DummyTool(Tool):
@@ -181,6 +193,24 @@ class ToolSetJsonSchemasTestCase(TestCase):
             [schema["function"]["name"] for schema in schemas],
             ["outer.inner.calculator"],
         )
+
+    def test_enabled_namespace_uses_segment_boundaries(self):
+        math_set = ToolSet(namespace="math", tools=[CalculatorTool()])
+        mathx_set = ToolSet(namespace="mathx", tools=[CalculatorTool()])
+
+        math_set.with_enabled_tools(["math"])
+        mathx_set.with_enabled_tools(["math"])
+
+        math_schemas = math_set.json_schemas()
+        mathx_schemas = mathx_set.json_schemas()
+
+        assert math_schemas is not None
+        assert mathx_schemas is not None
+        self.assertEqual(
+            [schema["function"]["name"] for schema in math_schemas],
+            ["math.calculator"],
+        )
+        self.assertEqual(mathx_schemas, [])
 
 
 class ToolJsonSchemaUtilityTestCase(TestCase):

--- a/tests/tool/tool_set_test.py
+++ b/tests/tool/tool_set_test.py
@@ -227,7 +227,7 @@ class ToolJsonSchemaUtilityTestCase(TestCase):
         self.assertEqual(schema["function"]["name"], "maybe_count")
         self.assertEqual(
             schema["function"]["parameters"]["properties"]["value"]["type"],
-            "string",
+            ["string", "null"],
         )
         self.assertEqual(
             schema["function"]["parameters"]["properties"]["enabled"][

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,7 +8,21 @@ from uuid import UUID
 
 from avalan.cli.download import create_live_tqdm_class, tqdm_rich_progress
 from avalan.compat import override
-from avalan.utils import _j, _lf, logger_replace, to_json
+from avalan.entities import (
+    ToolCall,
+    ToolCallDiagnostic,
+    ToolCallDiagnosticCode,
+    ToolCallDiagnosticStage,
+    ToolCallError,
+)
+from avalan.utils import (
+    _j,
+    _lf,
+    logger_replace,
+    to_json,
+    tool_call_diagnostic_payload,
+    tool_call_error_payload,
+)
 
 
 class UtilsListJoinTestCase(TestCase):
@@ -71,6 +85,61 @@ class UtilsToJsonTestCase(TestCase):
     def test_to_json_unsupported_type(self) -> None:
         with self.assertRaises(TypeError):
             to_json(object())
+
+
+class UtilsToolCallErrorPayloadTestCase(TestCase):
+    def test_tool_call_diagnostic_payload_includes_canonical_name(
+        self,
+    ) -> None:
+        diagnostic = ToolCallDiagnostic(
+            id="diag",
+            requested_name="lookup",
+            canonical_name="lookup_weather",
+            code=ToolCallDiagnosticCode.UNKNOWN_TOOL,
+            stage=ToolCallDiagnosticStage.RESOLVE,
+            message="Unknown tool.",
+        )
+
+        payload = tool_call_diagnostic_payload(diagnostic)
+
+        self.assertEqual(payload["canonical_name"], "lookup_weather")
+
+    def test_tool_call_error_payload_projects_exception_safely(self) -> None:
+        call = ToolCall(id="call-1", name="tool", arguments={})
+        error = ToolCallError(
+            id="err-1",
+            call=call,
+            name="tool",
+            arguments={},
+            error=RuntimeError("secret-path"),
+            message="Tool failed.",
+        )
+
+        payload = tool_call_error_payload(error)
+
+        self.assertEqual(
+            payload, {"type": "RuntimeError", "message": "Tool failed."}
+        )
+        self.assertNotIn("secret-path", to_json(payload))
+
+    def test_tool_call_error_payload_uses_projected_error_type(self) -> None:
+        call = ToolCall(id="call-2", name="tool", arguments={})
+        error = ToolCallError(
+            id="err-2",
+            call=call,
+            name="tool",
+            arguments={},
+            error={"type": "ValidationError", "detail": "raw value"},
+            message="Arguments are invalid.",
+        )
+
+        payload = tool_call_error_payload(error)
+
+        self.assertEqual(
+            payload,
+            {"type": "ValidationError", "message": "Arguments are invalid."},
+        )
+        self.assertNotIn("raw value", to_json(payload))
 
 
 class CompatOverrideTestCase(TestCase):


### PR DESCRIPTION
This work is part of a broader tool parsing upgrade that makes tool calls observable, deterministic, and safe to execute across parser formats, provider-native structures, streaming output, agents, servers, and flow nodes. Once fully implemented, the system will distinguish successful executable tool candidates from malformed, unknown, disabled, ambiguous, filtered, repeated, rejected, cancelled, or validation-failed calls through a shared diagnostic vocabulary instead of collapsing those cases into silent `None` outcomes.

The completed design gives `ToolManager` the central execution authority: parsers normalize candidate calls and diagnostics, while enabled-tool descriptors and the resolver own canonical names, aliases, provider-safe projections, schema metadata, and validation decisions. That separation keeps existing CLI, server, provider, Harmony, DSML, and legacy manager behavior compatible while creating additive APIs for outcome-oriented execution.

When the full roadmap lands, provider-native tool calls, streamed marker formats, model-facing orchestration, protocol projections, and flow `tool` nodes will all use the same preparation and diagnostic pipeline. Recovery formats remain opt-in and gated behind resolution, validation, resource limits, and fixtures, so broader parsing support does not make execution more permissive by default.

- [x] Phase 0: Decision Lock And Compatibility Baseline
- [x] Phase 1: Parser Normalization
- [x] Phase 2: Enabled Tool Registry And Resolution
- [x] Phase 3: Execution Preparation And Diagnostics
- [x] Phase 4: Schema Fidelity And Runtime Validation
- [x] Phase 5: Provider And Streaming Parity
- [x] Phase 6: Orchestration And Protocol Projection
- [x] Phase 7: Opt-In Recovery Formats
- [x] Phase 8: Flow Tool Nodes
