### PR TITLE
Fix OpenAI Responses tool replay

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -95,6 +95,13 @@ top_p = 0.9
 max_new_tokens = 800
 ```
 
+OpenAI Responses empty `response.failed` stream handling defaults to 4 retries
+with a 1.0 second delay. Override them with
+`openai_response_failed_retries` and
+`openai_response_failed_retry_delay_seconds` under `[run]`, or with the
+matching `GenerationSettings` fields in SDK code. Set retries to `0` to
+disable this retry.
+
 For local models, use the model id plus the backend options supported by the
 runtime. See [MODELS.md](MODELS.md) and [ai_uri.md](ai_uri.md).
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -95,8 +95,8 @@ top_p = 0.9
 max_new_tokens = 800
 ```
 
-OpenAI Responses empty `response.failed` stream handling defaults to 4 retries
-with a 1.0 second delay. Override them with
+OpenAI Responses pre-output `response.failed` stream handling defaults to 24
+retries with a 1.0 second delay. Override them with
 `openai_response_failed_retries` and
 `openai_response_failed_retry_delay_seconds` under `[run]`, or with the
 matching `GenerationSettings` fields in SDK code. Set retries to `0` to

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -533,7 +533,7 @@ plicate}]
                                    [--memory-engine-max-tokens MEMORY_ENGINE_MAX_TOKENS]
                                    [--memory-engine-overlap MEMORY_ENGINE_OVERLAP]
                                    [--memory-engine-window MEMORY_ENGINE_WINDOW] [--run-max-new-tokens RUN_MAX_NEW_TOKENS]
-                                   [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--run-skip-special-tokens]
+                                   [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--block-repeated-tool-calls] [--run-skip-special-tokens]
                                    [--run-disable-cache]
                                    [--run-cache-strategy 
 {dynamic,static,offloaded_static,sliding_window,hybrid,mamba,quantized}]
@@ -646,6 +646,8 @@ inline agent settings:
   --maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES, --run-maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES
                         Maximum model/tool result cycles for an agent run,
                         or 'unlimited'
+  --block-repeated-tool-calls, --run-block-repeated-tool-calls
+                        Stop repeated same-name/same-argument tool calls.
   --run-skip-special-tokens
                         Skip special tokens on output
   --run-disable-cache   Disable generation cache
@@ -743,7 +745,7 @@ usage: avalan agent run [-h] [--cache-dir CACHE_DIR] [--subfolder SUBFOLDER]
                         [--memory-engine-window MEMORY_ENGINE_WINDOW]
                         [--run-max-new-tokens RUN_MAX_NEW_TOKENS]
                         [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES]
-                        [--run-skip-special-tokens] [--run-disable-cache]
+                        [--block-repeated-tool-calls] [--run-skip-special-tokens] [--run-disable-cache]
                         [--run-cache-strategy {dynamic,static,offloaded_static,sliding_window,hybrid,mamba,quantized}]
                         [--run-temperature RUN_TEMPERATURE]
                         [--run-top-k RUN_TOP_K] [--run-top-p RUN_TOP_P]
@@ -1006,6 +1008,8 @@ inline agent settings:
   --maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES, --run-maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES
                         Maximum model/tool result cycles for an agent run,
                         or 'unlimited'
+  --block-repeated-tool-calls, --run-block-repeated-tool-calls
+                        Stop repeated same-name/same-argument tool calls.
   --run-skip-special-tokens
                         Skip special tokens on output
   --run-disable-cache   Disable generation cache
@@ -1182,7 +1186,7 @@ plicate}]
                           [--memory-engine-max-tokens MEMORY_ENGINE_MAX_TOKENS]
                           [--memory-engine-overlap MEMORY_ENGINE_OVERLAP] [--memory-engine-window MEMORY_ENGINE_WINDOW]
                           [--run-max-new-tokens RUN_MAX_NEW_TOKENS]
-                          [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--run-skip-special-tokens]
+                          [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--block-repeated-tool-calls] [--run-skip-special-tokens]
                           [--run-disable-cache]
                           [--run-cache-strategy {dynamic,static,offloaded_static,sliding_window,hybrid,mamba,quantized}]
                           [--run-temperature RUN_TEMPERATURE] [--run-top-k RUN_TOP_K] [--run-top-p RUN_TOP_P] [--tool TOOL]
@@ -1313,6 +1317,8 @@ inline agent settings:
   --maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES, --run-maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES
                         Maximum model/tool result cycles for an agent run,
                         or 'unlimited'
+  --block-repeated-tool-calls, --run-block-repeated-tool-calls
+                        Stop repeated same-name/same-argument tool calls.
   --run-skip-special-tokens
                         Skip special tokens on output
   --run-disable-cache   Disable generation cache
@@ -1380,7 +1386,7 @@ plicate}]
                           [--memory-engine-max-tokens MEMORY_ENGINE_MAX_TOKENS]
                           [--memory-engine-overlap MEMORY_ENGINE_OVERLAP] [--memory-engine-window MEMORY_ENGINE_WINDOW]
                           [--run-max-new-tokens RUN_MAX_NEW_TOKENS]
-                          [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--run-skip-special-tokens]
+                          [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--block-repeated-tool-calls] [--run-skip-special-tokens]
                           [--run-disable-cache]
                           [--run-cache-strategy {dynamic,static,offloaded_static,sliding_window,hybrid,mamba,quantized}]
                           [--run-temperature RUN_TEMPERATURE] [--run-top-k RUN_TOP_K] [--run-top-p RUN_TOP_P] [--tool TOOL]
@@ -1511,6 +1517,8 @@ inline agent settings:
   --maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES, --run-maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES
                         Maximum model/tool result cycles for an agent run,
                         or 'unlimited'
+  --block-repeated-tool-calls, --run-block-repeated-tool-calls
+                        Stop repeated same-name/same-argument tool calls.
   --run-skip-special-tokens
                         Skip special tokens on output
   --run-disable-cache   Disable generation cache
@@ -1572,7 +1580,7 @@ plicate}]
                          [--memory-permanent MEMORY_PERMANENT] [--memory-engine-model-id MEMORY_ENGINE_MODEL_ID]
                          [--memory-engine-max-tokens MEMORY_ENGINE_MAX_TOKENS] [--memory-engine-overlap MEMORY_ENGINE_OVERLAP]
                          [--memory-engine-window MEMORY_ENGINE_WINDOW] [--run-max-new-tokens RUN_MAX_NEW_TOKENS]
-                         [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--run-skip-special-tokens]
+                         [--maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES] [--block-repeated-tool-calls] [--run-skip-special-tokens]
                          [--run-disable-cache]
                          [--run-cache-strategy {dynamic,static,offloaded_static,sliding_window,hybrid,mamba,quantized}]
                          [--run-temperature RUN_TEMPERATURE] [--run-top-k RUN_TOP_K] [--run-top-p RUN_TOP_P] [--tool TOOL]
@@ -1659,6 +1667,8 @@ inline agent settings:
   --maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES, --run-maximum-tool-cycles RUN_MAXIMUM_TOOL_CYCLES
                         Maximum model/tool result cycles for an agent run,
                         or 'unlimited'
+  --block-repeated-tool-calls, --run-block-repeated-tool-calls
+                        Stop repeated same-name/same-argument tool calls.
   --run-skip-special-tokens
                         Skip special tokens on output
   --run-disable-cache   Disable generation cache

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -927,6 +927,9 @@ local runs often use `harmony`, while DS4 native tool calls use `dsml`.
   browse authenticated sessions, call remote services, or spend money.
 - Set `--maximum-tool-cycles N` to cap model/tool loops, or use
   `--maximum-tool-cycles unlimited` to remove only the numeric cycle cap.
+- Repeated same-name/same-argument tool calls execute by default. Use
+  `--block-repeated-tool-calls` to restore repeated-call and duplicate
+  observation guards.
 - Prefer read-only database settings and narrow `allowed_commands`.
 - For read-only database agents, enable explicit database tools and exclude
   `database.kill`.

--- a/src/avalan/agent/orchestrator/__init__.py
+++ b/src/avalan/agent/orchestrator/__init__.py
@@ -53,6 +53,7 @@ from uuid import UUID, uuid4
 
 _INPUT_TEMPLATE_REFERENCE_PATTERN = compile_regex(r"{{\s*input\b")
 _MAXIMUM_TOOL_CYCLE_OPTION_KEYS = ("maximum_tool_cycles", "max_tool_cycles")
+_BLOCK_REPEATED_TOOL_CALLS_OPTION_KEY = "block_repeated_tool_calls"
 
 
 class Orchestrator:
@@ -143,6 +144,14 @@ class Orchestrator:
             return DEFAULT_MAXIMUM_TOOL_CYCLES
         value = next(iter(values.values()))
         return validate_maximum_tool_cycles(value)
+
+    @staticmethod
+    def _pop_block_repeated_tool_calls(engine_args: dict[str, Any]) -> bool:
+        if _BLOCK_REPEATED_TOOL_CALLS_OPTION_KEY not in engine_args:
+            return False
+        value = engine_args.pop(_BLOCK_REPEATED_TOOL_CALLS_OPTION_KEY)
+        assert type(value) is bool, "block_repeated_tool_calls must be a bool"
+        return value
 
     @property
     def engine_agent(self) -> EngineAgent | None:
@@ -262,6 +271,9 @@ class Orchestrator:
         # Execute operation
         engine_args = {**(self._call_options or {}), **kwargs}
         maximum_tool_cycles = self._pop_maximum_tool_cycles(engine_args)
+        block_repeated_tool_calls = self._pop_block_repeated_tool_calls(
+            engine_args
+        )
         start = perf_counter()
         await self._event_manager.trigger(
             Event(
@@ -325,6 +337,7 @@ class Orchestrator:
             agent_id=self._id,
             participant_id=participant_id,
             session_id=session_id,
+            block_repeated_tool_calls=block_repeated_tool_calls,
             maximum_tool_cycles=maximum_tool_cycles,
         )
 

--- a/src/avalan/agent/orchestrator/response/orchestrator_response.py
+++ b/src/avalan/agent/orchestrator/response/orchestrator_response.py
@@ -179,6 +179,7 @@ class OrchestratorResponse(AsyncIterator[CanonicalStreamItem]):
     _response_drained: bool
     _pending_tool_batch_task: Task[list[_ToolExecutionOutcome]] | None
     _maximum_tool_cycles: MaximumToolCycles
+    _block_repeated_tool_calls: bool
 
     def __init__(
         self,
@@ -197,10 +198,12 @@ class OrchestratorResponse(AsyncIterator[CanonicalStreamItem]):
         tool_confirm: (
             Callable[[ToolCall], _ToolConfirmationAction] | None
         ) = None,
+        block_repeated_tool_calls: bool = False,
         enable_tool_parsing: bool = True,
         maximum_tool_cycles: MaximumToolCycles = DEFAULT_MAXIMUM_TOOL_CYCLES,
     ) -> None:
         assert input and response and engine_agent and operation
+        assert type(block_repeated_tool_calls) is bool
         maximum_tool_cycles = validate_maximum_tool_cycles(maximum_tool_cycles)
         self._input = input
         self._response = response
@@ -265,6 +268,7 @@ class OrchestratorResponse(AsyncIterator[CanonicalStreamItem]):
         self._response_drained = False
         self._pending_tool_batch_task = None
         self._maximum_tool_cycles = maximum_tool_cycles
+        self._block_repeated_tool_calls = block_repeated_tool_calls
 
     @property
     def input_token_count(self) -> int:
@@ -2246,9 +2250,10 @@ class OrchestratorResponse(AsyncIterator[CanonicalStreamItem]):
     ) -> ToolCallOutcome | None:
         if self._tool_manager is None:
             return None
-        repeated_diagnostic = self._repeated_call_diagnostic(call)
-        if repeated_diagnostic is not None:
-            return repeated_diagnostic
+        if self._block_repeated_tool_calls:
+            repeated_diagnostic = self._repeated_call_diagnostic(call)
+            if repeated_diagnostic is not None:
+                return repeated_diagnostic
 
         self._attempted_call_signatures.add(self._call_signature(call))
         if type(self._tool_manager) is ToolManager:
@@ -2378,7 +2383,10 @@ class OrchestratorResponse(AsyncIterator[CanonicalStreamItem]):
             return False
 
         cycle_signature = self._tool_cycle_signature(tool_messages)
-        if cycle_signature in self._tool_cycle_signatures:
+        if (
+            self._block_repeated_tool_calls
+            and cycle_signature in self._tool_cycle_signatures
+        ):
             self._append_canonical_guard_diagnostic(
                 code="orchestrator.tool_cycle.duplicate_observation",
                 message="Tool cycle stopped after repeated observations.",

--- a/src/avalan/agent/templates/blueprint.toml
+++ b/src/avalan/agent/templates/blueprint.toml
@@ -85,6 +85,9 @@ openai_response_failed_retry_delay_seconds = {{ orchestrator.call_options['opena
 {% else %}maximum_tool_cycles = "{{ orchestrator.call_options['maximum_tool_cycles'] }}"
 {% endif %}
 {% endif %}
+{% if orchestrator.call_options.get('block_repeated_tool_calls') is not none %}
+block_repeated_tool_calls = {{ orchestrator.call_options['block_repeated_tool_calls'] | lower }}
+{% endif %}
 {% if orchestrator.call_options.get('chat_settings') %}
 
 [run.chat]

--- a/src/avalan/agent/templates/blueprint.toml
+++ b/src/avalan/agent/templates/blueprint.toml
@@ -74,6 +74,12 @@ use_cache = {{ orchestrator.call_options['use_cache'] | lower }}
 {% if orchestrator.call_options.get('cache_strategy') %}
 cache_strategy = "{{ orchestrator.call_options['cache_strategy'] }}"
 {% endif %}
+{% if orchestrator.call_options.get('openai_response_failed_retries') is not none %}
+openai_response_failed_retries = {{ orchestrator.call_options['openai_response_failed_retries'] }}
+{% endif %}
+{% if orchestrator.call_options.get('openai_response_failed_retry_delay_seconds') is not none %}
+openai_response_failed_retry_delay_seconds = {{ orchestrator.call_options['openai_response_failed_retry_delay_seconds'] }}
+{% endif %}
 {% if orchestrator.call_options.get('maximum_tool_cycles') is not none %}
 {% if orchestrator.call_options['maximum_tool_cycles'] is number %}maximum_tool_cycles = {{ orchestrator.call_options['maximum_tool_cycles'] }}
 {% else %}maximum_tool_cycles = "{{ orchestrator.call_options['maximum_tool_cycles'] }}"

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -3169,7 +3169,7 @@ class CLI:
             type=CLI._non_negative_integer,
             default=None,
             help=(
-                "OpenAI Responses empty response.failed stream retries. "
+                "OpenAI Responses pre-output response.failed stream retries. "
                 "Set to 0 to disable."
             ),
         )
@@ -3178,7 +3178,7 @@ class CLI:
             type=CLI._non_negative_number,
             default=None,
             help=(
-                "OpenAI Responses empty response.failed retry delay "
+                "OpenAI Responses pre-output response.failed retry delay "
                 "in seconds."
             ),
         )
@@ -3862,7 +3862,7 @@ class CLI:
             type=CLI._non_negative_integer,
             default=None,
             help=(
-                "OpenAI Responses empty response.failed stream retries. "
+                "OpenAI Responses pre-output response.failed stream retries. "
                 "Set to 0 to disable."
             ),
         )
@@ -3871,7 +3871,7 @@ class CLI:
             type=CLI._non_negative_number,
             default=None,
             help=(
-                "OpenAI Responses empty response.failed retry delay "
+                "OpenAI Responses pre-output response.failed retry delay "
                 "in seconds."
             ),
         )

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -42,7 +42,11 @@ from ..tool_cycles import (
     UNLIMITED_TOOL_CYCLES,
     MaximumToolCycles,
 )
