### PR TITLE
Fix pytest warnings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3000,6 +3000,29 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 
 [[package]]
+name = "httpcore2"
+version = "2.3.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415"},
+    {file = "httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 description = "A collection of framework independent HTTP protocol utils."
@@ -3096,6 +3119,32 @@ files = [
     {file = "httpx_sse-0.4.2-py3-none-any.whl", hash = "sha256:a9fa4afacb293fa50ef9bacb6cae8287ba5fd1f4b1c2d10a35bb981c41da31ab"},
     {file = "httpx_sse-0.4.2.tar.gz", hash = "sha256:5bb6a2771a51e6c7a5f5c645e40b8a5f57d8de708f46cb5f3868043c3c18124e"},
 ]
+
+
+[[package]]
+name = "httpx2"
+version = "2.3.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7"},
+    {file = "httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9"},
+]
+
+[package.dependencies]
+anyio = "*"
+httpcore2 = "2.3.0"
+idna = "*"
+truststore = ">=0.10"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<15)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
 
 [[package]]
 name = "huggingface-hub"
@@ -9540,6 +9589,19 @@ tutorials = ["matplotlib", "pandas", "tabulate"]
 
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">= 3.10"
+groups = ["test"]
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
+
+
+[[package]]
 name = "typer"
 version = "0.19.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -10309,4 +10371,4 @@ youtube = ["youtube-transcript-api"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "ec864d6cb179ffad85eb802101921b5a2ea8b4aa0933a1c05b875ffb94fdfa30"
+content-hash = "0c2c6561d9aed610b3f1bec24c40bc743fb901c14002597cd3368885d6158ab5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ version = "1.5.0"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+httpx2 = ">=2.3.0,<3.0.0"
 matplotlib = ">=3.8.0,<4.0.0"
 pyds4 = {version = ">=1.0.2,<2.0.0", markers = "platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')"}
 pytest = ">=9.0.3,<10.0.0"