-from ..types import assert_positive_int
+from ..types import (
+    assert_non_negative_int,
+    assert_non_negative_number,
+    assert_positive_int,
+)
 from ..utils import logger_replace
 
 import gettext
@@ -834,6 +838,30 @@ class CLI:
             raise ArgumentTypeError("must be an integer") from exc
         try:
             assert_positive_int(parsed, "value")
+        except AssertionError as exc:
+            raise ArgumentTypeError(str(exc)) from exc
+        return parsed
+
+    @staticmethod
+    def _non_negative_integer(value: str) -> int:
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise ArgumentTypeError("must be an integer") from exc
+        try:
+            assert_non_negative_int(parsed, "value")
+        except AssertionError as exc:
+            raise ArgumentTypeError(str(exc)) from exc
+        return parsed
+
+    @staticmethod
+    def _non_negative_number(value: str) -> float:
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ArgumentTypeError("must be numeric") from exc
+        try:
+            assert_non_negative_number(parsed, "value")
         except AssertionError as exc:
             raise ArgumentTypeError(str(exc)) from exc
         return parsed
@@ -3137,6 +3165,24 @@ class CLI:
             help="Maximum number of tokens to generate",
         )
         model_run_parser.add_argument(
+            "--openai-response-failed-retries",
+            type=CLI._non_negative_integer,
+            default=None,
+            help=(
+                "OpenAI Responses empty response.failed stream retries. "
+                "Set to 0 to disable."
+            ),
+        )
+        model_run_parser.add_argument(
+            "--openai-response-failed-retry-delay-seconds",
+            type=CLI._non_negative_number,
+            default=None,
+            help=(
+                "OpenAI Responses empty response.failed retry delay "
+                "in seconds."
+            ),
+        )
+        model_run_parser.add_argument(
             "--modality",
             default=Modality.TEXT_GENERATION,
             type=str,
@@ -3802,6 +3848,24 @@ class CLI:
             choices=[c.value for c in GenerationCacheStrategy],
             dest="run_cache_strategy",
             help="Cache implementation to use for generation",
+        )
+        group.add_argument(
+            "--run-openai-response-failed-retries",
+            type=CLI._non_negative_integer,
+            default=None,
+            help=(
+                "OpenAI Responses empty response.failed stream retries. "
+                "Set to 0 to disable."
+            ),
+        )
+        group.add_argument(
+            "--run-openai-response-failed-retry-delay-seconds",
+            type=CLI._non_negative_number,
+            default=None,
+            help=(
+                "OpenAI Responses empty response.failed retry delay "
+                "in seconds."
+            ),
         )
         group.add_argument(
             "--run-temperature",

--- a/src/avalan/cli/__main__.py
+++ b/src/avalan/cli/__main__.py
@@ -3830,6 +3830,14 @@ class CLI:
             default=None,
         )
         group.add_argument(
+            "--block-repeated-tool-calls",
+            "--run-block-repeated-tool-calls",
+            action="store_true",
+            default=None,
+            dest="run_block_repeated_tool_calls",
+            help="Stop repeated same-name/same-argument tool calls.",
+        )
+        group.add_argument(
             "--run-skip-special-tokens",
             action="store_true",
             default=False,

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -170,6 +170,7 @@ def get_orchestrator_settings(
     memory_permanent_message: str | None = None,
     memory_permanent: list[str] | None = None,
     maximum_tool_cycles: MaximumToolCycles | None = None,
+    block_repeated_tool_calls: bool | None = None,
     max_new_tokens: int | None = None,
     temperature: float | None = None,
     tools: list[str] | None | _Unset = _UNSET,
@@ -205,6 +206,11 @@ def get_orchestrator_settings(
         maximum_tool_cycles
         if maximum_tool_cycles is not None
         else getattr(args, "run_maximum_tool_cycles", None)
+    )
+    call_block_repeated_tool_calls = (
+        block_repeated_tool_calls
+        if block_repeated_tool_calls is not None
+        else getattr(args, "run_block_repeated_tool_calls", None)
     )
     call_tool_choice = (
         tool_choice
@@ -259,6 +265,10 @@ def get_orchestrator_settings(
         )
     if call_maximum_tool_cycles is not None:
         call_options["maximum_tool_cycles"] = call_maximum_tool_cycles
+    if call_block_repeated_tool_calls is not None:
+        call_options["block_repeated_tool_calls"] = (
+            call_block_repeated_tool_calls
+        )
     if call_tool_choice is not None:
         call_options["tool_choice"] = call_tool_choice
     engine_config: dict[str, Any] = {

--- a/src/avalan/cli/commands/agent.py
+++ b/src/avalan/cli/commands/agent.py
@@ -178,6 +178,8 @@ def get_orchestrator_settings(
     top_p: float | None = None,
     use_cache: bool | None = None,
     cache_strategy: GenerationCacheStrategy | None = None,
+    openai_response_failed_retries: int | None = None,
+    openai_response_failed_retry_delay_seconds: int | float | None = None,
 ) -> OrchestratorSettings:
     """Create ``OrchestratorSettings`` from CLI arguments."""
     assert not (
@@ -233,6 +235,28 @@ def get_orchestrator_settings(
         call_options["use_cache"] = use_cache
     if cache_strategy is not None:
         call_options["cache_strategy"] = cache_strategy
+    call_openai_response_failed_retries = (
+        openai_response_failed_retries
+        if openai_response_failed_retries is not None
+        else getattr(args, "run_openai_response_failed_retries", None)
+    )
+    if call_openai_response_failed_retries is not None:
+        call_options["openai_response_failed_retries"] = (
+            call_openai_response_failed_retries
+        )
+    call_openai_response_failed_retry_delay_seconds = (
+        openai_response_failed_retry_delay_seconds
+        if openai_response_failed_retry_delay_seconds is not None
+        else getattr(
+            args,
+            "run_openai_response_failed_retry_delay_seconds",
+            None,
+        )
+    )
+    if call_openai_response_failed_retry_delay_seconds is not None:
+        call_options["openai_response_failed_retry_delay_seconds"] = (
+            call_openai_response_failed_retry_delay_seconds
+        )
     if call_maximum_tool_cycles is not None:
         call_options["maximum_tool_cycles"] = call_maximum_tool_cycles
     if call_tool_choice is not None:

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -1,4 +1,9 @@
-from .types import LooseJsonValue, SkillRegistryProtocol
+from .types import (
+    LooseJsonValue,
+    SkillRegistryProtocol,
+    assert_optional_non_negative_int,
+    assert_optional_non_negative_number,
+)
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -535,6 +540,20 @@ class GenerationSettings:
     response_format: dict[str, Any] | None = None
     # Force an available tool by canonical name, when supported.
     tool_choice: str | None = None
+    # OpenAI Responses empty response.failed stream retries. None uses the
+    # provider default.
+    openai_response_failed_retries: int | None = None
+    openai_response_failed_retry_delay_seconds: int | float | None = None
+
+    def __post_init__(self) -> None:
+        assert_optional_non_negative_int(
+            self.openai_response_failed_retries,
+            "openai_response_failed_retries",
+        )
+        assert_optional_non_negative_number(
+            self.openai_response_failed_retry_delay_seconds,
+            "openai_response_failed_retry_delay_seconds",
+        )
 
 
 @final

--- a/src/avalan/entities.py
+++ b/src/avalan/entities.py
@@ -540,7 +540,7 @@ class GenerationSettings:
     response_format: dict[str, Any] | None = None
     # Force an available tool by canonical name, when supported.
     tool_choice: str | None = None
-    # OpenAI Responses empty response.failed stream retries. None uses the
+    # OpenAI Responses pre-output response.failed stream retries. None uses the
     # provider default.
     openai_response_failed_retries: int | None = None
     openai_response_failed_retry_delay_seconds: int | float | None = None

--- a/src/avalan/model/modalities/registry.py
+++ b/src/avalan/model/modalities/registry.py
@@ -163,6 +163,16 @@ class ModalityRegistry:
             max_length=getattr(args, "text_max_length", None),
             min_p=args.min_p,
             num_beams=getattr(args, "text_num_beams", None),
+            openai_response_failed_retries=getattr(
+                args,
+                "openai_response_failed_retries",
+                None,
+            ),
+            openai_response_failed_retry_delay_seconds=getattr(
+                args,
+                "openai_response_failed_retry_delay_seconds",
+                None,
+            ),
             repetition_penalty=args.repetition_penalty,
             temperature=args.temperature,
             top_k=args.top_k,

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -285,11 +285,11 @@ class OpenAIStream(TextGenerationVendorStream):
 
     async def _call_stream_cleanup(self, method_name: str) -> None:
         assert method_name in ("cancel", "aclose")
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
         for source in self._cleanup_sources():
             try:
                 await self._call_stream_source_cleanup(source, method_name)
-            except BaseException as exc:
+            except Exception as exc:
                 errors.append(exc)
         if len(errors) == 1:
             raise errors[0]

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -25,7 +25,11 @@ from .....model.stream import (
     is_stream_terminal_kind,
 )
 from .....tool.manager import ToolManager
-from .....types import LooseJsonValue
+from .....types import (
+    LooseJsonValue,
+    assert_non_negative_int,
+    assert_non_negative_number,
+)
 from .....utils import to_json, tool_call_diagnostic_payload
 from ....message import TemplateMessage, TemplateMessageRole
 from ....vendor import TextGenerationVendor, TextGenerationVendorStream
@@ -999,6 +1003,8 @@ class OpenAIClient(TextGenerationVendor):
     _client: Any
     _extra_query: dict[str, str] | None
     _is_azure: bool
+    _stream_response_failed_retries: int
+    _stream_response_failed_retry_delay_seconds: float
     _stateless_response_items: list[dict[str, Any]]
 
     def __init__(
@@ -1007,9 +1013,25 @@ class OpenAIClient(TextGenerationVendor):
         base_url: str | None,
         *,
         azure_api_version: str | None = None,
+        stream_response_failed_retries: int = (
+            _STREAM_RESPONSE_FAILED_RETRIES
+        ),
+        stream_response_failed_retry_delay_seconds: int | float = (
+            _STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS
+        ),
     ):
         global Omit
 
+        self._stream_response_failed_retries = (
+            self._normalize_response_failed_retries(
+                stream_response_failed_retries
+            )
+        )
+        self._stream_response_failed_retry_delay_seconds = (
+            self._normalize_response_failed_retry_delay_seconds(
+                stream_response_failed_retry_delay_seconds
+            )
+        )
         self._is_azure = self._is_azure_base_url(base_url)
         self._extra_query = self._azure_extra_query(
             base_url, azure_api_version
@@ -1086,6 +1108,16 @@ class OpenAIClient(TextGenerationVendor):
             )
             if prompt_cache_retention is not None:
                 kwargs["prompt_cache_retention"] = prompt_cache_retention
+        stream_response_failed_retries = OpenAIClient._response_failed_retries(
+            settings,
+            default=self._stream_response_failed_retries,
+        )
+        stream_response_failed_retry_delay_seconds = (
+            OpenAIClient._response_failed_retry_delay_seconds(
+                settings,
+                default=(self._stream_response_failed_retry_delay_seconds),
+            )
+        )
         if tool:
             schemas = OpenAIClient._tool_schemas(tool)
             if schemas:
@@ -1115,9 +1147,9 @@ class OpenAIClient(TextGenerationVendor):
                 output_item_sink=self._record_stateless_response_item,
                 stream_factory=stream_factory,
                 stream_retry_delay_seconds=(
-                    self._STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS
+                    stream_response_failed_retry_delay_seconds
                 ),
-                stream_retries=self._STREAM_RESPONSE_FAILED_RETRIES,
+                stream_retries=stream_response_failed_retries,
                 **stream_kwargs,
             )
 
@@ -1138,6 +1170,66 @@ class OpenAIClient(TextGenerationVendor):
             ProviderFamily.AZURE_OPENAI
             if self._is_azure
             else ProviderFamily.OPENAI
+        )
+
+    @staticmethod
+    def _response_failed_retries(
+        settings: GenerationSettings | None,
+        *,
+        default: int,
+    ) -> int:
+        if settings is None or settings.openai_response_failed_retries is None:
+            return default
+        return OpenAIClient._normalize_response_failed_retries(
+            settings.openai_response_failed_retries
+        )
+
+    @staticmethod
+    def _response_failed_retry_delay_seconds(
+        settings: GenerationSettings | None,
+        *,
+        default: float,
+    ) -> float:
+        if (
+            settings is None
+            or settings.openai_response_failed_retry_delay_seconds is None
+        ):
+            return default
+        return OpenAIClient._normalize_response_failed_retry_delay_seconds(
+            settings.openai_response_failed_retry_delay_seconds
+        )
+
+    @staticmethod
+    def _normalize_response_failed_retries(value: object) -> int:
+        assert_non_negative_int(value, "openai_response_failed_retries")
+        assert isinstance(value, int)
+        return value
+
+    @staticmethod
+    def _normalize_response_failed_retry_delay_seconds(
+        value: object,
+    ) -> float:
+        assert_non_negative_number(
+            value,
+            "openai_response_failed_retry_delay_seconds",
+        )
+        assert isinstance(value, int | float)
+        return float(value)
+
+    @staticmethod
+    def _provider_response_failed_retries(
+        provider_options: Mapping[str, object],
+    ) -> int:
+        return OpenAIClient._normalize_response_failed_retries(
+            provider_options["openai_response_failed_retries"]
+        )
+
+    @staticmethod
+    def _provider_retry_delay_seconds(
+        provider_options: Mapping[str, object],
+    ) -> float:
+        return OpenAIClient._normalize_response_failed_retry_delay_seconds(
+            provider_options["openai_response_failed_retry_delay_seconds"]
         )
 
     def _template_messages(
@@ -1740,12 +1832,33 @@ class OpenAIModel(TextGenerationVendorModel):
             self._settings.provider_options,
             "azure_api_version",
         )
-        client_kwargs: dict[str, str | None] = {
+        client_kwargs: dict[str, Any] = {
             "api_key": self._settings.access_token,
             "base_url": self._settings.base_url,
         }
         if azure_api_version is not None:
             client_kwargs["azure_api_version"] = azure_api_version
+        provider_options = self._settings.provider_options
+        if (
+            provider_options is not None
+            and "openai_response_failed_retries" in provider_options
+        ):
+            client_kwargs["stream_response_failed_retries"] = (
+                OpenAIClient._provider_response_failed_retries(
+                    provider_options
+                )
+            )
+        if (
+            provider_options is not None
+            and "openai_response_failed_retry_delay_seconds"
+            in provider_options
+        ):
+            retry_delay = OpenAIClient._provider_retry_delay_seconds(
+                provider_options
+            )
+            client_kwargs["stream_response_failed_retry_delay_seconds"] = (
+                retry_delay
+            )
         return OpenAIClient(**client_kwargs)
 
     async def __call__(

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -22,7 +22,6 @@ from .....model.stream import (
     StreamVisibility,
     TextGenerationSingleStream,
     TextGenerationStream,
-    is_stream_terminal_kind,
 )
 from .....tool.manager import ToolManager
 from .....types import (
@@ -63,6 +62,7 @@ Omit: type[Any] = _OmitPlaceholder
 
 
 class OpenAIStream(TextGenerationVendorStream):
+    _STREAM_RETRY_MAX_DELAY_SECONDS = 8.0
     _TEXT_DELTA_EVENTS = {"response.text.delta", "response.output_text.delta"}
     _TEXT_DONE_EVENTS = {"response.text.done", "response.output_text.done"}
     _REASONING_DELTA_EVENTS = {"response.reasoning_text.delta"}
@@ -95,6 +95,10 @@ class OpenAIStream(TextGenerationVendorStream):
     _stream_retry_delay_seconds: float
     _stream_retries: int
     _tool_manager: ToolManager | None
+    _last_text_delta_alias_key: tuple[object, ...] | None
+    _last_text_delta_alias_event_type: str | None
+    _attempt_output_item_count: int
+    _output_item_rollback: Callable[[int], None] | None
 
     def __init__(
         self,
@@ -102,6 +106,7 @@ class OpenAIStream(TextGenerationVendorStream):
         *,
         provider_family: ProviderFamily | str = ProviderFamily.OPENAI,
         output_item_sink: Callable[[dict[str, Any]], None] | None = None,
+        output_item_rollback: Callable[[int], None] | None = None,
         stream_factory: (
             Callable[[], Awaitable[AsyncIterator[Any]]] | None
         ) = None,
@@ -117,10 +122,14 @@ class OpenAIStream(TextGenerationVendorStream):
         self._answer_text_seen = False
         self._answer_done_seen = False
         self._output_item_sink = output_item_sink
+        self._output_item_rollback = output_item_rollback
         self._stream_factory = stream_factory
         self._stream_retry_delay_seconds = stream_retry_delay_seconds
         self._stream_retries = stream_retries
         self._tool_manager = tool
+        self._last_text_delta_alias_key = None
+        self._last_text_delta_alias_event_type = None
+        self._attempt_output_item_count = 0
 
         async def generator() -> AsyncIterator[CanonicalStreamItem]:
             async for item in self.canonical_stream(
@@ -156,12 +165,7 @@ class OpenAIStream(TextGenerationVendorStream):
         capabilities: StreamProviderCapabilities | None = None,
         close_after_terminal: bool = True,
     ) -> AsyncIterator[CanonicalStreamItem]:
-        self._canonical_tool_calls = {}
-        self._tool_call_ids_by_item_id = {}
-        self._canonical_ready_tool_call_ids = set()
-        self._canonical_done_tool_call_ids = set()
-        self._answer_text_seen = False
-        self._answer_done_seen = False
+        self._reset_response_attempt_state()
         return self._provider_canonical_stream(
             self._provider_events(),
             stream_session_id=stream_session_id,
@@ -221,9 +225,17 @@ class OpenAIStream(TextGenerationVendorStream):
                 if not retry:
                     break
                 await self._close_current_stream()
+                self._rollback_response_attempt_output_items()
+                self._reset_response_attempt_state()
                 await self._raise_if_retry_interrupted()
                 assert self._stream_factory is not None
-                delay = self._stream_retry_delay_seconds * (2**attempts)
+                delay = min(
+                    self._stream_retry_delay_seconds * (2**attempts),
+                    max(
+                        self._stream_retry_delay_seconds,
+                        self._STREAM_RETRY_MAX_DELAY_SECONDS,
+                    ),
+                )
                 if delay > 0:
                     await sleep(delay)
                 await self._raise_if_retry_interrupted()
@@ -254,9 +266,6 @@ class OpenAIStream(TextGenerationVendorStream):
         response = OpenAIClient._response_field(event, "response")
         if OpenAIClient._response_field(response, "error") is not None:
             return False
-        output = OpenAIClient._response_field(response, "output")
-        if isinstance(output, Sequence) and output:
-            return False
         return any(
             provider_event.kind is StreamItemKind.STREAM_ERRORED
             for provider_event in provider_events
@@ -264,11 +273,55 @@ class OpenAIStream(TextGenerationVendorStream):
 
     @staticmethod
     def _is_model_output_event(event: StreamProviderEvent) -> bool:
-        return event.kind not in {
-            StreamItemKind.STREAM_COMPLETED,
-            StreamItemKind.STREAM_DIAGNOSTIC,
-            StreamItemKind.USAGE_COMPLETED,
-        } and not is_stream_terminal_kind(event.kind)
+        return event.kind in {
+            StreamItemKind.ANSWER_DELTA,
+            StreamItemKind.ANSWER_DONE,
+            StreamItemKind.TOOL_CALL_ARGUMENT_DELTA,
+            StreamItemKind.TOOL_CALL_READY,
+            StreamItemKind.TOOL_CALL_DONE,
+        }
+
+    def _is_duplicate_text_delta_alias(
+        self,
+        event: object,
+        event_type: str,
+        delta: str,
+    ) -> bool:
+        key = (
+            delta,
+            OpenAIClient._response_field(event, "item_id"),
+            OpenAIClient._response_field(event, "output_index"),
+            OpenAIClient._response_field(event, "content_index"),
+            OpenAIClient._response_field(event, "sequence_number"),
+        )
+        duplicate = (
+            self._last_text_delta_alias_key == key
+            and self._last_text_delta_alias_event_type != event_type
+            and self._last_text_delta_alias_event_type
+            in self._TEXT_DELTA_EVENTS
+        )
+        self._last_text_delta_alias_key = key
+        self._last_text_delta_alias_event_type = event_type
+        return duplicate
+
+    def _reset_response_attempt_state(self) -> None:
+        self._canonical_tool_calls = {}
+        self._tool_call_ids_by_item_id = {}
+        self._canonical_ready_tool_call_ids = set()
+        self._canonical_done_tool_call_ids = set()
+        self._answer_text_seen = False
+        self._answer_done_seen = False
+        self._last_text_delta_alias_key = None
+        self._last_text_delta_alias_event_type = None
+        self._attempt_output_item_count = 0
+
+    def _rollback_response_attempt_output_items(self) -> None:
+        if self._attempt_output_item_count <= 0:
+            return
+        rollback = self._output_item_rollback
+        if rollback is None:
+            return
+        rollback(self._attempt_output_item_count)
 
     async def _close_current_stream(self) -> None:
         await self._call_stream_source_cleanup(self._stream, "aclose")
@@ -366,18 +419,27 @@ class OpenAIStream(TextGenerationVendorStream):
         if event_type == "response.completed":
             return self._completion_events(event, provider_payload, event_type)
         if event_type in self._TEXT_DELTA_EVENTS:
+            if self._answer_done_seen:
+                return ()
+            delta = self._response_string_field(event, "delta", event_type)
+            if self._is_duplicate_text_delta_alias(
+                event,
+                event_type,
+                delta,
+            ):
+                return ()
             self._answer_text_seen = True
             return (
                 StreamProviderEvent(
                     kind=StreamItemKind.ANSWER_DELTA,
-                    text_delta=self._response_string_field(
-                        event, "delta", event_type
-                    ),
+                    text_delta=delta,
                     provider_payload=provider_payload,
                     provider_event_type=event_type,
                 ),
             )
         if event_type in self._TEXT_DONE_EVENTS:
+            if self._answer_done_seen:
+                return ()
             text = self._response_optional_string_field(
                 event, event_type, "text", "delta"
             )
@@ -454,6 +516,7 @@ class OpenAIStream(TextGenerationVendorStream):
         if item_type not in {"function_call", "reasoning"}:
             return
         self._output_item_sink(cast(dict[str, Any], payload))
+        self._attempt_output_item_count += 1
 
     @classmethod
     def _response_input_item_payload(
@@ -1050,7 +1113,7 @@ class OpenAIStream(TextGenerationVendorStream):
 
 class OpenAIClient(TextGenerationVendor):
     _DEFAULT_MODEL_ID = "default"
-    _STREAM_RESPONSE_FAILED_RETRIES = 4
+    _STREAM_RESPONSE_FAILED_RETRIES = 24
     _STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS = 1.0
     _client: Any
     _extra_query: dict[str, str] | None
@@ -1197,6 +1260,7 @@ class OpenAIClient(TextGenerationVendor):
                 stream=cast(AsyncIterator[Any], client_stream),
                 provider_family=self._usage_provider_family.value,
                 output_item_sink=self._record_stateless_response_item,
+                output_item_rollback=(self._rollback_stateless_response_items),
                 stream_factory=stream_factory,
                 stream_retry_delay_seconds=(
                     stream_response_failed_retry_delay_seconds
@@ -1454,6 +1518,11 @@ class OpenAIClient(TextGenerationVendor):
 
     def _record_stateless_response_item(self, item: dict[str, Any]) -> None:
         self._stateless_response_items.append(deepcopy(item))
+
+    def _rollback_stateless_response_items(self, count: int) -> None:
+        assert isinstance(count, int)
+        assert count > 0
+        del self._stateless_response_items[-count:]
 
     @staticmethod
     def _has_function_call_context(

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -22,6 +22,7 @@ from .....model.stream import (
     StreamVisibility,
     TextGenerationSingleStream,
     TextGenerationStream,
+    is_stream_terminal_kind,
 )
 from .....tool.manager import ToolManager
 from .....types import LooseJsonValue
@@ -34,7 +35,15 @@ from . import (
     TextGenerationVendorModel,
 )
 
-from collections.abc import AsyncIterator, Mapping, Sequence
+from asyncio import sleep
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Mapping,
+    Sequence,
+)
+from copy import deepcopy
 from importlib import import_module
 from mimetypes import guess_type
 from typing import Any, cast
@@ -76,6 +85,10 @@ class OpenAIStream(TextGenerationVendorStream):
     _canonical_done_tool_call_ids: set[str]
     _answer_text_seen: bool
     _answer_done_seen: bool
+    _output_item_sink: Callable[[dict[str, Any]], None] | None
+    _stream_factory: Callable[[], Awaitable[AsyncIterator[Any]]] | None
+    _stream_retry_delay_seconds: float
+    _stream_retries: int
     _tool_manager: ToolManager | None
 
     def __init__(
@@ -83,6 +96,12 @@ class OpenAIStream(TextGenerationVendorStream):
         stream: AsyncIterator[Any],
         *,
         provider_family: ProviderFamily | str = ProviderFamily.OPENAI,
+        output_item_sink: Callable[[dict[str, Any]], None] | None = None,
+        stream_factory: (
+            Callable[[], Awaitable[AsyncIterator[Any]]] | None
+        ) = None,
+        stream_retry_delay_seconds: float = 0,
+        stream_retries: int = 0,
         tool: ToolManager | None = None,
     ) -> None:
         self._stream = stream
@@ -92,6 +111,10 @@ class OpenAIStream(TextGenerationVendorStream):
         self._canonical_done_tool_call_ids = set()
         self._answer_text_seen = False
         self._answer_done_seen = False
+        self._output_item_sink = output_item_sink
+        self._stream_factory = stream_factory
+        self._stream_retry_delay_seconds = stream_retry_delay_seconds
+        self._stream_retries = stream_retries
         self._tool_manager = tool
 
         async def generator() -> AsyncIterator[CanonicalStreamItem]:
@@ -155,25 +178,92 @@ class OpenAIStream(TextGenerationVendorStream):
 
     async def _provider_events(self) -> AsyncIterator[StreamProviderEvent]:
         try:
-            async for event in self._stream:
-                event_type_value = OpenAIClient._response_field(event, "type")
-                provider_event_type = (
-                    event_type_value
-                    if isinstance(event_type_value, str)
-                    else None
-                )
-                try:
-                    provider_events = self._provider_events_from_event(event)
-                except Exception as exc:
-                    raise StreamProviderAdapterError(
-                        exc,
-                        provider_payload=self._provider_payload(event),
-                        provider_event_type=provider_event_type,
-                    ) from exc
-                for provider_event in provider_events:
-                    yield provider_event
+            attempts = 0
+            while True:
+                retry = False
+                output_seen = False
+                async for event in self._stream:
+                    event_type_value = OpenAIClient._response_field(
+                        event, "type"
+                    )
+                    provider_event_type = (
+                        event_type_value
+                        if isinstance(event_type_value, str)
+                        else None
+                    )
+                    try:
+                        provider_events = self._provider_events_from_event(
+                            event
+                        )
+                    except Exception as exc:
+                        raise StreamProviderAdapterError(
+                            exc,
+                            provider_payload=self._provider_payload(event),
+                            provider_event_type=provider_event_type,
+                        ) from exc
+                    if self._should_retry_stream_failure(
+                        event,
+                        provider_events,
+                        output_seen=output_seen,
+                        attempts=attempts,
+                    ):
+                        retry = True
+                        break
+                    for provider_event in provider_events:
+                        if self._is_model_output_event(provider_event):
+                            output_seen = True
+                        yield provider_event
+                if not retry:
+                    break
+                await self._close_current_stream()
+                assert self._stream_factory is not None
+                delay = self._stream_retry_delay_seconds * (2**attempts)
+                if delay > 0:
+                    await sleep(delay)
+                attempts += 1
+                self._stream = await self._stream_factory()
         finally:
             await self.aclose()
+
+    def _should_retry_stream_failure(
+        self,
+        event: object,
+        provider_events: tuple[StreamProviderEvent, ...],
+        *,
+        output_seen: bool,
+        attempts: int,
+    ) -> bool:
+        if (
+            self._stream_factory is None
+            or attempts >= self._stream_retries
+            or output_seen
+        ):
+            return False
+        if OpenAIClient._response_field(event, "type") != "response.failed":
+            return False
+        response = OpenAIClient._response_field(event, "response")
+        if OpenAIClient._response_field(response, "error") is not None:
+            return False
+        output = OpenAIClient._response_field(response, "output")
+        if isinstance(output, Sequence) and output:
+            return False
+        return any(
+            provider_event.kind is StreamItemKind.STREAM_ERRORED
+            for provider_event in provider_events
+        )
+
+    @staticmethod
+    def _is_model_output_event(event: StreamProviderEvent) -> bool:
+        return event.kind not in {
+            StreamItemKind.STREAM_COMPLETED,
+            StreamItemKind.STREAM_DIAGNOSTIC,
+            StreamItemKind.USAGE_COMPLETED,
+        } and not is_stream_terminal_kind(event.kind)
+
+    async def _close_current_stream(self) -> None:
+        close = getattr(self._stream, "aclose", None)
+        if callable(close):
+            await close()
 
     def _provider_events_from_event(
         self, event: object
@@ -292,8 +382,48 @@ class OpenAIStream(TextGenerationVendorStream):
         if event_type in self._TOOL_ARGUMENT_DONE_EVENTS:
             return self._tool_ready_events(event, provider_payload, event_type)
         if event_type == "response.output_item.done":
+            self._record_done_output_item(event)
             return self._tool_done_events(event, provider_payload, event_type)
         return ()
+
+    def _record_done_output_item(self, event: object) -> None:
+        if self._output_item_sink is None:
+            return
+        item = OpenAIClient._response_field(event, "item")
+        payload = self._provider_payload(item)
+        if not isinstance(payload, dict):
+            return
+        payload = self._response_input_item_payload(payload)
+        item_type = payload.get("type")
+        if item_type not in {"function_call", "reasoning"}:
+            return
+        self._output_item_sink(cast(dict[str, Any], payload))
+
+    @classmethod
+    def _response_input_item_payload(
+        cls,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        cleaned: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key == "status" or value is None:
+                continue
+            if (
+                payload.get("type") == "reasoning"
+                and key == "content"
+                and value == []
+            ):
+                continue
+            cleaned[key] = cls._response_input_item_value(value)
+        return cleaned
+
+    @classmethod
+    def _response_input_item_value(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return cls._response_input_item_payload(value)
+        if isinstance(value, list):
+            return [cls._response_input_item_value(item) for item in value]
+        return value
 
     def _incomplete_events(
         self,
@@ -864,9 +994,12 @@ class OpenAIStream(TextGenerationVendorStream):
 
 class OpenAIClient(TextGenerationVendor):
     _DEFAULT_MODEL_ID = "default"
+    _STREAM_RESPONSE_FAILED_RETRIES = 4
+    _STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS = 1.0
     _client: Any
     _extra_query: dict[str, str] | None
     _is_azure: bool
+    _stateless_response_items: list[dict[str, Any]]
 
     def __init__(
         self,
@@ -881,6 +1014,7 @@ class OpenAIClient(TextGenerationVendor):
         self._extra_query = self._azure_extra_query(
             base_url, azure_api_version
         )
+        self._stateless_response_items = []
         if self._is_azure and api_key is None:
             raise AssertionError(
                 "Azure OpenAI Responses requires api-key authentication"
@@ -912,6 +1046,8 @@ class OpenAIClient(TextGenerationVendor):
         use_async_generator: bool = True,
     ) -> TextGenerationStream:
         template_messages = self._template_messages(messages, tool=tool)
+        if not self._has_function_call_context(template_messages):
+            self._stateless_response_items.clear()
         use_reasoning_profile = self._uses_reasoning_profile(model_id)
         kwargs: dict[str, Any] = {
             "extra_headers": {
@@ -944,6 +1080,7 @@ class OpenAIClient(TextGenerationVendor):
             reasoning = OpenAIClient._reasoning_config(settings)
             if reasoning:
                 kwargs["reasoning"] = reasoning
+                kwargs["include"] = ["reasoning.encrypted_content"]
             prompt_cache_retention = (
                 OpenAIClient._prompt_cache_retention_config(settings)
             )
@@ -959,15 +1096,28 @@ class OpenAIClient(TextGenerationVendor):
                         schemas,
                         tool=tool,
                     )
-        client_stream = await self._client.responses.create(**kwargs)
+
+        async def create_response() -> Any:
+            return await self._client.responses.create(**kwargs)
+
+        async def stream_factory() -> AsyncIterator[Any]:
+            return cast(AsyncIterator[Any], await create_response())
+
+        client_stream = await create_response()
 
         if use_async_generator:
             stream_kwargs: dict[str, Any] = {}
             if isinstance(tool, ToolManager):
                 stream_kwargs["tool"] = tool
             return OpenAIStream(
-                stream=client_stream,
+                stream=cast(AsyncIterator[Any], client_stream),
                 provider_family=self._usage_provider_family.value,
+                output_item_sink=self._record_stateless_response_item,
+                stream_factory=stream_factory,
+                stream_retry_delay_seconds=(
+                    self._STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS
+                ),
+                stream_retries=self._STREAM_RESPONSE_FAILED_RETRIES,
                 **stream_kwargs,
             )
 
@@ -1031,47 +1181,117 @@ class OpenAIClient(TextGenerationVendor):
                     for block in content
                     if isinstance(block, dict)
                 ]
+        response_item_messages = self._response_item_tool_messages(
+            tool_messages,
+            tool=tool,
+        )
+        if response_item_messages is not None:
+            messages_out.extend(response_item_messages)
+            return messages_out
+
         for tool_message in tool_messages:
-            outcome = (
-                tool_message.tool_call_result
-                or tool_message.tool_call_error
-                or tool_message.tool_call_diagnostic
+            messages_out.extend(
+                self._synthetic_tool_messages(tool_message, tool=tool)
             )
-            assert outcome is not None
+        return messages_out
 
-            output: Any
-            if isinstance(outcome, ToolCallDiagnostic):
-                call_id_value = outcome.call_id
-                if call_id_value is None:
-                    messages_out.append(
-                        {
-                            "role": str(MessageRole.ASSISTANT),
-                            "content": to_json(
-                                tool_call_diagnostic_payload(outcome)
-                            ),
-                        }
-                    )
-                    continue
-                call_id = str(call_id_value)
-                name = (
-                    tool_message.name
-                    or outcome.canonical_name
-                    or outcome.requested_name
-                    or "tool"
-                )
-                arguments = tool_message.arguments
-                output = tool_call_diagnostic_payload(outcome)
-            else:
-                call_id = str(outcome.call.id)
-                name = outcome.call.name
-                arguments = outcome.call.arguments
-                output = (
-                    outcome.result
-                    if isinstance(outcome, ToolCallResult)
-                    else {"error": outcome.message}
-                )
+    def _response_item_tool_messages(
+        self,
+        tool_messages: list[Message],
+        *,
+        tool: ToolManager | None = None,
+    ) -> list[dict[str, Any]] | None:
+        if not self._stateless_response_items:
+            return None
 
-            call_message = {
+        synthetic_records: list[tuple[str | None, list[dict[str, Any]]]] = []
+        outputs_by_call_id: dict[str, dict[str, Any]] = {}
+        for tool_message in tool_messages:
+            synthetic = self._synthetic_tool_messages(
+                tool_message,
+                tool=tool,
+            )
+            call_id: str | None = None
+            if len(synthetic) == 2:
+                synthetic_call_id = synthetic[0].get("call_id")
+                if isinstance(synthetic_call_id, str) and synthetic_call_id:
+                    call_id = synthetic_call_id
+                    outputs_by_call_id[call_id] = synthetic[1]
+            synthetic_records.append((call_id, synthetic))
+
+        if not synthetic_records:
+            return []
+
+        messages: list[dict[str, Any]] = []
+        matched_call_ids: set[str] = set()
+        for response_item in self._stateless_response_items:
+            item_type = response_item.get("type")
+            if item_type == "reasoning":
+                messages.append(deepcopy(response_item))
+                continue
+            if item_type != "function_call":
+                continue
+            call_id = response_item.get("call_id")
+            if not isinstance(call_id, str):
+                continue
+            result_message = outputs_by_call_id.get(call_id)
+            if result_message is not None:
+                messages.append(deepcopy(response_item))
+                messages.append(deepcopy(result_message))
+                matched_call_ids.add(call_id)
+
+        for call_id, synthetic in synthetic_records:
+            if call_id is not None and call_id in matched_call_ids:
+                continue
+            messages.extend(deepcopy(synthetic))
+        return messages
+
+    def _synthetic_tool_messages(
+        self,
+        tool_message: Message,
+        *,
+        tool: ToolManager | None = None,
+    ) -> list[dict[str, Any]]:
+        outcome = (
+            tool_message.tool_call_result
+            or tool_message.tool_call_error
+            or tool_message.tool_call_diagnostic
+        )
+        assert outcome is not None
+
+        output: Any
+        if isinstance(outcome, ToolCallDiagnostic):
+            call_id_value = outcome.call_id
+            if call_id_value is None:
+                return [
+                    {
+                        "role": str(MessageRole.ASSISTANT),
+                        "content": to_json(
+                            tool_call_diagnostic_payload(outcome)
+                        ),
+                    }
+                ]
+            call_id = str(call_id_value)
+            name = (
+                tool_message.name
+                or outcome.canonical_name
+                or outcome.requested_name
+                or "tool"
+            )
+            arguments = tool_message.arguments
+            output = tool_call_diagnostic_payload(outcome)
+        else:
+            call_id = str(outcome.call.id)
+            name = outcome.call.name
+            arguments = outcome.call.arguments
+            output = (
+                outcome.result
+                if isinstance(outcome, ToolCallResult)
+                else {"error": outcome.message}
+            )
+
+        return [
+            {
                 "type": "function_call",
                 "name": TextGenerationVendor.provider_tool_name(
                     name,
@@ -1080,16 +1300,30 @@ class OpenAIClient(TextGenerationVendor):
                 ),
                 "call_id": call_id,
                 "arguments": to_json(arguments),
-            }
-            messages_out.append(call_message)
-
-            result_message = {
+            },
+            {
                 "type": "function_call_output",
                 "call_id": call_id,
                 "output": to_json(output),
-            }
-            messages_out.append(result_message)
-        return messages_out
+            },
+        ]
+
+    def _record_stateless_response_item(self, item: dict[str, Any]) -> None:
+        self._stateless_response_items.append(deepcopy(item))
+
+    @staticmethod
+    def _has_function_call_context(
+        messages: list[TemplateMessage] | list[dict[str, Any]],
+    ) -> bool:
+        for message in messages:
+            if not isinstance(message, Mapping):
+                continue
+            if message.get("type") in {
+                "function_call",
+                "function_call_output",
+            }:
+                return True
+        return False
 
     @staticmethod
     def _reasoning_config(

--- a/src/avalan/model/nlp/text/vendor/openai.py
+++ b/src/avalan/model/nlp/text/vendor/openai.py
@@ -39,7 +39,7 @@ from . import (
     TextGenerationVendorModel,
 )
 
-from asyncio import sleep
+from asyncio import CancelledError, sleep
 from collections.abc import (
     AsyncIterator,
     Awaitable,
@@ -49,6 +49,7 @@ from collections.abc import (
 )
 from copy import deepcopy
 from importlib import import_module
+from inspect import isawaitable
 from mimetypes import guess_type
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -220,12 +221,17 @@ class OpenAIStream(TextGenerationVendorStream):
                 if not retry:
                     break
                 await self._close_current_stream()
+                await self._raise_if_retry_interrupted()
                 assert self._stream_factory is not None
                 delay = self._stream_retry_delay_seconds * (2**attempts)
                 if delay > 0:
                     await sleep(delay)
+                await self._raise_if_retry_interrupted()
                 attempts += 1
-                self._stream = await self._stream_factory()
+                stream = await self._stream_factory()
+                await self._raise_if_retry_interrupted(stream)
+                self._stream = stream
+                self._stream_sources = (self._stream,)
         finally:
             await self.aclose()
 
@@ -265,9 +271,55 @@ class OpenAIStream(TextGenerationVendorStream):
         } and not is_stream_terminal_kind(event.kind)
 
     async def _close_current_stream(self) -> None:
-        close = getattr(self._stream, "aclose", None)
-        if callable(close):
-            await close()
+        await self._call_stream_source_cleanup(self._stream, "aclose")
+
+    async def _raise_if_retry_interrupted(
+        self,
+        stream: AsyncIterator[Any] | None = None,
+    ) -> None:
+        if not (self._stream_cancelled or self._stream_closed):
+            return
+        if stream is not None:
+            await self._call_stream_source_cleanup(stream, "aclose")
+        raise CancelledError()
+
+    async def _call_stream_cleanup(self, method_name: str) -> None:
+        assert method_name in ("cancel", "aclose")
+        errors: list[BaseException] = []
+        for source in self._cleanup_sources():
+            try:
+                await self._call_stream_source_cleanup(source, method_name)
+            except BaseException as exc:
+                errors.append(exc)
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise BaseExceptionGroup("vendor stream cleanup failed", errors)
+
+    @staticmethod
+    async def _call_stream_source_cleanup(
+        source: object,
+        method_name: str,
+    ) -> None:
+        method_names = (
+            ("cancel", "close", "aclose")
+            if method_name == "cancel"
+            else ("aclose", "close")
+        )
+        method = None
+        for cleanup_method_name in method_names:
+            method = getattr(source, cleanup_method_name, None)
+            if method is not None:
+                break
+        else:
+            return
+        assert callable(method)
+        result = method()
+        if isawaitable(result):
+            awaited_result = await cast(Awaitable[object], result)
+            assert awaited_result is None
+        else:
+            assert result is None
 
     def _provider_events_from_event(
         self, event: object

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -5029,6 +5029,8 @@ temperature = 0.5
 top_p = 0.9
 top_k = 5
 max_new_tokens = 42
+openai_response_failed_retries = 0
+openai_response_failed_retry_delay_seconds = 0.5
 maximum_tool_cycles = 64
 """
         with TemporaryDirectory() as tmp:
@@ -5057,6 +5059,16 @@ maximum_tool_cycles = 64
                 self.assertEqual(settings.call_options["top_p"], 0.9)
                 self.assertEqual(settings.call_options["top_k"], 5)
                 self.assertEqual(settings.call_options["max_new_tokens"], 42)
+                self.assertEqual(
+                    settings.call_options["openai_response_failed_retries"],
+                    0,
+                )
+                self.assertEqual(
+                    settings.call_options[
+                        "openai_response_failed_retry_delay_seconds"
+                    ],
+                    0.5,
+                )
                 self.assertEqual(
                     settings.call_options["maximum_tool_cycles"], 64
                 )
@@ -5116,6 +5128,7 @@ maximum_tool_cycles = \"unlimited\"
         env.filters["toml_value"] = agent_cmds._toml_template_value
         template = env.get_template("blueprint.toml")
         cases = [(64, 64), (UNLIMITED_TOOL_CYCLES, UNLIMITED_TOOL_CYCLES)]
+        retry_delay_key = "openai_response_failed_retry_delay_seconds"
 
         for value, expected in cases:
             with self.subTest(value=value):
@@ -5133,6 +5146,8 @@ maximum_tool_cycles = \"unlimited\"
                             "max_new_tokens": 42,
                             "skip_special_tokens": False,
                             "maximum_tool_cycles": value,
+                            "openai_response_failed_retries": 0,
+                            retry_delay_key: 0.5,
                         },
                         tools=[],
                     ),
@@ -5154,6 +5169,14 @@ maximum_tool_cycles = \"unlimited\"
 
                 self.assertEqual(
                     config["run"]["maximum_tool_cycles"], expected
+                )
+                self.assertEqual(
+                    config["run"]["openai_response_failed_retries"],
+                    0,
+                )
+                self.assertEqual(
+                    config["run"][retry_delay_key],
+                    0.5,
                 )
 
     async def test_run_response_format_schema_ref_is_resolved(self):

--- a/tests/agent/loader_test.py
+++ b/tests/agent/loader_test.py
@@ -5032,6 +5032,7 @@ max_new_tokens = 42
 openai_response_failed_retries = 0
 openai_response_failed_retry_delay_seconds = 0.5
 maximum_tool_cycles = 64
+block_repeated_tool_calls = true
 """
         with TemporaryDirectory() as tmp:
             path = f"{tmp}/agent.toml"
@@ -5071,6 +5072,9 @@ maximum_tool_cycles = 64
                 )
                 self.assertEqual(
                     settings.call_options["maximum_tool_cycles"], 64
+                )
+                self.assertTrue(
+                    settings.call_options["block_repeated_tool_calls"]
                 )
             await stack.aclose()
 
@@ -5127,11 +5131,17 @@ maximum_tool_cycles = \"unlimited\"
         )
         env.filters["toml_value"] = agent_cmds._toml_template_value
         template = env.get_template("blueprint.toml")
-        cases = [(64, 64), (UNLIMITED_TOOL_CYCLES, UNLIMITED_TOOL_CYCLES)]
+        cases = [
+            (64, 64, True),
+            (UNLIMITED_TOOL_CYCLES, UNLIMITED_TOOL_CYCLES, False),
+        ]
         retry_delay_key = "openai_response_failed_retry_delay_seconds"
 
-        for value, expected in cases:
-            with self.subTest(value=value):
+        for value, expected, block_repeated_tool_calls in cases:
+            with self.subTest(
+                value=value,
+                block_repeated_tool_calls=block_repeated_tool_calls,
+            ):
                 rendered = template.render(
                     orchestrator=Namespace(
                         agent_config={},
@@ -5146,6 +5156,9 @@ maximum_tool_cycles = \"unlimited\"
                             "max_new_tokens": 42,
                             "skip_special_tokens": False,
                             "maximum_tool_cycles": value,
+                            "block_repeated_tool_calls": (
+                                block_repeated_tool_calls
+                            ),
                             "openai_response_failed_retries": 0,
                             retry_delay_key: 0.5,
                         },
@@ -5169,6 +5182,10 @@ maximum_tool_cycles = \"unlimited\"
 
                 self.assertEqual(
                     config["run"]["maximum_tool_cycles"], expected
+                )
+                self.assertEqual(
+                    config["run"]["block_repeated_tool_calls"],
+                    block_repeated_tool_calls,
                 )
                 self.assertEqual(
                     config["run"]["openai_response_failed_retries"],

--- a/tests/agent/orchestrator_response_additional_test.py
+++ b/tests/agent/orchestrator_response_additional_test.py
@@ -2546,6 +2546,7 @@ class OrchestratorResponseAdditionalCoverageTestCase(IsolatedAsyncioTestCase):
             operation,
             {},
             tool=tool,
+            block_repeated_tool_calls=True,
         )
         context = ToolCallContext(input=response._input, calls=[])
 

--- a/tests/agent/orchestrator_response_test.py
+++ b/tests/agent/orchestrator_response_test.py
@@ -11005,6 +11005,51 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         self.assertIs(tool_result_messages[0].tool_call_result, result)
         validate_canonical_stream_items(resp.canonical_items)
 
+    async def test_repeated_tool_attempt_executes_by_default(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={"value": 1})
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+        tool.return_value = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result="ok",
+        )
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+            tool=tool,
+        )
+        context = ToolCallContext(input=resp._input, calls=[])
+
+        first = await resp._execute_tool_call(
+            call,
+            context,
+            confirm=False,
+        )
+        second = await resp._execute_tool_call(
+            call,
+            context,
+            confirm=False,
+        )
+
+        self.assertIsInstance(first, ToolCallResult)
+        self.assertIsInstance(second, ToolCallResult)
+        self.assertEqual(tool.await_count, 2)
+        self.assertEqual(
+            resp._attempted_call_signature_details(),
+            [resp._call_signature(call)],
+        )
+
     async def test_repeated_tool_attempt_returns_guard_diagnostic(self):
         engine = _DummyEngine()
         agent = MagicMock(spec=EngineAgent)
@@ -11028,6 +11073,7 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
             operation,
             {},
             tool=tool,
+            block_repeated_tool_calls=True,
         )
         context = ToolCallContext(input=resp._input, calls=[])
 
@@ -11074,6 +11120,7 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
             operation,
             {},
             tool=tool,
+            block_repeated_tool_calls=True,
         )
         context = ToolCallContext(input=resp._input, calls=[])
 
@@ -11143,7 +11190,7 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         )
         validate_canonical_stream_items(resp.canonical_items)
 
-    async def test_tool_cycle_guard_rejects_duplicate_and_maximum_cycles(
+    async def test_tool_cycle_guard_allows_duplicate_observation_by_default(
         self,
     ):
         engine = _DummyEngine()
@@ -11171,6 +11218,45 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         )
 
         self.assertTrue(resp._should_continue_tool_cycle(messages, [result]))
+        self.assertTrue(resp._should_continue_tool_cycle(messages, [result]))
+        self.assertEqual(resp._tool_cycle_count, 2)
+        self.assertFalse(
+            any(
+                item.kind is StreamItemKind.STREAM_DIAGNOSTIC
+                and item.data
+                and item.data.get("code")
+                == "orchestrator.tool_cycle.duplicate_observation"
+                for item in resp.canonical_items
+            )
+        )
+
+    async def test_tool_cycle_guard_rejects_duplicate_when_enabled(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={"value": 1})
+        result = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result="ok",
+        )
+        messages = OrchestratorResponse._tool_observation_messages(
+            result,
+            json_output=False,
+        )
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _string_response("call", async_gen=False),
+            agent,
+            operation,
+            {},
+            block_repeated_tool_calls=True,
+        )
+
+        self.assertTrue(resp._should_continue_tool_cycle(messages, [result]))
         self.assertFalse(resp._should_continue_tool_cycle(messages, [result]))
         self.assertEqual(
             resp.canonical_items[-1].data["code"],
@@ -11179,6 +11265,24 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             resp.canonical_items[-1].data["stage"],
             ToolCallDiagnosticStage.GUARD.value,
+        )
+
+    async def test_tool_cycle_guard_rejects_maximum_cycles(self):
+        engine = _DummyEngine()
+        agent = MagicMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        call = ToolCall(id="call1", name="calc", arguments={"value": 1})
+        result = ToolCallResult(
+            id="result1",
+            call=call,
+            name=call.name,
+            arguments=call.arguments,
+            result="ok",
+        )
+        messages = OrchestratorResponse._tool_observation_messages(
+            result,
+            json_output=False,
         )
 
         limited = _make_response(
@@ -11717,6 +11821,92 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
         validate_canonical_stream_items(resp.canonical_items)
         validate_tool_lifecycle_items(resp.canonical_items)
 
+    async def test_iteration_repeated_tool_call_executes_by_default(self):
+        engine = _DummyEngine()
+        agent = AsyncMock(spec=EngineAgent)
+        agent.engine = engine
+        operation = _dummy_operation()
+        event_manager = MagicMock(spec=EventManager)
+        event_manager.trigger = AsyncMock()
+
+        call = ToolCall(
+            id="call1",
+            name="calc",
+            arguments={"expression": "25 * 2"},
+        )
+        repeated_call = ToolCall(
+            id="call2",
+            name="calc",
+            arguments={"expression": "25 * 2"},
+        )
+        agent.side_effect = [
+            _tool_call_response(repeated_call),
+            _string_response("done", async_gen=True),
+        ]
+
+        tool = AsyncMock(spec=ToolManager)
+        tool.is_empty = False
+
+        async def execute(
+            requested_call: ToolCall, _: ToolCallContext
+        ) -> ToolCallResult:
+            return ToolCallResult(
+                id=f"result-{requested_call.id}",
+                call=requested_call,
+                name=requested_call.name,
+                arguments=requested_call.arguments,
+                result="50",
+            )
+
+        tool.side_effect = execute
+
+        resp = _make_response(
+            Message(role=MessageRole.USER, content="hi"),
+            _tool_call_response(call),
+            agent,
+            operation,
+            {},
+            event_manager=event_manager,
+            tool=tool,
+        )
+
+        items = await _collect_stream_items(resp)
+
+        self.assertEqual(_answer_text(items), "done")
+        self.assertEqual(tool.await_count, 2)
+        self.assertEqual(agent.await_count, 2)
+
+        first_context = agent.await_args_list[0].args[0]
+        second_context = agent.await_args_list[1].args[0]
+        assert isinstance(first_context.input, list)
+        assert isinstance(second_context.input, list)
+        first_tool_messages = [
+            message
+            for message in first_context.input
+            if message.role is MessageRole.TOOL
+        ]
+        second_tool_messages = [
+            message
+            for message in second_context.input
+            if message.role is MessageRole.TOOL
+        ]
+        self.assertEqual(len(first_tool_messages), 1)
+        self.assertEqual(len(second_tool_messages), 2)
+        self.assertIsNotNone(second_tool_messages[-1].tool_call_result)
+        self.assertIsNone(second_tool_messages[-1].tool_call_diagnostic)
+        self.assertFalse(
+            any(
+                item.kind is StreamItemKind.TOOL_EXECUTION_ERROR
+                and item.data
+                and item.data.get("code")
+                == ToolCallDiagnosticCode.REPEATED_CALL.value
+                for item in resp.canonical_items
+            )
+        )
+
+        validate_canonical_stream_items(resp.canonical_items)
+        validate_tool_lifecycle_items(resp.canonical_items)
+
     async def test_iteration_repeated_tool_skip_continues_to_model(self):
         engine = _DummyEngine()
         agent = AsyncMock(spec=EngineAgent)
@@ -11758,6 +11948,7 @@ class OrchestratorResponseToStrTestCase(IsolatedAsyncioTestCase):
             {},
             event_manager=event_manager,
             tool=tool,
+            block_repeated_tool_calls=True,
         )
 
         items = await _collect_stream_items(resp)

--- a/tests/agent/orchestrator_test.py
+++ b/tests/agent/orchestrator_test.py
@@ -113,6 +113,7 @@ class OrchestratorCallTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(resp, "resp")
         self.assertEqual(captured["kwargs"]["maximum_tool_cycles"], 24)
+        self.assertFalse(captured["kwargs"]["block_repeated_tool_calls"])
 
     async def test_call_consumes_maximum_tool_cycles_option(self):
         captured = {}
@@ -152,6 +153,61 @@ class OrchestratorCallTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(resp, "resp")
         self.assertEqual(captured["kwargs"]["maximum_tool_cycles"], 32)
+
+    async def test_call_consumes_block_repeated_tool_calls_option(self):
+        captured = {}
+        self.orch._call_options = {
+            "max_new_tokens": 10,
+            "block_repeated_tool_calls": True,
+        }
+
+        def response_factory(*args, **kwargs):
+            captured["kwargs"] = kwargs
+            return "resp"
+
+        with patch(
+            "avalan.agent.orchestrator.OrchestratorResponse",
+            response_factory,
+        ):
+            resp = await self.orch("hi")
+
+        self.assertEqual(resp, "resp")
+        self.assertTrue(captured["kwargs"]["block_repeated_tool_calls"])
+        context = self.engine_agent.await_args.args[0]
+        self.assertEqual(context.engine_args, {"max_new_tokens": 10})
+
+    async def test_call_consumes_block_repeated_tool_calls_kwarg(self):
+        captured = {}
+
+        def response_factory(*args, **kwargs):
+            captured["kwargs"] = kwargs
+            return "resp"
+
+        with patch(
+            "avalan.agent.orchestrator.OrchestratorResponse",
+            response_factory,
+        ):
+            resp = await self.orch(
+                "hi",
+                block_repeated_tool_calls=True,
+                max_new_tokens=10,
+            )
+
+        self.assertEqual(resp, "resp")
+        self.assertTrue(captured["kwargs"]["block_repeated_tool_calls"])
+        context = self.engine_agent.await_args.args[0]
+        self.assertEqual(context.engine_args, {"max_new_tokens": 10})
+
+    async def test_call_rejects_invalid_block_repeated_tool_calls(self):
+        self.orch._call_options = {"block_repeated_tool_calls": "true"}
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "block_repeated_tool_calls must be a bool",
+        ):
+            await self.orch("hi")
+
+        self.engine_agent.assert_not_awaited()
 
     async def test_call_consumes_unlimited_maximum_tool_cycles_option(self):
         captured = {}

--- a/tests/cli/agent_test.py
+++ b/tests/cli/agent_test.py
@@ -1218,6 +1218,8 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
             run_top_p=0.82,
             run_use_cache=True,
             run_cache_strategy="hybrid",
+            run_openai_response_failed_retries=0,
+            run_openai_response_failed_retry_delay_seconds=0.5,
             run_reasoning_effort="xhigh",
             run_chat_add_generation_prompt=False,
             run_chat_enable_thinking=True,
@@ -1249,6 +1251,11 @@ class CliAgentInitTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn("top_p = 0.82", output)
         self.assertIn("use_cache = true", output)
         self.assertIn('cache_strategy = "hybrid"', output)
+        self.assertIn("openai_response_failed_retries = 0", output)
+        self.assertIn(
+            "openai_response_failed_retry_delay_seconds = 0.5",
+            output,
+        )
         self.assertIn("[run.chat]", output)
         self.assertIn("add_generation_prompt = false", output)
         self.assertIn("enable_thinking = true", output)
@@ -4766,6 +4773,8 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.args.run_top_p = 0.9
         self.args.run_top_k = 5
         self.args.run_max_new_tokens = 42
+        self.args.run_openai_response_failed_retries = 0
+        self.args.run_openai_response_failed_retry_delay_seconds = 0.5
         self.args.tool_choice = "mcp.call"
 
         with (
@@ -4797,6 +4806,16 @@ class CliAgentRunTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(settings.call_options["top_p"], 0.9)
         self.assertEqual(settings.call_options["top_k"], 5)
         self.assertEqual(settings.call_options["max_new_tokens"], 42)
+        self.assertEqual(
+            settings.call_options["openai_response_failed_retries"],
+            0,
+        )
+        self.assertEqual(
+            settings.call_options[
+                "openai_response_failed_retry_delay_seconds"
+            ],
+            0.5,
+        )
         self.assertEqual(settings.call_options["tool_choice"], "mcp.call")
 
     async def test_run_engine_uri_use_cache_cli(self):

--- a/tests/cli/get_orchestrator_settings_test.py
+++ b/tests/cli/get_orchestrator_settings_test.py
@@ -75,6 +75,45 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             },
         )
 
+    def test_openai_response_failed_retry_options(self):
+        args = Namespace(
+            name="a",
+            role="r",
+            task=None,
+            instructions=None,
+            engine_uri="ai://m",
+            backend="transformers",
+            run_max_new_tokens=10,
+            run_skip_special_tokens=False,
+            run_openai_response_failed_retries=None,
+            run_openai_response_failed_retry_delay_seconds=None,
+            memory_recent=None,
+            no_session=False,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=200,
+            memory_engine_overlap=20,
+            memory_engine_window=40,
+            tool=None,
+        )
+        uid = UUID("00000000-0000-0000-0000-000000000013")
+        result = agent_cmds.get_orchestrator_settings(
+            args,
+            agent_id=uid,
+            openai_response_failed_retries=0,
+            openai_response_failed_retry_delay_seconds=0.5,
+        )
+
+        self.assertEqual(
+            result.call_options["openai_response_failed_retries"],
+            0,
+        )
+        self.assertEqual(
+            result.call_options["openai_response_failed_retry_delay_seconds"],
+            0.5,
+        )
+
     def test_unlimited_maximum_tool_cycles(self):
         args = Namespace(
             name="a",

--- a/tests/cli/get_orchestrator_settings_test.py
+++ b/tests/cli/get_orchestrator_settings_test.py
@@ -36,6 +36,7 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
         self.assertEqual(result.uri, "ai://m")
         self.assertEqual(result.call_options["max_new_tokens"], 10)
         self.assertEqual(result.call_options["maximum_tool_cycles"], 64)
+        self.assertNotIn("block_repeated_tool_calls", result.call_options)
         self.assertEqual(result.engine_config, {"backend": "transformers"})
         self.assertEqual(result.agent_config, {"name": "a", "role": "r"})
         self.assertEqual(result.tools, [])
@@ -43,6 +44,62 @@ class GetOrchestratorSettingsTestCase(unittest.TestCase):
             result.sentence_model_id,
             OrchestratorLoader.DEFAULT_SENTENCE_MODEL_ID,
         )
+
+    def test_block_repeated_tool_calls_from_cli(self):
+        args = Namespace(
+            name="a",
+            role="r",
+            task=None,
+            instructions=None,
+            engine_uri="ai://m",
+            backend="transformers",
+            run_max_new_tokens=10,
+            run_block_repeated_tool_calls=True,
+            run_skip_special_tokens=False,
+            memory_recent=None,
+            no_session=False,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=200,
+            memory_engine_overlap=20,
+            memory_engine_window=40,
+            tool=None,
+        )
+        uid = UUID("00000000-0000-0000-0000-000000000014")
+        result = agent_cmds.get_orchestrator_settings(args, agent_id=uid)
+
+        self.assertTrue(result.call_options["block_repeated_tool_calls"])
+
+    def test_block_repeated_tool_calls_from_kwarg(self):
+        args = Namespace(
+            name="a",
+            role="r",
+            task=None,
+            instructions=None,
+            engine_uri="ai://m",
+            backend="transformers",
+            run_max_new_tokens=10,
+            run_block_repeated_tool_calls=None,
+            run_skip_special_tokens=False,
+            memory_recent=None,
+            no_session=False,
+            memory_permanent_message=None,
+            memory_permanent=None,
+            memory_engine_model_id=None,
+            memory_engine_max_tokens=200,
+            memory_engine_overlap=20,
+            memory_engine_window=40,
+            tool=None,
+        )
+        uid = UUID("00000000-0000-0000-0000-000000000015")
+        result = agent_cmds.get_orchestrator_settings(
+            args,
+            agent_id=uid,
+            block_repeated_tool_calls=True,
+        )
+
+        self.assertTrue(result.call_options["block_repeated_tool_calls"])
 
     def test_engine_base_url(self):
         args = Namespace(

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -381,6 +381,143 @@ class CliMaximumToolCyclesOptionTestCase(TestCase):
         self.assertIn("positive integer or 'unlimited'", stderr.getvalue())
 
 
+class CliOpenAIResponseFailedRetryOptionTestCase(TestCase):
+    def test_agent_run_accepts_openai_response_failed_retry_options(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+
+        args = cli._parser.parse_args(
+            [
+                "agent",
+                "run",
+                "--run-openai-response-failed-retries",
+                "0",
+                "--run-openai-response-failed-retry-delay-seconds",
+                "0.5",
+            ]
+        )
+
+        self.assertEqual(args.run_openai_response_failed_retries, 0)
+        self.assertEqual(
+            args.run_openai_response_failed_retry_delay_seconds,
+            0.5,
+        )
+
+    def test_model_run_accepts_openai_response_failed_retry_options(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+
+        args = cli._parser.parse_args(
+            [
+                "model",
+                "run",
+                "ai://env:OPENAI_API_KEY@openai/gpt-4o",
+                "--openai-response-failed-retries",
+                "0",
+                "--openai-response-failed-retry-delay-seconds",
+                "0.25",
+            ]
+        )
+
+        self.assertEqual(args.openai_response_failed_retries, 0)
+        self.assertEqual(
+            args.openai_response_failed_retry_delay_seconds,
+            0.25,
+        )
+
+    def test_model_run_rejects_negative_openai_response_failed_retries(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+        stderr = StringIO()
+
+        with (
+            patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            cli._parser.parse_args(
+                [
+                    "model",
+                    "run",
+                    "ai://env:OPENAI_API_KEY@openai/gpt-4o",
+                    "--openai-response-failed-retries",
+                    "-1",
+                ]
+            )
+
+        self.assertEqual(exit_context.exception.code, 2)
+        self.assertIn("must not be negative", stderr.getvalue())
+
+    def test_agent_run_rejects_invalid_openai_response_failed_retries(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+        stderr = StringIO()
+
+        with (
+            patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            cli._parser.parse_args(
+                [
+                    "agent",
+                    "run",
+                    "--run-openai-response-failed-retries",
+                    "many",
+                ]
+            )
+
+        self.assertEqual(exit_context.exception.code, 2)
+        self.assertIn("must be an integer", stderr.getvalue())
+
+    def test_agent_run_rejects_negative_openai_response_failed_delay(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+        stderr = StringIO()
+
+        with (
+            patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            cli._parser.parse_args(
+                [
+                    "agent",
+                    "run",
+                    "--run-openai-response-failed-retry-delay-seconds",
+                    "-0.1",
+                ]
+            )
+
+        self.assertEqual(exit_context.exception.code, 2)
+        self.assertIn("must not be negative", stderr.getvalue())
+
+    def test_model_run_rejects_invalid_openai_response_failed_delay(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+        stderr = StringIO()
+
+        with (
+            patch.object(sys, "stderr", stderr),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            cli._parser.parse_args(
+                [
+                    "model",
+                    "run",
+                    "ai://env:OPENAI_API_KEY@openai/gpt-4o",
+                    "--openai-response-failed-retry-delay-seconds",
+                    "soon",
+                ]
+            )
+
+        self.assertEqual(exit_context.exception.code, 2)
+        self.assertIn("must be numeric", stderr.getvalue())
+
+
 class CliParallelOptionTestCase(TestCase):
     def test_default_flow_parallel_count_uses_cpu_count(self) -> None:
         with patch("avalan.cli.__main__.cpu_count", return_value=12):

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -312,6 +312,29 @@ class CliThemeOptionTestCase(TestCase):
 
 
 class CliMaximumToolCyclesOptionTestCase(TestCase):
+    def test_agent_run_repeated_tool_calls_default_to_unspecified(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+
+        args = cli._parser.parse_args(["agent", "run"])
+
+        self.assertIsNone(args.run_block_repeated_tool_calls)
+
+    def test_agent_run_accepts_block_repeated_tool_calls_aliases(
+        self,
+    ) -> None:
+        cli = CLI(MagicMock())
+
+        for flag in (
+            "--block-repeated-tool-calls",
+            "--run-block-repeated-tool-calls",
+        ):
+            with self.subTest(flag=flag):
+                args = cli._parser.parse_args(["agent", "run", flag])
+
+                self.assertTrue(args.run_block_repeated_tool_calls)
+
     def test_agent_run_accepts_numeric_tool_cycles(self) -> None:
         cli = CLI(MagicMock())
 

--- a/tests/model/modality_registry_test.py
+++ b/tests/model/modality_registry_test.py
@@ -36,6 +36,8 @@ def test_get_operation_from_arguments_maps_reasoning_effort():
         max_new_tokens=32,
         min_p=None,
         no_reasoning=False,
+        openai_response_failed_retries=0,
+        openai_response_failed_retry_delay_seconds=0.5,
         reasoning_effort="xhigh",
         reasoning_max_new_tokens=12,
         reasoning_stop_on_max_new_tokens=True,
@@ -58,4 +60,9 @@ def test_get_operation_from_arguments_maps_reasoning_effort():
     assert reasoning.stop_on_max_new_tokens is True
     assert reasoning.tag == ReasoningTag.THINK
     assert operation.generation_settings.chat_settings.enable_thinking is False
+    assert operation.generation_settings.openai_response_failed_retries == 0
+    assert (
+        operation.generation_settings.openai_response_failed_retry_delay_seconds
+        == 0.5
+    )
     assert operation.input == "hi"

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -10,7 +10,7 @@ from logging import getLogger
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import UUID
 
 from avalan.agent.orchestrator.response.orchestrator_response import (
@@ -284,6 +284,12 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         StreamMock.assert_called_once_with(
             stream=stream_instance,
             provider_family="openai",
+            output_item_sink=client._record_stateless_response_item,
+            stream_factory=ANY,
+            stream_retry_delay_seconds=(
+                client._STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS
+            ),
+            stream_retries=client._STREAM_RESPONSE_FAILED_RETRIES,
         )
         self.assertIs(result, StreamMock.return_value)
 
@@ -445,6 +451,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             max_output_tokens=10,
             text={"format": {"type": "json_object"}, "stop": ["END"]},
             reasoning={"effort": "high"},
+            include=["reasoning.encrypted_content"],
             prompt_cache_retention="24h",
             tools=[{"type": "function", "name": "avl_cGtnLmxvb2t1cA"}],
             tool_choice={"type": "function", "name": "avl_cGtnLmxvb2t1cA"},
@@ -452,6 +459,43 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertNotIn(
             "top-level policy", str(create_mock.await_args.kwargs["input"])
         )
+
+    async def test_responses_payload_preserves_tool_history(self):
+        response = SimpleNamespace(
+            output=[SimpleNamespace(content=[SimpleNamespace(text="ok")])]
+        )
+        create_mock = AsyncMock(return_value=response)
+        self.openai_stub.AsyncOpenAI.return_value.responses.create = (
+            create_mock
+        )
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        call = ToolCall(
+            id="call1",
+            name="shell.rg",
+            arguments={"pattern": "needle"},
+        )
+        result = ToolCallResult(
+            id="result1",
+            name="shell.rg",
+            arguments=call.arguments,
+            call=call,
+            result="match",
+        )
+        messages = [
+            Message(role=MessageRole.USER, content="search"),
+            Message(role=MessageRole.TOOL, tool_call_result=result),
+        ]
+
+        await client("gpt-5", messages, use_async_generator=False)
+
+        kwargs = create_mock.await_args.kwargs
+        self.assertNotIn("truncation", kwargs)
+        self.assertEqual(
+            kwargs["input"][0],
+            {"role": "user", "content": "search"},
+        )
+        self.assertEqual(kwargs["input"][1]["type"], "function_call")
+        self.assertEqual(kwargs["input"][2]["type"], "function_call_output")
 
     async def test_rejects_tool_choice_missing_from_schemas(self):
         create_mock = AsyncMock()
@@ -901,6 +945,228 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             accumulate_canonical_stream_items(items).answer_text,
             "done",
+        )
+
+    async def test_stream_records_stateless_reasoning_output_items(self):
+        collected = []
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "content": [],
+            "encrypted_content": "encrypted",
+            "status": None,
+        }
+        call_item = {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": "{}",
+            "namespace": None,
+            "metadata": {
+                "status": "ignored",
+                "items": [
+                    {"namespace": None, "value": 1},
+                ],
+            },
+            "status": "completed",
+        }
+        expected_reasoning = dict(reasoning_item)
+        expected_reasoning.pop("status")
+        expected_reasoning.pop("content")
+        expected_call = dict(call_item)
+        expected_call.pop("status")
+        expected_call.pop("namespace")
+        expected_call["metadata"] = {"items": [{"value": 1}]}
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    {
+                        "type": "response.output_item.done",
+                        "item": reasoning_item,
+                    },
+                    {
+                        "type": "response.output_item.done",
+                        "item": call_item,
+                    },
+                ]
+            ),
+            output_item_sink=collected.append,
+        )
+
+        await _stream_items(stream)
+
+        self.assertEqual(collected, [expected_reasoning, expected_call])
+
+    async def test_stream_ignores_non_replayable_stateless_output_items(self):
+        collected = []
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    {
+                        "type": "response.output_item.done",
+                        "item": "raw",
+                    },
+                    {
+                        "type": "response.output_item.done",
+                        "item": {"type": "message", "id": "msg_1"},
+                    },
+                ]
+            ),
+            output_item_sink=collected.append,
+        )
+
+        await _stream_items(stream)
+
+        self.assertEqual(collected, [])
+
+    async def test_stream_retries_empty_response_failed_before_output(self):
+        retry_streams = []
+
+        async def retry_stream():
+            retry_streams.append("retry")
+            return AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta", delta="ok"
+                    ),
+                    SimpleNamespace(
+                        type="response.completed",
+                        response=SimpleNamespace(usage={}),
+                    ),
+                ]
+            )
+
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.failed",
+                        response=SimpleNamespace(
+                            status="failed",
+                            error=None,
+                            output=[],
+                        ),
+                    )
+                ]
+            ),
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+
+        items = await _stream_items(stream)
+
+        self.assertEqual(retry_streams, ["retry"])
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_client_retry_stream_factory_after_empty_response_failed(
+        self,
+    ):
+        failed_stream = TrackedAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[],
+                    ),
+                )
+            ]
+        )
+        recovered_stream = AsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="ok")]
+        )
+        create_mock = AsyncMock(side_effect=[failed_stream, recovered_stream])
+        self.openai_stub.AsyncOpenAI.return_value.responses.create = (
+            create_mock
+        )
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        client._template_messages = MagicMock(
+            return_value=[{"role": "user", "content": "hi"}]
+        )
+
+        with patch.object(self.mod, "sleep", new=AsyncMock()) as sleep_mock:
+            stream = await client("m", [])
+            items = await _stream_items(stream)
+
+        self.assertGreaterEqual(failed_stream.close_count, 1)
+        sleep_mock.assert_awaited_once_with(1.0)
+        self.assertEqual(create_mock.await_count, 2)
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_stream_does_not_retry_failed_response_with_error_or_output(
+        self,
+    ):
+        cases = [
+            SimpleNamespace(
+                status="failed",
+                error=SimpleNamespace(message="boom"),
+                output=[],
+            ),
+            SimpleNamespace(
+                status="failed",
+                error=None,
+                output=[{"type": "message"}],
+            ),
+        ]
+
+        for response in cases:
+            with self.subTest(response=response):
+                retry_stream = AsyncMock()
+                stream = self.mod.OpenAIStream(
+                    AsyncIter(
+                        [
+                            SimpleNamespace(
+                                type="response.failed",
+                                response=response,
+                            )
+                        ]
+                    ),
+                    stream_factory=retry_stream,
+                    stream_retries=1,
+                )
+
+                items = await _stream_items(stream)
+
+                retry_stream.assert_not_awaited()
+                self.assertIn(
+                    StreamItemKind.STREAM_ERRORED,
+                    [item.kind for item in items],
+                )
+
+    async def test_stream_does_not_retry_response_failed_after_output(self):
+        retry_stream = AsyncMock()
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta", delta="partial"
+                    ),
+                    SimpleNamespace(
+                        type="response.failed",
+                        response=SimpleNamespace(
+                            status="failed",
+                            error=None,
+                            output=[],
+                        ),
+                    ),
+                ]
+            ),
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+
+        items = await _stream_items(stream)
+
+        retry_stream.assert_not_awaited()
+        self.assertIn(
+            StreamItemKind.STREAM_ERRORED, [item.kind for item in items]
         )
 
     async def test_stream_completion_output_emits_structured_answer(self):
@@ -2752,6 +3018,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             max_output_tokens=20,
             text={"format": {"type": "json_object"}, "stop": "END"},
             reasoning={"effort": "high"},
+            include=["reasoning.encrypted_content"],
         )
 
     async def test_azure_legacy_api_version_uses_extra_query(self):
@@ -2865,6 +3132,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
 
         kwargs = create_mock.await_args.kwargs
         self.assertEqual(kwargs["reasoning"], {"effort": "xhigh"})
+        self.assertEqual(kwargs["include"], ["reasoning.encrypted_content"])
 
     def test_response_text_format_normalizes_supported_shapes(self):
         self.assertEqual(
@@ -3546,6 +3814,219 @@ class TemplateAndToolSchemaTestCase(TestCase):
                     "type": "function_call_output",
                     "call_id": "c2",
                     "output": '{"x": 3}',
+                },
+            ],
+        )
+
+    def test_has_function_call_context(self):
+        self.assertFalse(
+            self.mod.OpenAIClient._has_function_call_context(
+                [{"role": "user", "content": "hi"}]
+            )
+        )
+        self.assertFalse(
+            self.mod.OpenAIClient._has_function_call_context(
+                ["raw", {"role": "user", "content": "hi"}]  # type: ignore[arg-type]
+            )
+        )
+        self.assertTrue(
+            self.mod.OpenAIClient._has_function_call_context(
+                [
+                    {"role": "user", "content": "hi"},
+                    {"type": "function_call_output", "call_id": "c1"},
+                ]
+            )
+        )
+
+    def test_template_messages_ignores_stateless_items_without_tool_outputs(
+        self,
+    ):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        client._record_stateless_response_item(
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "encrypted_content": "encrypted",
+            }
+        )
+
+        templated = client._template_messages(
+            [Message(role=MessageRole.USER, content="hi")]
+        )
+
+        self.assertEqual(templated, [{"role": "user", "content": "hi"}])
+
+    def test_template_messages_replays_stateless_reasoning_items(self):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "encrypted",
+        }
+        call_item = {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "rg",
+            "arguments": '{"pattern": "needle"}',
+        }
+        client._record_stateless_response_item(reasoning_item)
+        client._record_stateless_response_item(call_item)
+        call = ToolCall(
+            id="call_1",
+            name="shell.rg",
+            arguments={"pattern": "needle"},
+        )
+        result = ToolCallResult(
+            id="result_1",
+            name="shell.rg",
+            arguments=call.arguments,
+            call=call,
+            result="match",
+        )
+
+        templated = client._template_messages(
+            [
+                Message(role=MessageRole.USER, content="search"),
+                Message(role=MessageRole.TOOL, tool_call_result=result),
+            ]
+        )
+
+        self.assertEqual(
+            templated,
+            [
+                {"role": "user", "content": "search"},
+                reasoning_item,
+                call_item,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": '"match"',
+                },
+            ],
+        )
+
+    def test_template_messages_omits_stateless_calls_without_outputs(self):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "encrypted",
+        }
+        missing_call_item = {
+            "type": "function_call",
+            "call_id": "call_missing",
+            "name": "rg",
+            "arguments": "{}",
+        }
+        call_item_a = {
+            "type": "function_call",
+            "call_id": "call_a",
+            "name": "rg",
+            "arguments": '{"pattern": "a"}',
+        }
+        call_item_b = {
+            "type": "function_call",
+            "call_id": "call_b",
+            "name": "rg",
+            "arguments": '{"pattern": "b"}',
+        }
+        client._record_stateless_response_item(reasoning_item)
+        client._record_stateless_response_item(missing_call_item)
+        client._record_stateless_response_item(call_item_a)
+        client._record_stateless_response_item(call_item_b)
+        call_a = ToolCall(
+            id="call_a",
+            name="shell.rg",
+            arguments={"pattern": "a"},
+        )
+        call_b = ToolCall(
+            id="call_b",
+            name="shell.rg",
+            arguments={"pattern": "b"},
+        )
+        result_a = ToolCallResult(
+            id="result_a",
+            name="shell.rg",
+            arguments=call_a.arguments,
+            call=call_a,
+            result="match a",
+        )
+        result_b = ToolCallResult(
+            id="result_b",
+            name="shell.rg",
+            arguments=call_b.arguments,
+            call=call_b,
+            result="match b",
+        )
+
+        templated = client._template_messages(
+            [
+                Message(role=MessageRole.USER, content="search"),
+                Message(role=MessageRole.TOOL, tool_call_result=result_b),
+                Message(role=MessageRole.TOOL, tool_call_result=result_a),
+            ]
+        )
+
+        self.assertEqual(
+            templated,
+            [
+                {"role": "user", "content": "search"},
+                reasoning_item,
+                call_item_a,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_a",
+                    "output": '"match a"',
+                },
+                call_item_b,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_b",
+                    "output": '"match b"',
+                },
+            ],
+        )
+
+    def test_template_messages_falls_back_after_unmatched_stateless_items(
+        self,
+    ):
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        client._record_stateless_response_item(
+            {"type": "message", "id": "msg_1"}
+        )
+        client._record_stateless_response_item(
+            {
+                "type": "function_call",
+                "name": "rg",
+                "arguments": "{}",
+            }
+        )
+        call = ToolCall(id="call_1", name="shell.rg", arguments={})
+        result = ToolCallResult(
+            id="result_1",
+            name="shell.rg",
+            arguments=call.arguments,
+            call=call,
+            result="match",
+        )
+
+        templated = client._template_messages(
+            [Message(role=MessageRole.TOOL, tool_call_result=result)]
+        )
+
+        self.assertEqual(
+            templated,
+            [
+                {
+                    "type": "function_call",
+                    "name": "avl_c2hlbGwucmc",
+                    "call_id": "call_1",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": '"match"',
                 },
             ],
         )

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -344,6 +344,7 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             stream=stream_instance,
             provider_family="openai",
             output_item_sink=client._record_stateless_response_item,