--- a/src/avalan/model/audio/classification.py
+++ b/src/avalan/model/audio/classification.py
@@ -1,10 +1,9 @@
 from ...model.audio import BaseAudioModel
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.vendor import TextGenerationVendor
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import inference_mode
 from transformers import (
     AutoFeatureExtractor,

--- a/src/avalan/model/audio/generation.py
+++ b/src/avalan/model/audio/generation.py
@@ -1,27 +1,34 @@
 from ...model.audio import BaseAudioModel
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.vendor import TextGenerationVendor
 
+from importlib import import_module
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import from_numpy, inference_mode
 from torchaudio import save
-from transformers import (
-    AutoProcessor,
-    PreTrainedModel,
-)
-from transformers import (
-    MusicgenForConditionalGeneration as TransformersMusicgen,
-)
-
+from transformers import PreTrainedModel
 
 # MusicGen checkpoints include this non-persistent sinusoidal buffer. Ignore
 # only that key so unrelated load report diagnostics still surface.
-class MusicgenForConditionalGeneration(TransformersMusicgen):  # type: ignore[no-untyped-call]
-    _keys_to_ignore_on_load_unexpected = [
-        r"decoder\.model\.decoder\.embed_positions\.weights",
-    ]
+MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED = [
+    r"decoder\.model\.decoder\.embed_positions\.weights",
+]
+
+
+def _auto_processor() -> Any:
+    return getattr(import_module("transformers"), "AutoProcessor")
+
+
+def _musicgen_for_conditional_generation() -> Any:
+    model_class = getattr(
+        import_module("transformers"),
+        "MusicgenForConditionalGeneration",
+    )
+    model_class._keys_to_ignore_on_load_unexpected = (
+        MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED
+    )
+    return model_class
 
 
 class AudioGenerationModel(BaseAudioModel):
@@ -32,11 +39,11 @@ class AudioGenerationModel(BaseAudioModel):
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = cast(
             Any,
-            cast(Any, AutoProcessor).from_pretrained(self._model_id),
+            cast(Any, _auto_processor()).from_pretrained(self._model_id),
         )
         model = cast(
             PreTrainedModel,
-            cast(Any, MusicgenForConditionalGeneration)
+            cast(Any, _musicgen_for_conditional_generation())
             .from_pretrained(
                 self._model_id,
                 device_map=self._device,

--- a/src/avalan/model/audio/speech.py
+++ b/src/avalan/model/audio/speech.py
@@ -1,22 +1,28 @@
 from ...model.audio import BaseAudioModel
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.vendor import TextGenerationVendor
 
 from copy import deepcopy
+from importlib import import_module
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import inference_mode
 from transformers import (
     AutoFeatureExtractor,
-    AutoTokenizer,
     DiaConfig,
     DiaForConditionalGeneration,
-    DiaProcessor,
     PreTrainedModel,
 )
 
 _DIA_TOKEN_ID_FIELDS = ("pad_token_id", "eos_token_id", "bos_token_id")
+
+
+def _auto_tokenizer() -> Any:
+    return getattr(import_module("transformers"), "AutoTokenizer")
+
+
+def _dia_processor() -> Any:
+    return getattr(import_module("transformers"), "DiaProcessor")
 
 
 class TextToSpeechModel(BaseAudioModel):
@@ -68,14 +74,15 @@ class TextToSpeechModel(BaseAudioModel):
         self._sync_dia_config_token_ids(config)
         return config
 
-    def _load_processor(self, config: DiaConfig) -> DiaProcessor:
+    def _load_processor(self, config: DiaConfig) -> Any:
         assert self._model_id
         processor_kwargs = {
             **self._hub_kwargs(self._settings.tokenizer_subfolder),
             "trust_remote_code": self._settings.trust_remote_code,
         }
+        dia_processor = _dia_processor()
         processor_dict, processor_init_kwargs = (
-            DiaProcessor.get_processor_dict(
+            dia_processor.get_processor_dict(
                 self._model_id,
                 **processor_kwargs,
             )
@@ -84,14 +91,14 @@ class TextToSpeechModel(BaseAudioModel):
             self._model_id,
             **processor_kwargs,
         )
-        tokenizer = cast(Any, AutoTokenizer).from_pretrained(
+        tokenizer = cast(Any, _auto_tokenizer()).from_pretrained(
             self._model_id,
             config=config,
             **processor_kwargs,
         )
         return cast(
-            DiaProcessor,
-            DiaProcessor.from_args_and_dict(
+            Any,
+            dia_processor.from_args_and_dict(
                 [feature_extractor, tokenizer],
                 processor_dict,
                 **processor_init_kwargs,

--- a/src/avalan/model/audio/speech_recognition.py
+++ b/src/avalan/model/audio/speech_recognition.py
@@ -1,16 +1,19 @@
 from ...model.audio import BaseAudioModel
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.vendor import TextGenerationVendor
 
+from importlib import import_module
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
 from transformers import (
     AutoModelForCTC,
-    AutoProcessor,
     PreTrainedModel,
 )
+
+
+def _auto_processor() -> Any:
+    return getattr(import_module("transformers"), "AutoProcessor")
 
 
 class SpeechRecognitionModel(BaseAudioModel):
@@ -21,7 +24,7 @@ class SpeechRecognitionModel(BaseAudioModel):
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         self._processor = cast(
             Any,
-            cast(Any, AutoProcessor).from_pretrained(
+            cast(Any, _auto_processor()).from_pretrained(
                 self._model_id,
                 trust_remote_code=self._settings.trust_remote_code,
                 # default behavior in transformers v4.48

--- a/src/avalan/model/engine.py
+++ b/src/avalan/model/engine.py
@@ -88,10 +88,7 @@ def _optional_type(module_name: str, type_name: str) -> type[Any] | None:
     if module_name in modules:
         module = modules[module_name]
         return cast(type[Any], getattr(module, type_name))
-    if find_spec(module_name) is None:
-        return None
-    module = import_module(module_name)
-    return cast(type[Any], getattr(module, type_name))
+    return None
 
 
 def _pretrained_model_type() -> type[Any] | None:
@@ -481,36 +478,41 @@ class Engine(ABC):
             pretrained_model_type = (
                 None if is_vendor else _pretrained_model_type()
             )
-            diffusion_pipeline_type = (
-                None if is_vendor else _diffusion_pipeline_type()
-            )
             is_pretrained_model = (
                 pretrained_model_type is not None
                 and isinstance(self._model, pretrained_model_type)
             )
-            is_diffusion_pipeline = (
+            accepts_loaded_model = False
+            if not is_pretrained_model and not is_vendor:
+                accepts_loaded_model = self._accepts_loaded_model(self._model)
+            diffusion_pipeline_type = (
+                None
+                if is_vendor or is_pretrained_model or accepts_loaded_model
+                else _diffusion_pipeline_type()
+            )
+            is_diffusion_pipeline = bool(
                 diffusion_pipeline_type is not None
                 and isinstance(self._model, diffusion_pipeline_type)
             )
-            accepts_loaded_model = False
 
             if (
                 not is_pretrained_model
                 and not is_vendor
                 and not is_diffusion_pipeline
+                and not accepts_loaded_model
             ):
                 is_mlx = Engine._is_mlx_model(self._model)
 
-                if not is_mlx and Engine._has_module("sentence_transformers"):
-                    from sentence_transformers import SentenceTransformer
-
-                    is_sentence_transformer = isinstance(
-                        self._model, SentenceTransformer
+                sentence_transformer_type = (
+                    None
+                    if is_mlx
+                    else _optional_type(
+                        "sentence_transformers", "SentenceTransformer"
                     )
-
-                if not is_mlx and not is_sentence_transformer:
-                    accepts_loaded_model = self._accepts_loaded_model(
-                        self._model
+                )
+                if sentence_transformer_type is not None:
+                    is_sentence_transformer = isinstance(
+                        self._model, sentence_transformer_type
                     )
 
             assert (

--- a/src/avalan/model/lazy.py
+++ b/src/avalan/model/lazy.py
@@ -1,0 +1,36 @@
+from importlib import import_module
+from typing import Any
+
+
+class LazyExternal:
+    __test__ = False
+
+    def __init__(self, module_name: str, name: str) -> None:
+        self._module_name = module_name
+        self._name = name
+
+    def __call__(self, *args: object, **kwargs: object) -> Any:
+        target = self._target()
+        return target(*args, **kwargs)
+
+    def for_model(self, *args: object, **kwargs: object) -> Any:
+        return self._target().for_model(*args, **kwargs)
+
+    def from_config(self, *args: object, **kwargs: object) -> Any:
+        return self._target().from_config(*args, **kwargs)
+
+    def from_pretrained(self, *args: object, **kwargs: object) -> Any:
+        return self._target().from_pretrained(*args, **kwargs)
+
+    def get_config_dict(self, *args: object, **kwargs: object) -> Any:
+        return self._target().get_config_dict(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_is_coroutine" or (
+            name.startswith("__") and name.endswith("__")
+        ):
+            raise AttributeError(name)
+        return getattr(self._target(), name)
+
+    def _target(self) -> Any:
+        return getattr(import_module(self._module_name), self._name)

--- a/src/avalan/model/nlp/question.py
+++ b/src/avalan/model/nlp/question.py
@@ -1,11 +1,10 @@
 from ...entities import Input
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.nlp import BaseNLPModel
 from ...model.vendor import TextGenerationVendor
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
 from transformers import (
     AutoModelForQuestionAnswering,

--- a/src/avalan/model/nlp/sequence.py
+++ b/src/avalan/model/nlp/sequence.py
@@ -1,12 +1,11 @@
 from ...entities import GenerationSettings, Input
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.nlp import BaseNLPModel
 from ...model.vendor import TextGenerationVendor
 
 from dataclasses import replace
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import Tensor, argmax, inference_mode, softmax
 from transformers import (
     AutoModelForSeq2SeqLM,

--- a/src/avalan/model/nlp/text/generation.py
+++ b/src/avalan/model/nlp/text/generation.py
@@ -55,11 +55,17 @@ else:
     Tensor: TypeAlias = Any
 
     class _LazyExternal:
+        __test__ = False
+
         def __init__(self, module_name: str, name: str) -> None:
             self._module_name = module_name
             self._name = name
 
         def __getattr__(self, name: str) -> Any:
+            if name == "_is_coroutine" or (
+                name.startswith("__") and name.endswith("__")
+            ):
+                raise AttributeError(name)
             module = import_module(self._module_name)
             target = getattr(module, self._name)
             return getattr(target, name)

--- a/src/avalan/model/nlp/token.py
+++ b/src/avalan/model/nlp/token.py
@@ -1,11 +1,10 @@
 from ...entities import Input
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine
 from ...model.nlp import BaseNLPModel
 from ...model.vendor import TextGenerationVendor
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import argmax, inference_mode
 from transformers import (
     AutoModelForTokenClassification,

--- a/src/avalan/model/transformer.py
+++ b/src/avalan/model/transformer.py
@@ -31,11 +31,22 @@ else:
         pass
 
     class _LazyExternal:
+        __test__ = False
+
         def __init__(self, module_name: str, name: str) -> None:
             self._module_name = module_name
             self._name = name
 
+        def from_pretrained(self, *args: object, **kwargs: object) -> Any:
+            module = import_module(self._module_name)
+            target = getattr(module, self._name)
+            return target.from_pretrained(*args, **kwargs)
+
         def __getattr__(self, name: str) -> Any:
+            if name == "_is_coroutine" or (
+                name.startswith("__") and name.endswith("__")
+            ):
+                raise AttributeError(name)
             module = import_module(self._module_name)
             target = getattr(module, self._name)
             return getattr(target, name)

--- a/src/avalan/model/vision/classification.py
+++ b/src/avalan/model/vision/classification.py
@@ -1,17 +1,17 @@
 from ...entities import ImageEntity
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine, PreTrainedModel
+from ...model.lazy import LazyExternal
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import inference_mode
-from transformers import (
-    AutoImageProcessor,
-    AutoModelForImageClassification,
-    PreTrainedModel,
+
+AutoImageProcessor = LazyExternal("transformers", "AutoImageProcessor")
+AutoModelForImageClassification = LazyExternal(
+    "transformers", "AutoModelForImageClassification"
 )
 
 

--- a/src/avalan/model/vision/decoder.py
+++ b/src/avalan/model/vision/decoder.py
@@ -1,19 +1,17 @@
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine, PreTrainedModel
+from ...model.lazy import LazyExternal
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from ...model.vision.text import ImageToTextModel
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import inference_mode
-from transformers import (
-    AutoImageProcessor,
-    PreTrainedModel,
-)
-from transformers import (
-    VisionEncoderDecoderModel as VisionEncoderDecoderModelImpl,
+
+AutoImageProcessor = LazyExternal("transformers", "AutoImageProcessor")
+VisionEncoderDecoderModelImpl = LazyExternal(
+    "transformers", "VisionEncoderDecoderModel"
 )
 
 

--- a/src/avalan/model/vision/detection.py
+++ b/src/avalan/model/vision/detection.py
@@ -1,5 +1,6 @@
 from ...entities import EngineSettings, ImageEntity
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine, PreTrainedModel
+from ...model.lazy import LazyExternal
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 from ...model.vision.classification import ImageClassificationModel
@@ -10,18 +11,16 @@ from logging import Logger, getLogger
 from os import environ
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import inference_mode, tensor
-from transformers import (
-    AutoConfig,
-    AutoImageProcessor,
-    AutoModelForObjectDetection,
-    PretrainedConfig,
-    PreTrainedModel,
-)
 
 _DISABLE_SAFETENSORS_CONVERSION = "DISABLE_SAFETENSORS_CONVERSION"
+AutoConfig = LazyExternal("transformers", "AutoConfig")
+AutoImageProcessor = LazyExternal("transformers", "AutoImageProcessor")
+AutoModelForObjectDetection = LazyExternal(
+    "transformers", "AutoModelForObjectDetection"
+)
+PretrainedConfig = LazyExternal("transformers", "PretrainedConfig")
 
 
 class ObjectDetectionModel(ImageClassificationModel):
@@ -76,7 +75,7 @@ class ObjectDetectionModel(ImageClassificationModel):
             else:
                 environ[_DISABLE_SAFETENSORS_CONVERSION] = previous_value
 
-    def _load_config(self) -> PretrainedConfig:
+    def _load_config(self) -> Any:
         assert self._model_id
         config_dict, _ = PretrainedConfig.get_config_dict(
             self._model_id,
@@ -92,7 +91,7 @@ class ObjectDetectionModel(ImageClassificationModel):
             return AutoConfig.for_model(model_type, **normalized_config)
 
         return cast(
-            PretrainedConfig,
+            Any,
             AutoConfig.from_pretrained(
                 self._model_id,
                 revision=self._revision,

--- a/src/avalan/model/vision/diffusion/animation.py
+++ b/src/avalan/model/vision/diffusion/animation.py
@@ -1,29 +1,61 @@
 from ....entities import BetaSchedule, EngineSettings, Input, TimestepSpacing
-from ....model.engine import Engine
+from ....model.engine import DiffusionPipeline, Engine, PreTrainedModel
 from ....model.vendor import TextGenerationVendor
 from ....model.vision import BaseVisionModel
 
 from dataclasses import replace
+from importlib import import_module
 from logging import Logger, getLogger
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
-import diffusers.utils as diffusers_utils
 import numpy as np
-from diffusers import (
-    AnimateDiffPipeline,
-    DiffusionPipeline,
-    EulerDiscreteScheduler,
-    MotionAdapter,
-)
-from diffusers.schedulers.scheduling_utils import SchedulerMixin
 from huggingface_hub import hf_hub_download
 from numpy.typing import NDArray
 from PIL import Image
 from safetensors.torch import load_file
 from torch import inference_mode
-from transformers import PreTrainedModel
 
-export_to_gif = cast(Any, diffusers_utils).export_to_gif
+if TYPE_CHECKING:
+    from diffusers.schedulers.scheduling_utils import SchedulerMixin
+else:
+    SchedulerMixin: TypeAlias = Any
+
+
+class _LazyDiffusersClass:
+    __test__ = False
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __call__(self, *args: object, **kwargs: object) -> Any:
+        target = getattr(import_module("diffusers"), self._name)
+        return target(*args, **kwargs)
+
+    def from_config(self, *args: object, **kwargs: object) -> Any:
+        target = getattr(import_module("diffusers"), self._name)
+        return target.from_config(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_is_coroutine" or (
+            name.startswith("__") and name.endswith("__")
+        ):
+            raise AttributeError(name)
+        target = getattr(import_module("diffusers"), self._name)
+        return getattr(target, name)
+
+
+EulerDiscreteScheduler = _LazyDiffusersClass("EulerDiscreteScheduler")
+MotionAdapter = _LazyDiffusersClass("MotionAdapter")
+
+
+def export_to_gif(*args: object, **kwargs: object) -> Any:
+    return getattr(import_module("diffusers.utils"), "export_to_gif")(
+        *args, **kwargs
+    )
+
+
+def _animate_diff_pipeline() -> Any:
+    return getattr(import_module("diffusers"), "AnimateDiffPipeline")
 
 
 class TextToAnimationModel(BaseVisionModel):
@@ -56,7 +88,7 @@ class TextToAnimationModel(BaseVisionModel):
         )
         pipe = cast(
             DiffusionPipeline,
-            cast(Any, AnimateDiffPipeline)
+            cast(Any, _animate_diff_pipeline())
             .from_pretrained(
                 self._settings.base_model_id,
                 feature_extractor=None,

--- a/src/avalan/model/vision/diffusion/image.py
+++ b/src/avalan/model/vision/diffusion/image.py
@@ -4,18 +4,21 @@ from ....entities import (
     VisionColorModel,
     VisionImageFormat,
 )
-from ....model.engine import Engine
+from ....model.engine import DiffusionPipeline, Engine, PreTrainedModel
 from ....model.vendor import TextGenerationVendor
 from ....model.vision import BaseVisionModel
 
 from dataclasses import replace
+from importlib import import_module
 from logging import Logger, getLogger
 from types import MethodType
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from torch import float32, inference_mode
-from transformers import PreTrainedModel
+
+
+def _diffusion_pipeline() -> Any:
+    return getattr(import_module("diffusers"), "DiffusionPipeline")
 
 
 class TextToImageModel(BaseVisionModel):
@@ -37,10 +40,11 @@ class TextToImageModel(BaseVisionModel):
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         dtype = Engine.weight(self._settings.weight_type)
         dtype_variant = self._settings.weight_type
+        pipeline = _diffusion_pipeline()
 
         base = cast(
             DiffusionPipeline,
-            cast(Any, DiffusionPipeline).from_pretrained(
+            cast(Any, pipeline).from_pretrained(
                 self._model_id,
                 torch_dtype=dtype,
                 variant=dtype_variant,
@@ -52,7 +56,7 @@ class TextToImageModel(BaseVisionModel):
 
         refiner = cast(
             DiffusionPipeline,
-            cast(Any, DiffusionPipeline).from_pretrained(
+            cast(Any, pipeline).from_pretrained(
                 self._settings.refiner_model_id,
                 text_encoder_2=cast(Any, base).text_encoder_2,
                 vae=cast(Any, base).vae,

--- a/src/avalan/model/vision/diffusion/video.py
+++ b/src/avalan/model/vision/diffusion/video.py
@@ -1,21 +1,43 @@
 from ....entities import EngineSettings, Input
-from ....model.engine import Engine
+from ....model.engine import DiffusionPipeline, Engine, PreTrainedModel
 from ....model.vendor import TextGenerationVendor
 from ....model.vision import BaseVisionModel
 
 from dataclasses import replace
+from importlib import import_module
 from logging import Logger, getLogger
 from typing import Any, cast
 
-from diffusers import DiffusionPipeline
-from diffusers.pipelines.ltx.pipeline_ltx_condition import LTXVideoCondition
-from diffusers.utils import (  # type: ignore[attr-defined]
-    export_to_video,
-    load_image,
-    load_video,
-)
 from torch import Generator, inference_mode
-from transformers import PreTrainedModel
+
+
+def _diffusion_pipeline() -> Any:
+    return getattr(import_module("diffusers"), "DiffusionPipeline")
+
+
+def _ltx_video_condition() -> Any:
+    return getattr(
+        import_module("diffusers.pipelines.ltx.pipeline_ltx_condition"),
+        "LTXVideoCondition",
+    )
+
+
+def export_to_video(*args: object, **kwargs: object) -> Any:
+    return getattr(import_module("diffusers.utils"), "export_to_video")(
+        *args, **kwargs
+    )
+
+
+def load_image(*args: object, **kwargs: object) -> Any:
+    return getattr(import_module("diffusers.utils"), "load_image")(
+        *args, **kwargs
+    )
+
+
+def load_video(*args: object, **kwargs: object) -> Any:
+    return getattr(import_module("diffusers.utils"), "load_video")(
+        *args, **kwargs
+    )
 
 
 class TextToVideoModel(BaseVisionModel):
@@ -37,20 +59,21 @@ class TextToVideoModel(BaseVisionModel):
     ) -> PreTrainedModel | TextGenerationVendor | DiffusionPipeline:
         assert self._model_id, "A model id is required."
         dtype = Engine.weight(self._settings.weight_type)
+        pipeline = _diffusion_pipeline()
         base_pipe = cast(
             Any,
-            DiffusionPipeline.from_pretrained(
+            pipeline.from_pretrained(
                 self._model_id,
                 torch_dtype=dtype,
-            ),  # type: ignore[no-untyped-call]
+            ),
         ).to(self._device)
         self._upsampler_pipe = cast(
             Any,
-            DiffusionPipeline.from_pretrained(
+            pipeline.from_pretrained(
                 self._settings.upsampler_model_id,
                 vae=base_pipe.vae,
                 torch_dtype=dtype,
-            ),  # type: ignore[no-untyped-call]
+            ),
         ).to(self._device)
         cast(Any, base_pipe.vae).enable_tiling()
         return cast(DiffusionPipeline, base_pipe)
@@ -75,10 +98,11 @@ class TextToVideoModel(BaseVisionModel):
     ) -> str:
         model = cast(Any, self._model)
         upsampler = cast(Any, self._upsampler_pipe)
+        condition_class = _ltx_video_condition()
         ratio = int(getattr(model, "vae_spatial_compression_ratio", 1))
         image = load_image(reference_path)
         video = load_video(export_to_video([image]))
-        condition = LTXVideoCondition(video=video, frame_index=0)
+        condition = condition_class(video=video, frame_index=0)
 
         down_h = int(height * downscale)
         down_w = int(width * downscale)

--- a/src/avalan/model/vision/segmentation.py
+++ b/src/avalan/model/vision/segmentation.py
@@ -1,16 +1,16 @@
-from ...model.engine import Engine
+from ...model.engine import DiffusionPipeline, Engine, PreTrainedModel
+from ...model.lazy import LazyExternal
 from ...model.vendor import TextGenerationVendor
 from ...model.vision import BaseVisionModel
 
 from typing import Any, Literal, cast
 
-from diffusers import DiffusionPipeline
 from PIL import Image
 from torch import inference_mode, unique
-from transformers import (
-    AutoImageProcessor,
-    AutoModelForSemanticSegmentation,
-    PreTrainedModel,
+
+AutoImageProcessor = LazyExternal("transformers", "AutoImageProcessor")
+AutoModelForSemanticSegmentation = LazyExternal(
+    "transformers", "AutoModelForSemanticSegmentation"
 )
 
 

--- a/src/avalan/model/vision/text.py
+++ b/src/avalan/model/vision/text.py
@@ -4,23 +4,49 @@ from ...entities import (
     MessageRole,
 )
 from ...model.engine import Engine
+from ...model.lazy import LazyExternal
 from ...model.transformer import TransformerModel
 from ...model.vision import BaseVisionModel
 
+from importlib import import_module
 from typing import Any, Literal, cast
 
 from PIL import Image
 from torch import Tensor, inference_mode
-from transformers import (
-    AutoImageProcessor,
-    AutoModelForImageTextToText,
-    AutoProcessor,
-    Gemma3ForConditionalGeneration,
-    Qwen2VLForConditionalGeneration,
-)
 from transformers.tokenization_utils_base import BatchEncoding
 
+AutoImageProcessor = LazyExternal("transformers", "AutoImageProcessor")
+AutoModelForImageTextToText = LazyExternal(
+    "transformers", "AutoModelForImageTextToText"
+)
 AutoModelForVision2Seq = AutoModelForImageTextToText
+
+
+class _AutoProcessorProxy:
+    def from_pretrained(self, *args: object, **kwargs: object) -> Any:
+        return _auto_processor().from_pretrained(*args, **kwargs)
+
+
+class _LazyTransformersModelProxy:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def from_pretrained(self, *args: object, **kwargs: object) -> Any:
+        model_class = getattr(import_module("transformers"), self._name)
+        return model_class.from_pretrained(*args, **kwargs)
+
+
+def _auto_processor() -> Any:
+    return getattr(import_module("transformers"), "AutoProcessor")
+
+
+AutoProcessor = _AutoProcessorProxy()
+Gemma3ForConditionalGeneration = _LazyTransformersModelProxy(
+    "Gemma3ForConditionalGeneration"
+)
+Qwen2VLForConditionalGeneration = _LazyTransformersModelProxy(
+    "Qwen2VLForConditionalGeneration"
+)
 
 
 class ImageToTextModel(TransformerModel):

--- a/src/avalan/task/artifact.py
+++ b/src/avalan/task/artifact.py
@@ -493,7 +493,11 @@ def bounded_artifact_reader(
     *,
     max_bytes: int | None,
 ) -> BinaryIO:
-    _assert_optional_size(max_bytes, "max_bytes")
+    try:
+        _assert_optional_size(max_bytes, "max_bytes")
+    except Exception:
+        reader.close()
+        raise
     if max_bytes is None:
         return reader
     return cast(BinaryIO, _BoundedArtifactReader(reader, max_bytes=max_bytes))

--- a/tests/agent/orchestrator_loader_coverage_test.py
+++ b/tests/agent/orchestrator_loader_coverage_test.py
@@ -155,8 +155,9 @@ debug_source = \"{debug_file.name}\"
                     },
                 )
                 bts_patch.assert_called_once()
-                self.assertEqual(
-                    bts_patch.call_args.kwargs["debug_source"].name,
-                    debug_file.name,
-                )
+                debug_source = bts_patch.call_args.kwargs["debug_source"]
+                try:
+                    self.assertEqual(debug_source.name, debug_file.name)
+                finally:
+                    debug_source.close()
             await stack.aclose()

--- a/tests/model/audio/audio_generation_test.py
+++ b/tests/model/audio/audio_generation_test.py
@@ -7,9 +7,8 @@ from transformers import PreTrainedModel
 
 from avalan.entities import EngineSettings
 from avalan.model.audio.generation import (
+    MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED,
     AudioGenerationModel,
-    AutoProcessor,
-    MusicgenForConditionalGeneration,
 )
 from avalan.model.engine import Engine
 
@@ -19,24 +18,33 @@ class AudioGenerationModelInstantiationTestCase(TestCase):
 
     def test_instantiation_no_load(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
+        musicgen = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
             patch.object(
-                MusicgenForConditionalGeneration, "from_pretrained"
-            ) as model_mock,
+                AudioGenerationModel,
+                "_load_model",
+            ) as load_model_mock,
+            patch(
+                "avalan.model.audio.generation._auto_processor",
+                return_value=processor,
+            ) as processor_helper_mock,
+            patch(
+                "avalan.model.audio.generation._musicgen_for_conditional_generation",
+                return_value=musicgen,
+            ) as model_helper_mock,
         ):
             settings = EngineSettings(auto_load_model=False)
             model = AudioGenerationModel(
                 self.model_id, settings, logger=logger_mock
             )
             self.assertIsInstance(model, AudioGenerationModel)
-            processor_mock.assert_not_called()
-            model_mock.assert_not_called()
+            load_model_mock.assert_not_called()
+            processor_helper_mock.assert_not_called()
+            model_helper_mock.assert_not_called()
 
     def test_ignores_non_persistent_position_embedding_load_report_key(self):
-        patterns = (
-            MusicgenForConditionalGeneration._keys_to_ignore_on_load_unexpected
-        )
+        patterns = MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED
         self.assertIn(
             r"decoder\.model\.decoder\.embed_positions\.weights",
             patterns,
@@ -48,12 +56,20 @@ class AudioGenerationModelInstantiationTestCase(TestCase):
 
     def test_instantiation_with_load_model(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
+        musicgen = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
-            patch.object(
-                MusicgenForConditionalGeneration, "from_pretrained"
-            ) as model_mock,
+            patch(
+                "avalan.model.audio.generation._auto_processor",
+                return_value=processor,
+            ),
+            patch(
+                "avalan.model.audio.generation._musicgen_for_conditional_generation",
+                return_value=musicgen,
+            ),
         ):
+            processor_mock = processor.from_pretrained
+            model_mock = musicgen.from_pretrained
             processor_instance = MagicMock()
             processor_mock.return_value = processor_instance
 
@@ -81,11 +97,17 @@ class AudioGenerationModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
+        musicgen = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
-            patch.object(
-                MusicgenForConditionalGeneration, "from_pretrained"
-            ) as model_mock,
+            patch(
+                "avalan.model.audio.generation._auto_processor",
+                return_value=processor,
+            ),
+            patch(
+                "avalan.model.audio.generation._musicgen_for_conditional_generation",
+                return_value=musicgen,
+            ),
             patch(
                 "avalan.model.audio.generation.inference_mode",
                 return_value=nullcontext(),
@@ -95,6 +117,8 @@ class AudioGenerationModelCallTestCase(IsolatedAsyncioTestCase):
             ) as from_numpy_mock,
             patch("avalan.model.audio.generation.save") as save_mock,
         ):
+            processor_mock = processor.from_pretrained
+            model_mock = musicgen.from_pretrained
 
             class Dummy(dict):
                 def __init__(self, *args, **kwargs):

--- a/tests/model/audio/audio_generation_test.py
+++ b/tests/model/audio/audio_generation_test.py
@@ -1,11 +1,13 @@
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, patch
 
 from transformers import PreTrainedModel
 
 from avalan.entities import EngineSettings
+from avalan.model.audio import generation as audio_generation
 from avalan.model.audio.generation import (
     MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED,
     AudioGenerationModel,
@@ -52,6 +54,32 @@ class AudioGenerationModelInstantiationTestCase(TestCase):
         self.assertRegex(
             "decoder.model.decoder.embed_positions.weights",
             patterns[0],
+        )
+
+    def test_lazy_transformers_helpers_import_targets(self):
+        processor = object()
+
+        class MusicgenForConditionalGeneration:
+            pass
+
+        module = SimpleNamespace(
+            AutoProcessor=processor,
+            MusicgenForConditionalGeneration=MusicgenForConditionalGeneration,
+        )
+
+        with patch(
+            "avalan.model.audio.generation.import_module",
+            return_value=module,
+        ):
+            self.assertIs(audio_generation._auto_processor(), processor)
+            self.assertIs(
+                audio_generation._musicgen_for_conditional_generation(),
+                MusicgenForConditionalGeneration,
+            )
+
+        self.assertEqual(
+            MusicgenForConditionalGeneration._keys_to_ignore_on_load_unexpected,
+            MUSICGEN_KEYS_TO_IGNORE_ON_LOAD_UNEXPECTED,
         )
 
     def test_instantiation_with_load_model(self):

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -8,7 +8,6 @@ from transformers import PreTrainedModel
 from avalan.entities import EngineSettings
 from avalan.model.audio.speech_recognition import (
     AutoModelForCTC,
-    AutoProcessor,
     SpeechRecognitionModel,
 )
 from avalan.model.engine import Engine
@@ -19,8 +18,12 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
 
     def test_instantiation_no_load(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch(
+                "avalan.model.audio.speech_recognition._auto_processor",
+                return_value=processor,
+            ) as processor_helper_mock,
             patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
         ):
             settings = EngineSettings(auto_load_model=False)
@@ -30,15 +33,20 @@ class SpeechRecognitionModelInstantiationTestCase(TestCase):
                 logger=logger_mock,
             )
             self.assertIsInstance(model, SpeechRecognitionModel)
-            processor_mock.assert_not_called()
+            processor_helper_mock.assert_not_called()
             model_mock.assert_not_called()
 
     def test_instantiation_with_load_model(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch(
+                "avalan.model.audio.speech_recognition._auto_processor",
+                return_value=processor,
+            ),
             patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
         ):
+            processor_mock = processor.from_pretrained
             processor_instance = MagicMock()
             type(processor_instance.tokenizer).pad_token_id = PropertyMock(
                 return_value=1
@@ -79,8 +87,12 @@ class SpeechRecognitionModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call_with_resampling(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch(
+                "avalan.model.audio.speech_recognition._auto_processor",
+                return_value=processor,
+            ),
             patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
             patch.object(
                 SpeechRecognitionModel, "_resample"
@@ -93,6 +105,7 @@ class SpeechRecognitionModelCallTestCase(IsolatedAsyncioTestCase):
                 return_value=nullcontext(),
             ) as inference_mode_mock,
         ):
+            processor_mock = processor.from_pretrained
             processor_instance = MagicMock()
             processor_call = MagicMock(input_values="inputs")
             processor_call.to.return_value = processor_call
@@ -143,8 +156,12 @@ class SpeechRecognitionNoResampleTestCase(IsolatedAsyncioTestCase):
 
     async def test_call_without_resampling(self):
         logger_mock = MagicMock(spec=Logger)
+        processor = MagicMock()
         with (
-            patch.object(AutoProcessor, "from_pretrained") as processor_mock,
+            patch(
+                "avalan.model.audio.speech_recognition._auto_processor",
+                return_value=processor,
+            ),
             patch.object(AutoModelForCTC, "from_pretrained") as model_mock,
             patch.object(
                 SpeechRecognitionModel, "_resample"
@@ -157,6 +174,7 @@ class SpeechRecognitionNoResampleTestCase(IsolatedAsyncioTestCase):
                 return_value=nullcontext(),
             ) as inf_mock,
         ):
+            processor_mock = processor.from_pretrained
             processor_instance = MagicMock()
             processor_call = MagicMock(input_values="inputs")
             processor_call.to.return_value = processor_call

--- a/tests/model/audio/speech_recognition_test.py
+++ b/tests/model/audio/speech_recognition_test.py
@@ -1,11 +1,13 @@
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import PreTrainedModel
 
 from avalan.entities import EngineSettings
+from avalan.model.audio import speech_recognition as speech_recognition_module
 from avalan.model.audio.speech_recognition import (
     AutoModelForCTC,
     SpeechRecognitionModel,
@@ -15,6 +17,18 @@ from avalan.model.engine import Engine
 
 class SpeechRecognitionModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
+
+    def test_lazy_transformers_helper_imports_target(self):
+        processor = object()
+        module = SimpleNamespace(AutoProcessor=processor)
+
+        with patch(
+            "avalan.model.audio.speech_recognition.import_module",
+            return_value=module,
+        ):
+            self.assertIs(
+                speech_recognition_module._auto_processor(), processor
+            )
 
     def test_instantiation_no_load(self):
         logger_mock = MagicMock(spec=Logger)

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -8,10 +8,8 @@ from transformers import PreTrainedModel
 from avalan.entities import EngineSettings
 from avalan.model.audio.speech import (
     AutoFeatureExtractor,
-    AutoTokenizer,
     DiaConfig,
     DiaForConditionalGeneration,
-    DiaProcessor,
     TextToSpeechModel,
 )
 from avalan.model.engine import Engine
@@ -157,8 +155,10 @@ class TextToSpeechModelInstantiationTestCase(TestCase):
         logger_mock = MagicMock(spec=Logger)
         config = MagicMock(spec=DiaConfig)
         feature_extractor = MagicMock()
-        processor = MagicMock(spec=DiaProcessor)
+        processor = MagicMock()
         tokenizer = MagicMock()
+        dia_processor = MagicMock()
+        auto_tokenizer = MagicMock()
         settings = EngineSettings(
             access_token="token",
             auto_load_model=False,
@@ -178,27 +178,30 @@ class TextToSpeechModelInstantiationTestCase(TestCase):
         }
 
         with (
-            patch.object(
-                DiaProcessor,
-                "get_processor_dict",
-                return_value=(processor_dict, {"unused": "ok"}),
-            ) as get_processor_dict_mock,
+            patch(
+                "avalan.model.audio.speech._dia_processor",
+                return_value=dia_processor,
+            ),
+            patch(
+                "avalan.model.audio.speech._auto_tokenizer",
+                return_value=auto_tokenizer,
+            ),
             patch.object(
                 AutoFeatureExtractor,
                 "from_pretrained",
                 return_value=feature_extractor,
             ) as feature_extractor_mock,
-            patch.object(
-                AutoTokenizer,
-                "from_pretrained",
-                return_value=tokenizer,
-            ) as tokenizer_mock,
-            patch.object(
-                DiaProcessor,
-                "from_args_and_dict",
-                return_value=processor,
-            ) as from_args_mock,
         ):
+            get_processor_dict_mock = dia_processor.get_processor_dict
+            get_processor_dict_mock.return_value = (
+                processor_dict,
+                {"unused": "ok"},
+            )
+            tokenizer_mock = auto_tokenizer.from_pretrained
+            tokenizer_mock.return_value = tokenizer
+            from_args_mock = dia_processor.from_args_and_dict
+            from_args_mock.return_value = processor
+
             result = model._load_processor(config)
 
         self.assertIs(result, processor)

--- a/tests/model/audio/text_to_speech_test.py
+++ b/tests/model/audio/text_to_speech_test.py
@@ -1,11 +1,13 @@
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, patch
 
 from transformers import PreTrainedModel
 
 from avalan.entities import EngineSettings
+from avalan.model.audio import speech as speech_module
 from avalan.model.audio.speech import (
     AutoFeatureExtractor,
     DiaConfig,
@@ -17,6 +19,21 @@ from avalan.model.engine import Engine
 
 class TextToSpeechModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
+
+    def test_lazy_transformers_helpers_import_targets(self):
+        tokenizer = object()
+        processor = object()
+        module = SimpleNamespace(
+            AutoTokenizer=tokenizer,
+            DiaProcessor=processor,
+        )
+
+        with patch(
+            "avalan.model.audio.speech.import_module",
+            return_value=module,
+        ):
+            self.assertIs(speech_module._auto_tokenizer(), tokenizer)
+            self.assertIs(speech_module._dia_processor(), processor)
 
     def test_instantiation_no_load(self):
         logger_mock = MagicMock(spec=Logger)

--- a/tests/model/engine_more_coverage_test.py
+++ b/tests/model/engine_more_coverage_test.py
@@ -100,20 +100,19 @@ class WeightAndDeviceTestCase(TestCase):
                 engine_module._optional_type("missing_module", "Missing")
             )
 
-        class Imported:
-            pass
-
-        imported_module = types.SimpleNamespace(Imported=Imported)
         with (
             patch.object(engine_module, "modules", {}),
             patch.object(engine_module, "find_spec", return_value=object()),
             patch.object(
-                engine_module, "import_module", return_value=imported_module
+                engine_module,
+                "import_module",
+                side_effect=AssertionError(
+                    "optional type should not import unloaded modules"
+                ),
             ),
         ):
-            self.assertIs(
+            self.assertIsNone(
                 engine_module._optional_type("imported_module", "Imported"),
-                Imported,
             )
 
     def test_pretrained_model_type_uses_loaded_global(self) -> None:

--- a/tests/model/engine_test.py
+++ b/tests/model/engine_test.py
@@ -382,11 +382,16 @@ class EngineLoadTestCase(TestCase):
                 self.accepted_model = model
                 return model is self.fake_model
 
-        engine = NativeEngine()
+        with patch(
+            "avalan.model.engine._diffusion_pipeline_type",
+            side_effect=AssertionError("diffusers should not be imported"),
+        ) as diffusion_type_mock:
+            engine = NativeEngine()
 
         self.assertIs(engine.model, engine.fake_model)
         self.assertIs(engine.accepted_model, engine.fake_model)
         self.assertTrue(engine._loaded_model)
+        diffusion_type_mock.assert_not_called()
 
     def test_unknown_native_model_is_rejected_when_hook_returns_false(self):
         class NativeEngine(Engine):

--- a/tests/model/lazy_test.py
+++ b/tests/model/lazy_test.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest import TestCase, main
+from unittest.mock import patch
+
+from avalan.model.lazy import LazyExternal
+
+
+class _Target:
+    marker = "attribute"
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return ("call", args, kwargs)
+
+    def for_model(self, *args: object, **kwargs: object) -> object:
+        return ("for_model", args, kwargs)
+
+    def from_config(self, *args: object, **kwargs: object) -> object:
+        return ("from_config", args, kwargs)
+
+    def from_pretrained(self, *args: object, **kwargs: object) -> object:
+        return ("from_pretrained", args, kwargs)
+
+    def get_config_dict(self, *args: object, **kwargs: object) -> object:
+        return ("get_config_dict", args, kwargs)
+
+
+class LazyExternalTestCase(TestCase):
+    def test_forwards_supported_operations_to_imported_target(self) -> None:
+        target = _Target()
+        module = SimpleNamespace(Target=target)
+
+        with patch("avalan.model.lazy.import_module", return_value=module):
+            lazy = LazyExternal("external.module", "Target")
+
+            self.assertEqual(
+                lazy(1, named=True),
+                ("call", (1,), {"named": True}),
+            )
+            self.assertEqual(
+                lazy.for_model("id"),
+                ("for_model", ("id",), {}),
+            )
+            self.assertEqual(
+                lazy.from_config("cfg"),
+                ("from_config", ("cfg",), {}),
+            )
+            self.assertEqual(
+                lazy.from_pretrained("model"),
+                ("from_pretrained", ("model",), {}),
+            )
+            self.assertEqual(
+                lazy.get_config_dict("model"),
+                ("get_config_dict", ("model",), {}),
+            )
+            self.assertEqual(lazy.marker, "attribute")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/model/nlp/sequence_test.py
+++ b/tests/model/nlp/sequence_test.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
     AutoModelForSequenceClassification,
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
@@ -13,6 +12,7 @@ from transformers import (
 from avalan.entities import TransformerEngineSettings
 from avalan.model.engine import Engine
 from avalan.model.nlp.sequence import SequenceClassificationModel
+from avalan.model.transformer import AutoTokenizer
 
 
 class SequenceClassificationModelInstantiationTestCase(TestCase):

--- a/tests/model/nlp/sequence_to_sequence_model_test.py
+++ b/tests/model/nlp/sequence_to_sequence_model_test.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
     AutoModelForSeq2SeqLM,
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
@@ -12,6 +11,7 @@ from transformers import (
 from avalan.entities import GenerationSettings, TransformerEngineSettings
 from avalan.model.engine import Engine
 from avalan.model.nlp.sequence import SequenceToSequenceModel
+from avalan.model.transformer import AutoTokenizer
 
 
 class SequenceToSequenceModelInstantiationTestCase(TestCase):

--- a/tests/model/nlp/vllm_test.py
+++ b/tests/model/nlp/vllm_test.py
@@ -3,13 +3,13 @@ from unittest import TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
 
 from avalan.entities import TransformerEngineSettings
 from avalan.model.nlp.text.vllm import VllmModel
+from avalan.model.transformer import AutoTokenizer
 
 
 class VllmModelTestCase(TestCase):

--- a/tests/model/transformer_extra_test.py
+++ b/tests/model/transformer_extra_test.py
@@ -1,5 +1,6 @@
 import sys
 from logging import Logger
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,27 @@ class TransformerModelPropertyTestCase(TestCase):
         self.assertFalse(getattr(AutoTokenizer, "__test__", False))
         self.assertNotIn(
             "transformers.models.auto.tokenization_auto", sys.modules
+        )
+
+    def test_lazy_auto_tokenizer_forwards_to_imported_target(self) -> None:
+        target = MagicMock()
+        target.model_input_names = ["input_ids"]
+        tokenizer = object()
+        target.from_pretrained.return_value = tokenizer
+        module = SimpleNamespace(AutoTokenizer=target)
+
+        with patch(
+            "avalan.model.transformer.import_module",
+            return_value=module,
+        ):
+            self.assertIs(
+                AutoTokenizer.from_pretrained("tokenizer", use_fast=True),
+                tokenizer,
+            )
+            self.assertEqual(AutoTokenizer.model_input_names, ["input_ids"])
+
+        target.from_pretrained.assert_called_once_with(
+            "tokenizer", use_fast=True
         )
 
     def test_properties_and_tokenize(self) -> None:

--- a/tests/model/transformer_extra_test.py
+++ b/tests/model/transformer_extra_test.py
@@ -1,3 +1,4 @@
+import sys
 from logging import Logger
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,14 @@ class DummyTransformerModel(TransformerModel):
 
 
 class TransformerModelPropertyTestCase(TestCase):
+    def test_lazy_auto_tokenizer_ignores_pytest_introspection(self) -> None:
+        sys.modules.pop("transformers.models.auto.tokenization_auto", None)
+
+        self.assertFalse(getattr(AutoTokenizer, "__test__", False))
+        self.assertNotIn(
+            "transformers.models.auto.tokenization_auto", sys.modules
+        )
+
     def test_properties_and_tokenize(self) -> None:
         model = DummyTransformerModel(
             "id",

--- a/tests/model/vision/animation_test.py
+++ b/tests/model/vision/animation_test.py
@@ -1,6 +1,7 @@
 import itertools
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, call, patch
 
@@ -14,6 +15,7 @@ from avalan.entities import (
 )
 from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToAnimationModel
+from avalan.model.vision.diffusion import animation as animation_module
 
 
 class DummyDiffusionPipeline:
@@ -23,6 +25,59 @@ class DummyDiffusionPipeline:
 
 class TextToAnimationModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
+
+    def test_lazy_diffusers_helpers_import_targets(self) -> None:
+        class MotionAdapter:
+            marker = "motion"
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                self.args = args
+                self.kwargs = kwargs
+
+        class EulerDiscreteScheduler:
+            marker = "scheduler"
+
+            @classmethod
+            def from_config(cls, *args: object, **kwargs: object) -> object:
+                return ("scheduler", args, kwargs)
+
+        def export_to_gif(*args: object, **kwargs: object) -> object:
+            return ("gif", args, kwargs)
+
+        pipeline = object()
+        modules = {
+            "diffusers": SimpleNamespace(
+                AnimateDiffPipeline=pipeline,
+                EulerDiscreteScheduler=EulerDiscreteScheduler,
+                MotionAdapter=MotionAdapter,
+            ),
+            "diffusers.utils": SimpleNamespace(export_to_gif=export_to_gif),
+        }
+
+        with patch(
+            "avalan.model.vision.diffusion.animation.import_module",
+            side_effect=modules.__getitem__,
+        ):
+            adapter = animation_module.MotionAdapter("repo", dtype="float16")
+            self.assertIsInstance(adapter, MotionAdapter)
+            self.assertEqual(adapter.args, ("repo",))
+            self.assertEqual(adapter.kwargs, {"dtype": "float16"})
+            self.assertEqual(
+                animation_module.EulerDiscreteScheduler.from_config(
+                    "cfg", beta_schedule="scaled_linear"
+                ),
+                (
+                    "scheduler",
+                    ("cfg",),
+                    {"beta_schedule": "scaled_linear"},
+                ),
+            )
+            self.assertEqual(animation_module.MotionAdapter.marker, "motion")
+            self.assertEqual(
+                animation_module.export_to_gif(["frame"], "out.gif"),
+                ("gif", (["frame"], "out.gif"), {}),
+            )
+            self.assertIs(animation_module._animate_diff_pipeline(), pipeline)
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)

--- a/tests/model/vision/animation_test.py
+++ b/tests/model/vision/animation_test.py
@@ -5,7 +5,6 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, call, patch
 
 import numpy as np
-from diffusers import AnimateDiffPipeline, DiffusionPipeline
 from PIL import Image
 
 from avalan.entities import (
@@ -17,15 +16,25 @@ from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToAnimationModel
 
 
+class DummyDiffusionPipeline:
+    def to(self, *args: object, **kwargs: object) -> object:
+        return self
+
+
 class TextToAnimationModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        animate_pipeline = MagicMock()
         with (
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch("avalan.model.engine.find_spec", return_value=None),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch(
                 "avalan.model.vision.diffusion.animation.MotionAdapter"
             ) as adapter_cls,
@@ -37,13 +46,17 @@ class TextToAnimationModelInstantiationTestCase(TestCase):
                 "avalan.model.vision.diffusion.animation.load_file",
                 return_value={"sd": 1},
             ) as load_mock,
-            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+            patch(
+                "avalan.model.vision.diffusion.animation._animate_diff_pipeline",
+                return_value=animate_pipeline,
+            ),
         ):
+            pipe_mock = animate_pipeline.from_pretrained
             adapter_instance = MagicMock()
             adapter_instance.to.return_value = adapter_instance
             adapter_cls.return_value = adapter_instance
 
-            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance = MagicMock(spec=DummyDiffusionPipeline)
             pipe_instance.to.return_value = pipe_instance
             pipe_mock.return_value = pipe_instance
 
@@ -76,10 +89,15 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call_all_parameter_combinations(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        animate_pipeline = MagicMock()
         with (
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch("avalan.model.engine.find_spec", return_value=None),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch(
                 "avalan.model.vision.diffusion.animation.MotionAdapter"
             ) as adapter_cls,
@@ -91,7 +109,10 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
                 "avalan.model.vision.diffusion.animation.load_file",
                 return_value={},
             ),
-            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+            patch(
+                "avalan.model.vision.diffusion.animation._animate_diff_pipeline",
+                return_value=animate_pipeline,
+            ),
             patch(
                 "avalan.model.vision.diffusion.animation.EulerDiscreteScheduler.from_config"
             ) as scheduler_mock,
@@ -103,11 +124,12 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
                 return_value=nullcontext(),
             ),
         ):
+            pipe_mock = animate_pipeline.from_pretrained
             adapter_instance = MagicMock()
             adapter_instance.to.return_value = adapter_instance
             adapter_cls.return_value = adapter_instance
 
-            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance = MagicMock(spec=DummyDiffusionPipeline)
             pipe_instance.to.return_value = pipe_instance
             pipe_instance.scheduler = MagicMock(config="cfg")
             output = MagicMock()
@@ -171,10 +193,15 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call_invalid_steps(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        animate_pipeline = MagicMock()
         with (
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch("avalan.model.engine.find_spec", return_value=None),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch(
                 "avalan.model.vision.diffusion.animation.MotionAdapter"
             ) as adapter_cls,
@@ -186,12 +213,16 @@ class TextToAnimationModelCallTestCase(IsolatedAsyncioTestCase):
                 "avalan.model.vision.diffusion.animation.load_file",
                 return_value={},
             ),
-            patch.object(AnimateDiffPipeline, "from_pretrained") as pipe_mock,
+            patch(
+                "avalan.model.vision.diffusion.animation._animate_diff_pipeline",
+                return_value=animate_pipeline,
+            ),
         ):
+            pipe_mock = animate_pipeline.from_pretrained
             adapter_instance = MagicMock()
             adapter_instance.to.return_value = adapter_instance
             adapter_cls.return_value = adapter_instance
-            pipe_instance = MagicMock(spec=DiffusionPipeline)
+            pipe_instance = MagicMock(spec=DummyDiffusionPipeline)
             pipe_instance.to.return_value = pipe_instance
             pipe_mock.return_value = pipe_instance
 
@@ -217,7 +248,7 @@ class TextToAnimationModelFrameConversionTestCase(TestCase):
         self.assertEqual(images[0].mode, "RGB")
         self.assertEqual(images[0].size, (2, 1))
         self.assertEqual(
-            list(images[0].getdata()),
+            [images[0].getpixel((0, 0)), images[0].getpixel((1, 0))],
             [(0, 255, 0), (255, 102, 0)],
         )
 
@@ -229,7 +260,10 @@ class TextToAnimationModelFrameConversionTestCase(TestCase):
         self.assertEqual(len(images), 1)
         self.assertEqual(images[0].mode, "L")
         self.assertEqual(images[0].size, (2, 1))
-        self.assertEqual(list(images[0].getdata()), [128, 255])
+        self.assertEqual(
+            [images[0].getpixel((0, 0)), images[0].getpixel((1, 0))],
+            [128, 255],
+        )
 
     def test_frames_to_images_requires_frame_batches(self) -> None:
         with self.assertRaises(AssertionError):
@@ -244,10 +278,14 @@ class TextToAnimationModelBaseMethodsTestCase(TestCase):
         with (
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch("avalan.model.engine.find_spec", return_value=None),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(
                 TextToAnimationModel,
                 "_load_model",
-                return_value=MagicMock(spec=DiffusionPipeline),
+                return_value=MagicMock(spec=DummyDiffusionPipeline),
             ),
         ):
             model = TextToAnimationModel("id", settings)
@@ -263,10 +301,14 @@ class TextToAnimationModelBaseMethodsTestCase(TestCase):
         with (
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch("avalan.model.engine.find_spec", return_value=None),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(
                 TextToAnimationModel,
                 "_load_model",
-                return_value=MagicMock(spec=DiffusionPipeline),
+                return_value=MagicMock(spec=DummyDiffusionPipeline),
             ),
         ):
             model = TextToAnimationModel("id", settings)

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -1,5 +1,6 @@
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, call, patch
 
@@ -12,6 +13,7 @@ from avalan.entities import (
 )
 from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToImageModel
+from avalan.model.vision.diffusion import image as diffusion_image
 
 
 class DummyDiffusionPipeline:
@@ -22,6 +24,16 @@ class DummyDiffusionPipeline:
 class TextToImageModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
     refiner_id = "refiner/model"
+
+    def test_lazy_diffusers_helper_imports_pipeline(self) -> None:
+        pipeline = object()
+        module = SimpleNamespace(DiffusionPipeline=pipeline)
+
+        with patch(
+            "avalan.model.vision.diffusion.image.import_module",
+            return_value=module,
+        ):
+            self.assertIs(diffusion_image._diffusion_pipeline(), pipeline)
 
     def test_missing_refiner(self) -> None:
         with self.assertRaises(AssertionError):

--- a/tests/model/vision/diffusion_test.py
+++ b/tests/model/vision/diffusion_test.py
@@ -3,7 +3,6 @@ from logging import Logger
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, call, patch
 
-from diffusers import DiffusionPipeline
 from torch import float32
 
 from avalan.entities import (
@@ -13,6 +12,11 @@ from avalan.entities import (
 )
 from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToImageModel
+
+
+class DummyDiffusionPipeline:
+    def to(self, *args: object, **kwargs: object) -> object:
+        return self
 
 
 class TextToImageModelInstantiationTestCase(TestCase):
@@ -25,17 +29,24 @@ class TextToImageModelInstantiationTestCase(TestCase):
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        pipeline = MagicMock()
         with (
-            patch.object(
-                DiffusionPipeline, "from_pretrained"
-            ) as pipeline_mock,
+            patch(
+                "avalan.model.vision.diffusion.image._diffusion_pipeline",
+                return_value=pipeline,
+            ),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
         ):
-            base_instance = MagicMock(spec=DiffusionPipeline)
+            pipeline_mock = pipeline.from_pretrained
+            base_instance = MagicMock(spec=DummyDiffusionPipeline)
             base_instance.text_encoder_2 = "te2"
             base_instance.vae = MagicMock()
-            refiner_instance = MagicMock(spec=DiffusionPipeline)
+            refiner_instance = MagicMock(spec=DummyDiffusionPipeline)
             refiner_instance.vae = base_instance.vae
             pipeline_mock.side_effect = [base_instance, refiner_instance]
 
@@ -87,10 +98,16 @@ class TextToImageModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        pipeline = MagicMock()
         with (
-            patch.object(
-                DiffusionPipeline, "from_pretrained"
-            ) as pipeline_mock,
+            patch(
+                "avalan.model.vision.diffusion.image._diffusion_pipeline",
+                return_value=pipeline,
+            ),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
@@ -98,12 +115,13 @@ class TextToImageModelCallTestCase(IsolatedAsyncioTestCase):
                 return_value=nullcontext(),
             ) as inf_mock,
         ):
-            base_instance = MagicMock(spec=DiffusionPipeline)
+            pipeline_mock = pipeline.from_pretrained
+            base_instance = MagicMock(spec=DummyDiffusionPipeline)
             base_instance.text_encoder_2 = "te2"
             base_instance.vae = "vae"
             base_instance.return_value = MagicMock(images="latent")
             refiner_image = MagicMock()
-            refiner_instance = MagicMock(spec=DiffusionPipeline)
+            refiner_instance = MagicMock(spec=DummyDiffusionPipeline)
             refiner_instance.return_value = MagicMock(images=[refiner_image])
             pipeline_mock.side_effect = [base_instance, refiner_instance]
 

--- a/tests/model/vision/image_test.py
+++ b/tests/model/vision/image_test.py
@@ -3,13 +3,13 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
 
 from avalan.entities import TransformerEngineSettings
 from avalan.model.engine import Engine
+from avalan.model.transformer import AutoTokenizer
 from avalan.model.vision.text import (
     AutoImageProcessor,
     AutoModelForVision2Seq,

--- a/tests/model/vision/image_text_to_text_model_test.py
+++ b/tests/model/vision/image_text_to_text_model_test.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from PIL import Image
 from transformers import (
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
@@ -15,6 +14,7 @@ from avalan.entities import (
     TransformerEngineSettings,
 )
 from avalan.model.engine import Engine
+from avalan.model.transformer import AutoTokenizer
 from avalan.model.vision import BaseVisionModel
 from avalan.model.vision.text import (
     AutoModelForImageTextToText,

--- a/tests/model/vision/image_text_to_text_model_test.py
+++ b/tests/model/vision/image_text_to_text_model_test.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -16,6 +17,7 @@ from avalan.entities import (
 from avalan.model.engine import Engine
 from avalan.model.transformer import AutoTokenizer
 from avalan.model.vision import BaseVisionModel
+from avalan.model.vision import text as vision_text
 from avalan.model.vision.text import (
     AutoModelForImageTextToText,
     AutoProcessor,
@@ -43,6 +45,31 @@ class PTMWithGenerate(PreTrainedModel):
 
 class ImageTextToTextModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
+
+    def test_lazy_transformers_proxies_import_targets(self):
+        processor = MagicMock()
+        model = MagicMock()
+        module = SimpleNamespace(
+            AutoProcessor=processor,
+            Gemma3ForConditionalGeneration=model,
+        )
+
+        with patch(
+            "avalan.model.vision.text.import_module",
+            return_value=module,
+        ):
+            self.assertIs(vision_text._auto_processor(), processor)
+            self.assertIs(
+                AutoProcessor.from_pretrained("processor"),
+                processor.from_pretrained.return_value,
+            )
+            self.assertIs(
+                Gemma3ForConditionalGeneration.from_pretrained("model"),
+                model.from_pretrained.return_value,
+            )
+
+        processor.from_pretrained.assert_called_once_with("processor")
+        model.from_pretrained.assert_called_once_with("model")
 
     def test_instantiation_with_load_model(self):
         logger_mock = MagicMock(spec=Logger)

--- a/tests/model/vision/image_to_text_model_test.py
+++ b/tests/model/vision/image_to_text_model_test.py
@@ -4,7 +4,6 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
@@ -15,6 +14,7 @@ from avalan.entities import (
     TransformerEngineSettings,
 )
 from avalan.model.engine import Engine
+from avalan.model.transformer import AutoTokenizer
 from avalan.model.vision import BaseVisionModel
 from avalan.model.vision.text import (
     AutoImageProcessor,

--- a/tests/model/vision/video_test.py
+++ b/tests/model/vision/video_test.py
@@ -1,11 +1,13 @@
 from contextlib import nullcontext
 from logging import Logger
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import ANY, MagicMock, call, patch
 
 from avalan.entities import EngineSettings
 from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToVideoModel
+from avalan.model.vision.diffusion import video as diffusion_video
 
 
 class DummyDiffusionPipeline:
@@ -16,6 +18,50 @@ class DummyDiffusionPipeline:
 class TextToVideoModelInstantiationTestCase(TestCase):
     model_id = "dummy/model"
     upsampler_id = "up/model"
+
+    def test_lazy_diffusers_helpers_import_targets(self) -> None:
+        pipeline = object()
+        condition = object()
+
+        def export_to_video(*args: object, **kwargs: object) -> object:
+            return ("export", args, kwargs)
+
+        def load_image(*args: object, **kwargs: object) -> object:
+            return ("image", args, kwargs)
+
+        def load_video(*args: object, **kwargs: object) -> object:
+            return ("video", args, kwargs)
+
+        modules = {
+            "diffusers": SimpleNamespace(DiffusionPipeline=pipeline),
+            "diffusers.pipelines.ltx.pipeline_ltx_condition": SimpleNamespace(
+                LTXVideoCondition=condition
+            ),
+            "diffusers.utils": SimpleNamespace(
+                export_to_video=export_to_video,
+                load_image=load_image,
+                load_video=load_video,
+            ),
+        }
+
+        with patch(
+            "avalan.model.vision.diffusion.video.import_module",
+            side_effect=modules.__getitem__,
+        ):
+            self.assertIs(diffusion_video._diffusion_pipeline(), pipeline)
+            self.assertIs(diffusion_video._ltx_video_condition(), condition)
+            self.assertEqual(
+                diffusion_video.export_to_video("frame", fps=12),
+                ("export", ("frame",), {"fps": 12}),
+            )
+            self.assertEqual(
+                diffusion_video.load_image("image.png"),
+                ("image", ("image.png",), {}),
+            )
+            self.assertEqual(
+                diffusion_video.load_video("video.mp4"),
+                ("video", ("video.mp4",), {}),
+            )
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)

--- a/tests/model/vision/video_test.py
+++ b/tests/model/vision/video_test.py
@@ -3,11 +3,14 @@ from logging import Logger
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import ANY, MagicMock, call, patch
 
-from diffusers import DiffusionPipeline
-
 from avalan.entities import EngineSettings
 from avalan.model.engine import Engine
 from avalan.model.vision.diffusion import TextToVideoModel
+
+
+class DummyDiffusionPipeline:
+    def to(self, *args: object, **kwargs: object) -> object:
+        return self
 
 
 class TextToVideoModelInstantiationTestCase(TestCase):
@@ -16,18 +19,25 @@ class TextToVideoModelInstantiationTestCase(TestCase):
 
     def test_instantiation_with_load_model(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        pipeline = MagicMock()
         with (
-            patch.object(
-                DiffusionPipeline, "from_pretrained"
-            ) as pipeline_mock,
+            patch(
+                "avalan.model.vision.diffusion.video._diffusion_pipeline",
+                return_value=pipeline,
+            ),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
         ):
-            base_instance = MagicMock(spec=DiffusionPipeline)
+            pipeline_mock = pipeline.from_pretrained
+            base_instance = MagicMock(spec=DummyDiffusionPipeline)
             base_instance.to.return_value = base_instance
             base_instance.vae = MagicMock()
             base_instance.vae.enable_tiling = MagicMock()
-            upsampler_instance = MagicMock(spec=DiffusionPipeline)
+            upsampler_instance = MagicMock(spec=DummyDiffusionPipeline)
             upsampler_instance.to.return_value = upsampler_instance
             pipeline_mock.side_effect = [base_instance, upsampler_instance]
 
@@ -58,10 +68,16 @@ class TextToVideoModelCallTestCase(IsolatedAsyncioTestCase):
 
     async def test_call(self) -> None:
         logger_mock = MagicMock(spec=Logger)
+        pipeline = MagicMock()
         with (
-            patch.object(
-                DiffusionPipeline, "from_pretrained"
-            ) as pipeline_mock,
+            patch(
+                "avalan.model.vision.diffusion.video._diffusion_pipeline",
+                return_value=pipeline,
+            ),
+            patch(
+                "avalan.model.engine.DiffusionPipeline",
+                DummyDiffusionPipeline,
+            ),
             patch.object(Engine, "weight", return_value="dtype"),
             patch.object(Engine, "get_default_device", return_value="cpu"),
             patch(
@@ -79,10 +95,11 @@ class TextToVideoModelCallTestCase(IsolatedAsyncioTestCase):
                 return_value=nullcontext(),
             ),
             patch(
-                "avalan.model.vision.diffusion.video.LTXVideoCondition"
+                "avalan.model.vision.diffusion.video._ltx_video_condition"
             ) as cond_cls,
         ):
-            base_instance = MagicMock(spec=DiffusionPipeline)
+            pipeline_mock = pipeline.from_pretrained
+            base_instance = MagicMock(spec=DummyDiffusionPipeline)
             base_instance.to.return_value = base_instance
             base_instance.vae = MagicMock()
             base_instance.vae_spatial_compression_ratio = 2
@@ -92,13 +109,15 @@ class TextToVideoModelCallTestCase(IsolatedAsyncioTestCase):
             frame = MagicMock()
             second_out.frames = [[frame]]
             base_instance.side_effect = [first_out, second_out]
-            upsampler_instance = MagicMock(spec=DiffusionPipeline)
+            upsampler_instance = MagicMock(spec=DummyDiffusionPipeline)
             upsampler_instance.to.return_value = upsampler_instance
             upsampler_instance.return_value = MagicMock(frames=["upscaled"])
             pipeline_mock.side_effect = [base_instance, upsampler_instance]
 
+            condition_class = MagicMock()
             cond_instance = MagicMock()
-            cond_cls.return_value = cond_instance
+            condition_class.return_value = cond_instance
+            cond_cls.return_value = condition_class
             load_image_mock.return_value = "img"
 
             settings = EngineSettings(upsampler_model_id=self.upsampler_id)

--- a/tests/model/vision/vision_encoder_decoder_test.py
+++ b/tests/model/vision/vision_encoder_decoder_test.py
@@ -3,13 +3,13 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from transformers import (
-    AutoTokenizer,
     PreTrainedModel,
     PreTrainedTokenizerFast,
 )
 
 from avalan.entities import TransformerEngineSettings
 from avalan.model.engine import Engine
+from avalan.model.transformer import AutoTokenizer
 from avalan.model.vision import BaseVisionModel
 from avalan.model.vision.decoder import (
     AutoImageProcessor,

--- a/tests/server/a2a_router_unit_extra_test.py
+++ b/tests/server/a2a_router_unit_extra_test.py
@@ -899,7 +899,9 @@ async def _run_create_task_error_paths(
     client = TestClient(app)
 
     response = client.post(
-        "/tasks", data="not json", headers={"content-type": "application/json"}
+        "/tasks",
+        content="not json",
+        headers={"content-type": "application/json"},
     )
     assert response.status_code == 400
 


### PR DESCRIPTION
## Summary
- Remove Avalan-owned pytest warnings by replacing deprecated test APIs and lazy-loading optional heavy dependencies.
- Add `httpx2` as a test dependency so Starlette's TestClient no longer falls back to deprecated `httpx` behavior.
- Cover the lazy optional-dependency wrappers so CI's 100% coverage gate remains green.

## Testing
- `make lint`
- `make test coverage no-install` -> `5049 passed, 30 skipped, 2166 subtests passed`; `Required test coverage of 100% reached. Total coverage: 100.00%`
- `poetry run pytest -q -W default` -> `5049 passed, 30 skipped, 2164 subtests passed` with no warnings.