+            output_item_rollback=client._rollback_stateless_response_items,
             stream_factory=ANY,
             stream_retry_delay_seconds=(
                 client._STREAM_RESPONSE_FAILED_RETRY_DELAY_SECONDS
@@ -377,6 +378,127 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(items[1].text_delta, "hi")
         self.assertEqual({item.provider_family for item in items}, {"openai"})
+
+    async def test_stream_ignores_text_events_after_answer_done(self):
+        late_events = [
+            SimpleNamespace(type="response.output_text.delta", delta="late"),
+            SimpleNamespace(type="response.output_text.done", text="late"),
+        ]
+
+        for late_event in late_events:
+            with self.subTest(late_event=late_event.type):
+                stream = self.mod.OpenAIStream(
+                    AsyncIter(
+                        [
+                            SimpleNamespace(
+                                type="response.output_text.delta",
+                                delta="done",
+                            ),
+                            SimpleNamespace(type="response.output_text.done"),
+                            late_event,
+                        ]
+                    )
+                )
+
+                items = await _stream_items(stream)
+
+                self.assertEqual(
+                    [
+                        item.kind
+                        for item in items
+                        if item.kind
+                        in {
+                            StreamItemKind.ANSWER_DELTA,
+                            StreamItemKind.ANSWER_DONE,
+                        }
+                    ],
+                    [
+                        StreamItemKind.ANSWER_DELTA,
+                        StreamItemKind.ANSWER_DONE,
+                    ],
+                )
+                self.assertEqual(
+                    accumulate_canonical_stream_items(items).answer_text,
+                    "done",
+                )
+
+    async def test_stream_deduplicates_text_delta_alias_events(self):
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta",
+                        delta="{",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=1,
+                    ),
+                    SimpleNamespace(
+                        type="response.text.delta",
+                        delta="{",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=1,
+                    ),
+                    SimpleNamespace(
+                        type="response.output_text.delta",
+                        delta="x",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=2,
+                    ),
+                    SimpleNamespace(
+                        type="response.text.delta",
+                        delta="x",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=2,
+                    ),
+                ]
+            )
+        )
+
+        items = await _stream_items(stream)
+
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "{x",
+        )
+
+    async def test_stream_preserves_repeated_text_delta_tokens(self):
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta",
+                        delta="0",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=1,
+                    ),
+                    SimpleNamespace(
+                        type="response.output_text.delta",
+                        delta="0",
+                        item_id="msg_1",
+                        output_index=0,
+                        content_index=0,
+                        sequence_number=2,
+                    ),
+                ]
+            )
+        )
+
+        items = await _stream_items(stream)
+
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "00",
+        )
 
     async def test_stream_direct_anext_yields_canonical_items(self):
         stream = self.mod.OpenAIStream(
@@ -926,6 +1048,15 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             0.25,
         )
 
+    async def test_client_response_failed_retry_default_budget(self):
+        client = self.mod.OpenAIClient(api_key="token", base_url="b")
+
+        self.assertEqual(client._stream_response_failed_retries, 24)
+        self.assertEqual(
+            client._stream_response_failed_retry_delay_seconds,
+            1.0,
+        )
+
     async def test_model_rejects_invalid_provider_retry_options(self):
         cases: list[dict[str, Any]] = [
             {"openai_response_failed_retries": -1},
@@ -1166,6 +1297,179 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             "ok",
         )
 
+    async def test_stream_retries_reasoning_only_response_failed(self):
+        retry_streams = []
+        collected: list[dict[str, Any]] = []
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "ciphertext",
+            "content": [],
+        }
+
+        def rollback(count: int) -> None:
+            del collected[-count:]
+
+        async def retry_stream():
+            retry_streams.append("retry")
+            return AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta", delta="ok"
+                    ),
+                    SimpleNamespace(
+                        type="response.completed",
+                        response=SimpleNamespace(usage={}),
+                    ),
+                ]
+            )
+
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_item.done",
+                        item=reasoning_item,
+                    ),
+                    SimpleNamespace(
+                        type="response.failed",
+                        response=SimpleNamespace(
+                            status="failed",
+                            error=None,
+                            output=[reasoning_item],
+                        ),
+                    ),
+                ]
+            ),
+            output_item_sink=collected.append,
+            output_item_rollback=rollback,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+
+        items = await _stream_items(stream)
+
+        self.assertEqual(retry_streams, ["retry"])
+        self.assertEqual(collected, [])
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_stream_retry_keeps_output_items_without_rollback(self):
+        retry_streams = []
+        collected: list[dict[str, Any]] = []
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "ciphertext",
+            "content": [],
+        }
+
+        async def retry_stream():
+            retry_streams.append("retry")
+            return AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_text.delta", delta="ok"
+                    ),
+                    SimpleNamespace(
+                        type="response.completed",
+                        response=SimpleNamespace(usage={}),
+                    ),
+                ]
+            )
+
+        stream = self.mod.OpenAIStream(
+            AsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.output_item.done",
+                        item=reasoning_item,
+                    ),
+                    SimpleNamespace(
+                        type="response.failed",
+                        response=SimpleNamespace(
+                            status="failed",
+                            error=None,
+                            output=[reasoning_item],
+                        ),
+                    ),
+                ]
+            ),
+            output_item_sink=collected.append,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+
+        items = await _stream_items(stream)
+
+        self.assertEqual(retry_streams, ["retry"])
+        self.assertEqual(
+            collected,
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "ciphertext",
+                }
+            ],
+        )
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_stream_retries_unstreamed_failed_response_output(self):
+        cases = [
+            [{"type": "message", "id": "msg_1"}],
+            [{"type": "function_call", "call_id": "call_1"}],
+        ]
+
+        for output in cases:
+            with self.subTest(output=output):
+                retry_streams = []
+
+                async def retry_stream():
+                    retry_streams.append("retry")
+                    return AsyncIter(
+                        [
+                            SimpleNamespace(
+                                type="response.output_text.delta",
+                                delta="ok",
+                            ),
+                            SimpleNamespace(
+                                type="response.completed",
+                                response=SimpleNamespace(usage={}),
+                            ),
+                        ]
+                    )
+
+                stream = self.mod.OpenAIStream(
+                    AsyncIter(
+                        [
+                            SimpleNamespace(
+                                type="response.failed",
+                                response=SimpleNamespace(
+                                    status="failed",
+                                    error=None,
+                                    output=output,
+                                ),
+                            ),
+                        ]
+                    ),
+                    stream_factory=retry_stream,
+                    stream_retries=1,
+                )
+
+                items = await _stream_items(stream)
+
+                self.assertEqual(retry_streams, ["retry"])
+                self.assertEqual(
+                    accumulate_canonical_stream_items(items).answer_text,
+                    "ok",
+                )
+
     async def test_client_retry_stream_factory_after_empty_response_failed(
         self,
     ):
@@ -1200,6 +1504,95 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(failed_stream.close_count, 1)
         sleep_mock.assert_awaited_once_with(1.0)
         self.assertEqual(create_mock.await_count, 2)
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_stream_retry_delay_caps_exponential_backoff(self):
+        failed_streams = [
+            TrackedAsyncIter(
+                [
+                    SimpleNamespace(
+                        type="response.failed",
+                        response=SimpleNamespace(
+                            status="failed",
+                            error=None,
+                            output=[],
+                        ),
+                    )
+                ]
+            )
+            for _ in range(5)
+        ]
+        recovered_stream = AsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="ok")]
+        )
+        streams = [*failed_streams, recovered_stream]
+
+        async def retry_stream() -> AsyncIter | TrackedAsyncIter:
+            return streams.pop(0)
+
+        stream = self.mod.OpenAIStream(
+            streams.pop(0),
+            stream_factory=retry_stream,
+            stream_retries=5,
+            stream_retry_delay_seconds=1,
+        )
+
+        with patch.object(self.mod, "sleep", new=AsyncMock()) as sleep_mock:
+            items = await _stream_items(stream)
+
+        self.assertEqual(
+            [call.args[0] for call in sleep_mock.await_args_list],
+            [1, 2, 4, 8, 8],
+        )
+        self.assertEqual(
+            accumulate_canonical_stream_items(items).answer_text,
+            "ok",
+        )
+
+    async def test_client_retry_rolls_back_failed_reasoning_items(self):
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "ciphertext",
+            "content": [],
+        }
+        failed_stream = TrackedAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=reasoning_item,
+                ),
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[reasoning_item],
+                    ),
+                ),
+            ]
+        )
+        recovered_stream = AsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="ok")]
+        )
+        create_mock = AsyncMock(side_effect=[failed_stream, recovered_stream])
+        self.openai_stub.AsyncOpenAI.return_value.responses.create = (
+            create_mock
+        )
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        client._template_messages = MagicMock(
+            return_value=[{"role": "user", "content": "hi"}]
+        )
+
+        with patch.object(self.mod, "sleep", new=AsyncMock()):
+            stream = await client("m", [])
+            items = await _stream_items(stream)
+
+        self.assertEqual(create_mock.await_count, 2)
+        self.assertEqual(client._stateless_response_items, [])
         self.assertEqual(
             accumulate_canonical_stream_items(items).answer_text,
             "ok",
@@ -1510,24 +1903,18 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             stream=stream_instance,
             provider_family="openai",
             output_item_sink=client._record_stateless_response_item,
+            output_item_rollback=client._rollback_stateless_response_items,
             stream_factory=ANY,
             stream_retry_delay_seconds=2.5,
             stream_retries=0,
         )
 
-    async def test_stream_does_not_retry_failed_response_with_error_or_output(
-        self,
-    ):
+    async def test_stream_does_not_retry_failed_response_with_error(self):
         cases = [
             SimpleNamespace(
                 status="failed",
                 error=SimpleNamespace(message="boom"),
                 output=[],
-            ),
-            SimpleNamespace(
-                status="failed",
-                error=None,
-                output=[{"type": "message"}],
             ),
         ]
 

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -82,6 +82,64 @@ class TrackedAsyncIter:
         self._iter = iter(items)
         self.read_count = 0
         self.close_count = 0
+        self.cancel_count = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.read_count += 1
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+    async def cancel(self) -> None:
+        self.cancel_count += 1
+
+
+class CloseOnlyAsyncIter:
+    def __init__(self, items):
+        self._iter = iter(items)
+        self.read_count = 0
+        self.close_count = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.read_count += 1
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+class SyncCloseOnlyAsyncIter(CloseOnlyAsyncIter):
+    def close(self) -> None:
+        self.close_count += 1
+
+
+class FailingCloseOnlyAsyncIter(CloseOnlyAsyncIter):
+    def __init__(self, items, error: BaseException):
+        super().__init__(items)
+        self._error = error
+
+    async def close(self) -> None:
+        raise self._error
+
+
+class AcloseOnlyAsyncIter:
+    def __init__(self, items):
+        self._iter = iter(items)
+        self.read_count = 0
+        self.close_count = 0
 
     def __aiter__(self):
         return self
@@ -1145,6 +1203,277 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             accumulate_canonical_stream_items(items).answer_text,
             "ok",
+        )
+
+    async def test_stream_retry_aclose_closes_active_retried_stream(self):
+        failed_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[],
+                    ),
+                )
+            ]
+        )
+        retried_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="ok"),
+                SimpleNamespace(
+                    type="response.output_text.delta", delta="later"
+                ),
+            ]
+        )
+
+        async def retry_stream():
+            return retried_stream
+
+        stream = self.mod.OpenAIStream(
+            failed_stream,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+        canonical = stream.canonical_stream(
+            stream_session_id="responses-stream",
+            run_id="run-1",
+            turn_id="turn-1",
+        )
+
+        started = await anext(canonical)
+        delta = await anext(canonical)
+        await canonical.aclose()
+
+        self.assertIs(started.kind, StreamItemKind.STREAM_STARTED)
+        self.assertIs(delta.kind, StreamItemKind.ANSWER_DELTA)
+        self.assertEqual(delta.text_delta, "ok")
+        self.assertEqual(retried_stream.read_count, 1)
+        self.assertGreaterEqual(failed_stream.close_count, 1)
+        self.assertGreaterEqual(retried_stream.close_count, 1)
+
+    async def test_stream_retry_cancel_closes_active_retried_stream(self):
+        failed_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[],
+                    ),
+                )
+            ]
+        )
+        retried_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="ok"),
+                SimpleNamespace(
+                    type="response.output_text.delta", delta="later"
+                ),
+            ]
+        )
+
+        async def retry_stream():
+            return retried_stream
+
+        stream = self.mod.OpenAIStream(
+            failed_stream,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+        canonical = stream.canonical_stream(
+            stream_session_id="responses-stream",
+            run_id="run-1",
+            turn_id="turn-1",
+        )
+
+        started = await anext(canonical)
+        delta = await anext(canonical)
+        try:
+            await stream.cancel()
+            self.assertEqual(retried_stream.close_count, 1)
+        finally:
+            await canonical.aclose()
+
+        self.assertIs(started.kind, StreamItemKind.STREAM_STARTED)
+        self.assertIs(delta.kind, StreamItemKind.ANSWER_DELTA)
+        self.assertEqual(delta.text_delta, "ok")
+        self.assertEqual(retried_stream.read_count, 1)
+        self.assertGreaterEqual(failed_stream.close_count, 1)
+        self.assertGreaterEqual(retried_stream.close_count, 1)
+
+    async def test_stream_cancel_during_retry_factory_closes_replacement(
+        self,
+    ):
+        factory_started = Event()
+        factory_release = Event()
+        failed_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[],
+                    ),
+                )
+            ]
+        )
+        replacement_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.output_text.delta",
+                    delta="leaked",
+                )
+            ]
+        )
+
+        async def retry_stream():
+            factory_started.set()
+            await factory_release.wait()
+            return replacement_stream
+
+        stream = self.mod.OpenAIStream(
+            failed_stream,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+        canonical = stream.canonical_stream(
+            stream_session_id="responses-stream",
+            run_id="run-1",
+            turn_id="turn-1",
+        )
+
+        started = await anext(canonical)
+        pull = create_task(anext(canonical))
+        try:
+            await wait_for(factory_started.wait(), 1.0)
+            await stream.cancel()
+            factory_release.set()
+            item = await wait_for(pull, 1.0)
+        finally:
+            factory_release.set()
+            if not pull.done():
+                pull.cancel()
+            await canonical.aclose()
+
+        self.assertIs(started.kind, StreamItemKind.STREAM_STARTED)
+        self.assertIs(item.kind, StreamItemKind.STREAM_CANCELLED)
+        self.assertGreaterEqual(failed_stream.close_count, 1)
+        self.assertEqual(replacement_stream.read_count, 0)
+        self.assertEqual(replacement_stream.close_count, 1)
+
+    async def test_stream_aclose_during_retry_factory_closes_replacement(
+        self,
+    ):
+        factory_started = Event()
+        factory_release = Event()
+        failed_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.failed",
+                    response=SimpleNamespace(
+                        status="failed",
+                        error=None,
+                        output=[],
+                    ),
+                )
+            ]
+        )
+        replacement_stream = CloseOnlyAsyncIter(
+            [
+                SimpleNamespace(
+                    type="response.output_text.delta",
+                    delta="leaked",
+                )
+            ]
+        )
+
+        async def retry_stream():
+            factory_started.set()
+            await factory_release.wait()
+            return replacement_stream
+
+        stream = self.mod.OpenAIStream(
+            failed_stream,
+            stream_factory=retry_stream,
+            stream_retries=1,
+        )
+        canonical = stream.canonical_stream(
+            stream_session_id="responses-stream",
+            run_id="run-1",
+            turn_id="turn-1",
+        )
+
+        started = await anext(canonical)
+        pull = create_task(anext(canonical))
+        try:
+            await wait_for(factory_started.wait(), 1.0)
+            await stream.aclose()
+            factory_release.set()
+            item = await wait_for(pull, 1.0)
+        finally:
+            factory_release.set()
+            if not pull.done():
+                pull.cancel()
+            await canonical.aclose()
+
+        self.assertIs(started.kind, StreamItemKind.STREAM_STARTED)
+        self.assertIs(item.kind, StreamItemKind.STREAM_CANCELLED)
+        self.assertGreaterEqual(failed_stream.close_count, 1)
+        self.assertEqual(replacement_stream.read_count, 0)
+        self.assertEqual(replacement_stream.close_count, 1)
+
+    async def test_stream_cancel_closes_aclose_only_source(self):
+        source = AcloseOnlyAsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="late")]
+        )
+        stream = self.mod.OpenAIStream(source)
+
+        await stream.cancel()
+
+        self.assertEqual(source.read_count, 0)
+        self.assertEqual(source.close_count, 1)
+
+    async def test_stream_aclose_accepts_sync_close_source(self):
+        source = SyncCloseOnlyAsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="late")]
+        )
+        stream = self.mod.OpenAIStream(source)
+
+        await stream.aclose()
+
+        self.assertEqual(source.read_count, 0)
+        self.assertEqual(source.close_count, 1)
+
+    async def test_stream_aclose_propagates_single_cleanup_error(self):
+        error = RuntimeError("close failed")
+        source = FailingCloseOnlyAsyncIter(
+            [SimpleNamespace(type="response.output_text.delta", delta="late")],
+            error,
+        )
+        stream = self.mod.OpenAIStream(source)
+
+        with self.assertRaises(RuntimeError) as context:
+            await stream.aclose()
+
+        self.assertIs(context.exception, error)
+
+    async def test_stream_aclose_groups_multiple_cleanup_errors(self):
+        first_error = RuntimeError("first")
+        second_error = ValueError("second")
+        first = FailingCloseOnlyAsyncIter([], first_error)
+        second = FailingCloseOnlyAsyncIter([], second_error)
+        stream = self.mod.OpenAIStream(first)
+        stream._stream_sources = (first, second)
+
+        with self.assertRaises(BaseExceptionGroup) as context:
+            await stream.aclose()
+
+        self.assertEqual(
+            context.exception.exceptions,
+            (first_error, second_error),
         )
 
     async def test_client_response_failed_retry_settings_override_defaults(

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -1460,6 +1460,19 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
 
         self.assertIs(context.exception, error)
 
+    async def test_stream_aclose_base_exception_skips_later_sources(self):
+        error = BaseException("close interrupted")
+        first = FailingCloseOnlyAsyncIter([], error)
+        second = CloseOnlyAsyncIter([])
+        stream = self.mod.OpenAIStream(first)
+        stream._stream_sources = (first, second)
+
+        with self.assertRaises(BaseException) as context:
+            await stream.aclose()
+
+        self.assertIs(context.exception, error)
+        self.assertEqual(second.close_count, 0)
+
     async def test_stream_aclose_groups_multiple_cleanup_errors(self):
         first_error = RuntimeError("first")
         second_error = ValueError("second")

--- a/tests/model/nlp/vendor_openai_test.py
+++ b/tests/model/nlp/vendor_openai_test.py
@@ -9,6 +9,7 @@ from json import loads
 from logging import getLogger
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import UUID
@@ -843,6 +844,52 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         with self.assertRaises(AssertionError):
             model._load_model()
 
+    async def test_model_loads_with_provider_retry_options(self):
+        settings = TransformerEngineSettings(
+            auto_load_model=False,
+            auto_load_tokenizer=False,
+            access_token="token",
+            base_url="https://api.openai.com/v1",
+            provider_options={
+                "openai_response_failed_retries": 2,
+                "openai_response_failed_retry_delay_seconds": 0.25,
+            },
+        )
+        model = self.mod.OpenAIModel("deployment", settings)
+        loaded = model._load_model()
+
+        self.openai_stub.AsyncOpenAI.assert_called_once_with(
+            base_url="https://api.openai.com/v1",
+            api_key="token",
+        )
+        self.assertEqual(loaded._stream_response_failed_retries, 2)
+        self.assertEqual(
+            loaded._stream_response_failed_retry_delay_seconds,
+            0.25,
+        )
+
+    async def test_model_rejects_invalid_provider_retry_options(self):
+        cases: list[dict[str, Any]] = [
+            {"openai_response_failed_retries": -1},
+            {"openai_response_failed_retries": 1.5},
+            {"openai_response_failed_retry_delay_seconds": -0.1},
+            {"openai_response_failed_retry_delay_seconds": False},
+        ]
+
+        for provider_options in cases:
+            with self.subTest(provider_options=provider_options):
+                settings = TransformerEngineSettings(
+                    auto_load_model=False,
+                    auto_load_tokenizer=False,
+                    access_token="token",
+                    base_url="https://api.openai.com/v1",
+                    provider_options=provider_options,
+                )
+                model = self.mod.OpenAIModel("deployment", settings)
+
+                with self.assertRaises(AssertionError):
+                    model._load_model()
+
     async def test_stream_event_types(self):
         events = [
             SimpleNamespace(type="response.output_item.added"),
@@ -1098,6 +1145,32 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             accumulate_canonical_stream_items(items).answer_text,
             "ok",
+        )
+
+    async def test_client_response_failed_retry_settings_override_defaults(
+        self,
+    ):
+        stream_instance = AsyncIter([])
+        self.openai_stub.AsyncOpenAI.return_value.responses.create = AsyncMock(
+            return_value=stream_instance
+        )
+        client = self.mod.OpenAIClient(api_key="k", base_url="b")
+        client._template_messages = MagicMock(return_value=[])
+        settings = GenerationSettings(
+            openai_response_failed_retries=0,
+            openai_response_failed_retry_delay_seconds=2.5,
+        )
+
+        with patch.object(self.mod, "OpenAIStream") as stream_mock:
+            await client("m", [], settings=settings)
+
+        stream_mock.assert_called_once_with(
+            stream=stream_instance,
+            provider_family="openai",
+            output_item_sink=client._record_stateless_response_item,
+            stream_factory=ANY,
+            stream_retry_delay_seconds=2.5,
+            stream_retries=0,
         )
 
     async def test_stream_does_not_retry_failed_response_with_error_or_output(
@@ -2976,6 +3049,19 @@ class OpenAITestCase(IsolatedAsyncioTestCase):
             tools=[{"type": "function", "name": "avl_cGtnLmZ1bmM"}],
         )
 
+    def test_generation_settings_rejects_invalid_openai_retry_values(self):
+        cases: list[dict[str, Any]] = [
+            {"openai_response_failed_retries": -1},
+            {"openai_response_failed_retries": 1.5},
+            {"openai_response_failed_retry_delay_seconds": -0.1},
+            {"openai_response_failed_retry_delay_seconds": False},
+        ]
+
+        for kwargs in cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(AssertionError):
+                    GenerationSettings(**kwargs)
+
     async def test_azure_responses_payload_uses_text_format(self):
         response = SimpleNamespace(
             output=[SimpleNamespace(content=[SimpleNamespace(text="ok")])]
@@ -3992,7 +4078,10 @@ class TemplateAndToolSchemaTestCase(TestCase):
     ):
         client = self.mod.OpenAIClient(api_key="k", base_url="b")
         client._record_stateless_response_item(
-            {"type": "message", "id": "msg_1"}
+            {
+                "type": "message",
+                "id": "msg_1",
+            }
         )
         client._record_stateless_response_item(
             {


### PR DESCRIPTION
## Summary
- Preserve OpenAI Responses reasoning and function-call context across stateless tool cycles by requesting encrypted reasoning content, capturing replayable output items, and replaying only function calls that have matching local tool outputs.
- Sanitize replayed provider response items so Azure does not receive response-only fields such as `status`, null fields, or empty reasoning content.
- Add a narrow pre-output retry for empty `response.failed` stream failures, matching the transient Azure failure observed in the repro.

## Testing
- Azure repro command completed successfully with the corrected `--maximum-tool-cycles` flag.
- `make tests no-install coverage` -> `9261 passed, 63 skipped, 6834 subtests passed`; total `src/` coverage `100.00%`.
- `poetry run pytest tests/model/nlp/vendor_openai_test.py -q` -> `110 passed, 19 subtests passed`.
- `poetry run black --check --preview --enable-unstable-feature=string_processing src/avalan/model/nlp/text/vendor/openai.py tests/model/nlp/vendor_openai_test.py`.
- `poetry run ruff check src/avalan/model/nlp/text/vendor/openai.py tests/model/nlp/vendor_openai_test.py`.
- `poetry run mypy`.
- `git diff --check`.